### PR TITLE
Pedantic changes in `AddDependencyCallsCompilerPass::fixTemplates()`

### DIFF
--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -186,10 +186,10 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
         } elseif ($container->getParameter('sonata.admin.configuration.sort_admins')) {
             $groups = $groupDefaults;
 
-            $elementSort = static function (&$element) {
+            $elementSort = static function (array &$element): void {
                 usort(
                     $element['items'],
-                    static function ($a, $b) {
+                    static function (array $a, array $b): int {
                         $a = !empty($a['label']) ? $a['label'] : $a['admin'];
                         $b = !empty($b['label']) ? $b['label'] : $b['admin'];
 

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -221,6 +221,8 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
     }
 
     /**
+     * NEXT_MAJOR: Change visibility to private.
+     *
      * This method read the attribute keys and configure admin class to use the related dependency.
      */
     public function applyConfigurationFromAttribute(Definition $definition, array $attributes)
@@ -253,6 +255,8 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
     }
 
     /**
+     * NEXT_MAJOR: Change visibility to private.
+     *
      * Apply the default values required by the AdminInterface to the Admin service definition.
      *
      * @param string $serviceId
@@ -364,6 +368,8 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
     }
 
     /**
+     * NEXT_MAJOR: Change visibility to private.
+     *
      * @param string $serviceId
      */
     public function fixTemplates(

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -376,22 +376,22 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
         $methods = [];
         $pos = 0;
-        foreach ($definition->getMethodCalls() as $method) {
-            if ('setTemplates' === $method[0]) {
-                $definedTemplates = array_merge($definedTemplates, $method[1][0]);
+        foreach ($definition->getMethodCalls() as [$method, $args]) {
+            if ('setTemplates' === $method) {
+                $definedTemplates = array_merge($definedTemplates, $args[0]);
 
                 continue;
             }
 
-            if ('setTemplate' === $method[0]) {
-                $definedTemplates[$method[1][0]] = $method[1][1];
+            if ('setTemplate' === $method) {
+                $definedTemplates[$args[0]] = $args[1];
 
                 continue;
             }
 
             // set template for simple pager if it is not already overwritten
-            if ('setPagerType' === $method[0]
-                && Pager::TYPE_SIMPLE === $method[1][0]
+            if ('setPagerType' === $method
+                && Pager::TYPE_SIMPLE === $args[0]
                 && (
                     !isset($definedTemplates['pager_results'])
                     || '@SonataAdmin/Pager/results.html.twig' === $definedTemplates['pager_results']
@@ -400,7 +400,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                 $definedTemplates['pager_results'] = '@SonataAdmin/Pager/simple_pager_results.html.twig';
             }
 
-            $methods[$pos] = $method;
+            $methods[$pos] = [$method, $args];
             ++$pos;
         }
 

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -193,11 +193,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                         $a = !empty($a['label']) ? $a['label'] : $a['admin'];
                         $b = !empty($b['label']) ? $b['label'] : $b['admin'];
 
-                        if ($a === $b) {
-                            return 0;
-                        }
-
-                        return $a < $b ? -1 : 1;
+                        return $a <=> $b;
                     }
                 );
             };


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
* Use list syntax for method and args at `AddDependencyCallsCompilerPass::fixTemplates()`;
* Add "NEXT_MAJOR" comments in order to change the visibility of some methods to private;
* Use spaceship operator in `sort()` callback at `AddDependencyCallsCompilerPass::process()`;
* Add missing type declarations in some anonymous functions at `AddDependencyCallsCompilerPass::process()`.

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are pedantic.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
