### PR TITLE
Avoid conflict with by_reference option

### DIFF
--- a/src/Form/Type/AdminType.php
+++ b/src/Form/Type/AdminType.php
@@ -112,7 +112,7 @@ class AdminType extends AbstractType
                         // no object here, we create a new one
                         $subject = $admin->getNewInstance();
 
-                        if ($options['by_reference']) {
+                        if ($options['collection_by_reference']) {
                             $subject = ObjectManipulator::addInstance($parentSubject, $subject, $parentFieldDescription);
                         } else {
                             $subject = ObjectManipulator::setObject($subject, $parentSubject, $parentFieldDescription);
@@ -163,6 +163,7 @@ class AdminType extends AbstractType
             'btn_list' => 'link_list',
             'btn_delete' => 'link_delete',
             'btn_catalogue' => 'SonataAdminBundle',
+            'collection_by_reference' => true,
         ]);
     }
 

--- a/tests/Form/Type/AdminTypeTest.php
+++ b/tests/Form/Type/AdminTypeTest.php
@@ -231,7 +231,7 @@ class AdminTypeTest extends TypeTestCase
                 'sonata_field_description' => $field,
                 'delete' => false, // not needed
                 'property_path' => '[0]', // actual test case
-                'by_reference' => false,
+                'collection_by_reference' => false,
             ]);
         } catch (NoSuchPropertyException $exception) {
             $this->fail($exception->getMessage());
@@ -282,7 +282,7 @@ class AdminTypeTest extends TypeTestCase
                 'sonata_field_description' => $field,
                 'delete' => false, // not needed
                 'property_path' => '[0]', // actual test case
-                'by_reference' => true,
+                'collection_by_reference' => true,
             ]);
         } catch (NoSuchPropertyException $exception) {
             $this->fail($exception->getMessage());


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because bug fix.

Related to #6564.

See https://github.com/sonata-project/SonataAdminBundle/issues/6564#issuecomment-721078947
Then persistence bundle should pass `collection_by_reference` instead of  `by_reference`.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `collection_by_reference` option for AdminType

### Changed
- `collection_by_reference` is used instead of `by_reference` in AdminType in order to know which call should be used between `ObjectManipulator::addInstance` and `ObjectManipulator::setObject`.
```