### PR TITLE
#6629 Replace jQuery "load" with "on"

### DIFF
--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -809,7 +809,7 @@ jQuery(document).on('sonata-admin-append-form-element', function(e) {
     Admin.setup_collection_counter(e.target);
 });
 
-jQuery(window).load(function() {
+jQuery(window).on('load', function() {
     if (Admin.get_config('CONFIRM_EXIT')) {
         jQuery('.sonata-ba-form form').each(function() {
             jQuery(this).confirmExit();


### PR DESCRIPTION
Replace jQuery(window).load with jQuery(window).on('load', handler)

#6629

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This is a simple PR to replace the deprecated (since jQuery 1.8) and removed (since jQuery 3.0) usage of jQuery.load(handler) with jQuery.on('load', handler).
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because I would like our Sonata projects to have better compatibility with newer versions of jQuery.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6629.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Replaced jQuery "load()" with "on()" in Admin.js
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
