### PR TITLE
Fix sonata-project name and some comments and deprecations

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -722,11 +722,14 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         return $this->getModelManager()->getDataSourceIterator($datagrid, $fields);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function validate(ErrorElement $errorElement, $object)
     {
         if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
             @trigger_error(sprintf(
-                'The %s method is deprecated since version 3.81 and will be removed in 4.0.',
+                'The %s method is deprecated since version 3.x and will be removed in 4.0.',
                 __METHOD__
             ), E_USER_DEPRECATED);
         }
@@ -817,6 +820,10 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, will be removed in 4.0.
+     *
      * @param object $object
      *
      * @phpstan-param T $object
@@ -825,7 +832,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     {
         if ('sonata_deprecation_mute' !== \func_get_args()[1] ?? null) {
             @trigger_error(sprintf(
-                'The %s method is deprecated since version 3.81 and will be removed in 4.0.',
+                'The %s method is deprecated since version 3.x and will be removed in 4.0.',
                 __METHOD__
             ), E_USER_DEPRECATED);
         }
@@ -1493,6 +1500,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
             $extension->configureFormFields($mapper);
         }
 
+        // NEXT_MAJOR: Remove this line.
         $this->attachInlineValidator('sonata_deprecation_mute');
     }
 
@@ -3555,6 +3563,7 @@ EOT;
         $this->loaded['form'] = true;
 
         $formBuilder = $this->getFormBuilder();
+        // NEXT_MAJOR: Remove this call.
         $formBuilder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
             $this->preValidate($event->getData(), 'sonata_deprecation_mute');
         }, 100);
@@ -3586,13 +3595,13 @@ EOT;
      *
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.81
+     * @deprecated since sonata-project/admin-bundle 3.x.
      */
     protected function attachInlineValidator()
     {
         if ('sonata_deprecation_mute' !== \func_get_args()[0] ?? null) {
             @trigger_error(sprintf(
-                'The %s method is deprecated since version 3.81 and will be removed in 4.0.',
+                'The %s method is deprecated since version 3.x and will be removed in 4.0.',
                 __METHOD__
             ), E_USER_DEPRECATED);
         }

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -713,7 +713,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
         }
 
         @trigger_error(sprintf(
-            'Using "%s()" without setting a "%s" instance in the admin is deprecated since sonata-admin/admin-bundle 3.79'
+            'Using "%s()" without setting a "%s" instance in the admin is deprecated since sonata-project/admin-bundle 3.79'
             .' and won\'t be possible in 4.0.',
             __METHOD__,
             DataSourceInterface::class
@@ -1013,7 +1013,7 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     {
         if (\is_string($this->parentAssociationMapping)) {
             @trigger_error(sprintf(
-                'Calling "%s" when $this->parentAssociationMapping is string is deprecated since sonata-admin/admin-bundle 3.75 and will be removed in 4.0.',
+                'Calling "%s" when $this->parentAssociationMapping is string is deprecated since sonata-project/admin-bundle 3.75 and will be removed in 4.0.',
                 __METHOD__
             ), E_USER_DEPRECATED);
         }
@@ -3586,7 +3586,7 @@ EOT;
      *
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-admin/admin-bundle 3.81
+     * @deprecated since sonata-project/admin-bundle 3.81
      */
     protected function attachInlineValidator()
     {

--- a/src/Admin/AbstractAdminExtension.php
+++ b/src/Admin/AbstractAdminExtension.php
@@ -58,11 +58,14 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
         $this->configureSideMenu($admin, $menu, $action, $childAdmin);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function validate(AdminInterface $admin, ErrorElement $errorElement, $object)
     {
         if ('sonata_deprecation_mute' !== (\func_get_args()[3] ?? null)) {
             @trigger_error(sprintf(
-                'The %s method is deprecated since version 3.81 and will be removed in 4.0.',
+                'The %s method is deprecated since version 3.x and will be removed in 4.0.',
                 __METHOD__
             ), E_USER_DEPRECATED);
         }

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -106,7 +106,7 @@ interface AdminExtensionInterface
      *
      * @return void
      *
-     * @deprecated since sonata-admin/admin-bundle 3.81
+     * @deprecated since sonata-project/admin-bundle 3.81
      *
      * @phpstan-param AdminInterface<object> $admin
      */

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -106,7 +106,7 @@ interface AdminExtensionInterface
      *
      * @return void
      *
-     * @deprecated since sonata-project/admin-bundle 3.81
+     * @deprecated since sonata-project/admin-bundle 3.x.
      *
      * @phpstan-param AdminInterface<object> $admin
      */

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -546,7 +546,7 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      *
      * @return void
      *
-     * @deprecated since sonata-project/admin-bundle 3.81
+     * @deprecated since sonata-project/admin-bundle 3.x.
      *
      * @phpstan-param T $object
      */

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -546,7 +546,7 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      *
      * @return void
      *
-     * @deprecated since sonata-admin/admin-bundle 3.81
+     * @deprecated since sonata-project/admin-bundle 3.81
      *
      * @phpstan-param T $object
      */

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -288,7 +288,7 @@ interface ModelManagerInterface extends DatagridManagerInterface
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-admin/admin-bundle 3.80 and will be removed in 4.0.
+     * @deprecated since sonata-project/admin-bundle 3.80 and will be removed in 4.0.
      *
      * @param string $class
      * @param object $instance
@@ -315,7 +315,7 @@ interface ModelManagerInterface extends DatagridManagerInterface
      * @param int|null $firstResult
      * @param int|null $maxResult
      *
-     * @deprecated since sonata-admin/admin-bundle 3.79 and will be removed in 4.0.
+     * @deprecated since sonata-project/admin-bundle 3.79 and will be removed in 4.0.
      *
      * @return SourceIteratorInterface
      */

--- a/src/Templating/TemplateRegistry.php
+++ b/src/Templating/TemplateRegistry.php
@@ -30,7 +30,7 @@ final class TemplateRegistry extends AbstractTemplateRegistry implements Mutable
         $this->templates = $templates;
 
         @trigger_error(sprintf(
-            'Method "%s()" is deprecated since sonata-admin/admin-bundle 3.39 and will be removed in 4.0.',
+            'Method "%s()" is deprecated since sonata-project/admin-bundle 3.39 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
     }
@@ -45,7 +45,7 @@ final class TemplateRegistry extends AbstractTemplateRegistry implements Mutable
         $this->templates[$name] = $template;
 
         @trigger_error(sprintf(
-            'Method "%s()" is deprecated since sonata-admin/admin-bundle 3.39 and will be removed in 4.0.',
+            'Method "%s()" is deprecated since sonata-project/admin-bundle 3.39 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
     }

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -2632,7 +2632,7 @@ class AdminTest extends TestCase
                 return $label;
             });
 
-        $this->expectDeprecation('Using "Sonata\AdminBundle\Admin\AbstractAdmin::getDataSourceIterator()" without setting a "Sonata\AdminBundle\Exporter\DataSourceInterface" instance in the admin is deprecated since sonata-admin/admin-bundle 3.79 and won\'t be possible in 4.0.');
+        $this->expectDeprecation('Using "Sonata\AdminBundle\Admin\AbstractAdmin::getDataSourceIterator()" without setting a "Sonata\AdminBundle\Exporter\DataSourceInterface" instance in the admin is deprecated since sonata-project/admin-bundle 3.79 and won\'t be possible in 4.0.');
         $admin->getDataSourceIterator();
     }
 


### PR DESCRIPTION
We've been referencing `sonata-admin/x`, now it's corrected to `sonata-project/x`.

In https://github.com/sonata-project/SonataAdminBundle/pull/6618 there were missing some NEXT_MAJOR comments and also the deprecated version was specified and there hasn't been released yet.