### PR TITLE
Prevent load entities when pass empty choices for ModelType

### DIFF
--- a/src/Form/ChoiceList/ModelChoiceLoader.php
+++ b/src/Form/ChoiceList/ModelChoiceLoader.php
@@ -56,7 +56,7 @@ class ModelChoiceLoader implements ChoiceLoaderInterface
     private $query;
 
     /**
-     * @var object[]
+     * @var object[]|null
      */
     private $choices;
 
@@ -76,10 +76,10 @@ class ModelChoiceLoader implements ChoiceLoaderInterface
     private $choiceList;
 
     /**
-     * @param string      $class
-     * @param string|null $property
-     * @param object|null $query
-     * @param object[]    $choices
+     * @param string        $class
+     * @param string|null   $property
+     * @param object|null   $query
+     * @param object[]|null $choices
      *
      * @phpstan-param class-string $class
      */
@@ -88,7 +88,7 @@ class ModelChoiceLoader implements ChoiceLoaderInterface
         $class,
         $property = null,
         $query = null,
-        $choices = [],
+        $choices = null,
         ?PropertyAccessorInterface $propertyAccessor = null
     ) {
         $this->modelManager = $modelManager;
@@ -128,7 +128,7 @@ class ModelChoiceLoader implements ChoiceLoaderInterface
         if (!$this->choiceList) {
             if ($this->query) {
                 $entities = $this->modelManager->executeQuery($this->query);
-            } elseif (\is_array($this->choices) && \count($this->choices) > 0) {
+            } elseif (\is_array($this->choices)) {
                 $entities = $this->choices;
             } else {
                 $entities = $this->modelManager->findBy($this->class);

--- a/src/Form/Type/ModelType.php
+++ b/src/Form/Type/ModelType.php
@@ -125,7 +125,7 @@ class ModelType extends AbstractType
             'class' => null,
             'property' => null,
             'query' => null,
-            'choices' => [],
+            'choices' => null,
             'preferred_choices' => [],
             'btn_add' => 'link_add',
             'btn_list' => 'link_list',

--- a/tests/Form/Type/ModelTypeTest.php
+++ b/tests/Form/Type/ModelTypeTest.php
@@ -31,31 +31,48 @@ class ModelTypeTest extends TypeTestCase
         $this->type = new ModelType(PropertyAccess::createPropertyAccessor());
     }
 
-    public function testGetDefaultOptions(): void
+    /**
+     * @dataProvider getGetOptionsTests
+     */
+    public function testGetOptions(array $options, int $expectedModelManagerFindCalls): void
     {
         $modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
 
-        $optionResolver = new OptionsResolver();
+        $optionsResolver = new OptionsResolver();
 
-        $this->type->configureOptions($optionResolver);
+        $this->type->configureOptions($optionsResolver);
 
-        $options = $optionResolver->resolve(['model_manager' => $modelManager, 'choices' => []]);
+        $resolvedOptions = $optionsResolver->resolve(['model_manager' => $modelManager] + $options);
 
-        $this->assertFalse($options['compound']);
-        $this->assertSame('choice', $options['template']);
-        $this->assertFalse($options['multiple']);
-        $this->assertFalse($options['expanded']);
-        $this->assertInstanceOf(ModelManagerInterface::class, $options['model_manager']);
-        $this->assertNull($options['class']);
-        $this->assertNull($options['property']);
-        $this->assertNull($options['query']);
-        $this->assertCount(0, $options['choices']);
-        $this->assertCount(0, $options['preferred_choices']);
-        $this->assertSame('link_add', $options['btn_add']);
-        $this->assertSame('link_list', $options['btn_list']);
-        $this->assertSame('link_delete', $options['btn_delete']);
-        $this->assertSame('SonataAdminBundle', $options['btn_catalogue']);
-        $this->assertInstanceOf(ModelChoiceLoader::class, $options['choice_loader']);
+        $this->assertFalse($resolvedOptions['compound']);
+        $this->assertSame('choice', $resolvedOptions['template']);
+        $this->assertFalse($resolvedOptions['multiple']);
+        $this->assertFalse($resolvedOptions['expanded']);
+        $this->assertInstanceOf(ModelManagerInterface::class, $resolvedOptions['model_manager']);
+        $this->assertNull($resolvedOptions['class']);
+        $this->assertNull($resolvedOptions['property']);
+        $this->assertNull($resolvedOptions['query']);
+        $this->assertSame($options['choices'] ?? null, $resolvedOptions['choices']);
+        $this->assertCount(0, $resolvedOptions['preferred_choices']);
+        $this->assertSame('link_add', $resolvedOptions['btn_add']);
+        $this->assertSame('link_list', $resolvedOptions['btn_list']);
+        $this->assertSame('link_delete', $resolvedOptions['btn_delete']);
+        $this->assertSame('SonataAdminBundle', $resolvedOptions['btn_catalogue']);
+        $this->assertInstanceOf(ModelChoiceLoader::class, $resolvedOptions['choice_loader']);
+
+        $modelManager->expects($this->exactly($expectedModelManagerFindCalls))
+            ->method('findBy')
+            ->willReturn([]);
+        $resolvedOptions['choice_loader']->loadChoiceList();
+    }
+
+    public function getGetOptionsTests(): iterable
+    {
+        return [
+            [[], 1],
+            [['choices' => null], 1],
+            [['choices' => []], 0],
+        ];
     }
 
     /**


### PR DESCRIPTION
## Subject

I am targeting this branch, because would like make better our admin.

Closes #6517.

## Changelog

```markdown

### Changed
- Prevent load entities when pass empty choices for ModelType. Use null for native loading.

```