### PR TITLE
Add deprecation for not passing empty boxes option

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,13 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+### Sonata\AdminBundle\Block\AdminSearchBlockService
+
+Not passing the `empty_boxes` option as argument 4 to `Sonata\AdminBundle\Block\AdminSearchBlockService()` is deprecated.
+
+UPGRADE FROM 3.79 to 3.80
+=========================
+
 ### Sonata\AdminBundle\Form\Type\Operator\StringOperatorType
 
 Added "Not equal" in the default list for "choices" option in order to allow filtering by strings that are not equal to the model data.

--- a/src/Block/AdminSearchBlockService.php
+++ b/src/Block/AdminSearchBlockService.php
@@ -42,13 +42,26 @@ class AdminSearchBlockService extends AbstractBlockService
     protected $searchHandler;
 
     /**
-     * NEXT_MAJOR: Change signature for (Environment $twig, Pool $pool, SearchHandler $searchHandler).
+     * NEXT_MAJOR: Change var to string and phpstan-var to 'show'|'hide'|'fade'.
+     *
+     * @var string|null
+     *
+     * @phpstan-var 'show'|'hide'|'fade'|null
+     */
+    private $emptyBoxesOption;
+
+    /**
+     * NEXT_MAJOR: Change signature for (Environment $twig, Pool $pool, SearchHandler $searchHandler, string $emptyBoxesOption).
      *
      * @param Environment|string        $twigOrName
      * @param Pool|EngineInterface|null $poolOrTemplating
      * @param SearchHandler|Pool        $searchHandlerOrPool
+     * @param string|SearchHandler|null $emptyBoxesOptionOrSearchHandler
+     *
+     * @phpstan-param 'show'|'hide'|'fade'|SearchHandler|null $emptyBoxesOptionOrSearchHandler
+     * @phpstan-param 'show'|'hide'|'fade'|null               $emptyBoxesOption
      */
-    public function __construct($twigOrName, ?object $poolOrTemplating, object $searchHandlerOrPool, ?SearchHandler $searchHandler = null)
+    public function __construct($twigOrName, ?object $poolOrTemplating, object $searchHandlerOrPool, $emptyBoxesOptionOrSearchHandler = null, ?string $emptyBoxesOption = null)
     {
         if ($poolOrTemplating instanceof Pool) {
             if (!$twigOrName instanceof Environment) {
@@ -71,8 +84,17 @@ class AdminSearchBlockService extends AbstractBlockService
 
             parent::__construct($twigOrName);
 
+            if (!\is_string($emptyBoxesOptionOrSearchHandler)) {
+                @trigger_error(sprintf(
+                    'Not passing a string as argument 4 to %s() is deprecated since sonata-project/admin-bundle 3.x'
+                    .' and will throw a \TypeError in version 4.0.',
+                    __METHOD__
+                ), E_USER_DEPRECATED);
+            }
+
             $this->pool = $poolOrTemplating;
             $this->searchHandler = $searchHandlerOrPool;
+            $this->emptyBoxesOption = $emptyBoxesOptionOrSearchHandler;
         } elseif (null === $poolOrTemplating || $poolOrTemplating instanceof EngineInterface) {
             @trigger_error(sprintf(
                 'Passing %s as argument 2 to %s() is deprecated since sonata-project/admin-bundle 3.76'
@@ -91,7 +113,7 @@ class AdminSearchBlockService extends AbstractBlockService
                 ));
             }
 
-            if (null === $searchHandler) {
+            if (null === $emptyBoxesOptionOrSearchHandler) {
                 throw new \TypeError(sprintf(
                     'Passing null as argument 3 to %s() is not allowed when %s is passed as argument 2.'
                     .' You must pass an instance of %s instead.',
@@ -104,7 +126,8 @@ class AdminSearchBlockService extends AbstractBlockService
             parent::__construct($twigOrName, $poolOrTemplating);
 
             $this->pool = $searchHandlerOrPool;
-            $this->searchHandler = $searchHandler;
+            $this->searchHandler = $emptyBoxesOptionOrSearchHandler;
+            $this->emptyBoxesOption = $emptyBoxesOption;
         } else {
             throw new \TypeError(sprintf(
                 'Argument 2 passed to %s() must be either null or an instance of %s or preferably %s, instance of %s given.',
@@ -149,6 +172,7 @@ class AdminSearchBlockService extends AbstractBlockService
             'admin_pool' => $this->pool,
             'pager' => $pager,
             'admin' => $admin,
+            'show_empty_boxes' => $this->emptyBoxesOption,
         ], $response);
     }
 

--- a/src/Resources/config/block.php
+++ b/src/Resources/config/block.php
@@ -38,6 +38,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ReferenceConfigurator('twig'),
                 new ReferenceConfigurator('sonata.admin.pool'),
                 new ReferenceConfigurator('sonata.admin.search.handler'),
+                '%sonata.admin.configuration.global_search.empty_boxes%',
             ])
 
         ->set('sonata.admin.block.stats', AdminStatsBlockService::class)

--- a/src/Resources/views/Block/block_search_result.html.twig
+++ b/src/Resources/views/Block/block_search_result.html.twig
@@ -12,7 +12,8 @@ file that was distributed with this source code.
 {% extends sonata_block.templates.block_base %}
 
 {% block block %}
-    {% set show_empty_boxes = sonata_admin.adminPool.container.getParameter('sonata.admin.configuration.global_search.empty_boxes') %}
+    {# NEXT_MAJOR: Remove the following line #}
+    {% set show_empty_boxes = show_empty_boxes|default(sonata_admin.adminPool.container.getParameter('sonata.admin.configuration.global_search.empty_boxes')) %}
     {% set visibility_class = 'sonata-search-result-' ~ show_empty_boxes %}
     {% if pager and pager.getResults()|length %}
         {% set visibility_class = 'sonata-search-result-show' %}

--- a/tests/Block/AdminSearchBlockServiceTest.php
+++ b/tests/Block/AdminSearchBlockServiceTest.php
@@ -18,6 +18,7 @@ use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Block\AdminSearchBlockService;
 use Sonata\AdminBundle\Search\SearchHandler;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
 
@@ -26,6 +27,8 @@ use Twig\Environment;
  */
 class AdminSearchBlockServiceTest extends BlockServiceTestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @var Pool
      */
@@ -49,7 +52,33 @@ class AdminSearchBlockServiceTest extends BlockServiceTestCase
         $blockService = new AdminSearchBlockService(
             $this->createMock(Environment::class),
             $this->pool,
-            $this->searchHandler
+            $this->searchHandler,
+            'show'
+        );
+        $blockContext = $this->getBlockContext($blockService);
+
+        $this->assertSettings([
+            'admin_code' => '',
+            'query' => '',
+            'page' => 0,
+            'per_page' => 10,
+            'icon' => '<i class="fa fa-list"></i>',
+        ], $blockContext);
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
+    public function testDefaultSettingsWithoutEmptyBoxOption(): void
+    {
+        $this->expectDeprecation('Not passing a string as argument 4 to %s() is deprecated since sonata-project/admin-bundle 3.x and will throw a \TypeError in version 4.0.');
+
+        $blockService = new AdminSearchBlockService(
+            $this->createMock(Environment::class),
+            $this->pool,
+            $this->searchHandler,
         );
         $blockContext = $this->getBlockContext($blockService);
 
@@ -69,7 +98,8 @@ class AdminSearchBlockServiceTest extends BlockServiceTestCase
         $blockService = new AdminSearchBlockService(
             $this->createMock(Environment::class),
             $this->pool,
-            $this->searchHandler
+            $this->searchHandler,
+            'show'
         );
         $blockContext = $this->getBlockContext($blockService);
 


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

Related to https://github.com/sonata-project/SonataAdminBundle/pull/6589

## Changelog

```markdown
### Deprecated
- Not passing 'show', 'hide' or 'fade' as argument 4 to `Sonata\AdminBundle\Block\AdminSearchBlockService()`
```