### PR TITLE
[3.x] Add deprecation notices related to validate methods

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -8,6 +8,18 @@ UPGRADE FROM 3.80 to 3.81
 
 Not passing the `empty_boxes` option as argument 4 to `Sonata\AdminBundle\Block\AdminSearchBlockService()` is deprecated.
 
+### Deprecated `Sonata\AdminBundle\Admin\AdminInterface::validate()` method.
+
+Use `Symfony\Component\Validator\Validation::validate()` instead.
+
+### Deprecated `Sonata\AdminBundle\Admin\AbstractAdmin::attachInlineValidator()` method.
+
+This method has been deprecated without replacement.
+
+### Deprecated `Sonata\AdminBundle\Admin\AdminExtensionInterface::validate()` method.
+
+This method has been deprecated without replacement.
+
 UPGRADE FROM 3.79 to 3.80
 =========================
 

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -724,6 +724,12 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
 
     public function validate(ErrorElement $errorElement, $object)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s method is deprecated since version 3.81 and will be removed in 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
     }
 
     /**
@@ -817,6 +823,12 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
      */
     public function preValidate($object)
     {
+        if ('sonata_deprecation_mute' !== \func_get_args()[1] ?? null) {
+            @trigger_error(sprintf(
+                'The %s method is deprecated since version 3.81 and will be removed in 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
     }
 
     public function preUpdate($object)
@@ -1481,7 +1493,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
             $extension->configureFormFields($mapper);
         }
 
-        $this->attachInlineValidator();
+        $this->attachInlineValidator('sonata_deprecation_mute');
     }
 
     public function attachAdminClass(FieldDescriptionInterface $fieldDescription)
@@ -3544,7 +3556,7 @@ EOT;
 
         $formBuilder = $this->getFormBuilder();
         $formBuilder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
-            $this->preValidate($event->getData());
+            $this->preValidate($event->getData(), 'sonata_deprecation_mute');
         }, 100);
 
         $this->form = $formBuilder->getForm();
@@ -3571,9 +3583,20 @@ EOT;
 
     /**
      * Attach the inline validator to the model metadata, this must be done once per admin.
+     *
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-admin/admin-bundle 3.81
      */
     protected function attachInlineValidator()
     {
+        if ('sonata_deprecation_mute' !== \func_get_args()[0] ?? null) {
+            @trigger_error(sprintf(
+                'The %s method is deprecated since version 3.81 and will be removed in 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         $admin = $this;
 
         // add the custom inline validation option
@@ -3600,10 +3623,11 @@ EOT;
                     return;
                 }
 
-                $admin->validate($errorElement, $object);
+                $admin->validate($errorElement, $object, 'sonata_deprecation_mute');
 
                 foreach ($admin->getExtensions() as $extension) {
-                    $extension->validate($admin, $errorElement, $object);
+                    /* @phpstan-ignore-next-line */
+                    $extension->validate($admin, $errorElement, $object, 'sonata_deprecation_mute');
                 }
             },
             'serializingWarning' => true,

--- a/src/Admin/AbstractAdminExtension.php
+++ b/src/Admin/AbstractAdminExtension.php
@@ -60,6 +60,12 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
 
     public function validate(AdminInterface $admin, ErrorElement $errorElement, $object)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[3] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s method is deprecated since version 3.81 and will be removed in 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
     }
 
     public function configureQuery(AdminInterface $admin, ProxyQueryInterface $query, $context = 'list')

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -100,9 +100,13 @@ interface AdminExtensionInterface
     );
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * @param object $object
      *
      * @return void
+     *
+     * @deprecated since sonata-admin/admin-bundle 3.81
      *
      * @phpstan-param AdminInterface<object> $admin
      */

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -546,8 +546,7 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      *
      * @return void
      *
-     * @deprecated this feature cannot be stable, use a custom validator,
-     *             the feature will be removed with Symfony 2.2
+     * @deprecated since sonata-admin/admin-bundle 3.81
      *
      * @phpstan-param T $object
      */

--- a/src/Admin/LifecycleHookProviderInterface.php
+++ b/src/Admin/LifecycleHookProviderInterface.php
@@ -19,8 +19,6 @@ namespace Sonata\AdminBundle\Admin;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
- * @method void preValidate($object)
- *
  * @phpstan-template T of object
  */
 interface LifecycleHookProviderInterface
@@ -55,12 +53,6 @@ interface LifecycleHookProviderInterface
      * @phpstan-param T $object
      */
     public function delete($object);
-
-    //NEXT_MAJOR: uncomment this method for 4.0
-    //    /**
-    //     * @param object $object
-    //     */
-    //    public function preValidate($object);
 
     /**
      * @param object $object


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6233 