### PR TITLE
Set default label to filter if null

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -116,6 +116,12 @@ parameters:
             path: src/Datagrid/Datagrid.php
 
         -
+            # will be fixed in v4. Code is marked as deprecated
+            message: "#^Method Sonata\\\\AdminBundle\\\\Admin\\\\FieldDescriptionInterface\\:\\:getLabel\\(\\) invoked with 1 parameter, 0 required\\.$#"
+            count: 1
+            path: src/Datagrid/DatagridMapper.php
+
+        -
             # will be fixed in v4. Currently BC break
             message: "#^Method Sonata\\\\AdminBundle\\\\Admin\\\\FieldDescriptionInterface\\:\\:getLabel\\(\\) invoked with 1 parameter, 0 required\\.$#"
             count: 1

--- a/src/Datagrid/DatagridMapper.php
+++ b/src/Datagrid/DatagridMapper.php
@@ -99,6 +99,11 @@ class DatagridMapper extends BaseMapper
             );
         }
 
+        // NEXT_MAJOR: Remove the argument "sonata_deprecation_mute" in the following call.
+        if (null === $fieldDescription->getLabel('sonata_deprecation_mute')) {
+            $fieldDescription->setOption('label', $this->admin->getLabelTranslatorStrategy()->getLabel($fieldDescription->getName(), 'filter', 'label'));
+        }
+
         if (!isset($fieldDescriptionOptions['role']) || $this->admin->isGranted($fieldDescriptionOptions['role'])) {
             // add the field with the DatagridBuilder
             $this->builder->addFilter($this->datagrid, $type, $fieldDescription, $this->admin);

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -66,6 +66,7 @@ use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Tag;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooToString;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooToStringNull;
 use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
+use Sonata\AdminBundle\Translator\NoopLabelTranslatorStrategy;
 use Sonata\Doctrine\Adapter\AdapterInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -1940,6 +1941,7 @@ class AdminTest extends TestCase
     public function testGetFilterFieldDescription(): void
     {
         $modelAdmin = new ModelAdmin('sonata.post.admin.model', 'Application\Sonata\FooBundle\Entity\Model', 'Sonata\FooBundle\Controller\ModelAdminController');
+        $modelAdmin->setLabelTranslatorStrategy(new NoopLabelTranslatorStrategy());
 
         $fooFieldDescription = new FieldDescription('foo');
         $barFieldDescription = new FieldDescription('bar');

--- a/tests/Datagrid/DatagridMapperTest.php
+++ b/tests/Datagrid/DatagridMapperTest.php
@@ -26,6 +26,7 @@ use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Filter\Filter;
 use Sonata\AdminBundle\Filter\FilterInterface;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilder;
 
@@ -102,6 +103,17 @@ class DatagridMapperTest extends TestCase
                 return self::DEFAULT_GRANTED_ROLE === $name;
             });
 
+        $labelTranslatorStrategy = $this->createStub(LabelTranslatorStrategyInterface::class);
+        $labelTranslatorStrategy->method('getLabel')->willReturnCallback(
+            static function ($label, $context = '', $type = ''): string {
+                return sprintf('%s.%s_%s', $context, $type, $label);
+            }
+        );
+
+        $admin
+            ->method('getLabelTranslatorStrategy')
+            ->willReturn($labelTranslatorStrategy);
+
         $this->datagridMapper = new DatagridMapper($datagridBuilder, $this->datagrid, $admin);
     }
 
@@ -175,10 +187,11 @@ class DatagridMapperTest extends TestCase
 
         $this->assertTrue($this->datagridMapper->has('fooName'));
 
-        $fieldDescription = $this->datagridMapper->get('fooName');
+        $filter = $this->datagridMapper->get('fooName');
 
-        $this->assertInstanceOf(FilterInterface::class, $fieldDescription);
-        $this->assertSame('fooName', $fieldDescription->getName());
+        $this->assertInstanceOf(FilterInterface::class, $filter);
+        $this->assertSame('fooName', $filter->getName());
+        $this->assertSame('filter.label_fooName', $filter->getLabel());
     }
 
     public function testAddWithoutFieldName(): void
@@ -187,11 +200,11 @@ class DatagridMapperTest extends TestCase
 
         $this->assertTrue($this->datagridMapper->has('foo.bar'));
 
-        $fieldDescription = $this->datagridMapper->get('foo.bar');
+        $filter = $this->datagridMapper->get('foo.bar');
 
-        $this->assertInstanceOf(FilterInterface::class, $fieldDescription);
-        $this->assertSame('foo.bar', $fieldDescription->getName());
-        $this->assertSame('bar', $fieldDescription->getOption('field_name'));
+        $this->assertInstanceOf(FilterInterface::class, $filter);
+        $this->assertSame('foo.bar', $filter->getName());
+        $this->assertSame('bar', $filter->getOption('field_name'));
     }
 
     public function testAddRemove(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

When investigating in https://github.com/sonata-project/SonataAdminBundle/pull/6570

I discovered that we have this code
https://github.com/sonata-project/SonataAdminBundle/blob/f2dba48d52ecd60186a7f4f530131f9fd4e1ed62/src/Show/ShowMapper.php#L93-L95
In every mapper, except the Datagrid one.

For the datagridbuilder, it's in the persistence bundle for no reason
https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/src/Builder/DatagridBuilder.php#L173-L175

So I add this code here, and we'll be able to remove it from every persistence bundle.

I am targeting this branch, because BC.

## Changelog

```markdown
### Fixed
- If no label is provided to the filter, the default label is used following the label translator strategy
```