### PR TITLE
Restrict visibility of class/property

### DIFF
--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -20,17 +20,14 @@ use Sonata\AdminBundle\Exception\NoValueException;
 use Sonata\AdminBundle\Manipulator\ObjectManipulator;
 use Sonata\AdminBundle\Util\FormBuilderIterator;
 use Sonata\AdminBundle\Util\FormViewIterator;
-use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
- * @final since sonata-project/admin-bundle 3.52
- *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class AdminHelper
+final class AdminHelper
 {
     /**
      * @var string
@@ -40,7 +37,7 @@ class AdminHelper
     /**
      * @var PropertyAccessorInterface
      */
-    protected $propertyAccessor;
+    private $propertyAccessor;
 
     public function __construct(PropertyAccessorInterface $propertyAccessor)
     {
@@ -228,7 +225,7 @@ class AdminHelper
     /**
      * Recursively find the class name of the admin responsible for the element at the end of an association chain.
      */
-    protected function getModelClassName(AdminInterface $admin, array $elements): string
+    private function getModelClassName(AdminInterface $admin, array $elements): string
     {
         $element = array_shift($elements);
         $associationAdmin = $admin->getFormFieldDescription($element)->getAssociationAdmin();

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -18,58 +18,56 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
- * @final since sonata-project/admin-bundle 3.52
- *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class Pool
+final class Pool
 {
     /**
      * @var ContainerInterface
      */
-    protected $container;
+    private $container;
 
     /**
      * @var string[]
      */
-    protected $adminServiceIds = [];
+    private $adminServiceIds = [];
 
     /**
      * @var array
      */
-    protected $adminGroups = [];
+    private $adminGroups = [];
 
     /**
      * @var array<string, string[]>
      *
      * @phpstan-var array<class-string, string[]>
      */
-    protected $adminClasses = [];
+    private $adminClasses = [];
 
     /**
      * @var array
      */
-    protected $assets = [];
+    private $assets = [];
 
     /**
      * @var string
      */
-    protected $title;
+    private $title;
 
     /**
      * @var string
      */
-    protected $titleLogo;
+    private $titleLogo;
 
     /**
      * @var array
      */
-    protected $options = [];
+    private $options = [];
 
     /**
      * @var PropertyAccessorInterface
      */
-    protected $propertyAccessor;
+    private $propertyAccessor;
 
     public function __construct(
         ContainerInterface $container,
@@ -258,7 +256,7 @@ class Pool
     /**
      * Checks if an admin with a certain admin code exists.
      */
-    final public function hasAdminByAdminCode(string $adminCode): bool
+    public function hasAdminByAdminCode(string $adminCode): bool
     {
         try {
             $this->getAdminByAdminCode($adminCode);

--- a/src/Datagrid/DatagridMapper.php
+++ b/src/Datagrid/DatagridMapper.php
@@ -22,21 +22,19 @@ use Sonata\AdminBundle\Mapper\BaseMapper;
 /**
  * This class is use to simulate the Form API.
  *
- * @final since sonata-project/admin-bundle 3.52
- *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class DatagridMapper extends BaseMapper
+final class DatagridMapper extends BaseMapper
 {
-    /**
-     * @var DatagridInterface
-     */
-    protected $datagrid;
-
     /**
      * @var DatagridBuilderInterface
      */
     protected $builder;
+
+    /**
+     * @var DatagridInterface
+     */
+    private $datagrid;
 
     public function __construct(
         DatagridBuilderInterface $datagridBuilder,
@@ -116,7 +114,7 @@ class DatagridMapper extends BaseMapper
         return $this->datagrid->hasFilter($key);
     }
 
-    final public function keys(): array
+    public function keys(): array
     {
         return array_keys($this->datagrid->getFilters());
     }

--- a/src/Datagrid/ListMapper.php
+++ b/src/Datagrid/ListMapper.php
@@ -22,25 +22,23 @@ use Sonata\AdminBundle\Mapper\BaseMapper;
 /**
  * This class is used to simulate the Form API.
  *
- * @final since sonata-project/admin-bundle 3.52
- *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class ListMapper extends BaseMapper
+final class ListMapper extends BaseMapper
 {
     public const TYPE_ACTIONS = 'actions';
     public const TYPE_BATCH = 'batch';
     public const TYPE_SELECT = 'select';
 
     /**
-     * @var FieldDescriptionCollection
-     */
-    protected $list;
-
-    /**
      * @var ListBuilderInterface
      */
     protected $builder;
+
+    /**
+     * @var FieldDescriptionCollection
+     */
+    private $list;
 
     public function __construct(
         ListBuilderInterface $listBuilder,
@@ -173,7 +171,7 @@ class ListMapper extends BaseMapper
     /**
      * @return string[]
      */
-    final public function keys(): array
+    public function keys(): array
     {
         return array_keys($this->list->getElements());
     }

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -23,21 +23,19 @@ use Symfony\Component\Form\FormBuilderInterface;
 /**
  * This class is use to simulate the Form API.
  *
- * @final since sonata-project/admin-bundle 3.52
- *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class FormMapper extends BaseGroupedMapper
+final class FormMapper extends BaseGroupedMapper
 {
-    /**
-     * @var FormBuilderInterface
-     */
-    protected $formBuilder;
-
     /**
      * @var FormContractorInterface
      */
     protected $builder;
+
+    /**
+     * @var FormBuilderInterface
+     */
+    private $formBuilder;
 
     public function __construct(
         FormContractorInterface $formContractor,
@@ -168,7 +166,7 @@ class FormMapper extends BaseGroupedMapper
     /**
      * @return string[]
      */
-    final public function keys(): array
+    public function keys(): array
     {
         return array_keys($this->formBuilder->all());
     }
@@ -235,17 +233,6 @@ class FormMapper extends BaseGroupedMapper
         return $this->formBuilder->create($name, $type, $options);
     }
 
-    /**
-     * Symfony default form class sadly can't handle
-     * form element with dots in its name (when data
-     * get bound, the default dataMapper is a PropertyPathMapper).
-     * So use this trick to avoid any issue.
-     */
-    protected function sanitizeFieldName(string $fieldName): string
-    {
-        return str_replace(['__', '.'], ['____', '__'], $fieldName);
-    }
-
     protected function getGroups(): array
     {
         return $this->admin->getFormGroups();
@@ -269,5 +256,16 @@ class FormMapper extends BaseGroupedMapper
     protected function getName(): string
     {
         return 'form';
+    }
+
+    /**
+     * Symfony default form class sadly can't handle
+     * form element with dots in its name (when data
+     * get bound, the default dataMapper is a PropertyPathMapper).
+     * So use this trick to avoid any issue.
+     */
+    private function sanitizeFieldName(string $fieldName): string
+    {
+        return str_replace(['__', '.'], ['____', '__'], $fieldName);
     }
 }

--- a/src/Search/SearchHandler.php
+++ b/src/Search/SearchHandler.php
@@ -18,11 +18,9 @@ use Sonata\AdminBundle\Datagrid\PagerInterface;
 use Sonata\AdminBundle\Filter\FilterInterface;
 
 /**
- * @final since sonata-project/admin-bundle 3.52
- *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class SearchHandler
+final class SearchHandler
 {
     /**
      * @var bool

--- a/src/Show/ShowMapper.php
+++ b/src/Show/ShowMapper.php
@@ -22,21 +22,19 @@ use Sonata\AdminBundle\Mapper\BaseGroupedMapper;
 /**
  * This class is used to simulate the Form API.
  *
- * @final since sonata-project/admin-bundle 3.52
- *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class ShowMapper extends BaseGroupedMapper
+final class ShowMapper extends BaseGroupedMapper
 {
-    /**
-     * @var FieldDescriptionCollection
-     */
-    protected $list;
-
     /**
      * @var ShowBuilderInterface
      */
     protected $builder;
+
+    /**
+     * @var FieldDescriptionCollection
+     */
+    private $list;
 
     public function __construct(
         ShowBuilderInterface $showBuilder,
@@ -162,7 +160,7 @@ class ShowMapper extends BaseGroupedMapper
         return $this;
     }
 
-    final public function keys(): array
+    public function keys(): array
     {
         return array_keys($this->list->getElements());
     }

--- a/src/Util/AdminObjectAclData.php
+++ b/src/Util/AdminObjectAclData.php
@@ -21,63 +21,58 @@ use Symfony\Component\Security\Acl\Model\MutableAclInterface;
 /**
  * AdminObjectAclData holds data manipulated by {@link AdminObjectAclManipulator}.
  *
- * @final since sonata-project/admin-bundle 3.52
- *
  * @author Kévin Dunglas <kevin@les-tilleuls.coop>
  */
-class AdminObjectAclData
+final class AdminObjectAclData
 {
-    /**
-     * @var string[] Permissions managed only by a OWNER
-     */
-    protected static $ownerPermissions = ['MASTER', 'OWNER'];
+    private const OWNER_PERMISSIONS = ['MASTER', 'OWNER'];
 
     /**
      * @var AdminInterface
      */
-    protected $admin;
+    private $admin;
 
     /**
      * @var object
      */
-    protected $object;
+    private $object;
 
     /**
      * @var \Traversable Users to set ACL for
      */
-    protected $aclUsers;
+    private $aclUsers;
 
     /**
      * @var \Traversable Roles to set ACL for
      */
-    protected $aclRoles;
+    private $aclRoles;
 
     /**
      * @var array<string, mixed> Cache of masks
      */
-    protected $masks = [];
+    private $masks = [];
 
     /**
      * @var FormInterface|null
      */
-    protected $aclUsersForm;
+    private $aclUsersForm;
 
     /**
      * @var FormInterface|null
      */
-    protected $aclRolesForm;
+    private $aclRolesForm;
 
     /**
      * @var MutableAclInterface|null
      */
-    protected $acl;
+    private $acl;
 
     /**
      * @var string
      *
      * @phpstan-var class-string
      */
-    protected $maskBuilderClass;
+    private $maskBuilderClass;
 
     /**
      * @phpstan-param class-string $maskBuilderClass
@@ -178,7 +173,7 @@ class AdminObjectAclData
         $permissions = $this->getPermissions();
 
         if (!$this->isOwner()) {
-            foreach (self::$ownerPermissions as $permission) {
+            foreach (self::OWNER_PERMISSIONS as $permission) {
                 $key = array_search($permission, $permissions, true);
                 if (false !== $key) {
                     unset($permissions[$key]);
@@ -191,7 +186,7 @@ class AdminObjectAclData
 
     public function getOwnerPermissions(): array
     {
-        return self::$ownerPermissions;
+        return self::OWNER_PERMISSIONS;
     }
 
     /**
@@ -219,7 +214,7 @@ class AdminObjectAclData
     /**
      * Cache masks.
      */
-    protected function updateMasks(): void
+    private function updateMasks(): void
     {
         $permissions = $this->getPermissions();
 

--- a/src/Util/AdminObjectAclManipulator.php
+++ b/src/Util/AdminObjectAclManipulator.php
@@ -28,12 +28,10 @@ use Symfony\Component\Security\Core\User\UserInterface;
 /**
  * A manipulator for updating ACL related to an object.
  *
- * @final since sonata-project/admin-bundle 3.52
- *
  * @author Kévin Dunglas <kevin@les-tilleuls.coop>
  * @author Baptiste Meyer <baptiste@les-tilleuls.coop>
  */
-class AdminObjectAclManipulator
+final class AdminObjectAclManipulator
 {
     public const ACL_USERS_FORM_NAME = 'acl_users_form';
     public const ACL_ROLES_FORM_NAME = 'acl_roles_form';
@@ -41,14 +39,14 @@ class AdminObjectAclManipulator
     /**
      * @var FormFactoryInterface
      */
-    protected $formFactory;
+    private $formFactory;
 
     /**
      * @var string
      *
      * @phpstan-var class-string
      */
-    protected $maskBuilderClass;
+    private $maskBuilderClass;
 
     /**
      * @phpstan-param class-string $maskBuilderClass
@@ -105,7 +103,7 @@ class AdminObjectAclManipulator
      *
      * @phpstan-param \Traversable<array-key, UserInterface|string> $aclValues
      */
-    protected function buildAcl(AdminObjectAclData $data, FormInterface $form, \Traversable $aclValues): void
+    private function buildAcl(AdminObjectAclData $data, FormInterface $form, \Traversable $aclValues): void
     {
         $masks = $data->getMasks();
         $acl = $data->getAcl();
@@ -174,7 +172,7 @@ class AdminObjectAclManipulator
      *
      * @phpstan-param \Traversable<array-key, UserInterface|string> $aclValues
      */
-    protected function buildForm(AdminObjectAclData $data, FormBuilderInterface $formBuilder, \Traversable $aclValues): FormInterface
+    private function buildForm(AdminObjectAclData $data, FormBuilderInterface $formBuilder, \Traversable $aclValues): FormInterface
     {
         // Retrieve object identity
         $objectIdentity = ObjectIdentity::fromDomainObject($data->getObject());
@@ -233,7 +231,7 @@ class AdminObjectAclManipulator
      *
      * @return RoleSecurityIdentity|UserSecurityIdentity
      */
-    protected function getSecurityIdentity($aclValue): SecurityIdentityInterface
+    private function getSecurityIdentity($aclValue): SecurityIdentityInterface
     {
         return ($aclValue instanceof UserInterface)
             ? UserSecurityIdentity::fromAccount($aclValue)


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I'm using this PR to list all the work needed to restrict visibility.
Test are failing, because we're now mocking `final` class.

There is 3 solutions for this:
- Not marking the class as `final`.
- Creating an interface.
- Using a real instance of the class in the tests.

The classes with this issue are:
- `AdminHelper` => Should not have an interface ; Either use the real service, either not marking this class as final.
- `Pool`
- `DatagridMapper`
- `ListMapper`
- `FormMapper`
- `SearchHandler`
- `ShowMapper`
- `AdminObjectAclData`
- `AdminObjectAclManipulator`

Closes #5791

## Changelog