### PR TITLE
Use `DateType::HTML5_FORMAT` constants as values for "format" and "date_format" form options

### DIFF
--- a/src/Form/Type/Filter/DateRangeType.php
+++ b/src/Form/Type/Filter/DateRangeType.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 use Sonata\AdminBundle\Form\Type\Operator\DateRangeOperatorType;
 use Sonata\Form\Type\DateRangeType as FormDateRangeType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -84,7 +85,7 @@ class DateRangeType extends AbstractType
     {
         $resolver->setDefaults([
             'field_type' => FormDateRangeType::class,
-            'field_options' => ['format' => 'yyyy-MM-dd'],
+            'field_options' => ['format' => DateType::HTML5_FORMAT],
         ]);
     }
 }

--- a/src/Form/Type/Filter/DateTimeRangeType.php
+++ b/src/Form/Type/Filter/DateTimeRangeType.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 use Sonata\AdminBundle\Form\Type\Operator\DateRangeOperatorType;
 use Sonata\Form\Type\DateTimeRangeType as FormDateTimeRangeType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -84,7 +85,7 @@ class DateTimeRangeType extends AbstractType
     {
         $resolver->setDefaults([
             'field_type' => FormDateTimeRangeType::class,
-            'field_options' => ['date_format' => 'yyyy-MM-dd'],
+            'field_options' => ['date_format' => DateType::HTML5_FORMAT],
         ]);
     }
 }

--- a/src/Form/Type/Filter/DateTimeType.php
+++ b/src/Form/Type/Filter/DateTimeType.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 use Sonata\AdminBundle\Form\Type\Operator\DateOperatorType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType as FormDateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -109,7 +110,7 @@ class DateTimeType extends AbstractType
     {
         $resolver->setDefaults([
             'field_type' => FormDateTimeType::class,
-            'field_options' => ['date_format' => 'yyyy-MM-dd'],
+            'field_options' => ['date_format' => DateType::HTML5_FORMAT],
         ]);
     }
 }

--- a/src/Form/Type/Filter/DateType.php
+++ b/src/Form/Type/Filter/DateType.php
@@ -109,7 +109,7 @@ class DateType extends AbstractType
     {
         $resolver->setDefaults([
             'field_type' => FormDateType::class,
-            'field_options' => ['date_format' => 'yyyy-MM-dd'],
+            'field_options' => ['date_format' => FormDateType::HTML5_FORMAT],
         ]);
     }
 }

--- a/tests/Form/Type/Filter/DateTimeRangeTypeTest.php
+++ b/tests/Form/Type/Filter/DateTimeRangeTypeTest.php
@@ -15,27 +15,28 @@ namespace Sonata\AdminBundle\Tests\Form\Type\Filter;
 
 use Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType;
 use Sonata\Form\Type\DateTimeRangeType as FormDateTimeRangeType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
 
-class DateTimeRangeTypeTest extends TypeTestCase
+final class DateTimeRangeTypeTest extends TypeTestCase
 {
     public function testGetDefaultOptions(): void
     {
-        $stub = $this->getMockForAbstractClass(TranslatorInterface::class);
+        $translator = $this->createStub(TranslatorInterface::class);
 
-        $type = new DateTimeRangeType($stub);
+        $type = new DateTimeRangeType($translator);
 
-        $optionResolver = new OptionsResolver();
+        $optionsResolver = new OptionsResolver();
 
-        $type->configureOptions($optionResolver);
+        $type->configureOptions($optionsResolver);
 
-        $options = $optionResolver->resolve();
+        $options = $optionsResolver->resolve();
 
         $expected = [
             'field_type' => FormDateTimeRangeType::class,
-            'field_options' => ['date_format' => 'yyyy-MM-dd'],
+            'field_options' => ['date_format' => DateType::HTML5_FORMAT],
         ];
         $this->assertSame($expected, $options);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Use `DateType::HTML5_FORMAT` constants as values for "format" and "date_format" form options.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are pedantic and respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

