### PR TITLE
Fix not to call an id method without object.

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -462,10 +462,10 @@ This code manages the many-to-[one|many] association field popup
 
             Admin.log('[{{ id }}|on:change] update the label');
 
-            var objectId =  jQuery(this).val();
+            var objectId = jQuery(this).val();
 
             // Skip short object information call if object is missing.
-            if (!objectId) {
+            if (objectId === undefined || objectId === null || objectId === "") {
                 jQuery('#field_widget_{{ id }}').html('{{ 'short_object_description_placeholder'|trans({}, 'SonataAdminBundle') }}');
 
                 {% if btn_edit %}

--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -465,7 +465,7 @@ This code manages the many-to-[one|many] association field popup
             var objectId = jQuery(this).val();
 
             // Skip short object information call if object is missing.
-            if (objectId === undefined || objectId === null || objectId === "") {
+            if (undefined === objectId || null === objectId || '' === objectId) {
                 jQuery('#field_widget_{{ id }}').html('{{ 'short_object_description_placeholder'|trans({}, 'SonataAdminBundle') }}');
 
                 {% if btn_edit %}

--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -462,12 +462,17 @@ This code manages the many-to-[one|many] association field popup
 
             Admin.log('[{{ id }}|on:change] update the label');
 
+            var objectId =  jQuery(this).val();
+
             // Skip short object information call if object is missing.
-            if (!jQuery(this).val()) {
+            if (!objectId) {
                 jQuery('#field_widget_{{ id }}').html('{{ 'short_object_description_placeholder'|trans({}, 'SonataAdminBundle') }}');
-                // Hide edit button if exist
-                jQuery('#field_actions_{{ id }} a.btn-warning').addClass('hidden');
-                return ;
+
+                {% if btn_edit %}
+                    jQuery('#field_actions_{{ id }} a.btn-warning').addClass('hidden');
+                {% endif %}
+
+                return;
             }
 
             jQuery('#field_widget_{{ id }}').html("<span><img src=\"{{ asset('bundles/sonataadmin/ajax-loader.gif') }}\" style=\"vertical-align: middle; margin-right: 10px\"/>{{ 'loading_information'|trans([], 'SonataAdminBundle') }}</span>");
@@ -478,7 +483,7 @@ This code manages the many-to-[one|many] association field popup
                     'uniqid': associationadmin.uniqid,
                     'code': associationadmin.code,
                     'linkParameters': sonata_admin.field_description.options.link_parameters
-                })}}'.replace('OBJECT_ID', jQuery(this).val()),
+                })}}'.replace('OBJECT_ID', objectId),
                 dataType: 'html',
                 success: function(html) {
                     jQuery('#field_widget_{{ id }}').html(html);
@@ -488,14 +493,9 @@ This code manages the many-to-[one|many] association field popup
             {% if btn_edit %}
                 var edit_button_url = '{{
                     associationadmin.generateUrl('edit', {'id' : 'OBJECT_ID'})
-                }}'.replace('OBJECT_ID', jQuery(this).val());
+                }}'.replace('OBJECT_ID', objectId);
 
-                var edit_button_node = jQuery('#field_actions_{{ id }} a.btn-warning');
-                if (jQuery(this).val()) {
-                    edit_button_node.removeClass('hidden').attr('href', edit_button_url);
-                } else {
-                    edit_button_node.addClass('hidden');
-                }
+                jQuery('#field_actions_{{ id }} a.btn-warning').removeClass('hidden').attr('href', edit_button_url);
             {% endif %}
         });
 

--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -462,6 +462,14 @@ This code manages the many-to-[one|many] association field popup
 
             Admin.log('[{{ id }}|on:change] update the label');
 
+            // Skip short object information call if object is missing.
+            if (!jQuery(this).val()) {
+                jQuery('#field_widget_{{ id }}').html('{{ 'short_object_description_placeholder'|trans({}, 'SonataAdminBundle') }}');
+                // Hide edit button if exist
+                jQuery('#field_actions_{{ id }} a.btn-warning').addClass('hidden');
+                return ;
+            }
+
             jQuery('#field_widget_{{ id }}').html("<span><img src=\"{{ asset('bundles/sonataadmin/ajax-loader.gif') }}\" style=\"vertical-align: middle; margin-right: 10px\"/>{{ 'loading_information'|trans([], 'SonataAdminBundle') }}</span>");
             jQuery.ajax({
                 type: 'GET',


### PR DESCRIPTION
## Subject

In next major only object will be allowed as argument for the `id` method, so we need to skip short object information call if object is missing. I find out this when working on [SonataDoctrineORMAdminBundle/pull/1193](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1193). This is happen if delete button of `ModelListType` is used.

I am targeting this branch, because this change respects BC.