### PR TITLE
Change parent filter label for child admin to be NULL

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2772,7 +2772,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         if ($this->isChild() && $this->getParentAssociationMapping() && !$mapper->has($this->getParentAssociationMapping())) {
             $mapper->add($this->getParentAssociationMapping(), null, [
                 'show_filter' => false,
-                'label' => null,
+                'label' => false,
                 'field_type' => ModelHiddenType::class,
                 'field_options' => [
                     'model_manager' => $this->getModelManager(),

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2772,7 +2772,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         if ($this->isChild() && $this->getParentAssociationMapping() && !$mapper->has($this->getParentAssociationMapping())) {
             $mapper->add($this->getParentAssociationMapping(), null, [
                 'show_filter' => false,
-                'label' => false,
+                'label' => null,
                 'field_type' => ModelHiddenType::class,
                 'field_options' => [
                     'model_manager' => $this->getModelManager(),

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -109,7 +109,7 @@ abstract class Filter implements FilterInterface
         $this->options['field_options'][$name] = $value;
     }
 
-    public function getLabel(): ?string
+    public function getLabel()
     {
         return $this->getOption('label');
     }

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -114,7 +114,7 @@ abstract class Filter implements FilterInterface
         return $this->getOption('label');
     }
 
-    public function setLabel(string $label): void
+    public function setLabel($label): void
     {
         $this->setOption('label', $label);
     }

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -59,7 +59,10 @@ interface FilterInterface
      */
     public function getLabel();
 
-    public function setLabel(string $label): void;
+    /**
+     * @param string|false|null $label
+     */
+    public function setLabel($label): void;
 
     /**
      * @return array<string, mixed>

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -51,7 +51,13 @@ interface FilterInterface
      */
     public function getFormName(): string;
 
-    public function getLabel(): ?string;
+    /**
+     * Returns the label to use for the current field.
+     * Use null to fallback to the default label and false to hide the label.
+     *
+     * @return string|false|null
+     */
+    public function getLabel();
 
     public function setLabel(string $label): void;
 


### PR DESCRIPTION
## Subject
I am targeting this branch, because BC.
Fix the parent filter label in relation to the return type of Sonata\AdminBundle\Filter\Filter::getLabel() must be of the type string or null, not bool.

## Changelog
### Fixed
- Inconsistencies with wrong type passed to Sonata\AdminBundle\Filter\Filter::getLabel()
