### PR TITLE
[Docs] Remove note with a broken link

### DIFF
--- a/docs/getting_started/creating_an_admin.rst
+++ b/docs/getting_started/creating_an_admin.rst
@@ -175,12 +175,6 @@ provides a compiler pass which takes care of configuring it correctly for you.
 You can often tweak things using tag attributes. The code shown here is the
 shortest code needed to get it working.
 
-.. note::
-
-    If you don't like writing configuration and want to some more magic,
-    have a look at the [SonataAutoConfigureBundle](https://symfony.com/doc/master/bundles/SonataAdminBundle/cookbook/recipe_auto_configure_admin_classes.html)
-    described in chapter 24.
-
 Step 4: Register SonataAdmin custom Routes
 ------------------------------------------
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

The note/paragraph points to a non-existing page related to a bundle which is abandoned and no longer maintained (SonataAutoConfigureBundle).
