### PR TITLE
Add generics to AdminExtensionInterface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
         "symfony/maker-bundle": "^1.17",
         "symfony/phpunit-bridge": "^5.1.8",
         "symfony/yaml": "^4.4 || ^5.1",
-        "vimeo/psalm": "^4.1"
+        "vimeo/psalm": "^4.3.2"
     },
     "suggest": {
         "jms/translation-bundle": "Extract message keys from Admins",

--- a/src/Admin/AbstractAdminExtension.php
+++ b/src/Admin/AbstractAdminExtension.php
@@ -24,6 +24,9 @@ use Sonata\Form\Validator\ErrorElement;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @phpstan-template T of object
+ * @template-implements AdminExtensionInterface<T>
  */
 abstract class AbstractAdminExtension implements AdminExtensionInterface
 {
@@ -91,7 +94,7 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
     /**
      * @return array<string, string|string[]>
      *
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
      */
     public function getAccessMapping(AdminInterface $admin)
     {
@@ -99,7 +102,7 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
     }
 
     /**
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
      */
     public function configureBatchActions(AdminInterface $admin, array $actions)
     {
@@ -107,7 +110,7 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
     }
 
     /**
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
      */
     public function configureExportFields(AdminInterface $admin, array $fields)
     {
@@ -145,7 +148,7 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
      *
      * @return array<string, mixed>
      *
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
      */
     public function configureActionButtons(AdminInterface $admin, $list, $action, $object)
     {
@@ -153,14 +156,14 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
     }
 
     /**
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
      */
     public function configureDefaultFilterValues(AdminInterface $admin, array &$filterValues)
     {
     }
 
     /**
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
      */
     public function configureDefaultSortValues(AdminInterface $admin, array &$sortValues): void
     {

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -31,6 +31,8 @@ use Sonata\Form\Validator\ErrorElement;
  * @method array configureActionButtons(AdminInterface $admin, array $list, string $action, object $object)
  * @method void  configureDefaultFilterValues(AdminInterface $admin, array &$filterValues)
  * @method void  configureDefaultSortValues(AdminInterface $admin, array &$sortValues)
+ *
+ * @phpstan-template T of object
  */
 interface AdminExtensionInterface
 {
@@ -57,7 +59,7 @@ interface AdminExtensionInterface
     /**
      * @return void
      *
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
      */
     public function configureRoutes(AdminInterface $admin, RouteCollection $collection);
 
@@ -70,8 +72,8 @@ interface AdminExtensionInterface
      *
      * @return void
      *
-     * @phpstan-param AdminInterface<object> $admin
-     * @phpstan-param AdminInterface<object>|null $childAdmin
+     * @phpstan-param AdminInterface<T> $admin
+     * @phpstan-param AdminInterface<T>|null $childAdmin
      *
      * @deprecated
      */
@@ -89,8 +91,8 @@ interface AdminExtensionInterface
      *
      * @return void
      *
-     * @phpstan-param AdminInterface<object> $admin
-     * @phpstan-param AdminInterface<object>|null $childAdmin
+     * @phpstan-param AdminInterface<T> $admin
+     * @phpstan-param AdminInterface<T>|null $childAdmin
      */
     public function configureTabMenu(
         AdminInterface $admin,
@@ -108,7 +110,8 @@ interface AdminExtensionInterface
      *
      * @deprecated since sonata-project/admin-bundle 3.82.
      *
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
+     * @phpstan-param T $object
      */
     public function validate(AdminInterface $admin, ErrorElement $errorElement, $object);
 
@@ -117,7 +120,7 @@ interface AdminExtensionInterface
      *
      * @return void
      *
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
      */
     public function configureQuery(AdminInterface $admin, ProxyQueryInterface $query, $context = 'list');
 
@@ -128,7 +131,8 @@ interface AdminExtensionInterface
      *
      * @return void
      *
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
+     * @phpstan-param T $object
      */
     public function alterNewInstance(AdminInterface $admin, $object);
 
@@ -139,7 +143,8 @@ interface AdminExtensionInterface
      *
      * @return void
      *
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
+     * @phpstan-param T $object
      */
     public function alterObject(AdminInterface $admin, $object);
 
@@ -148,7 +153,7 @@ interface AdminExtensionInterface
      *
      * @return array<string, mixed>
      *
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
      */
     public function getPersistentParameters(AdminInterface $admin);
 
@@ -157,7 +162,7 @@ interface AdminExtensionInterface
      *
      * @return array<string, string|string[]>
      *
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
      */
     // NEXT_MAJOR: Uncomment this method
     // public function getAccessMapping(AdminInterface $admin): array;
@@ -165,7 +170,7 @@ interface AdminExtensionInterface
     /**
      * Returns the list of batch actions.
      *
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
      */
     // NEXT_MAJOR: Uncomment this method
     // public function configureBatchActions(AdminInterface $admin, array $actions): array;
@@ -175,7 +180,7 @@ interface AdminExtensionInterface
      *
      * @return string[]
      *
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
      */
     // NEXT_MAJOR: Uncomment this method
     // public function configureExportFields(AdminInterface $admin, array $fields): array;
@@ -185,7 +190,8 @@ interface AdminExtensionInterface
      *
      * @return void
      *
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
+     * @phpstan-param T $object
      */
     public function preUpdate(AdminInterface $admin, $object);
 
@@ -194,7 +200,8 @@ interface AdminExtensionInterface
      *
      * @return void
      *
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
+     * @phpstan-param T $object
      */
     public function postUpdate(AdminInterface $admin, $object);
 
@@ -203,7 +210,8 @@ interface AdminExtensionInterface
      *
      * @return void
      *
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
+     * @phpstan-param T $object
      */
     public function prePersist(AdminInterface $admin, $object);
 
@@ -212,7 +220,8 @@ interface AdminExtensionInterface
      *
      * @return void
      *
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
+     * @phpstan-param T $object
      */
     public function postPersist(AdminInterface $admin, $object);
 
@@ -221,7 +230,8 @@ interface AdminExtensionInterface
      *
      * @return void
      *
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
+     * @phpstan-param T $object
      */
     public function preRemove(AdminInterface $admin, $object);
 
@@ -230,14 +240,16 @@ interface AdminExtensionInterface
      *
      * @return void
      *
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
+     * @phpstan-param T $object
      */
     public function postRemove(AdminInterface $admin, $object);
 
     /*
      * Get all action buttons for an action
      *
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
+     * @phpstan-param T $object
      */
     // NEXT_MAJOR: Uncomment this method
     // public function configureActionButtons(AdminInterface $admin, array $list, string $action, object $object): array;
@@ -247,7 +259,7 @@ interface AdminExtensionInterface
      *
      * Returns a list of default filters
      *
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
      */
     // public function configureDefaultFilterValues(AdminInterface $admin, array &$filterValues): void;
 
@@ -256,7 +268,7 @@ interface AdminExtensionInterface
      *
      * Returns a list of default sort values
      *
-     * @phpstan-param AdminInterface<object> $admin
+     * @phpstan-param AdminInterface<T> $admin
      */
     // public function configureDefaultSortValues(AdminInterface $admin, array &$sortValues): void;
 }

--- a/src/Admin/Extension/LockExtension.php
+++ b/src/Admin/Extension/LockExtension.php
@@ -25,6 +25,8 @@ use Symfony\Component\Form\FormEvents;
  * @final since sonata-project/admin-bundle 3.52
  *
  * @author Emmanuel Vella <vella.emmanuel@gmail.com>
+ *
+ * @phpstan-extends AbstractAdminExtension<object>
  */
 class LockExtension extends AbstractAdminExtension
 {

--- a/src/Event/AdminEventExtension.php
+++ b/src/Event/AdminEventExtension.php
@@ -27,6 +27,8 @@ use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
  * @final since sonata-project/admin-bundle 3.52
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @phpstan-extends AbstractAdminExtension<object>
  */
 class AdminEventExtension extends AbstractAdminExtension
 {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I'm not sure about this, if generics should apply to `AdminExtensionInterface`. I've made this PR since I was looking at [`AbstractTranslatableAdminExtension`](https://github.com/sonata-project/SonataTranslationBundle/blob/cdf35c8574751d86792c8ac60ca1c2ae5d37be75/src/Admin/Extension/AbstractTranslatableAdminExtension.php) and looks like `@phpstan-extends AbstractAdminExtension<TranslatableInterface>` could apply there.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added generics to `AdminExtensionInterface`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
