### PR TITLE
Make TemplateRegistry not mutable

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,21 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=========================
+
+### Template registry structure and responsibilities.
+
+The `Sonata\AdminBundle\Templating\TemplateRegistry` class has been splitted into 3 classes:
+   - `TemplateRegistry`, implementing `Sonata\AdminBundle\Templating\TemplateRegistryInterface`
+   - `MutableTemplateRegistry`, implementing `Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface`
+   - `AbstractTemplateRegistry`, implementing `Sonata\AdminBundle\Templating\TemplateRegistryInterface`. You MUST extend this class if you want to create your own template registry.
+
+The interface `Sonata\AdminBundle\Templating\TemplateRegistryAwareInterface` was updated in order to handle instances of `TemplateRegistryInterface`.
+The interface `Sonata\AdminBundle\Templating\MutableTemplateRegistryAwareInterface` was added to provide a simple contract for classes depending on a `MutableTemplateRegistryInterface`.
+
+`TemplateRegistry` will stop implementing `MutableTemplateRegistryInterface` in version 4.0. If you are using `setTemplate()` or `setTemplates()` methods, you MUST use `MutableTemplateRegistry` instead.
+
 ### Deprecated `Sonata\AdminBundle\Model\DatagridManagerInterface` interface.
 
 This interface has been deprecated without replacement.

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -80,6 +80,8 @@ class Pool
     protected $propertyAccessor;
 
     /**
+     * NEXT_MAJOR: change to TemplateRegistryInterface.
+     *
      * @var MutableTemplateRegistryInterface
      */
     private $templateRegistry;
@@ -469,6 +471,9 @@ class Pool
         return $this->adminClasses;
     }
 
+    /**
+     * NEXT_MAJOR: change to TemplateRegistryInterface.
+     */
     final public function setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry): void
     {
         $this->templateRegistry = $templateRegistry;

--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -238,6 +238,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->alias(TemplateRegistry::class, 'sonata.admin.global_template_registry')
 
+        // NEXT_MAJOR: remove this alias, global template registry SHOULD NOT be mutable
         ->alias(MutableTemplateRegistryInterface::class, 'sonata.admin.global_template_registry')
     ;
 };

--- a/src/Templating/AbstractTemplateRegistry.php
+++ b/src/Templating/AbstractTemplateRegistry.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Templating;
+
+abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
+{
+    /**
+     * @var array<string, string>
+     */
+    protected $templates = [];
+
+    /**
+     * @param string[] $templates
+     */
+    public function __construct(array $templates = [])
+    {
+        $this->templates = $templates;
+    }
+
+    public function getTemplates(): array
+    {
+        return $this->templates;
+    }
+
+    public function hasTemplate(string $name): bool
+    {
+        return isset($this->templates[$name]);
+    }
+
+    /**
+     * NEXT_MAJOR: add type hint.
+     *
+     * @param string $name
+     */
+    public function getTemplate($name): ?string
+    {
+        if ($this->hasTemplate($name)) {
+            return $this->templates[$name];
+        }
+
+        @trigger_error(sprintf(
+            'Passing a nonexistent template name as argument 1 to %s() is deprecated since'
+            .' sonata-project/admin-bundle 3.52 and will throw an exception in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
+        // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare string as return type
+        // throw new \InvalidArgumentException(sprintf(
+        //    'Template named "%s" doesn\'t exist.',
+        //    $name
+        // ));
+
+        return null;
+    }
+}

--- a/src/Templating/MutableTemplateRegistry.php
+++ b/src/Templating/MutableTemplateRegistry.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Templating;
+
+/**
+ * @author Wojciech Błoszyk <wbloszyk@gmail.com>
+ */
+final class MutableTemplateRegistry extends AbstractTemplateRegistry implements MutableTemplateRegistryInterface
+{
+    // NEXT_MAJOR: change method declaration for new one
+    // public function setTemplates(array $templates): void
+    public function setTemplates(array $templates)
+    {
+        $this->templates = $templates;
+    }
+
+    // NEXT_MAJOR: change method declaration for new one
+    // public function setTemplate(string $name, string $template): void
+    public function setTemplate($name, $template)
+    {
+        $this->templates[$name] = $template;
+    }
+}

--- a/src/Templating/MutableTemplateRegistryAwareInterface.php
+++ b/src/Templating/MutableTemplateRegistryAwareInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Templating;
+
+/**
+ * @author Wojciech Błoszyk <wbloszyk@gmail.com>
+ *
+ * @method MutableTemplateRegistryInterface getTemplateRegistry()
+ * @method bool                             hasTemplateRegistry()
+ * @method void                             setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry)
+ */
+interface MutableTemplateRegistryAwareInterface
+{
+    // NEXT_MAJOR: uncomment this method in 4.0
+    //public function getTemplateRegistry(): MutableTemplateRegistryInterface;
+
+    // NEXT_MAJOR: uncomment this method in 4.0
+    //public function setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry): void;
+}

--- a/src/Templating/MutableTemplateRegistryInterface.php
+++ b/src/Templating/MutableTemplateRegistryInterface.php
@@ -19,15 +19,26 @@ namespace Sonata\AdminBundle\Templating;
 interface MutableTemplateRegistryInterface extends TemplateRegistryInterface
 {
     /**
+     * NEXT_MAJOR: remove this method declaration with docblock and uncomment code below.
+     *
      * @param array<string, string> $templates 'name' => 'file_path.html.twig'
      */
     public function setTemplates(array $templates);
 
+    ///**
+    // * @param array<string, string> $templates 'name' => 'file_path.html.twig'
+    // */
+    //public function setTemplates(array $templates): void;
+
     /**
+     * NEXT_MAJOR: remove this method declaration with docblock and uncomment code below.
+     *
      * @param string $name
      * @param string $template
      *
      * @return void
      */
     public function setTemplate($name, $template);
+
+    //public function setTemplate(string $name, string $template): void;
 }

--- a/src/Templating/TemplateRegistry.php
+++ b/src/Templating/TemplateRegistry.php
@@ -15,109 +15,38 @@ namespace Sonata\AdminBundle\Templating;
 
 /**
  * @author Timo Bakx <timobakx@gmail.com>
+ *
+ * NEXT_MAJOR: remove `MutableTemplateRegistryInterface` implementation.
  */
-final class TemplateRegistry implements MutableTemplateRegistryInterface
+final class TemplateRegistry extends AbstractTemplateRegistry implements MutableTemplateRegistryInterface
 {
-    public const TYPE_ARRAY = 'array';
-    public const TYPE_BOOLEAN = 'boolean';
-    public const TYPE_DATE = 'date';
-    public const TYPE_TIME = 'time';
-    public const TYPE_DATETIME = 'datetime';
     /**
-     * NEXT_MAJOR: Remove this constant.
+     * NEXT_MAJOR: remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.68, to be removed in 4.0. Use Sonata\AdminBundle\Templating\TemplateRegistry::TYPE_STRING instead.
+     * @deprecated since version sonata-project/admin-bundle 3.39.0 and will be removed in 4.0. Use Sonata\AdminBundle\Templating\MutableTemplateRegistry instead.
      */
-    public const TYPE_TEXT = 'text';
-    public const TYPE_TEXTAREA = 'textarea';
-    public const TYPE_EMAIL = 'email';
-    public const TYPE_TRANS = 'trans';
-    public const TYPE_STRING = 'string';
-    /**
-     * NEXT_MAJOR: Remove this constant.
-     *
-     * @deprecated since sonata-project/admin-bundle 3.68, to be removed in 4.0. Use Sonata\AdminBundle\Templating\TemplateRegistry::TYPE_INTEGER instead.
-     */
-    public const TYPE_SMALLINT = 'smallint';
-    /**
-     * NEXT_MAJOR: Remove this constant.
-     *
-     * @deprecated since sonata-project/admin-bundle 3.68, to be removed in 4.0. Use Sonata\AdminBundle\Templating\TemplateRegistry::TYPE_INTEGER instead.
-     */
-    public const TYPE_BIGINT = 'bigint';
-    public const TYPE_INTEGER = 'integer';
-    /**
-     * NEXT_MAJOR: Remove this constant.
-     *
-     * @deprecated since sonata-project/admin-bundle 3.68, to be removed in 4.0. Use Sonata\AdminBundle\Templating\TemplateRegistry::TYPE_FLOAT instead.
-     */
-    public const TYPE_DECIMAL = 'decimal';
-    public const TYPE_FLOAT = 'float';
-    public const TYPE_IDENTIFIER = 'identifier';
-    public const TYPE_CURRENCY = 'currency';
-    public const TYPE_PERCENT = 'percent';
-    public const TYPE_CHOICE = 'choice';
-    public const TYPE_URL = 'url';
-    public const TYPE_HTML = 'html';
-    public const TYPE_MANY_TO_MANY = 'many_to_many';
-    public const TYPE_MANY_TO_ONE = 'many_to_one';
-    public const TYPE_ONE_TO_MANY = 'one_to_many';
-    public const TYPE_ONE_TO_ONE = 'one_to_one';
-
-    /**
-     * @var array<string, string>
-     */
-    private $templates = [];
-
-    /**
-     * @param string[] $templates
-     */
-    public function __construct(array $templates = [])
-    {
-        $this->templates = $templates;
-    }
-
-    public function getTemplates(): array
-    {
-        return $this->templates;
-    }
-
     public function setTemplates(array $templates)
     {
         $this->templates = $templates;
-    }
 
-    public function hasTemplate(string $name): bool
-    {
-        return isset($this->templates[$name]);
+        @trigger_error(sprintf(
+            'Method "%s()" is deprecated since sonata-admin/admin-bundle 3.39 and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
     }
 
     /**
-     * @param string $name
+     * NEXT_MAJOR: remove this method.
+     *
+     * @deprecated since version sonata-project/admin-bundle 3.39.0 and will be removed in 4.0. Use Sonata\AdminBundle\Templating\MutableTemplateRegistry instead.
      */
-    public function getTemplate($name): ?string
-    {
-        if (isset($this->templates[$name])) {
-            return $this->templates[$name];
-        }
-
-        @trigger_error(sprintf(
-            'Passing a nonexistent template name as argument 1 to %s() is deprecated since'
-            .' sonata-project/admin-bundle 3.52 and will throw an exception in 4.0.',
-            __METHOD__
-        ), E_USER_DEPRECATED);
-
-        // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement, uncomment the following exception and declare string as return type
-        // throw new \InvalidArgumentException(sprintf(
-        //    'Template named "%s" doesn\'t exist.',
-        //    $name
-        // ));
-
-        return null;
-    }
-
     public function setTemplate($name, $template)
     {
         $this->templates[$name] = $template;
+
+        @trigger_error(sprintf(
+            'Method "%s()" is deprecated since sonata-admin/admin-bundle 3.39 and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
     }
 }

--- a/src/Templating/TemplateRegistryAwareInterface.php
+++ b/src/Templating/TemplateRegistryAwareInterface.php
@@ -14,21 +14,20 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Templating;
 
 /**
- * /**
  * @author Wojciech Błoszyk <wbloszyk@gmail.com>
  *
- * @method MutableTemplateRegistryInterface getTemplateRegistry()
- * @method bool                             hasTemplateRegistry()
- * @method void                             setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry)
+ * @method TemplateRegistryInterface getTemplateRegistry()
+ * @method bool                      hasTemplateRegistry()
+ * @method void                      setTemplateRegistry(TemplateRegistryInterface $templateRegistry)
  */
 interface TemplateRegistryAwareInterface
 {
     // NEXT_MAJOR: uncomment this method in 4.0
-    //public function getTemplateRegistry(): MutableTemplateRegistryInterface;
+    //public function getTemplateRegistry(): TemplateRegistryInterface;
 
     // NEXT_MAJOR: uncomment this method in 4.0
     //public function hasTemplateRegistry(): bool;
 
     // NEXT_MAJOR: uncomment this method in 4.0
-    //public function setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry): void;
+    //public function setTemplateRegistry(TemplateRegistryInterface $templateRegistry): void;
 }

--- a/src/Templating/TemplateRegistryInterface.php
+++ b/src/Templating/TemplateRegistryInterface.php
@@ -20,6 +20,52 @@ namespace Sonata\AdminBundle\Templating;
  */
 interface TemplateRegistryInterface
 {
+    public const TYPE_ARRAY = 'array';
+    public const TYPE_BOOLEAN = 'boolean';
+    public const TYPE_DATE = 'date';
+    public const TYPE_TIME = 'time';
+    public const TYPE_DATETIME = 'datetime';
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.68, to be removed in 4.0. Use Sonata\AdminBundle\Templating\TemplateRegistry::TYPE_STRING instead.
+     */
+    public const TYPE_TEXT = 'text';
+    public const TYPE_TEXTAREA = 'textarea';
+    public const TYPE_EMAIL = 'email';
+    public const TYPE_TRANS = 'trans';
+    public const TYPE_STRING = 'string';
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.68, to be removed in 4.0. Use Sonata\AdminBundle\Templating\TemplateRegistry::TYPE_INTEGER instead.
+     */
+    public const TYPE_SMALLINT = 'smallint';
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.68, to be removed in 4.0. Use Sonata\AdminBundle\Templating\TemplateRegistry::TYPE_INTEGER instead.
+     */
+    public const TYPE_BIGINT = 'bigint';
+    public const TYPE_INTEGER = 'integer';
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.68, to be removed in 4.0. Use Sonata\AdminBundle\Templating\TemplateRegistry::TYPE_FLOAT instead.
+     */
+    public const TYPE_DECIMAL = 'decimal';
+    public const TYPE_FLOAT = 'float';
+    public const TYPE_IDENTIFIER = 'identifier';
+    public const TYPE_CURRENCY = 'currency';
+    public const TYPE_PERCENT = 'percent';
+    public const TYPE_CHOICE = 'choice';
+    public const TYPE_URL = 'url';
+    public const TYPE_HTML = 'html';
+    public const TYPE_MANY_TO_MANY = 'many_to_many';
+    public const TYPE_MANY_TO_ONE = 'many_to_one';
+    public const TYPE_ONE_TO_MANY = 'one_to_many';
+    public const TYPE_ONE_TO_ONE = 'one_to_one';
+
     /**
      * @return array<string, string> 'name' => 'file_path.html.twig'
      */

--- a/tests/Templating/MutableTemplateRegistryTest.php
+++ b/tests/Templating/MutableTemplateRegistryTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Templating;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Templating\MutableTemplateRegistry;
+use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+
+final class MutableTemplateRegistryTest extends TestCase
+{
+    use ExpectDeprecationTrait;
+
+    /**
+     * @var MutableTemplateRegistryInterface
+     */
+    private $templateRegistry;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->templateRegistry = new MutableTemplateRegistry(['list' => '@FooAdmin/CRUD/list.html.twig']);
+    }
+
+    public function testGetTemplates(): void
+    {
+        $this->assertSame(['list' => '@FooAdmin/CRUD/list.html.twig'], $this->templateRegistry->getTemplates());
+
+        $templates = [
+            'show' => '@FooAdmin/CRUD/show.html.twig',
+            'edit' => '@FooAdmin/CRUD/edit.html.twig',
+        ];
+
+        $this->templateRegistry->setTemplates($templates);
+        $this->assertSame($templates, $this->templateRegistry->getTemplates());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testGetTemplateAfterSetTemplate(): void
+    {
+        $this->templateRegistry->setTemplate('edit', '@FooAdmin/CRUD/edit.html.twig');
+
+        $this->assertTrue($this->templateRegistry->hasTemplate('edit'));
+        $this->assertSame('@FooAdmin/CRUD/edit.html.twig', $this->templateRegistry->getTemplate('edit'));
+
+        $this->assertFalse($this->templateRegistry->hasTemplate('nonexist_template'));
+        // NEXT_MAJOR: remove this line
+        $this->expectDeprecation('Passing a nonexistent template name as argument 1 to Sonata\AdminBundle\Templating\AbstractTemplateRegistry::getTemplate() is deprecated since sonata-project/admin-bundle 3.52 and will throw an exception in 4.0.');
+        $this->assertNull($this->templateRegistry->getTemplate('nonexist_template'));
+        // NEXT_MAJOR: Remove previous assertion, the "@group" annotations and uncomment the following line
+        // $this->assertFalse($this->templateRegistry->hasTemplate('nonexist_template'));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testGetTemplateAfterSetTemplates(): void
+    {
+        $templates = [
+            'show' => '@FooAdmin/CRUD/show.html.twig',
+            'edit' => '@FooAdmin/CRUD/edit.html.twig',
+        ];
+
+        $this->templateRegistry->setTemplates($templates);
+
+        $this->assertTrue($this->templateRegistry->hasTemplate('edit'));
+        $this->assertSame('@FooAdmin/CRUD/edit.html.twig', $this->templateRegistry->getTemplate('edit'));
+        // NEXT_MAJOR: remove this line
+        $this->expectDeprecation('Passing a nonexistent template name as argument 1 to Sonata\AdminBundle\Templating\AbstractTemplateRegistry::getTemplate() is deprecated since sonata-project/admin-bundle 3.52 and will throw an exception in 4.0.');
+        $this->assertNull($this->templateRegistry->getTemplate('nonexist_template'));
+        $this->assertFalse($this->templateRegistry->hasTemplate('nonexist_template'));
+        // NEXT_MAJOR: Remove previous assertion, the "@group" annotations and uncomment the following line
+        // $this->assertFalse($this->templateRegistry->hasTemplate('nonexist_template'));
+    }
+}

--- a/tests/Templating/TemplateRegistryTest.php
+++ b/tests/Templating/TemplateRegistryTest.php
@@ -15,9 +15,12 @@ namespace Sonata\AdminBundle\Tests\Templating;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Templating\TemplateRegistry;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
 class TemplateRegistryTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @var TemplateRegistry
      */
@@ -25,67 +28,37 @@ class TemplateRegistryTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->templateRegistry = new TemplateRegistry();
+        $this->templateRegistry = new TemplateRegistry([
+            'list' => '@FooAdmin/CRUD/list.html.twig',
+            'show' => '@FooAdmin/CRUD/show.html.twig',
+            'edit' => '@FooAdmin/CRUD/edit.html.twig',
+        ]);
     }
 
     public function testGetTemplates(): void
     {
-        $this->assertSame([], $this->templateRegistry->getTemplates());
-
         $templates = [
             'list' => '@FooAdmin/CRUD/list.html.twig',
             'show' => '@FooAdmin/CRUD/show.html.twig',
             'edit' => '@FooAdmin/CRUD/edit.html.twig',
         ];
 
-        $this->templateRegistry->setTemplates($templates);
         $this->assertSame($templates, $this->templateRegistry->getTemplates());
     }
 
     /**
      * @group legacy
-     *
-     * @expectedDeprecation Passing a nonexistent template name as argument 1 to Sonata\AdminBundle\Templating\TemplateRegistry::getTemplate() is deprecated since sonata-project/admin-bundle 3.52 and will throw an exception in 4.0.
      */
-    public function testGetTemplate1(): void
+    public function testGetTemplate(): void
     {
-        $this->assertFalse($this->templateRegistry->hasTemplate('edit'));
-        $this->assertNull($this->templateRegistry->getTemplate('edit'));
-        // NEXT_MAJOR: Remove previous assertion, the "@group" and "@expectedDeprecation" annotations and uncomment the following line
-        // $this->assertFalse($this->templateRegistry->hasTemplate('edit'));
-
-        $this->templateRegistry->setTemplate('edit', '@FooAdmin/CRUD/edit.html.twig');
-        $this->templateRegistry->setTemplate('show', '@FooAdmin/CRUD/show.html.twig');
+        $this->assertFalse($this->templateRegistry->hasTemplate('nonexist_template'));
+        // NEXT_MAJOR: remove this line
+        $this->expectDeprecation('Passing a nonexistent template name as argument 1 to Sonata\AdminBundle\Templating\AbstractTemplateRegistry::getTemplate() is deprecated since sonata-project/admin-bundle 3.52 and will throw an exception in 4.0.');
+        $this->assertNull($this->templateRegistry->getTemplate('nonexist_template'));
+        // NEXT_MAJOR: Remove previous assertion, the "@group" annotations and uncomment the following line
+        // $this->assertFalse($this->templateRegistry->hasTemplate('nonexist_template'));
 
         $this->assertTrue($this->templateRegistry->hasTemplate('edit'));
         $this->assertSame('@FooAdmin/CRUD/edit.html.twig', $this->templateRegistry->getTemplate('edit'));
-        $this->assertTrue($this->templateRegistry->hasTemplate('show'));
-        $this->assertSame('@FooAdmin/CRUD/show.html.twig', $this->templateRegistry->getTemplate('show'));
-    }
-
-    /**
-     * @group legacy
-     *
-     * @expectedDeprecation Passing a nonexistent template name as argument 1 to Sonata\AdminBundle\Templating\TemplateRegistry::getTemplate() is deprecated since sonata-project/admin-bundle 3.52 and will throw an exception in 4.0.
-     */
-    public function testGetTemplate2(): void
-    {
-        $this->assertFalse($this->templateRegistry->hasTemplate('edit'));
-        $this->assertNull($this->templateRegistry->getTemplate('edit'));
-        // NEXT_MAJOR: Remove previous assertion, the "@group" and "@expectedDeprecation" annotations and uncomment the following line
-        // $this->assertFalse($this->templateRegistry->hasTemplate('edit'));
-
-        $templates = [
-            'list' => '@FooAdmin/CRUD/list.html.twig',
-            'show' => '@FooAdmin/CRUD/show.html.twig',
-            'edit' => '@FooAdmin/CRUD/edit.html.twig',
-        ];
-
-        $this->templateRegistry->setTemplates($templates);
-
-        $this->assertTrue($this->templateRegistry->hasTemplate('edit'));
-        $this->assertSame('@FooAdmin/CRUD/edit.html.twig', $this->templateRegistry->getTemplate('edit'));
-        $this->assertTrue($this->templateRegistry->hasTemplate('show'));
-        $this->assertSame('@FooAdmin/CRUD/show.html.twig', $this->templateRegistry->getTemplate('show'));
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

Global templates should not be changeable in global template registry after created. This PR will add `NEXT_MAJOR` for do it. 
`Pool` should have `TemplateRegistryInterface`.
`Admin` should have `MutableTemplateRegistryInterface`.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `Sonata\AdminBundle\Templating\AbstractTemplateRegistry`
- Added `Sonata\AdminBundle\Templating\MutableTemplateRegistry` 
- Added `Sonata\AdminBundle\Templating\MutableTemplateRegistryAwareInterface`
### Changed
- Changed `Sonata\AdminBundle\Templating\TemplateRegistryAwareInterface` to handle instances of `TemplateRegistryInterface`.
### Deprecated
- Deprecated `Sonata\AdminBundle\Templating\TemplateRegistry:setTemplate()`
- Deprecated `Sonata\AdminBundle\Templating\TemplateRegistry:setTemplates()`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->

