### PR TITLE
Id method allow return null

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2003,17 +2003,17 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         return $this->cacheIsGranted[$key];
     }
 
-    public function getUrlSafeIdentifier(object $model): string
+    public function getUrlSafeIdentifier(object $model): ?string
     {
         return $this->getModelManager()->getUrlSafeIdentifier($model);
     }
 
-    public function getNormalizedIdentifier(object $model): string
+    public function getNormalizedIdentifier(object $model): ?string
     {
         return $this->getModelManager()->getNormalizedIdentifier($model);
     }
 
-    public function id(object $model): string
+    public function id(object $model): ?string
     {
         return $this->getNormalizedIdentifier($model);
     }

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -181,14 +181,14 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      *
      * @phpstan-param T $model
      */
-    public function getNormalizedIdentifier(object $model): string;
+    public function getNormalizedIdentifier(object $model): ?string;
 
     /**
      * Shorthand method for templating.
      *
      * @phpstan-param T $model
      */
-    public function id(object $model): string;
+    public function id(object $model): ?string;
 
     public function setValidator(ValidatorInterface $validator): void;
 

--- a/src/Admin/UrlGeneratorInterface.php
+++ b/src/Admin/UrlGeneratorInterface.php
@@ -75,5 +75,5 @@ interface UrlGeneratorInterface
     /**
      * @phpstan-param T $model
      */
-    public function getUrlSafeIdentifier(object $model): string;
+    public function getUrlSafeIdentifier(object $model): ?string;
 }

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -115,7 +115,7 @@ interface ModelManagerInterface
     /**
      * Get the identifiers for this model class as a string.
      */
-    public function getNormalizedIdentifier(object $model): string;
+    public function getNormalizedIdentifier(object $model): ?string;
 
     /**
      * Get the identifiers as a string that is safe to use in a url.
@@ -123,7 +123,7 @@ interface ModelManagerInterface
      * This is similar to getNormalizedIdentifier but guarantees an id that can
      * be used in a URL.
      */
-    public function getUrlSafeIdentifier(object $model): string;
+    public function getUrlSafeIdentifier(object $model): ?string;
 
     /**
      * Create a new instance of the model of the specified class.


### PR DESCRIPTION
## Subject

Allow null as return type for getUrlSafeIdentifier, getNormalizedIdentifier, and id.
- One on SonataDoctrineORM@3.x to remove the deprecation in getNormalizedIdentifier. [SonataDoctrineORMAdminBundle/pull/1194](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1194)
- One on SonataDoctrineORM@master to remove the exception and return null instead. [SonataDoctrineORMAdminBundle/pull/1195](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1195)

I am targeting this branch, because BC.

Closes #6535
