### PR TITLE
Avoid FQCN for controller id

### DIFF
--- a/src/Resources/config/actions.php
+++ b/src/Resources/config/actions.php
@@ -18,6 +18,7 @@ use Sonata\AdminBundle\Action\RetrieveAutocompleteItemsAction;
 use Sonata\AdminBundle\Action\RetrieveFormFieldElementAction;
 use Sonata\AdminBundle\Action\SearchAction;
 use Sonata\AdminBundle\Action\SetObjectFieldValueAction;
+use Sonata\AdminBundle\Util\BCDeprecationParameters;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
 
@@ -26,7 +27,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // Use "param" function for creating references to parameters when dropping support for Symfony 5.1
     $containerConfigurator->services()
 
-        ->set(DashboardAction::class, DashboardAction::class)
+        ->set('sonata.admin.action.dashboard', DashboardAction::class)
             ->public()
             ->args([
                 '%sonata.admin.configuration.dashboard_blocks%',
@@ -35,8 +36,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ReferenceConfigurator('sonata.admin.pool'),
                 new ReferenceConfigurator('twig'),
             ])
+            // NEXT_MAJOR: Remove the alias.
+            ->alias(DashboardAction::class, 'sonata.admin.action.dashboard')
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ))
 
-        ->set(SearchAction::class, SearchAction::class)
+        ->set('sonata.admin.action.search', SearchAction::class)
             ->public()
             ->args([
                 new ReferenceConfigurator('sonata.admin.pool'),
@@ -45,6 +52,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ReferenceConfigurator('sonata.admin.breadcrumbs_builder'),
                 new ReferenceConfigurator('twig'),
             ])
+            // NEXT_MAJOR: Remove the alias.
+            ->alias(SearchAction::class, 'sonata.admin.action.search')
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ))
 
         ->set('sonata.admin.action.append_form_field_element', AppendFormFieldElementAction::class)
             ->public()

--- a/src/Resources/config/routing/sonata_admin.xml
+++ b/src/Resources/config/routing/sonata_admin.xml
@@ -4,13 +4,13 @@
         <default key="route">sonata_admin_dashboard</default>
         <default key="permanent">true</default>
     </route>
-    <route id="sonata_admin_dashboard" path="/dashboard" controller="Sonata\AdminBundle\Action\DashboardAction"/>
+    <route id="sonata_admin_dashboard" path="/dashboard" controller="sonata.admin.action.dashboard"/>
     <route id="sonata_admin_retrieve_form_element" path="/core/get-form-field-element" controller="sonata.admin.action.retrieve_form_field_element"/>
     <route id="sonata_admin_append_form_element" path="/core/append-form-field-element" controller="sonata.admin.action.append_form_field_element"/>
     <route id="sonata_admin_short_object_information" path="/core/get-short-object-description.{_format}" format="html" controller="sonata.admin.action.get_short_object_description">
         <requirement key="_format">html|json</requirement>
     </route>
     <route id="sonata_admin_set_object_field_value" path="/core/set-object-field-value" controller="sonata.admin.action.set_object_field_value"/>
-    <route id="sonata_admin_search" path="/search" controller="Sonata\AdminBundle\Action\SearchAction"/>
+    <route id="sonata_admin_search" path="/search" controller="sonata.admin.action.search"/>
     <route id="sonata_admin_retrieve_autocomplete_items" path="/core/get-autocomplete-items" controller="sonata.admin.action.retrieve_autocomplete_items"/>
 </routes>


### PR DESCRIPTION
## Subject

Related to https://github.com/sonata-project/SonataAdminBundle/pull/6610#discussion_r528924541
I am targeting this branch, because BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Referencing to DashboardAction and SearchAction by FQCN class instead of id.
```