### PR TITLE
Improve "sonata.admin.template_registry" tag

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,8 +1,31 @@
 UPGRADE 3.x
 ===========
 
-UPGRADE FROM 3.xx to 3.xx
-=========================
+UPGRADE FROM 3.x to 3.x
+=======================
+
+### `sonata.admin.template_registry` tag functionality was improved
+
+You can now remove deprecations from yours `Admin` services configurations.
+
+Before:
+
+    Sonata\AdminBundle\Tests\App\Admin\FooAdmin:
+        arguments: [~, Sonata\AdminBundle\Tests\App\Model\Foo, ~]
+        tags:
+            - {name: sonata.admin, manager_type: test, label: Foo}
+       calls:
+           - [setTemplate, ['edit','@FooAdmin/CRUD/edit.html.twig']]
+           - [setTemplate, ['list', '@FooAdmin/CRUD/list.html.twig']]
+
+After:
+
+    Sonata\AdminBundle\Tests\App\Admin\FooAdmin:
+        arguments: [~, Sonata\AdminBundle\Tests\App\Model\Foo, ~]
+        tags:
+            - {name: sonata.admin, manager_type: test, label: Foo}
+            - {name: sonata.admin.template_registry, template_name:'edit', template_path: '@FooAdmin/CRUD/edit.html.twig'}
+            - {name: sonata.admin.template_registry, template_name:'list', template_path: '@FooAdmin/CRUD/list.html.twig'}
 
 ### `RouteCollection` now implements `RouteCollectionInterface`
 

--- a/docs/cookbook/recipe_customizing_a_mosaic_list.rst
+++ b/docs/cookbook/recipe_customizing_a_mosaic_list.rst
@@ -37,11 +37,11 @@ First, configure the ``outer_list_rows_mosaic`` template key:
             <argument/>
             <argument>%sonata.media.admin.media.entity%</argument>
             <argument>%sonata.media.admin.media.controller%</argument>
-            <call method="setTemplates">
-                <argument type="collection">
-                    <argument key="outer_list_rows_mosaic">@SonataMedia/MediaAdmin/list_outer_rows_mosaic.html.twig</argument>
-                </argument>
-            </call>
+            <tag
+                name="sonata.admin.template_registry"
+                template_name="outer_list_rows_mosaic"
+                template_path="@SonataMedia/MediaAdmin/list_outer_rows_mosaic.html.twig"
+                />
             <tag
                 name="sonata.admin"
                 manager_type="orm"

--- a/docs/cookbook/recipe_row_templates.rst
+++ b/docs/cookbook/recipe_row_templates.rst
@@ -36,16 +36,16 @@ Two template keys need to be set:
             <argument/>
             <argument>%sonata.admin.comment.entity%</argument>
             <argument>%sonata.admin.comment.controller%</argument>
-            <call method="setTemplates">
-                <argument type="collection">
-                    <argument key="inner_list_row">
-                        @App/Admin/inner_row_comment.html.twig
-                    </argument>
-                    <argument key="base_list_field">
-                        @SonataAdmin/CRUD/base_list_flat_field.html.twig
-                    </argument>
-                </argument>
-            </call>
+            <tag
+                name="sonata.admin.template_registry"
+                template_name="inner_list_row"
+                template_path="@App/Admin/inner_row_comment.html.twig"
+                />
+            <tag
+                name="sonata.admin.template_registry"
+                template_name="base_list_field"
+                template_path="@SonataAdmin/CRUD/base_list_flat_field.html.twig"
+                />
             <tag
                 name="sonata.admin"
                 manager_type="orm"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,6 +52,7 @@ The demo website can be found at https://demo.sonata-project.org.
    reference/console
    reference/troubleshooting
    reference/breadcrumbs
+   reference/tags
 
 .. toctree::
    :caption: Advanced Options

--- a/docs/reference/search.rst
+++ b/docs/reference/search.rst
@@ -62,14 +62,15 @@ You can also configure the block template per admin while defining the admin:
     .. code-block:: xml
 
         <service id="app.admin.post" class="App\Admin\PostAdmin">
-              <tag name="sonata.admin" manager_type="orm" group="Content" label="Post"/>
-              <argument/>
-              <argument>App\Entity\Post</argument>
-              <argument/>
-              <call method="setTemplate">
-                  <argument>search_result_block</argument>
-                  <argument>@SonataPost/Block/block_search_result.html.twig</argument>
-              </call>
+            <tag name="sonata.admin" manager_type="orm" group="Content" label="Post"/>
+            <argument/>
+            <argument>App\Entity\Post</argument>
+            <argument/>
+            <tag
+                name="sonata.admin.template_registry"
+                template_name="search_result_block"
+                template_path="@SonataPost/Block/block_search_result.html.twig"
+                />
           </service>
 
 Configure the default search result action

--- a/docs/reference/tags.rst
+++ b/docs/reference/tags.rst
@@ -1,0 +1,98 @@
+Tags
+======
+
+sonata.admin.template_registry
+------------------------------
+
+This tag have few feature to allow manage for template. It is depends on with which interface it is used.
+
+First case - use it directly on template registry:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/services.yaml
+
+        services:
+            app.admin.post.template_registry:
+                class: App\Templating\MyCustomTemplateRegistry
+                tags:
+                    - { name: sonata.admin.template_registry, template_name: 'show', template_path: 'PostAdmin/show.html.twig' }
+                    - { name: sonata.admin.template_registry, template_name: 'edit', template_path: 'PostAdmin/edit.html.twig' }
+
+    .. code-block:: xml
+
+       <!-- config/services.xml -->
+
+        <service id="app.admin.post.template_registry" class="App\Templating\MyCustomTemplateRegistry">
+            <tag
+                name="sonata.admin.template_registry"
+                template_name="show"
+                template_path="PostAdmin/show.html.twig"
+                />
+            <tag
+                name="sonata.admin.template_registry"
+                template_name="edit"
+                template_path="PostAdmin/edit.html.twig"
+                />
+        </service>
+
+Allow with interfaces:
+
+    - `Sonata\AminBundle\Templating\TemplateRegistryInterface`
+    - `Sonata\AminBundle\Templating\MutableTemplateRegistryInterface`
+
+Result:
+
+    - Templates will be set by order: `__construct()`, `setTemplate()` and `setTemplates()` methods call and by tag attributes.
+
+Second case - use it on template registry aware:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/services.yaml
+
+        services:
+            app.admin.post:
+                class: App\Admin\PostAdmin
+                arguments:
+                    - ~
+                    - App\Entity\Post
+                    - ~
+                tags:
+                    - { name: sonata.admin, manager_type: orm, group: 'Content', label: 'Post' }
+                    - { name: sonata.admin.template_registry, template_name: 'edit', template_path: 'PostAdmin/edit.html.twig' }
+
+    .. code-block:: xml
+
+       <!-- config/services.xml -->
+
+        <service id="app.admin.post" class="App\Admin\PostAdmin">
+            <tag name="sonata.admin" manager_type="orm" group="Content" label="Post"/>
+            <argument/>
+            <argument>App\Entity\Post</argument>
+            <argument/>
+            <tag
+                name="sonata.admin.template_registry"
+                template_name="edit"
+                template_path="PostAdmin/edit.html.twig"
+                />
+        </service>
+
+Allow with interfaces:
+
+    - `Sonata\AminBundle\Templating\TemplateRegistryAwareInterface`
+    - `Sonata\AminBundle\Templating\MutableTemplateRegistryAwareInterface`
+
+Result:
+
+    - Template registry will be set by `setTemplateRegistry` method call (optional)
+    - Template registry will be auto generate when `setTemplateRegistry` is not call
+    - Templates will be set/override
+
+.. note::
+
+    Using `sonata.admin.template_registry` tag with `setTemplateRegistry()` method call is not recommended. You CAN NOT override templates from `TemplateRegistry` and you SHOULD NOT override templates from `TemplateRegistryAware`.

--- a/docs/reference/templates.rst
+++ b/docs/reference/templates.rst
@@ -171,10 +171,9 @@ can specify the templates to use in the ``Admin`` service definition:
                     - ~
                     - App\Entity\Post
                     - ~
-                calls:
-                    - [setTemplate, ['edit', 'PostAdmin/edit.html.twig']]
                 tags:
                     - { name: sonata.admin, manager_type: orm, group: 'Content', label: 'Post' }
+                    - { name: sonata.admin.template_registry, template_name: 'edit', template_path: 'PostAdmin/edit.html.twig' }
 
     .. code-block:: xml
 
@@ -185,10 +184,11 @@ can specify the templates to use in the ``Admin`` service definition:
             <argument/>
             <argument>App\Entity\Post</argument>
             <argument/>
-            <call method="setTemplate">
-                <argument>edit</argument>
-                <argument>PostAdmin/edit.html.twig</argument>
-            </call>
+            <tag
+                name="sonata.admin.template_registry"
+                template_name="edit"
+                template_path="PostAdmin/edit.html.twig"
+                />
         </service>
 
 .. note::
@@ -207,14 +207,12 @@ a global custom template and then override that customization on a specific
 
 Finding configured templates
 ----------------------------
-Each ``Admin`` has a ``TemplateRegistry`` service connected to it that holds
-the templates registered through the configuration above. Through the method
-``getTemplate($name)`` of that class, you can access the templates set for
-that ``Admin``. The ``TemplateRegistry`` is available through ``$this->getTemplateRegistry()``
-within the ``Admin``. Using the service container the template registries can
-be accessed outside an ``Admin``. Use the ``Admin`` code + ``.template_registry``
-as the service ID (i.e. "app.admin.post" uses the Template Registry
-"app.admin.post.template_registry").
+Each ``Admin`` has a ``MutableTemplateRegistry`` service connected to it that holds
+the templates registered through the configuration above. The ``MutableTemplateRegistry``
+is available through ``$this->getTemplateRegistry()`` within the ``Admin``.
+Outside an ``Admin``, you can obtain the template registries through their service ID.
+Use the ``Admin`` code + ``.template_registry`` as the service ID (i.e.
+``app.admin.post`` uses the template registry ``app.admin.post.template_registry``).
 
 The ``TemplateRegistry`` service that holds the global templates can be accessed
 using the service ID "sonata.admin.global_template_registry".

--- a/src/DependencyInjection/Compiler/TemplateRegistryCompilerPass.php
+++ b/src/DependencyInjection/Compiler/TemplateRegistryCompilerPass.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\DependencyInjection\Compiler;
+
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Templating\MutableTemplateRegistry;
+use Sonata\AdminBundle\Templating\MutableTemplateRegistryAwareInterface;
+use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
+use Sonata\AdminBundle\Templating\TemplateRegistry;
+use Sonata\AdminBundle\Templating\TemplateRegistryAwareInterface;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * @author Wojciech Błoszyk <wbloszyk@gmail.com>
+ */
+final class TemplateRegistryCompilerPass implements CompilerPassInterface
+{
+    private const TAG = 'sonata.admin.template_registry';
+
+    public function process(ContainerBuilder $container): void
+    {
+        $taggedServices = $container->findTaggedServiceIds(self::TAG);
+
+        foreach ($taggedServices as $id => $tags) {
+            $templates = [];
+
+            foreach ($tags as $attributes) {
+                if (isset($attributes['template_name'], $attributes['template_path'])) {
+                    $templates[$attributes['template_name']] = $attributes['template_path'];
+                }
+            }
+
+            if (empty($templates)) {
+                continue;
+            }
+
+            $definition = $container->getDefinition($id);
+
+            if (is_a($definition->getClass(), MutableTemplateRegistryInterface::class, true)) {
+                $this->setTemplatesByMethod($definition, $templates, $definition);
+            } elseif (is_a($definition->getClass(), TemplateRegistryInterface::class, true)) {
+                $this->setTemplatesByArgument($container, $definition, $templates);
+            } elseif (is_a($definition->getClass(), MutableTemplateRegistryAwareInterface::class, true)) {
+                $templateRegistryDefinition = $this->getTemplateRegistryDefinition($container, $id);
+                if (null === $templateRegistryDefinition) {
+                    $templateRegistryDefinition = $this->generateTemplateRegistry($container, $definition, $id);
+                }
+                $this->setTemplatesByMethod($templateRegistryDefinition, $templates, $definition);
+            } elseif (is_a($definition->getClass(), TemplateRegistryAwareInterface::class, true)) {
+                $templateRegistryDefinition = $this->getTemplateRegistryDefinition($container, $id);
+                if (null !== $templateRegistryDefinition) {
+                    throw new \Exception('You cannot set templates where non mutable template registry is defined.');
+                }
+                $templateRegistryDefinition = $this->generateTemplateRegistry($container, $definition, $id);
+                $this->setTemplatesByArgument($container, $templateRegistryDefinition, $templates);
+            } else {
+                throw new \Exception(sprintf(
+                    'Tagged "%s" service must be instance of %s or %s or %s or %s.',
+                    $id,
+                    TemplateRegistryInterface::class,
+                    MutableTemplateRegistryInterface::class,
+                    TemplateRegistryAwareInterface::class,
+                    MutableTemplateRegistryAwareInterface::class
+                ));
+            }
+        }
+    }
+
+    /**
+     * @param array<string, string> $templates
+     */
+    private function setTemplatesByMethod(Definition $templateRegistryDefinition, array $templates, ?Definition $awareDefinition = null): void
+    {
+        foreach ($templates as $type => $template) {
+            // NEXT_MAJOR: remove this if
+            // support for deprecated `AbstractAdmin:setTemplate()` method to keep BC
+            if (null !== $awareDefinition && is_a($awareDefinition->getClass(), AbstractAdmin::class, true)) {
+                $awareDefinition->addMethodCall('setTemplate', [$type, $template]);
+
+                continue;
+            }
+
+            $templateRegistryDefinition->addMethodCall('setTemplate', [$type, $template]);
+        }
+    }
+
+    /**
+     * @param array<string, string> $templates
+     */
+    private function setTemplatesByArgument(ContainerBuilder $container, Definition $templateRegistryDefinition, array $templates): void
+    {
+        $arguments = $templateRegistryDefinition->getArguments();
+        $serviceTemplates = $arguments[0] ?? [];
+
+        if (\is_string($serviceTemplates)) {
+            $serviceTemplates = $container->getParameter($serviceTemplates);
+        }
+
+        $templateRegistryDefinition->setArgument(0, array_merge($serviceTemplates, $templates));
+    }
+
+    private function getTemplateRegistryDefinition(ContainerBuilder $container, string $id): ?Definition
+    {
+        $definition = $container->getDefinition($id);
+
+        if (is_a($definition->getClass(), TemplateRegistryInterface::class, true)) {
+            return $definition;
+        }
+
+        if ($templateRegistryDefinition = $this->getTemplateRegistryFromAwareDefinition($container, $definition, $id)) {
+            return $templateRegistryDefinition;
+        }
+
+        return null;
+    }
+
+    /**
+     * @phpstan-return class-string
+     */
+    private function getTemplateRegistryInterface(Definition $awareDefinition, string $id): string
+    {
+        $templateRegistryClass = null;
+        if (is_a($awareDefinition->getClass(), MutableTemplateRegistryAwareInterface::class, true)) {
+            $templateRegistryClass = MutableTemplateRegistryInterface::class;
+        } elseif (is_a($awareDefinition->getClass(), TemplateRegistryAwareInterface::class, true)) {
+            $templateRegistryClass = TemplateRegistryInterface::class;
+        }
+
+        if (null === $templateRegistryClass) {
+            throw new \Exception(sprintf(
+                'Tagged "%s" service must be instance of %s or %s.',
+                $id,
+                TemplateRegistryAwareInterface::class,
+                MutableTemplateRegistryAwareInterface::class
+            ));
+        }
+
+        return $templateRegistryClass;
+    }
+
+    private function getTemplateRegistryFromAwareDefinition(ContainerBuilder $container, Definition $awareDefinition, string $id): ?Definition
+    {
+        $templateRegistryInterface = $this->getTemplateRegistryInterface($awareDefinition, $id);
+
+        foreach ($awareDefinition->getMethodCalls() as [$method, $args]) {
+            if ('setTemplateRegistry' === $method) {
+                $reference = $args[0];
+                $templateRegistryDefinition = $container->getDefinition($reference->__toString());
+
+                if (!is_a($templateRegistryDefinition->getClass(), $templateRegistryInterface, true)) {
+                    throw new \Exception(sprintf(
+                        'Argument 1 passed to "setTemplateRegistry()" call in service "%s" MUST be an instance of "%s", instance of "%s" given.',
+                        $id,
+                        $templateRegistryInterface,
+                        $templateRegistryDefinition->getClass()
+                    ));
+                }
+
+                return $templateRegistryDefinition;
+            }
+        }
+
+        return null;
+    }
+
+    private function generateTemplateRegistry(ContainerBuilder $container, Definition $awareDefinition, string $id): Definition
+    {
+        $templateRegistryInterface = $this->getTemplateRegistryInterface($awareDefinition, $id);
+        $templateRegistryClass = TemplateRegistry::class;
+
+        if (MutableTemplateRegistryInterface::class === $templateRegistryInterface) {
+            $templateRegistryClass = MutableTemplateRegistry::class;
+        }
+
+        $templateRegistryId = sprintf('%s.template_registry', $id);
+        $templateRegistryDefinition = $container
+            ->register($templateRegistryId, $templateRegistryClass)
+            ->addTag('sonata.admin.template_registry')
+            ->setPublic(true);
+
+        $awareDefinition->addMethodCall('setTemplateRegistry', [new Reference($templateRegistryId)]);
+
+        return $templateRegistryDefinition;
+    }
+}

--- a/src/SonataAdminBundle.php
+++ b/src/SonataAdminBundle.php
@@ -21,6 +21,7 @@ use Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ModelManagerCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ObjectAclManipulatorCompilerPass;
+use Sonata\AdminBundle\DependencyInjection\Compiler\TemplateRegistryCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\TwigStringExtensionCompilerPass;
 use Sonata\AdminBundle\Form\Type\AdminType;
 use Sonata\AdminBundle\Form\Type\ChoiceFieldMaskType;
@@ -56,6 +57,7 @@ class SonataAdminBundle extends Bundle
         $container->addCompilerPass(new GlobalVariablesCompilerPass());
         $container->addCompilerPass(new ModelManagerCompilerPass());
         $container->addCompilerPass(new ObjectAclManipulatorCompilerPass());
+        $container->addCompilerPass(new TemplateRegistryCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
         $container->addCompilerPass(new TwigStringExtensionCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
 
         $this->registerFormMapping();

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -102,6 +102,7 @@ final class AppKernel extends Kernel
             'strict_variables' => '%kernel.debug%',
             'exception_controller' => null,
             'form_themes' => ['@SonataAdmin/Form/form_admin_fields.html.twig'],
+            'paths' => ['%kernel.project_dir%/Resources/views'],
         ]);
 
         $loader->load(sprintf('%s/config/services.yml', $this->getProjectDir()));

--- a/tests/App/Resources/views/CRUD/custom_edit.html.twig
+++ b/tests/App/Resources/views/CRUD/custom_edit.html.twig
@@ -1,0 +1,12 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends '@SonataAdmin/CRUD/base_edit.html.twig' %}

--- a/tests/App/Resources/views/CRUD/custom_list.html.twig
+++ b/tests/App/Resources/views/CRUD/custom_list.html.twig
@@ -1,0 +1,12 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends '@SonataAdmin/CRUD/base_list.html.twig' %}

--- a/tests/App/Resources/views/CRUD/custom_show.html.twig
+++ b/tests/App/Resources/views/CRUD/custom_show.html.twig
@@ -1,0 +1,12 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends '@SonataAdmin/CRUD/base_show.html.twig' %}

--- a/tests/App/config/services.yml
+++ b/tests/App/config/services.yml
@@ -41,6 +41,9 @@ services:
         arguments: [~, Sonata\AdminBundle\Tests\App\Model\Foo, ~]
         tags:
             - {name: sonata.admin, manager_type: test, label: Foo}
+            - {name: sonata.admin.template_registry, template_name: 'list', template_path: 'CRUD/custom_list.html.twig'}
+            - {name: sonata.admin.template_registry, template_name: 'show', template_path: 'CRUD/custom_show.html.twig'}
+            - {name: sonata.admin.template_registry, template_name: 'edit', template_path: 'CRUD/custom_edit.html.twig'}
 
     Sonata\AdminBundle\Tests\App\Admin\EmptyAdmin:
         arguments: [~, Sonata\AdminBundle\Tests\App\Model\Foo, ~]

--- a/tests/DependencyInjection/Compiler/TemplateRegistryCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/TemplateRegistryCompilerPassTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\DependencyInjection\Compiler\TemplateRegistryCompilerPass;
+use Sonata\AdminBundle\Templating\AbstractTemplateRegistry;
+use Sonata\AdminBundle\Templating\MutableTemplateRegistry;
+use Sonata\AdminBundle\Templating\MutableTemplateRegistryAwareInterface;
+use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
+use Sonata\AdminBundle\Templating\TemplateRegistryAwareInterface;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class TemplateRegistryCompilerPassTest extends TestCase
+{
+    /**
+     * @var ContainerBuilder
+     */
+    private $container;
+
+    protected function setUp(): void
+    {
+        $this->container = new ContainerBuilder();
+    }
+
+    public function testTemplateRegistry(): void
+    {
+        $compilerPass = new TemplateRegistryCompilerPass();
+
+        // NEXT_MAJOR: change NewTemplateRegistry to TemplateRegistr
+        $this->container
+            ->register('sonata.admin.custom_template_registry', NewTemplateRegistry::class)
+            ->addTag('sonata.admin.template_registry', ['template_name' => 'show', 'template_path' => 'CRUD/tag_show.html.twig'])
+            ->addTag('sonata.admin.template_registry', ['template_name' => 'edit', 'template_path' => 'CRUD/tag_edit.html.twig'])
+            ->setArgument(0, ['list' => 'CRUD/list.html.twig', 'edit' => 'CRUD/edit.html.twig'])
+            ->setPublic(true);
+
+        $compilerPass->process($this->container);
+        $this->container->compile();
+
+        $this->assertTrue($this->container->hasDefinition('sonata.admin.custom_template_registry'));
+
+        $templateRegistry = $this->container->get('sonata.admin.custom_template_registry');
+
+        $this->assertSame('CRUD/list.html.twig', $templateRegistry->getTemplate('list'));
+        $this->assertSame('CRUD/tag_show.html.twig', $templateRegistry->getTemplate('show'));
+        $this->assertSame('CRUD/tag_edit.html.twig', $templateRegistry->getTemplate('edit'));
+    }
+
+    public function testMutableTemplateRegistry(): void
+    {
+        $compilerPass = new TemplateRegistryCompilerPass();
+
+        $this->container
+            ->register('sonata.admin.custom_template_registry', MutableTemplateRegistry::class)
+            ->addTag('sonata.admin.template_registry', ['template_name' => 'show', 'template_path' => 'CRUD/tag_show.html.twig'])
+            ->addTag('sonata.admin.template_registry', ['template_name' => 'edit', 'template_path' => 'CRUD/tag_edit.html.twig'])
+            ->setArgument(0, ['list' => 'CRUD/list.html.twig', 'edit' => 'CRUD/edit.html.twig'])
+            ->setPublic(true);
+
+        $compilerPass->process($this->container);
+        $this->container->compile();
+
+        $this->assertTrue($this->container->has('sonata.admin.custom_template_registry'));
+
+        $templateRegistry = $this->container->get('sonata.admin.custom_template_registry');
+
+        $this->assertSame('CRUD/list.html.twig', $templateRegistry->getTemplate('list'));
+        $this->assertSame('CRUD/tag_show.html.twig', $templateRegistry->getTemplate('show'));
+        $this->assertSame('CRUD/tag_edit.html.twig', $templateRegistry->getTemplate('edit'));
+    }
+
+    public function testTemplateRegistryAware(): void
+    {
+        $compilerPass = new TemplateRegistryCompilerPass();
+
+        $this->container
+            ->register('sonata.admin.custom_template_registry_aware', TemplateRegistryAware::class)
+            ->addTag('sonata.admin.template_registry', ['template_name' => 'show', 'template_path' => 'CRUD/tag_show.html.twig'])
+            ->setPublic(true);
+
+        $compilerPass->process($this->container);
+        $this->container->compile();
+
+        $this->assertTrue($this->container->has('sonata.admin.custom_template_registry_aware.template_registry'));
+
+        $templateRegistry = $this->container->get('sonata.admin.custom_template_registry_aware.template_registry');
+
+        $this->assertSame('CRUD/tag_show.html.twig', $templateRegistry->getTemplate('show'));
+    }
+
+    public function testTemplateRegistryAwareWithTemplateRegistry(): void
+    {
+        $this->expectException(\Exception::class);
+
+        $compilerPass = new TemplateRegistryCompilerPass();
+
+        // NEXT_MAJOR: change NewTemplateRegistry to TemplateRegistry
+        $this->container
+            ->register('sonata.admin.custom_template_registry', NewTemplateRegistry::class)
+            ->addTag('sonata.admin.template_registry', ['template_name' => 'show', 'template_path' => 'CRUD/tag_show.html.twig'])
+            ->setArgument(0, ['list' => 'CRUD/list.html.twig', 'edit' => 'CRUD/edit.html.twig'])
+            ->setPublic(true);
+
+        $this->container
+            ->register('sonata.admin.custom_template_registry_aware', TemplateRegistryAware::class)
+            ->addTag('sonata.admin.template_registry', ['template_name' => 'edit', 'template_path' => 'CRUD/tag_aware_edit.html.twig'])
+            ->addTag('sonata.admin.template_registry', ['template_name' => 'delete', 'template_path' => 'CRUD/tag_aware_delete.html.twig'])
+            ->addMethodCall('setTemplateRegistry', [new Reference('sonata.admin.custom_template_registry')])
+            ->setPublic(true);
+
+        $compilerPass->process($this->container);
+        $this->container->compile();
+
+        $this->assertTrue($this->container->has('sonata.admin.custom_template_registry'));
+
+        $templateRegistry = $this->container->get('sonata.admin.custom_template_registry');
+
+        $this->assertSame('CRUD/list.html.twig', $templateRegistry->getTemplate('list'));
+        $this->assertSame('CRUD/tag_show.html.twig', $templateRegistry->getTemplate('show'));
+    }
+
+    public function testMutableTemplateRegistryAware(): void
+    {
+        $compilerPass = new TemplateRegistryCompilerPass();
+
+        $this->container
+            ->register('sonata.admin.custom_mutable_template_registry_aware', MutableTemplateRegistryAware::class)
+            ->addTag('sonata.admin.template_registry', ['template_name' => 'list', 'template_path' => 'CRUD/tag_list.html.twig'])
+            ->addTag('sonata.admin.template_registry', ['template_name' => 'show', 'template_path' => 'CRUD/tag_show.html.twig'])
+            ->setPublic(true);
+
+        $compilerPass->process($this->container);
+        $this->container->compile();
+
+        $this->assertTrue($this->container->has('sonata.admin.custom_mutable_template_registry_aware.template_registry'));
+
+        $templateRegistry = $this->container->get('sonata.admin.custom_mutable_template_registry_aware.template_registry');
+
+        $this->assertSame('CRUD/tag_list.html.twig', $templateRegistry->getTemplate('list'));
+        $this->assertSame('CRUD/tag_show.html.twig', $templateRegistry->getTemplate('show'));
+    }
+
+    public function testMutableTemplateRegistryAwareWithTemplateRegistry(): void
+    {
+        $compilerPass = new TemplateRegistryCompilerPass();
+
+        $this->container
+            ->register('sonata.admin.custom_template_registry', MutableTemplateRegistry::class)
+            ->setArgument(0, ['list' => 'CRUD/list.html.twig', 'edit' => 'CRUD/edit.html.twig'])
+            ->setPublic(true);
+
+        $this->container
+            ->register('sonata.admin.custom_template_registry_aware', MutableTemplateRegistryAware::class)
+            ->addTag('sonata.admin.template_registry', ['template_name' => 'show', 'template_path' => 'CRUD/tag_show.html.twig'])
+            ->addTag('sonata.admin.template_registry', ['template_name' => 'edit', 'template_path' => 'CRUD/tag_edit.html.twig'])
+            ->addMethodCall('setTemplateRegistry', [new Reference('sonata.admin.custom_template_registry')])
+            ->setPublic(true);
+
+        $compilerPass->process($this->container);
+        $this->container->compile();
+
+        $this->assertTrue($this->container->has('sonata.admin.custom_template_registry'));
+
+        $templateRegistry = $this->container->get('sonata.admin.custom_template_registry');
+
+        $this->assertSame('CRUD/list.html.twig', $templateRegistry->getTemplate('list'));
+        $this->assertSame('CRUD/tag_show.html.twig', $templateRegistry->getTemplate('show'));
+        $this->assertSame('CRUD/tag_edit.html.twig', $templateRegistry->getTemplate('edit'));
+    }
+}
+
+// NEXT_MAJOR: remove this class
+final class NewTemplateRegistry extends AbstractTemplateRegistry implements TemplateRegistryInterface
+{
+}
+
+final class TemplateRegistryAware implements TemplateRegistryAwareInterface
+{
+    /**
+     * @var TemplateRegistryInterface
+     */
+    private $templateRegistry;
+
+    public function getTemplateRegistry(): TemplateRegistryInterface
+    {
+        return $this->templateRegistry;
+    }
+
+    public function hasTemplateRegistry(): bool
+    {
+        return null !== $this->templateRegistry;
+    }
+
+    public function setTemplateRegistry(TemplateRegistryInterface $templateRegistry): void
+    {
+        $this->templateRegistry = $templateRegistry;
+    }
+}
+
+final class MutableTemplateRegistryAware implements MutableTemplateRegistryAwareInterface
+{
+    /**
+     * @var MutableTemplateRegistryInterface
+     */
+    private $templateRegistry;
+
+    public function getTemplateRegistry(): MutableTemplateRegistryInterface
+    {
+        return $this->templateRegistry;
+    }
+
+    public function hasTemplateRegistry(): bool
+    {
+        return null !== $this->templateRegistry;
+    }
+
+    public function setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry): void
+    {
+        $this->templateRegistry = $templateRegistry;
+    }
+}

--- a/tests/SonataAdminBundleTest.php
+++ b/tests/SonataAdminBundleTest.php
@@ -21,6 +21,7 @@ use Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ModelManagerCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ObjectAclManipulatorCompilerPass;
+use Sonata\AdminBundle\DependencyInjection\Compiler\TemplateRegistryCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\TwigStringExtensionCompilerPass;
 use Sonata\AdminBundle\SonataAdminBundle;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
@@ -36,7 +37,7 @@ class SonataAdminBundleTest extends TestCase
     {
         $containerBuilder = $this->createMock(ContainerBuilder::class);
 
-        $containerBuilder->expects($this->exactly(8))
+        $containerBuilder->expects($this->exactly(9))
             ->method('addCompilerPass')
             ->willReturnCallback(function (CompilerPassInterface $pass, $type = PassConfig::TYPE_BEFORE_OPTIMIZATION): void {
                 if ($pass instanceof AddDependencyCallsCompilerPass) {
@@ -67,6 +68,10 @@ class SonataAdminBundleTest extends TestCase
                     return;
                 }
 
+                if ($pass instanceof TemplateRegistryCompilerPass) {
+                    return;
+                }
+
                 if ($pass instanceof TwigStringExtensionCompilerPass) {
                     return;
                 }
@@ -80,6 +85,7 @@ class SonataAdminBundleTest extends TestCase
                     GlobalVariablesCompilerPass::class,
                     ModelManagerCompilerPass::class,
                     ObjectAclManipulatorCompilerPass::class,
+                    TemplateRegistryCompilerPass::class,
                     TwigStringExtensionCompilerPass::class,
                     \get_class($pass)
                 ));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

After move templates from `AbsractAdmin` to `TemplateRegistry` some methods were deprecated (like `setTemplate` and `setTemplates`). To allow configuration templates in easy way like it was before some important change are require. 

[Additional attributes on tag](https://symfony.com/doc/current/service_container/tags.html#define-services-with-a-custom-tag)

## Usages

#### with `TemplateRegistryInterface` 
You MUST set templates by argument but you can override it by tag.

#### with `MutableTemplateRegistryInterface`
You CAN set templates by argument, override it by call `setTemplate` or `setTemplates` method and than override it again by tag.

#### with `TemplateRegistryAwareInterface`
- You CAN NOT use tag when `setTemplateRegistry` is called. You should override template directly on this template registry then.
- You CAN use tag when `setTemplateRegistry` is not called. In this case `TemplateRegistry` will be auto generate with id equal to `tagged_service_id` + `.template_registry`. 

#### with `MutableTemplateRegistryAwareInterface`
- You CAN use tag when `setTemplateRegistry` is called but it is not recommended. 
- You CAN use tag when `setTemplateRegistry` is not called. In this case `MutableTemplateRegistry` will be auto generate with id equal to `tagged_service_id` + `.template_registry`. 
 
## Examples
```yaml
Sonata\AdminBundle\Tests\App\Admin\FooAdmin:
    arguments: [~, Sonata\AdminBundle\Tests\App\Model\Foo, ~]
    tags:
        - {name: sonata.admin, manager_type: test, label: Foo}
        - {name: sonata.admin.template_registry, template_name:'edit', template_path: '@FooAdmin/CRUD/edit.html.twig'}
        - {name: sonata.admin.template_registry, template_name:'list', template_path: '@FooAdmin/CRUD/list.html.twig'}
```
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respect BC and should be done in 3.x.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `Sonata\AdminBundle\DependencyInjection\Compiler\TemplateRegistryCompilerPass` 
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

## To do

- [x] Update the tests;
- [x] Update the documentation;
- [x] Update the documentation - new tags description;
- [x] Fix problem with order template override 