### PR TITLE
Fix AdminInterface Inheritance

### DIFF
--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -27,7 +27,7 @@ use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Object\MetadataInterface;
 use Sonata\AdminBundle\Route\RouteGeneratorInterface;
 use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
-use Sonata\AdminBundle\Templating\TemplateRegistryAwareInterface;
+use Sonata\AdminBundle\Templating\MutableTemplateRegistryAwareInterface;
 use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
 use Sonata\Exporter\Source\SourceIteratorInterface;
 use Sonata\Form\Validator\ErrorElement;
@@ -72,7 +72,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  * @phpstan-extends UrlGeneratorInterface<T>
  * @phpstan-extends LifecycleHookProviderInterface<T>
  */
-interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegistryInterface, LifecycleHookProviderInterface, MenuBuilderInterface, ParentAdminInterface, UrlGeneratorInterface, TemplateRegistryAwareInterface
+interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegistryInterface, LifecycleHookProviderInterface, MenuBuilderInterface, ParentAdminInterface, UrlGeneratorInterface, MutableTemplateRegistryAwareInterface
 {
     /**
      * @return void

--- a/src/Templating/MutableTemplateRegistryAwareInterface.php
+++ b/src/Templating/MutableTemplateRegistryAwareInterface.php
@@ -18,12 +18,15 @@ namespace Sonata\AdminBundle\Templating;
  *
  * @method MutableTemplateRegistryInterface getTemplateRegistry()
  * @method bool                             hasTemplateRegistry()
- * @method void                             setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry)
+ * @method void                             setTemplateRegistry(TemplateRegistryInterface $templateRegistry)
  */
 interface MutableTemplateRegistryAwareInterface
 {
     // NEXT_MAJOR: uncomment this method in 4.0
     //public function getTemplateRegistry(): MutableTemplateRegistryInterface;
+
+    // NEXT_MAJOR: uncomment this method in 4.0
+    //public function hasTemplateRegistry(): bool;
 
     // NEXT_MAJOR: uncomment this method in 4.0
     //public function setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry): void;


### PR DESCRIPTION
## Subject

When working on merge 3.x into master, I had to make this change because the signature wasn't compatible.
The issue didn't appear on 3.x because we were just using `@method`.

I am targeting this branch, because I consider this as a bug fix.

But I have some questions (cc @wbloszyk) 
- Shouldn't `MutableTemplateRegistryAwareInterface` extends `TemplateRegistryAwareInterface` this way ?
```
interface MutableTemplateRegistryAwareInterface extends TemplateRegistryAwareInterface
{
    /**
     * @return MutableTemplateRegistryInterface
     */
    public function getTemplateRegistry(): TemplateRegistryInterface;

    /**
     * @param TemplateRegistryInterface
     */
    public function setTemplateRegistry(TemplateRegistryInterface $templateRegistry): void;
}
```

- The `TemplateRegistryAwareInterface` is not used at all after this change. Is it useful to keep it ?


## Changelog

```markdown
### Fixed
- `AdminInterface` extends `MutableTemplateRegistryAwareInterface` instead of `TemplateRegistryAwareInterface`
```