### PR TITLE
Add some methods, coming from AbstractPager and used in twig to PagerInterface

### DIFF
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Datagrid;
 
 /**
+ * NEXT_MAJOR: Remove the \Iterator, \Countable and \Serializable implementation.
+ *
  * @author Fabien Potencier <fabien.potencier@symfony-project.com>
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
@@ -43,21 +45,37 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     protected $nbResults = 0;
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * @var int
      */
     protected $cursor = 1;
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * @var array<string, mixed>
      */
     protected $parameters = [];
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * @var int
      */
     protected $currentMaxLink = 1;
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * @var mixed bool|int
      */
     protected $maxRecordLimit = false;
@@ -67,13 +85,24 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      */
     protected $maxPageLinks = 0;
 
-    // used by iterator interface
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
+     * Used by iterator interface
+     *
      * @var object[]|null
      */
     protected $results;
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
+     * Used by iterator interface
+     *
      * @var int
      */
     protected $resultsCounter = 0;
@@ -84,6 +113,10 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     protected $query;
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * @var string[]
      */
     protected $countColumn = ['id'];
@@ -97,32 +130,59 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * Returns the current pager's max link.
      *
      * @return int
      */
     public function getCurrentMaxLink()
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $this->currentMaxLink;
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * Returns the current pager's max record limit.
      *
      * @return int
      */
     public function getMaxRecordLimit()
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $this->maxRecordLimit;
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * Sets the current pager's max record limit.
      *
      * @param int $limit
      */
     public function setMaxRecordLimit($limit)
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         $this->maxRecordLimit = $limit;
     }
 
@@ -149,6 +209,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
             $links[] = $i++;
         }
 
+        // NEXT_MAJOR: Remove this line.
         $this->currentMaxLink = \count($links) ? $links[\count($links) - 1] : 1;
 
         return $links;
@@ -165,22 +226,40 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * Returns the current cursor.
      *
      * @return int
      */
     public function getCursor()
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $this->cursor;
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * Sets the current cursor.
      *
      * @param int $pos
      */
     public function setCursor($pos)
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         if ($pos < 1) {
             $this->cursor = 1;
         } else {
@@ -193,6 +272,10 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * Returns an object by cursor position.
      *
      * @param int $pos
@@ -201,28 +284,51 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      */
     public function getObjectByCursor($pos)
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         $this->setCursor($pos);
 
         return $this->getCurrent();
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * Returns the current object.
      *
      * @return object
      */
     public function getCurrent()
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $this->retrieveObject($this->cursor);
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * Returns the next object.
      *
      * @return object|null
      */
     public function getNext()
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         if ($this->cursor + 1 > $this->nbResults) {
             return null;
         }
@@ -231,12 +337,21 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * Returns the previous object.
      *
      * @return mixed|null
      */
     public function getPrevious()
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         if ($this->cursor - 1 < 1) {
             return null;
         }
@@ -245,12 +360,21 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * Returns the first index on the current page.
      *
      * @return int
      */
     public function getFirstIndex()
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         if (0 === $this->page) {
             return 1;
         }
@@ -275,12 +399,21 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * Returns the last index on the current page.
      *
      * @return int
      */
     public function getLastIndex()
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         if (0 === $this->page) {
             return $this->nbResults;
         }
@@ -421,16 +554,29 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * Returns the current pager's parameter holder.
      *
      * @return array<string, mixed>
      */
     public function getParameters()
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $this->parameters;
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * Returns a parameter.
      *
      * @param string $name
@@ -440,10 +586,19 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      */
     public function getParameter($name, $default = null)
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $this->parameters[$name] ?? $default;
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * Checks whether a parameter has been set.
      *
      * @param string $name
@@ -452,10 +607,19 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      */
     public function hasParameter($name)
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return isset($this->parameters[$name]);
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * Sets a parameter.
      *
      * @param string $name
@@ -463,11 +627,26 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      */
     public function setParameter($name, $value)
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         $this->parameters[$name] = $value;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     */
     public function current()
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         if (!$this->isIteratorInitialized()) {
             $this->initializeIterator();
         }
@@ -475,8 +654,18 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         return current($this->results);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     */
     public function key()
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         if (!$this->isIteratorInitialized()) {
             $this->initializeIterator();
         }
@@ -484,8 +673,18 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         return key($this->results);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     */
     public function next()
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         if (!$this->isIteratorInitialized()) {
             $this->initializeIterator();
         }
@@ -496,8 +695,18 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         return next($this->results);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     */
     public function rewind()
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         if (!$this->isIteratorInitialized()) {
             $this->initializeIterator();
         }
@@ -508,8 +717,18 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         return reset($this->results);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     */
     public function valid()
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         if (!$this->isIteratorInitialized()) {
             $this->initializeIterator();
         }
@@ -517,21 +736,51 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         return $this->resultsCounter > 0;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, use getNbResults instead
+     */
     public function count()
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $this->getNbResults();
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     */
     public function serialize()
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         $vars = get_object_vars($this);
         unset($vars['query']);
 
         return serialize($vars);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     */
     public function unserialize($serialized)
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         $array = unserialize($serialized);
 
         foreach ($array as $name => $values) {
@@ -540,18 +789,36 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * @return string[]
      */
     public function getCountColumn()
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $this->countColumn;
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * @return string[]
      */
     public function setCountColumn(array $countColumn)
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $this->countColumn = $countColumn;
     }
 
@@ -594,38 +861,73 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * Returns true if the properties used for iteration have been initialized.
      *
      * @return bool
      */
     protected function isIteratorInitialized()
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return null !== $this->results;
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * Loads data into properties used for iteration.
      *
      * @return void
      */
     protected function initializeIterator()
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
+            @trigger_error(sprintf(
+                'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         $this->results = $this->getResults();
         $this->resultsCounter = \count($this->results);
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * Empties properties used for iteration.
      *
      * @return void
      */
     protected function resetIterator()
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
+            @trigger_error(sprintf(
+                'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         $this->results = null;
         $this->resultsCounter = 0;
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * Retrieve the object for a certain offset.
      *
      * @param int $offset
@@ -634,6 +936,11 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      */
     protected function retrieveObject($offset)
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         $queryForRetrieve = clone $this->getQuery();
         $queryForRetrieve
             ->setFirstResult($offset - 1)

--- a/src/Datagrid/PagerInterface.php
+++ b/src/Datagrid/PagerInterface.php
@@ -18,9 +18,17 @@ namespace Sonata\AdminBundle\Datagrid;
  *
  * NEXT_MAJOR: Remove these comments and uncomment corresponding methods.
  *
- * @method int  getPage()
- * @method bool isLastPage()
- * @method int  getNbResults()
+ * @method int                 getPage()
+ * @method int                 getFirstPage()
+ * @method int                 getLastPage()
+ * @method int                 getNextPage()
+ * @method int                 getPreviousPage()
+ * @method bool                isFirstPage()
+ * @method bool                isLastPage()
+ * @method int                 getNbResults()
+ * @method array               getLinks(?int $nbLinks = null)
+ * @method bool                haveToPaginate()
+ * @method ProxyQueryInterface getQuery()
  */
 interface PagerInterface
 {
@@ -43,19 +51,45 @@ interface PagerInterface
      */
     public function setMaxPerPage($max);
 
+//    NEXT_MAJOR: uncomment this method in 4.0
+//    public function getPage(): int;
+
     /**
-     * Sets the current page.
-     *
      * @param int $page
      */
     public function setPage($page);
 
+//    NEXT_MAJOR: uncomment this method in 4.0
+//    public function getNextPage(): bool;
+
+//    NEXT_MAJOR: uncomment this method in 4.0
+//    public function getPreviousPage(): bool;
+
+//    NEXT_MAJOR: uncomment this method in 4.0
+//    public function getFirstPage(): int;
+
+//    NEXT_MAJOR: uncomment this method in 4.0
+//    public function isFirstPage(): bool;
+
+//    NEXT_MAJOR: uncomment this method in 4.0
+//    public function getLastPage(): int;
+
+//    NEXT_MAJOR: uncomment this method in 4.0
+//    public function isLastPage(): bool;
+
+//    NEXT_MAJOR: uncomment this method in 4.0
+//    public function getQuery(): ProxyQueryInterface;
+
     /**
-     * Set query.
-     *
      * @param ProxyQueryInterface $query
      */
     public function setQuery($query);
+
+//    NEXT_MAJOR: uncomment this method in 4.0
+//    /**
+//     * Returns true if the current query requires pagination.
+//     */
+//    public function haveToPaginate(): bool;
 
     /**
      * Returns an array of results on the given page.
@@ -63,6 +97,19 @@ interface PagerInterface
      * @return object[]
      */
     public function getResults();
+
+//    NEXT_MAJOR: uncomment this method in 4.0
+//    public function getNbResults(): int;
+
+//    NEXT_MAJOR: uncomment this method 4.0
+//    /**
+//     * Returns an array of page numbers to use in pagination links.
+//     *
+//     * @param int $nbLinks The maximum number of page numbers to return
+//     *
+//     * @return int[]
+//     */
+//    public function getLinks(?int $nbLinks = null): array
 
     /**
      * Sets the maximum number of page numbers.
@@ -77,18 +124,4 @@ interface PagerInterface
      * @return int
      */
     public function getMaxPageLinks();
-
-//    NEXT_MAJOR: uncomment this method in 4.0
-//    /**
-//     * Returns true if on the last page.
-//     *
-//     * @return bool
-//     */
-//    public function isLastPage(): bool;
-
-//    NEXT_MAJOR: uncomment this method in 4.0
-//    public function getNbResults(): int;
-//
-//    NEXT_MAJOR: uncomment this method in 4.0
-//    public function getPage(): int;
 }

--- a/src/Datagrid/PagerInterface.php
+++ b/src/Datagrid/PagerInterface.php
@@ -60,10 +60,10 @@ interface PagerInterface
     public function setPage($page);
 
 //    NEXT_MAJOR: uncomment this method in 4.0
-//    public function getNextPage(): bool;
+//    public function getNextPage(): int;
 
 //    NEXT_MAJOR: uncomment this method in 4.0
-//    public function getPreviousPage(): bool;
+//    public function getPreviousPage(): int;
 
 //    NEXT_MAJOR: uncomment this method in 4.0
 //    public function getFirstPage(): int;

--- a/src/Datagrid/SimplePager.php
+++ b/src/Datagrid/SimplePager.php
@@ -24,6 +24,11 @@ use Doctrine\Common\Collections\ArrayCollection;
 class SimplePager extends Pager
 {
     /**
+     * @var object[]|null
+     */
+    protected $results;
+
+    /**
      * @var bool
      */
     protected $haveToPaginate;
@@ -106,7 +111,10 @@ class SimplePager extends Pager
         if (!$this->getQuery()) {
             throw new \RuntimeException('Uninitialized query');
         }
-        $this->resetIterator();
+
+        // NEXT_MAJOR: Remove this line and uncomment the following one instead.
+        $this->resetIterator('sonata_deprecation_mute');
+//        $this->haveToPaginate = false;
 
         if (0 === $this->getPage() || 0 === $this->getMaxPerPage()) {
             $this->setLastPage(0);
@@ -120,7 +128,10 @@ class SimplePager extends Pager
                 ? $this->getMaxPerPage() * $this->threshold + 1 : $this->getMaxPerPage() + 1;
 
             $this->getQuery()->setMaxResults($maxOffset);
-            $this->initializeIterator();
+
+            // NEXT_MAJOR: Remove this line and uncomment the following one instead.
+            $this->initializeIterator('sonata_deprecation_mute');
+//            $this->results = $this->getResults();
 
             $t = (int) ceil($this->thresholdCount / $this->getMaxPerPage()) + $this->getPage() - 1;
             $this->setLastPage(max(1, $t));
@@ -145,9 +156,21 @@ class SimplePager extends Pager
         return $this->threshold;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     */
     protected function resetIterator()
     {
-        parent::resetIterator();
+        if ('sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
+            @trigger_error(sprintf(
+                'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
+        parent::resetIterator('sonata_deprecation_mute');
         $this->haveToPaginate = false;
     }
 }

--- a/src/Resources/views/Block/block_stats.html.twig
+++ b/src/Resources/views/Block/block_stats.html.twig
@@ -17,10 +17,10 @@ file that was distributed with this source code.
     <!-- small box -->
     <div class="small-box {{ settings.color }}">
         <div class="inner">
-            <h3>{{ pager.count() }}</h3>
+            <h3>{{ pager.getNbResults() }}</h3>
             <p>
                 {% if translation_domain %}
-                    {{ settings.text|trans({'%count%': pager.count()}, translation_domain) }}
+                    {{ settings.text|trans({'%count%': pager.getNbResults()}, translation_domain) }}
                 {% else %}
                     {{ settings.text }}
                 {% endif %}

--- a/tests/App/Datagrid/Pager.php
+++ b/tests/App/Datagrid/Pager.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\App\Datagrid;
 
 use Sonata\AdminBundle\Datagrid\PagerInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Tests\App\Model\FooRepository;
 
 final class Pager implements PagerInterface
@@ -41,17 +42,72 @@ final class Pager implements PagerInterface
     {
     }
 
+    public function getPage(): int
+    {
+        return 1;
+    }
+
     public function setPage($page): void
     {
+    }
+
+    public function getNextPage(): int
+    {
+        return 1;
+    }
+
+    public function getPreviousPage(): int
+    {
+        return 1;
+    }
+
+    public function getFirstPage(): int
+    {
+        return 1;
+    }
+
+    public function isFirstPage(): bool
+    {
+        return true;
+    }
+
+    public function getLastPage(): int
+    {
+        return 2;
+    }
+
+    public function isLastPage(): bool
+    {
+        return true;
+    }
+
+    public function getQuery($query): ProxyQueryInterface
+    {
+        return new ProxyQuery();
     }
 
     public function setQuery($query): void
     {
     }
 
+    public function haveToPaginate(): bool
+    {
+        return false;
+    }
+
     public function getResults(): array
     {
         return $this->repository->all();
+    }
+
+    public function getNbResults()
+    {
+        return \count($this->getResults());
+    }
+
+    public function getLinks(?int $nbLinks = null): array
+    {
+        return [];
     }
 
     public function setMaxPageLinks($maxPageLinks): void
@@ -61,20 +117,5 @@ final class Pager implements PagerInterface
     public function getMaxPageLinks()
     {
         return 1;
-    }
-
-    public function getPage()
-    {
-        return 1;
-    }
-
-    public function isLastPage()
-    {
-        return true;
-    }
-
-    public function getNbResults()
-    {
-        return \count($this->getResults());
     }
 }

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -16,12 +16,15 @@ namespace Sonata\AdminBundle\Tests\Datagrid;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Datagrid\Pager;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 /**
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
 class PagerTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @var Pager
      */
@@ -97,8 +100,14 @@ class PagerTest extends TestCase
         $this->assertSame(1, $this->pager->getPage());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetCurrentMaxLink(): void
     {
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getCurrentMaxLink()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->assertSame(1, $this->pager->getCurrentMaxLink());
 
         $this->pager->getLinks();
@@ -113,8 +122,14 @@ class PagerTest extends TestCase
         $this->assertSame(10, $this->pager->getCurrentMaxLink());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetMaxRecordLimit(): void
     {
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getMaxRecordLimit()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->assertFalse($this->pager->getMaxRecordLimit());
 
         $this->pager->setMaxRecordLimit(99);
@@ -130,8 +145,14 @@ class PagerTest extends TestCase
         $this->assertSame(100, $this->pager->getNbResults());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testCount(): void
     {
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::count()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->assertSame(0, $this->pager->count());
 
         $this->callMethod($this->pager, 'setNbResults', [100]);
@@ -147,21 +168,36 @@ class PagerTest extends TestCase
         $this->assertSame($query, $this->pager->getQuery());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetCountColumn(): void
     {
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getCountColumn()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->assertSame(['id'], $this->pager->getCountColumn());
 
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::setCountColumn()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->pager->setCountColumn(['foo']);
         $this->assertSame(['foo'], $this->pager->getCountColumn());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testParameters(): void
     {
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getParameter()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->assertNull($this->pager->getParameter('foo', null));
         $this->assertSame('bar', $this->pager->getParameter('foo', 'bar'));
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::hasParameter()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->assertFalse($this->pager->hasParameter('foo'));
         $this->assertSame([], $this->pager->getParameters());
 
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::setParameter()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->pager->setParameter('foo', 'foo_value');
 
         $this->assertTrue($this->pager->hasParameter('foo'));
@@ -261,6 +297,11 @@ class PagerTest extends TestCase
         $this->assertTrue($this->pager->haveToPaginate());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testIterator(): void
     {
         $this->assertInstanceOf(\Iterator::class, $this->pager);
@@ -291,39 +332,63 @@ class PagerTest extends TestCase
         $this->assertSame($object3, $value);
         $this->assertSame($expectedObjects, $values);
 
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::valid()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->assertFalse($this->pager->valid());
 
         $this->callMethod($this->pager, 'resetIterator');
         $this->assertTrue($this->pager->valid());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testValid(): void
     {
         $this->pager
             ->method('getResults')
             ->willReturn([]);
 
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::valid()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->assertFalse($this->pager->valid());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testNext(): void
     {
         $this->pager
             ->method('getResults')
             ->willReturn([]);
 
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::next()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->assertFalse($this->pager->next());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testKey(): void
     {
         $this->pager
             ->method('getResults')
             ->willReturn([123 => new \stdClass()]);
 
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::key()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->assertSame(123, $this->pager->key());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testCurrent(): void
     {
         $object = new \stdClass();
@@ -332,11 +397,18 @@ class PagerTest extends TestCase
             ->method('getResults')
             ->willReturn([$object]);
 
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::current()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->assertSame($object, $this->pager->current());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetCursor(): void
     {
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getCursor()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->assertSame(1, $this->pager->getCursor());
 
         $this->pager->setCursor(0);
@@ -354,6 +426,11 @@ class PagerTest extends TestCase
         $this->assertSame(100, $this->pager->getCursor());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetObjectByCursor(): void
     {
         $object1 = new \stdClass();
@@ -397,7 +474,9 @@ class PagerTest extends TestCase
 
         $this->pager->setQuery($query);
 
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getObjectByCursor()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->assertSame($object1, $this->pager->getObjectByCursor(1));
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getCursor()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->assertSame(1, $this->pager->getCursor());
 
         $id = 1;
@@ -441,8 +520,14 @@ class PagerTest extends TestCase
         $this->assertSame(20, $this->pager->getPreviousPage());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetFirstIndex(): void
     {
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getFirstIndex()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->assertSame(1, $this->pager->getFirstIndex());
 
         $this->pager->setMaxPerPage(0);
@@ -458,8 +543,14 @@ class PagerTest extends TestCase
         $this->assertSame(22, $this->pager->getFirstIndex());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetLastIndex(): void
     {
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getLastIndex()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->assertSame(0, $this->pager->getLastIndex());
 
         $this->pager->setMaxPerPage(0);
@@ -480,8 +571,14 @@ class PagerTest extends TestCase
         $this->assertSame(100, $this->pager->getLastIndex());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetNext(): void
     {
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getNext()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->assertNull($this->pager->getNext());
 
         $object1 = new \stdClass();
@@ -538,8 +635,14 @@ class PagerTest extends TestCase
         $this->assertNull($this->pager->getNext());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetPrevious(): void
     {
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getPrevious()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->assertNull($this->pager->getPrevious());
 
         $object1 = new \stdClass();
@@ -596,9 +699,15 @@ class PagerTest extends TestCase
         $this->assertNull($this->pager->getPrevious());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testSerialize(): void
     {
         $pagerClone = clone $this->pager;
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::serialize()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $data = $this->pager->serialize();
         $this->assertNotEmpty($data);
 
@@ -612,6 +721,11 @@ class PagerTest extends TestCase
         $this->assertSame($pagerClone->getMaxPageLinks(), $this->pager->getMaxPageLinks());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testUnserialize(): void
     {
         $serialized = [
@@ -632,6 +746,7 @@ class PagerTest extends TestCase
             ->willReturn([]);
         $this->pager->current();
 
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::unserialize()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->pager->unserialize(serialize($serialized));
 
         $this->assertSame(7, $this->pager->getMaxPerPage());


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because BC.

Closes #6294

## Changelog

```markdown
### Added
- `getPage()` to the PagerInterface.
- `getFirstPage()` to the PagerInterface.
- `getLastPage()` to the PagerInterface.
- `getNextPage()` to the PagerInterface.
- `getPreviousPage()` to the PagerInterface.
- `isFirstPage()` to the PagerInterface.
- `isLastPage()` to the PagerInterface.
- `getNbResults()` to the PagerInterface.
- `getLinks()` to the PagerInterface.
- `haveToPaginate()` to the PagerInterface.
- `getQuery()` to the PagerInterface.

### Deprecated
- `AbstractPager::getCurrentMaxLink()`
- `AbstractPager::getMaxRecordLimit()` 
- `AbstractPager::setMaxRecordLimit()`
- `AbstractPager::getCursor()`
- `AbstractPager::setCursor()`
- `AbstractPager::getObjectByCursor()`
- `AbstractPager::getCurrent()`
- `AbstractPager::getNext()`
- `AbstractPager::getPrevious()`
- `AbstractPager::getFirstIndex()`
- `AbstractPager::getLastIndex()`
- `AbstractPager::getParameters()`
- `AbstractPager::getParameter()`
- `AbstractPager::hasParameter()`
- `AbstractPager::setParameter()`
```

## Why these changes:

### What is or should be in the interface

- [x] `getLinks` => Should be in the interface because used `{% for page in admin.datagrid.pager.getLinks(admin_pool.getOption('pager_links')) %}`
- [x] `haveToPaginate` => Should be in the interface because used `{% if admin.datagrid.pager.haveToPaginate() %}`
- [x] `getNbResults` => Will be in the Interface in 4.0 (and used: `{% if admin.datagrid.pager.page > 2 %}`)
- [x] `getFirstPage` => IMHO: Should be in the interface, to be similar to `getLastPage`
- [x] `getLastPage` => Should be in the interface because used `{{ admin.datagrid.pager.lastpage }}`
- [x] `getPage` => Will be in the Interface in 4.0 (and used: `{% if admin.datagrid.pager.page > 2 %}`)
- [x] `getNextPage` => Should be in the interface because used `{% if admin.datagrid.pager.page != admin.datagrid.pager.nextpage %}`
- [x] `getPreviousPage` => Should be in the interface because used `{% if admin.datagrid.pager.page != admin.datagrid.pager.previouspage %}`
- [x] `setPage` => Already in the Interface, used in Datagrid.
- [x] `getMaxPerPage` => Already in the Interface (and used: `{% if per_page == admin.datagrid.pager.maxperpage %}`)
- [x] `setMaxPerPage` => Already in the Interface, related to the getter.
- [x] `getMaxPageLinks` => Already in the Interface, related to the setter.
- [x] `setMaxPageLinks` => Already in the Interface, used in AbstractAdmin.
- [x] `isFirstPage` => IMHO: Should be in the interface, to be similar to `isLastPage`
- [x] `isLastPage` => Will be in the Interface in 4.0 (and used: `'more' => !$pager->isLastPage(),`)
- [x] `setQuery` => Already in the Interface, used in Datagrid.
- [x] `getQuery` => I found no usage, but IMHO it should be in the interface since the setter is.

### What is not and should not be in the Interface, and then removed from the BasePager

- [ ] `getCountColumn` => Used in DoctrineORM but not in DoctrineMongoDB, should be moved to DoctrineORM.
- [ ] `setCountColumn` => Used in DoctrineORM but not in DoctrineMongoDB, should be moved to DoctrineORM.

### What I found nowhere, so I suppose it shouldn't be

- [ ] `\Iterator` methods => Doesn't seem needed to me
- [ ] `\Countable` methods => Not in the interface, but count is sometimes used instead of `getNbResults` ; IMHO, since we're exposing a `getNbResults` method, there is no reason to expose `count` too.
- [ ] `\Serializable` methods => Doesn't seem needed to me

And for the following methods, I found no use for these methods, so I deprecate them.

- [ ] `getCurrentMaxLink`
- [ ] `getMaxRecordLimit` 
- [ ] `setMaxRecordLimit`
- [ ] `getCursor`
- [ ] `setCursor`
- [ ] `getObjectByCursor`
- [ ] `getCurrent`
- [ ] `getNext`
- [ ] `getPrevious`
- [ ] `getFirstIndex`
- [ ] `getLastIndex`
- [ ] `getParameters`
- [ ] `getParameter`
- [ ] `hasParameter`
- [ ] `setParameter`