### PR TITLE
Fix @method annotation for MutableTemplateRegistryAwareInterface

### DIFF
--- a/src/Templating/MutableTemplateRegistryAwareInterface.php
+++ b/src/Templating/MutableTemplateRegistryAwareInterface.php
@@ -18,7 +18,7 @@ namespace Sonata\AdminBundle\Templating;
  *
  * @method MutableTemplateRegistryInterface getTemplateRegistry()
  * @method bool                             hasTemplateRegistry()
- * @method void                             setTemplateRegistry(TemplateRegistryInterface $templateRegistry)
+ * @method void                             setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry)
  */
 interface MutableTemplateRegistryAwareInterface
 {


### PR DESCRIPTION
I don't know why I made this change in https://github.com/sonata-project/SonataAdminBundle/pull/6597
But it seems wrong to me now.

One clue is the fact that the `@method` and the `NEXT_MAJOR` comment doesn't use the same typehint.