### PR TITLE
[Datagrid] Allow only int on setPage & setMaxPerPage

### DIFF
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -284,9 +284,9 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         return max($this->getPage() - 1, $this->getFirstPage());
     }
 
-    public function setPage($page): void
+    public function setPage(int $page): void
     {
-        $this->page = (int) $page;
+        $this->page = $page;
 
         if ($this->page <= 0) {
             // set first page, which depends on a maximum set
@@ -299,10 +299,8 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
         return $this->maxPerPage;
     }
 
-    public function setMaxPerPage($max): void
+    public function setMaxPerPage(int $max): void
     {
-        $max = (int) $max;
-
         if ($max > 0) {
             $this->maxPerPage = $max;
             if (0 === $this->page) {

--- a/src/Datagrid/PagerInterface.php
+++ b/src/Datagrid/PagerInterface.php
@@ -29,12 +29,9 @@ interface PagerInterface
     public function getMaxPerPage(): int;
 
     /**
-     * TODO: allow only int to be set
      * Sets the maximum number of results per page.
-     *
-     * @param int|string $max
      */
-    public function setMaxPerPage($max): void;
+    public function setMaxPerPage(int $max): void;
 
     /**
      * Gets the current page.
@@ -42,12 +39,9 @@ interface PagerInterface
     public function getPage(): int;
 
     /**
-     * TODO: allow only int to be set
      * Sets the current page.
-     *
-     * @param int|string $page
      */
-    public function setPage($page): void;
+    public function setPage(int $page): void;
 
     /**
      * Set query.

--- a/tests/Datagrid/DatagridTest.php
+++ b/tests/Datagrid/DatagridTest.php
@@ -456,11 +456,11 @@ class DatagridTest extends TestCase
 
         $this->pager->expects($this->once())
             ->method('setMaxPerPage')
-            ->with($this->equalTo('50'));
+            ->with($this->equalTo(50));
 
         $this->pager->expects($this->once())
             ->method('setPage')
-            ->with($this->equalTo('3'));
+            ->with($this->equalTo(3));
 
         $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, ['_sort_by' => $sortBy, '_page' => $page, '_per_page' => $perPage]);
 
@@ -499,14 +499,9 @@ class DatagridTest extends TestCase
 
     public function getBuildPagerWithPageTests(): array
     {
-        // tests for php 5.3, because isset functionality was changed since php 5.4
         return [
             [3, 50],
-            ['3', '50'],
-            [3, '50'],
-            ['3', 50],
             [3, ['type' => null, 'value' => 50]],
-            [3, ['type' => null, 'value' => '50']],
         ];
     }
 
@@ -517,11 +512,11 @@ class DatagridTest extends TestCase
     {
         $this->pager->expects($this->once())
             ->method('setMaxPerPage')
-            ->with($this->equalTo('50'));
+            ->with($this->equalTo(50));
 
         $this->pager->expects($this->once())
             ->method('setPage')
-            ->with($this->equalTo('3'));
+            ->with($this->equalTo(3));
 
         $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, []);
         $this->datagrid->setValue('_per_page', null, $perPage);
@@ -541,12 +536,8 @@ class DatagridTest extends TestCase
 
     public function getBuildPagerWithPage2Tests(): array
     {
-        // tests for php 5.3, because isset functionality was changed since php 5.4
         return [
             [3, 50],
-            ['3', '50'],
-            [3, '50'],
-            ['3', 50],
         ];
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This is a follow up of #6404 to add param & return type hints.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added parameter type hints to `PagerInterface` and `Pager`.
