### PR TITLE
Add data source in configuration and documentation

### DIFF
--- a/docs/cookbook/recipe_overwrite_admin_configuration.rst
+++ b/docs/cookbook/recipe_overwrite_admin_configuration.rst
@@ -14,11 +14,12 @@ with the following templates:
         admin_services:
             id.of.admin.service:
                 # service configuration
-                model_manager:              sonata.admin.manager.doctrine_orm
-                form_contractor:            sonata.admin.builder.doctrine_orm
-                show_builder:               sonata.admin.builder.doctrine_orm
-                list_builder:               sonata.admin.builder.doctrine_orm
-                datagrid_builder:           sonata.admin.builder.doctrine_orm
+                model_manager:              sonata.admin.manager.orm
+                data_source:                sonata.admin.data_source.orm
+                form_contractor:            sonata.admin.builder.orm_form
+                show_builder:               sonata.admin.builder.orm_show
+                list_builder:               sonata.admin.builder.orm_list
+                datagrid_builder:           sonata.admin.builder.orm_datagrid
                 translator:                 translator
                 configuration_pool:         sonata.admin.pool
                 route_generator:            sonata.admin.route.default_generator

--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -11,6 +11,7 @@ the services which are injected by default are:
 Dependencies                  Service ID
 =========================     ===================================================================
 model_manager                 sonata.admin.manager.%manager-type%
+data_source                   sonata.admin.data_source.%manager-type%
 form_contractor               sonata.admin.builder.%manager-type%_form
 show_builder                  sonata.admin.builder.%manager-type%_show
 list_builder                  sonata.admin.builder.%manager-type%_list

--- a/docs/reference/architecture.rst
+++ b/docs/reference/architecture.rst
@@ -38,7 +38,8 @@ injected by the bundle:
 Class                           Description
 =========================       =========================================================================
 ConfigurationPool               configuration pool where all Admin class instances are stored
-ModelManager                    service which handles specific code relating to your persistence layer (e.g. Doctrine ORM)
+ModelManager                    handles specific code relating to your persistence layer (e.g. Doctrine ORM)
+DataSource                      handles code related to the sonata exporter
 FormContractor                  builds the forms for the edit/create views using the Symfony ``FormBuilder``
 ShowBuilder                     builds the show fields
 ListBuilder                     builds the list fields

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -120,6 +120,7 @@ Full Configuration Options
                     class: col-md-4
             admin_services:
                 model_manager: null
+                data_source: null
                 form_contractor: null
                 show_builder: null
                 list_builder: null

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -225,6 +225,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
     {
         $keys = [
             'model_manager',
+            'data_source',
             'form_contractor',
             'show_builder',
             'list_builder',

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -346,6 +346,7 @@ CASESENSITIVE;
                     ->prototype('array')
                         ->children()
                             ->scalarNode('model_manager')->defaultNull()->end()
+                            ->scalarNode('data_source')->defaultNull()->end()
                             ->scalarNode('form_contractor')->defaultNull()->end()
                             ->scalarNode('show_builder')->defaultNull()->end()
                             ->scalarNode('list_builder')->defaultNull()->end()

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -81,6 +81,7 @@ class ConfigurationTest extends TestCase
 
         $this->assertSame([
             'model_manager' => null,
+            'data_source' => null,
             'form_contractor' => null,
             'show_builder' => null,
             'list_builder' => null,


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Option to globally override the data source of all the admin
```