### PR TITLE
Add NOT_EQUAL operator for StringOperatorType

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,10 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+### Sonata\AdminBundle\Form\Type\Operator\StringOperatorType
+
+Added "Not equal" in the default list for "choices" option in order to allow filtering by strings that are not equal to the model data.
+
 ### Deprecated `Sonata\AdminBundle\Model\ModelManagerInterface::modelTransform()`
 
 This method has been deprecated without replacement.

--- a/src/Form/Type/Operator/StringOperatorType.php
+++ b/src/Form/Type/Operator/StringOperatorType.php
@@ -25,6 +25,7 @@ final class StringOperatorType extends AbstractType
     public const TYPE_EQUAL = 3;
     public const TYPE_STARTS_WITH = 4;
     public const TYPE_ENDS_WITH = 5;
+    public const TYPE_NOT_EQUAL = 6;
 
     /**
      * @return void
@@ -39,6 +40,7 @@ final class StringOperatorType extends AbstractType
                 'label_type_equals' => self::TYPE_EQUAL,
                 'label_type_starts_with' => self::TYPE_STARTS_WITH,
                 'label_type_ends_with' => self::TYPE_ENDS_WITH,
+                'label_type_not_equals' => self::TYPE_NOT_EQUAL,
             ],
         ]);
     }

--- a/tests/Form/Type/Operator/StringOperatorTypeTest.php
+++ b/tests/Form/Type/Operator/StringOperatorTypeTest.php
@@ -29,6 +29,7 @@ class StringOperatorTypeTest extends TypeTestCase
             'label_type_equals' => StringOperatorType::TYPE_EQUAL,
             'label_type_starts_with' => StringOperatorType::TYPE_STARTS_WITH,
             'label_type_ends_with' => StringOperatorType::TYPE_ENDS_WITH,
+            'label_type_not_equals' => StringOperatorType::TYPE_NOT_EQUAL,
         ];
         $formType->configureOptions($optionsResolver);
         $options = $optionsResolver->resolve([]);


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC. This is a new feature.
There is contains and not contains operator, but only the equal operator.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- `NOT_EQUAL` operator for `StringOperatorType`
```