### PR TITLE
Fix short object information call without object

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -462,6 +462,14 @@ This code manages the many-to-[one|many] association field popup
 
             Admin.log('[{{ id }}|on:change] update the label');
 
+            // Skip short object information call if object is missing.
+            if (!jQuery(this).val()) {
+                jQuery('#field_widget_{{ id }}').html('{{ 'short_object_description_placeholder'|trans({}, 'SonataAdminBundle') }}');
+                // Hide edit button if exist
+                jQuery('#field_actions_{{ id }} a.btn-warning').addClass('hidden');
+                return ;
+            }
+
             jQuery('#field_widget_{{ id }}').html("<span><img src=\"{{ asset('bundles/sonataadmin/ajax-loader.gif') }}\" style=\"vertical-align: middle; margin-right: 10px\"/>{{ 'loading_information'|trans([], 'SonataAdminBundle') }}</span>");
             jQuery.ajax({
                 type: 'GET',


### PR DESCRIPTION
## Subject

In next major only object will be allowed as argument for the `id` method, so we need to skip short object information call if object is missing.  I find out this when working on [SonataDoctrineORMAdminBundle/pull/1192](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1192). This is happen if delete button of ModelListType is used.
I am targeting this branch, because BC.
