### PR TITLE
Apply filter even if the operator is not provided

### DIFF
--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -296,9 +296,11 @@ class Datagrid implements DatagridInterface
         foreach ($this->getFilters() as $name => $filter) {
             $this->values[$name] = $this->values[$name] ?? null;
             $filterFormName = $filter->getFormName();
-            if (isset($this->values[$filterFormName]['type'], $this->values[$filterFormName]['value']) &&
-                ('' !== $this->values[$filterFormName]['type'] || '' !== $this->values[$filterFormName]['value'])
-            ) {
+
+            $value = $this->values[$filterFormName]['value'] ?? '';
+            $type = $this->values[$filterFormName]['type'] ?? '';
+
+            if ('' !== $value || '' !== $type) {
                 $filter->apply($this->query, $data[$filterFormName]);
             }
         }

--- a/tests/Datagrid/DatagridTest.php
+++ b/tests/Datagrid/DatagridTest.php
@@ -57,6 +57,11 @@ class DatagridTest extends TestCase
     private $formBuilder;
 
     /**
+     * @var mixed[]
+     */
+    private $formData;
+
+    /**
      * @var array
      */
     private $formTypes;
@@ -67,6 +72,7 @@ class DatagridTest extends TestCase
         $this->columns = new FieldDescriptionCollection();
         $this->pager = $this->createMock(PagerInterface::class);
 
+        $this->formData = [];
         $this->formTypes = [];
 
         $this->formBuilder = $this->getMockBuilder(FormBuilder::class)
@@ -93,13 +99,16 @@ class DatagridTest extends TestCase
                 );
             });
 
-        $this->formBuilder
-            ->method('getForm')
-            ->willReturnCallback(function () {
-                return $this->getMockBuilder(Form::class)
-                    ->disableOriginalConstructor()
-                    ->getMock();
-            });
+        $form = $this->createStub(Form::class);
+
+        $form->method('submit')->willReturnCallback(function (array $values): void {
+            $this->formData = $values;
+        });
+        $form->method('getData')->willReturnCallback(function (): array {
+            return $this->formData;
+        });
+
+        $this->formBuilder->method('getForm')->willReturn($form);
 
         $values = [];
 
@@ -383,6 +392,41 @@ class DatagridTest extends TestCase
         $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_sort_order'));
         $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_page'));
         $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_per_page'));
+    }
+
+    /**
+     * @dataProvider applyFilterDataProvider
+     */
+    public function testApplyFilter(?string $type, ?string $value, int $applyCallNumber): void
+    {
+        $this->datagrid->setValue('fooFormName', $type, $value);
+
+        $filter = $this->createMock(FilterInterface::class);
+        $filter->expects($this->once())->method('getName')->willReturn('foo');
+        $filter->method('getFormName')->willReturn('fooFormName');
+        $filter->method('isActive')->willReturn(false);
+        $filter->method('getRenderSettings')->willReturn(['foo1', ['bar1' => 'baz1']]);
+        $filter->expects($this->exactly($applyCallNumber))->method('apply');
+
+        $this->datagrid->addFilter($filter);
+
+        $this->datagrid->buildPager();
+    }
+
+    /**
+     * @return iterable<array{?string, ?string, int}>
+     */
+    public function applyFilterDataProvider(): iterable
+    {
+        yield ['fakeType', 'fakeValue', 1];
+        yield ['', 'fakeValue', 1];
+        yield [null, 'fakeValue', 1];
+        yield ['fakeType', '', 1];
+        yield ['fakeType', null, 1];
+        yield ['', '', 0];
+        yield ['', null, 0];
+        yield [null, '', 0];
+        yield [null, null, 0];
     }
 
     public function testBuildPagerWithException(): void


### PR DESCRIPTION
## Subject

Bug reported https://github.com/sonata-project/SonataAdminBundle/pull/6590

I am targeting this branch, because bug fix.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Apply filter even if the operator is not provided.
```