### PR TITLE
Add null check before calling the id method

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
@@ -19,7 +19,7 @@ file that was distributed with this source code.
     <div id="field_container_{{ id }}" class="field-container">
         {% if sonata_admin.edit == 'list' %}
             <span id="field_widget_{{ id }}" class="field-short-description">
-                {% if sonata_admin.field_description.associationadmin.id(sonata_admin.value) %}
+                {% if sonata_admin.value and sonata_admin.field_description.associationadmin.id(sonata_admin.value) is not null %}
                     {{ render(path('sonata_admin_short_object_information', {
                         'code':     sonata_admin.field_description.associationadmin.code,
                         'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),

--- a/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
@@ -19,7 +19,7 @@ file that was distributed with this source code.
     <div id="field_container_{{ id }}" class="field-container">
         {% if sonata_admin.edit == 'list' %}
             <span id="field_widget_{{ id }}" class="field-short-description">
-                {% if sonata_admin.field_description.associationadmin.id(sonata_admin.value) %}
+                {% if sonata_admin.value and sonata_admin.field_description.associationadmin.id(sonata_admin.value) is not null %}
                     {{ render(path('sonata_admin_short_object_information', {
                         'code':     sonata_admin.field_description.associationadmin.code,
                         'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),

--- a/src/Resources/views/CRUD/Association/list_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/list_many_to_one.html.twig
@@ -18,7 +18,7 @@ file that was distributed with this source code.
             and field_description.hasAssociationAdmin
             and field_description.associationadmin.hasRoute(route_name)
             and field_description.associationadmin.hasAccess(route_name, value)
-            and field_description.associationadmin.id(value)
+            and field_description.associationadmin.id(value) is not null
         %}
             <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.options.route.parameters) }}">
                 {{ value|render_relation_element(field_description) }}

--- a/src/Resources/views/CRUD/Association/list_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/list_one_to_one.html.twig
@@ -12,13 +12,18 @@ file that was distributed with this source code.
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
-    {% set route_name = field_description.options.route.name %}
-    {% if field_description.hasAssociationAdmin
-    and field_description.associationadmin.id(value)
-    and field_description.associationadmin.hasRoute(route_name)
-    and field_description.associationadmin.hasAccess(route_name, value) %}
-        <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.options.route.parameters) }}">{{ value|render_relation_element(field_description) }}</a>
-    {% else %}
-        {{ value|render_relation_element(field_description) }}
+    {% if value %}
+        {% set route_name = field_description.options.route.name %}
+        {% if field_description.hasAssociationAdmin
+            and field_description.associationadmin.id(value) is not null
+            and field_description.associationadmin.hasRoute(route_name)
+            and field_description.associationadmin.hasAccess(route_name, value)
+        %}
+            <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.options.route.parameters) }}">
+                {{ value|render_relation_element(field_description) }}
+            </a>
+        {% else %}
+            {{ value|render_relation_element(field_description) }}
+        {% endif %}
     {% endif %}
 {% endblock %}

--- a/src/Resources/views/CRUD/Association/show_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/show_one_to_one.html.twig
@@ -12,15 +12,18 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
-    {% set route_name = field_description.options.route.name %}
-    {% if field_description.hasAssociationAdmin
-    and field_description.associationadmin.id(value)
-    and field_description.associationadmin.hasRoute(route_name)
-    and field_description.associationadmin.hasAccess(route_name, value) %}
-        <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.options.route.parameters) }}">
+    {% if value %}
+        {% set route_name = field_description.options.route.name %}
+        {% if field_description.hasAssociationAdmin
+            and field_description.associationadmin.id(value) is not null
+            and field_description.associationadmin.hasRoute(route_name)
+            and field_description.associationadmin.hasAccess(route_name, value)
+        %}
+            <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.options.route.parameters) }}">
+                {{ value|render_relation_element(field_description) }}
+            </a>
+        {% else %}
             {{ value|render_relation_element(field_description) }}
-        </a>
-    {% else %}
-        {{ value|render_relation_element(field_description) }}
+        {% endif %}
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

In next major only object will be allowed as argument for the `id` method and it seems `null` was passed.
I am targeting this branch, because BC.

Related to discussion: https://github.com/sonata-project/SonataAdminBundle/pull/6573#discussion_r519220677

Seems Pedantic to me.