### PR TITLE
Make it possible to add extra form_row container attributes

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -357,7 +357,9 @@ file that was distributed with this source code.
 
 {% block form_row %}
     {% set show_label = show_label ?? true %}
-    <div class="form-group{% if errors|length > 0 %} has-error{% endif %}" id="sonata-ba-field-container-{{ id }}">
+    {% set row_id = 'sonata-ba-field-container-'~id %}
+    {% set row_class = (row_attr.class|default('') ~ ' form-group' ~ (errors|length > 0 ? ' has-error'))|trim %}
+    <div{% with {attr: row_attr|merge({id: row_id, class: row_class})} %}{{ block('attributes') }}{% endwith %}>
         {% if sonata_admin.field_description.options is defined %}
             {% set label = sonata_admin.field_description.options.name|default(label) %}
         {% endif %}

--- a/tests/Form/AdminLayoutTest.php
+++ b/tests/Form/AdminLayoutTest.php
@@ -74,4 +74,21 @@ EOD;
             $expression
         );
     }
+
+    public function testRowAttr(): void
+    {
+        $form = $this->factory->createNamed('name', TextType::class, '', [
+            'row_attr' => [
+                'class' => 'foo',
+                'data-value' => 'bar',
+            ],
+        ]);
+        $view = $form->createView();
+        $html = $this->renderRow($view);
+
+        $this->assertMatchesXpath(
+            $html,
+            '//div[@class="foo form-group"][@data-value="bar"][@id="sonata-ba-field-container-name"]'
+        );
+    }
 }


### PR DESCRIPTION
## Make it possible to add extra form_row container attributes

Implement the Symfony row_attr for form_row containter attributes.
Useful if you need to add extra classes or data attributes on the container. For example:

```php
$builder->add('period', DateRangeType::class, [
    ...
    'field_options_start' => [
        ...
        'row_attr' => [
            'class' => 'col-md-6'
        ],
    ],
    'field_options_end' => [
        ...
        'row_attr' => [
            'class' => 'col-md-6'
        ],
    ]
]);
```

Output:

```html
<div class="form-group col-md-6" id="sonata-ba-field-container-s5f996c9e7f416_feature_type_14_feature_126_period_start">

</div>
```

I am targeting this branch, because it's useful from 3.x.

## Changelog

```markdown
### Added
- Added `row_attr` to the form_row container.
```
