### PR TITLE
Avoid toggle filter button to be shown when the filter is hidden

### DIFF
--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -306,13 +306,15 @@ file that was distributed with this source code.
                                             {{ form_widget(form[filter.formName].children['value']) }}
                                         </div>
 
-                                        <div class="col-sm-1">
-                                            <label class="control-label">
-                                                <a href="#" class="sonata-toggle-filter sonata-ba-action" filter-target="filter-{{ admin.uniqid }}-{{ filter.name }}" filter-container="filter-container-{{ admin.uniqid() }}">
-                                                    <i class="fa fa-minus-circle" aria-hidden="true"></i>
-                                                </a>
-                                            </label>
-                                        </div>
+                                        {% if filterCanBeDisplayed %}
+                                            <div class="col-sm-1">
+                                                <label class="control-label">
+                                                    <a href="#" class="sonata-toggle-filter sonata-ba-action" filter-target="filter-{{ admin.uniqid }}-{{ filter.name }}" filter-container="filter-container-{{ admin.uniqid() }}">
+                                                        <i class="fa fa-minus-circle" aria-hidden="true"></i>
+                                                    </a>
+                                                </label>
+                                            </div>
+                                        {% endif %}
                                     </div>
 
                                     {% if filter.options['advanced_filter'] %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Avoid toggle filter button to be shown when the filter is hidden.
<!-- Describe your Pull Request content here -->
When an admin is child, a filter pointig to its parent is automatically added at [`AbstractAdmin::buildDatagrid()`](https://github.com/sonata-project/SonataAdminBundle/blob/0ecbf244051afc20869c0afb09597fb143ce46c4/src/Admin/AbstractAdmin.php#L942-L960) using the value from `getParentAssociationMapping()` as name. This filter is rendered as hidden, but since it's considered active, the toggle button used to remove the filter is shown.

![image](https://user-images.githubusercontent.com/1231441/98287933-d71bce80-1f84-11eb-804c-fe0ada56e49d.png)

This change uses the "show_filter" option to determine if this button must be shown.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

```markdown
### Fixed
- Showing toggle filter button when the filter is hidden in the admin list.
```