### PR TITLE
Fix file name in tests

### DIFF
--- a/tests/Form/AbstractLayoutTestCase.php
+++ b/tests/Form/AbstractLayoutTestCase.php
@@ -27,7 +27,7 @@ use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 use Twig\RuntimeLoader\FactoryRuntimeLoader;
 
-abstract class AbstractLayoutTest extends FormIntegrationTestCase
+abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
 {
     /**
      * @var FormRenderer

--- a/tests/Form/AdminLayoutTest.php
+++ b/tests/Form/AdminLayoutTest.php
@@ -32,6 +32,7 @@ final class AdminLayoutTest extends AbstractLayoutTestCase
         $form = $this->factory->createNamed('name', TextType::class);
         $form->addError(new FormError('[trans]Error 1[/trans]'));
         $form->addError(new FormError('[trans]Error 2[/trans]'));
+        $form->submit([]);
         $view = $form->createView();
         $html = $this->renderRow($view);
 

--- a/tests/Form/AdminLayoutTest.php
+++ b/tests/Form/AdminLayoutTest.php
@@ -16,7 +16,7 @@ namespace Sonata\AdminBundle\Tests\Form;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormError;
 
-final class AdminLayoutTestCase extends AbstractLayoutTest
+final class AdminLayoutTest extends AbstractLayoutTestCase
 {
     public function testRowSetId(): void
     {


### PR DESCRIPTION
In https://github.com/sonata-project/SonataAdminBundle/pull/6563 I wrongly named the files, the file name with tests was ending in TestCase.php and it did not run tests by PHPUnit.

Just in case, the [previous job](https://github.com/sonata-project/SonataAdminBundle/runs/1452354017): `Tests: 1798, Assertions: 4944, Skipped: 14.`
And [this one](https://github.com/sonata-project/SonataAdminBundle/pull/6627/checks?check_run_id=1457748369): `Tests: 1801, Assertions: 4947, Skipped: 14.`. 