### PR TITLE
Add filter operator in autocomplete item

### DIFF
--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -17,7 +17,7 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Filter\FilterInterface;
-use Symfony\Component\Form\Form;
+use Sonata\AdminBundle\Form\Type\Operator\StringOperatorType;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -125,7 +125,7 @@ final class RetrieveAutocompleteItemsAction
                     $filter = $datagrid->getFilter($prop);
                     $filter->setCondition(FilterInterface::CONDITION_OR);
 
-                    $datagrid->setValue($filter->getFormName(), null, $searchText);
+                    $datagrid->setValue($filter->getFormName(), StringOperatorType::TYPE_CONTAINS, $searchText);
                 }
             } else {
                 if (!$datagrid->hasFilter($property)) {
@@ -137,7 +137,7 @@ final class RetrieveAutocompleteItemsAction
                     ));
                 }
 
-                $datagrid->setValue($datagrid->getFilter($property)->getFormName(), null, $searchText);
+                $datagrid->setValue($datagrid->getFilter($property)->getFormName(), StringOperatorType::TYPE_CONTAINS, $searchText);
             }
         }
 

--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -17,7 +17,7 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Filter\FilterInterface;
-use Sonata\AdminBundle\Form\Type\Operator\StringOperatorType;
+use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -125,7 +125,7 @@ final class RetrieveAutocompleteItemsAction
                     $filter = $datagrid->getFilter($prop);
                     $filter->setCondition(FilterInterface::CONDITION_OR);
 
-                    $datagrid->setValue($filter->getFormName(), StringOperatorType::TYPE_CONTAINS, $searchText);
+                    $datagrid->setValue($filter->getFormName(), null, $searchText);
                 }
             } else {
                 if (!$datagrid->hasFilter($property)) {
@@ -137,7 +137,7 @@ final class RetrieveAutocompleteItemsAction
                     ));
                 }
 
-                $datagrid->setValue($datagrid->getFilter($property)->getFormName(), StringOperatorType::TYPE_CONTAINS, $searchText);
+                $datagrid->setValue($datagrid->getFilter($property)->getFormName(), null, $searchText);
             }
         }
 

--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Datagrid;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Filter\FilterInterface;
+use Sonata\AdminBundle\Form\Type\Operator\StringOperatorType;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
@@ -296,6 +297,7 @@ class Datagrid implements DatagridInterface
         foreach ($this->getFilters() as $name => $filter) {
             $this->values[$name] = $this->values[$name] ?? null;
             $filterFormName = $filter->getFormName();
+            $this->values[$filterFormName]['type'] = $this->values[$filterFormName]['type'] ?? StringOperatorType::TYPE_CONTAINS;
             if (isset($this->values[$filterFormName]['type'], $this->values[$filterFormName]['value']) &&
                 ('' !== $this->values[$filterFormName]['type'] || '' !== $this->values[$filterFormName]['value'])
             ) {

--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -297,10 +297,13 @@ class Datagrid implements DatagridInterface
         foreach ($this->getFilters() as $name => $filter) {
             $this->values[$name] = $this->values[$name] ?? null;
             $filterFormName = $filter->getFormName();
-            $this->values[$filterFormName]['type'] = $this->values[$filterFormName]['type'] ?? StringOperatorType::TYPE_CONTAINS;
-            if (isset($this->values[$filterFormName]['type'], $this->values[$filterFormName]['value']) &&
-                ('' !== $this->values[$filterFormName]['type'] || '' !== $this->values[$filterFormName]['value'])
-            ) {
+
+            $hasValue = isset($this->values[$filterFormName]['value'])
+                && '' !== $this->values[$filterFormName]['value'];
+            $hasType = isset($this->values[$filterFormName]['type'])
+                && '' !== $this->values[$filterFormName]['type'];
+
+            if ($hasValue || $hasType) {
                 $filter->apply($this->query, $data[$filterFormName]);
             }
         }


### PR DESCRIPTION
## Subject

In 3.80 filter is apply if [type and value](https://github.com/sonata-project/SonataAdminBundle/blob/d0cffae16f7d2e5badc995581b90f5dba583eabe/src/Datagrid/Datagrid.php#L299) are set, but autocomplete item not set the operator, so the `searchText` param is skipped.

I am targeting this branch, because BC.
