### PR TITLE
Deprecate Pool::getPropertyAccessor() method

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,32 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.xx to 3.xx
+=========================
+
+### Sonata\AdminBundle\Admin\Pool
+
+- Passing a `Symfony\Component\PropertyAccess\PropertyAccessorInterface` instance as 4 argument instantiating
+`Sonata\AdminBundle\Admin\Pool` is deprecated.
+- `Sonata\AdminBundle\Admin\Pool::getPropertyAccessor()` method has been deprecated. You SHOULD inject `Symfony\Component\PropertyAccess\PropertyAccessorInterface`
+where is needed.
+
+### Sonata\AdminBundle\Action\SetObjectFieldValueAction
+
+Not passing a `Symfony\Component\PropertyAccess\PropertyAccessorInterface` instance as argument 5 instantiating
+`Sonata\AdminBundle\Action\SetObjectFieldValueAction` is deprecated.
+
+### Sonata\AdminBundle\Admin\AdminHelper
+
+Not passing a `Symfony\Component\PropertyAccess\PropertyAccessorInterface` instance as argument 1 instantiating
+`Sonata\AdminBundle\Admin\AdminHelper` is deprecated.
+
+### Sonata\AdminBundle\Twig\Extension\SonataAdminExtension
+
+Argument 5 of `Sonata\AdminBundle\Admin\SonataAdminExtension` constructor SHOULD be a
+`Symfony\Component\PropertyAccess\PropertyAccessorInterface` instance and argument 6 SHOULD be a
+`Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface` instance or "null".
+
 UPGRADE FROM 3.80 to 3.81
 =========================
 

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -50,6 +50,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface as RoutingUrlGeneratorInterface;
 use Symfony\Component\Security\Acl\Model\DomainObjectInterface;
@@ -3722,7 +3723,7 @@ EOT;
             $parentObject = $parentAdmin->getObject($this->request->get($parentAdmin->getIdParameter()));
 
             if (null !== $parentObject) {
-                $propertyAccessor = $this->getConfigurationPool()->getPropertyAccessor();
+                $propertyAccessor = PropertyAccess::createPropertyAccessor();
                 $propertyPath = new PropertyPath($this->getParentAssociationMapping());
 
                 $value = $propertyAccessor->getValue($object, $propertyPath);

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -75,7 +75,11 @@ class Pool
     protected $options = [];
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
      * @var PropertyAccessorInterface
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, will be dropped in 4.0.
      */
     protected $propertyAccessor;
 
@@ -87,6 +91,8 @@ class Pool
     private $templateRegistry;
 
     /**
+     * NEXT_MAJOR: Remove $propertyAccessor argument.
+     *
      * @param string $title
      * @param string $logoTitle
      * @param array  $options
@@ -102,6 +108,17 @@ class Pool
         $this->title = $title;
         $this->titleLogo = $logoTitle;
         $this->options = $options;
+
+        // NEXT_MAJOR: Remove this block.
+        if (null !== $propertyAccessor) {
+            @trigger_error(sprintf(
+                'Passing an "%s" instance as argument 4 to "%s()" is deprecated since sonata-project/admin-bundle 3.x.',
+                PropertyAccessorInterface::class,
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
+        // NEXT_MAJOR: Remove next line.
         $this->propertyAccessor = $propertyAccessor;
     }
 
@@ -545,8 +562,16 @@ class Pool
         return $default;
     }
 
+    /**
+     * @deprecated since sonata-project/admin-bundle 3.x, will be dropped in 4.0. Use Symfony "PropertyAccess" instead.
+     */
     public function getPropertyAccessor()
     {
+        @trigger_error(sprintf(
+            'The "%s" method is deprecated since version 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         if (null === $this->propertyAccessor) {
             $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
         }

--- a/src/Resources/config/actions.php
+++ b/src/Resources/config/actions.php
@@ -89,6 +89,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ReferenceConfigurator('sonata.admin.pool'),
                 new ReferenceConfigurator('validator'),
                 new ReferenceConfigurator('sonata.admin.form.data_transformer_resolver'),
+                new ReferenceConfigurator('property_accessor'),
             ])
 
         ->set('sonata.admin.action.retrieve_autocomplete_items', RetrieveAutocompleteItemsAction::class)

--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -54,7 +54,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 '',
                 '',
                 [],
-                new ReferenceConfigurator('property_accessor'),
             ])
             ->call('setTemplateRegistry', [
                 new ReferenceConfigurator('sonata.admin.global_template_registry'),
@@ -76,6 +75,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set('sonata.admin.helper', AdminHelper::class)
             ->public()
             ->args([
+                new ReferenceConfigurator('property_accessor'),
+                // NEXT_MAJOR: Remove next line.
                 new ReferenceConfigurator('sonata.admin.pool'),
             ])
 

--- a/src/Resources/config/twig.php
+++ b/src/Resources/config/twig.php
@@ -51,6 +51,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 (new ReferenceConfigurator('logger'))->nullOnInvalid(),
                 new ReferenceConfigurator('translator'),
                 new ReferenceConfigurator('service_container'),
+                new ReferenceConfigurator('property_accessor'),
                 new ReferenceConfigurator('security.authorization_checker'),
             ])
             ->call('setXEditableTypeMapping', [

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -23,6 +23,7 @@ use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Security\Acl\Voter\FieldVote;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
@@ -81,11 +82,20 @@ class SonataAdminExtension extends AbstractExtension
      */
     private $securityChecker;
 
+    /**
+     * @var PropertyAccessorInterface
+     */
+    private $propertyAccessor;
+
+    /**
+     * NEXT_MAJOR: Make $propertyAccessor mandatory.
+     */
     public function __construct(
         Pool $pool,
         ?LoggerInterface $logger = null,
         $translator = null,
         ?ContainerInterface $templateRegistries = null,
+        $propertyAccessorOrSecurityChecker = null,
         ?AuthorizationCheckerInterface $securityChecker = null
     ) {
         // NEXT_MAJOR: make the translator parameter required, move TranslatorInterface check to method signature
@@ -114,11 +124,52 @@ class SonataAdminExtension extends AbstractExtension
             }
         }
 
+        // NEXT_MAJOR: Remove this block.
+        if (!$propertyAccessorOrSecurityChecker instanceof PropertyAccessorInterface
+            && !$propertyAccessorOrSecurityChecker instanceof AuthorizationCheckerInterface
+            && null !== $propertyAccessorOrSecurityChecker
+        ) {
+            throw new \TypeError(sprintf(
+                'Argument 5 must be an instance of "%s" or "%s" or null, %s given.',
+                PropertyAccessorInterface::class,
+                AuthorizationCheckerInterface::class,
+                \is_object($propertyAccessorOrSecurityChecker) ? 'instance of "'.\get_class($propertyAccessorOrSecurityChecker).'"' : '"'.\gettype($propertyAccessorOrSecurityChecker).'"'
+            ));
+        }
+
+        // NEXT_MAJOR: Remove this block and extract the else part outside.
+        if ($propertyAccessorOrSecurityChecker instanceof AuthorizationCheckerInterface) {
+            @trigger_error(sprintf(
+                'Passing an instance of "%s" as argument 5 for "%s()" is deprecated since sonata-project/admin-bundle'
+                .' 3.x and will throw a \TypeError error in version 4.0. You MUST pass an instance of "%s" instead and pass'
+                .' an instance of "%s" as argument 6.',
+                AuthorizationCheckerInterface::class,
+                __METHOD__,
+                PropertyAccessorInterface::class,
+                AuthorizationCheckerInterface::class
+            ), E_USER_DEPRECATED);
+
+            $this->securityChecker = $propertyAccessorOrSecurityChecker;
+            $this->propertyAccessor = $pool->getPropertyAccessor();
+        } elseif (null === $propertyAccessorOrSecurityChecker) {
+            @trigger_error(sprintf(
+                'Omitting the argument 5 for "%s()" or passing "null" is deprecated since sonata-project/admin-bundle'
+                .' 3.x and will throw a \TypeError error in version 4.0. You must pass an instance of "%s" instead.',
+                __METHOD__,
+                PropertyAccessorInterface::class
+            ), E_USER_DEPRECATED);
+
+            $this->propertyAccessor = $pool->getPropertyAccessor();
+            $this->securityChecker = $securityChecker;
+        } else {
+            $this->securityChecker = $securityChecker;
+            $this->propertyAccessor = $propertyAccessorOrSecurityChecker;
+        }
+
         $this->pool = $pool;
         $this->logger = $logger;
         $this->translator = $translator;
         $this->templateRegistries = $templateRegistries;
-        $this->securityChecker = $securityChecker;
     }
 
     /**
@@ -444,7 +495,7 @@ class SonataAdminExtension extends AbstractExtension
             return $propertyPath($element);
         }
 
-        return $this->pool->getPropertyAccessor()->getValue($element, $propertyPath);
+        return $this->propertyAccessor->getValue($element, $propertyPath);
     }
 
     /**

--- a/tests/Action/SetObjectFieldValueActionTest.php
+++ b/tests/Action/SetObjectFieldValueActionTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
@@ -71,6 +72,11 @@ final class SetObjectFieldValueActionTest extends TestCase
      */
     private $resolver;
 
+    /**
+     * @var PropertyAccessor
+     */
+    private $propertyAccessor;
+
     protected function setUp(): void
     {
         $this->twig = new Environment(new ArrayLoader([
@@ -84,11 +90,13 @@ final class SetObjectFieldValueActionTest extends TestCase
         $this->validator = $this->createStub(ValidatorInterface::class);
         $this->modelManager = $this->createStub(ModelManagerInterface::class);
         $this->resolver = new DataTransformerResolver();
+        $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
         $this->action = new SetObjectFieldValueAction(
             $this->twig,
             $this->pool,
             $this->validator,
-            $this->resolver
+            $this->resolver,
+            $this->propertyAccessor
         );
         $this->admin->method('getModelManager')->willReturn($this->modelManager);
     }
@@ -107,7 +115,6 @@ final class SetObjectFieldValueActionTest extends TestCase
         $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
         $pool = $this->createStub(Pool::class);
         $translator = $this->createStub(TranslatorInterface::class);
-        $propertyAccessor = new PropertyAccessor();
         $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
         $container = new Container();
 
@@ -120,12 +127,13 @@ final class SetObjectFieldValueActionTest extends TestCase
         $this->admin->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $container->set('sonata.post.admin.template_registry', $templateRegistry);
-        $this->pool->method('getPropertyAccessor')->willReturn($propertyAccessor);
         $this->twig->addExtension(new SonataAdminExtension(
             $pool,
             null,
             $translator,
-            $container
+            $container,
+            $this->propertyAccessor,
+            null
         ));
         $fieldDescription->method('getOption')->willReturnMap([
             ['editable', null, true],
@@ -174,7 +182,6 @@ final class SetObjectFieldValueActionTest extends TestCase
         $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
         $pool = $this->createStub(Pool::class);
         $translator = $this->createStub(TranslatorInterface::class);
-        $propertyAccessor = new PropertyAccessor();
         $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
         $container = new Container();
 
@@ -187,12 +194,13 @@ final class SetObjectFieldValueActionTest extends TestCase
         $this->admin->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $container->set('sonata.post.admin.template_registry', $templateRegistry);
-        $this->pool->method('getPropertyAccessor')->willReturn($propertyAccessor);
         $this->twig->addExtension(new SonataAdminExtension(
             $pool,
             null,
             $translator,
-            $container
+            $container,
+            $this->propertyAccessor,
+            null
         ));
         $fieldDescription->method('getOption')->willReturnMap([
             ['timezone', null, $timezone],
@@ -235,7 +243,6 @@ final class SetObjectFieldValueActionTest extends TestCase
             ->addMethods(['getTargetModel'])
             ->getMockForAbstractClass();
         $translator = $this->createStub(TranslatorInterface::class);
-        $propertyAccessor = new PropertyAccessor();
         $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
         $container = new Container();
 
@@ -253,9 +260,10 @@ final class SetObjectFieldValueActionTest extends TestCase
             $this->pool,
             null,
             $translator,
-            $container
+            $container,
+            $this->propertyAccessor,
+            null
         ));
-        $this->pool->method('getPropertyAccessor')->willReturn($propertyAccessor);
         $fieldDescription->method('getType')->willReturn('choice');
         $fieldDescription->method('getOption')->willReturnMap([
             ['class', null, Bar::class],
@@ -290,9 +298,7 @@ final class SetObjectFieldValueActionTest extends TestCase
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
-        $propertyAccessor = new PropertyAccessor();
 
-        $this->pool->method('getPropertyAccessor')->willReturn($propertyAccessor);
         $this->admin->method('getObject')->with(42)->willReturn($object);
         $this->admin->method('hasAccess')->with('edit', $object)->willReturn(true);
         $this->admin->method('getListFieldDescription')->with('bar.enabled')->willReturn($fieldDescription);
@@ -326,7 +332,6 @@ final class SetObjectFieldValueActionTest extends TestCase
         $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
         $pool = $this->createStub(Pool::class);
         $translator = $this->createStub(TranslatorInterface::class);
-        $propertyAccessor = new PropertyAccessor();
         $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
         $container = new Container();
 
@@ -339,12 +344,13 @@ final class SetObjectFieldValueActionTest extends TestCase
         $this->admin->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $container->set('sonata.post.admin.template_registry', $templateRegistry);
-        $this->pool->method('getPropertyAccessor')->willReturn($propertyAccessor);
         $this->twig->addExtension(new SonataAdminExtension(
             $pool,
             null,
             $translator,
-            $container
+            $container,
+            $this->propertyAccessor,
+            null
         ));
         $fieldDescription->method('getOption')->willReturnMap([
             ['data_transformer', null, null],
@@ -384,7 +390,6 @@ final class SetObjectFieldValueActionTest extends TestCase
         $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
         $pool = $this->createStub(Pool::class);
         $translator = $this->createStub(TranslatorInterface::class);
-        $propertyAccessor = new PropertyAccessor();
         $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
         $container = new Container();
 
@@ -397,12 +402,13 @@ final class SetObjectFieldValueActionTest extends TestCase
         $this->admin->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $container->set('sonata.post.admin.template_registry', $templateRegistry);
-        $this->pool->method('getPropertyAccessor')->willReturn($propertyAccessor);
         $this->twig->addExtension(new SonataAdminExtension(
             $pool,
             null,
             $translator,
-            $container
+            $container,
+            $this->propertyAccessor,
+            null
         ));
         $fieldDescription->method('getOption')->willReturnMap([
             ['data_transformer', null, $dataTransformer],
@@ -444,7 +450,6 @@ final class SetObjectFieldValueActionTest extends TestCase
         $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
         $pool = $this->createStub(Pool::class);
         $translator = $this->createStub(TranslatorInterface::class);
-        $propertyAccessor = new PropertyAccessor();
         $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
         $container = new Container();
 
@@ -457,12 +462,13 @@ final class SetObjectFieldValueActionTest extends TestCase
         $this->admin->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $container->set('sonata.post.admin.template_registry', $templateRegistry);
-        $this->pool->method('getPropertyAccessor')->willReturn($propertyAccessor);
         $this->twig->addExtension(new SonataAdminExtension(
             $pool,
             null,
             $translator,
-            $container
+            $container,
+            $this->propertyAccessor,
+            null
         ));
         $fieldDescription->method('getOption')->willReturnMap([
             ['data_transformer', null, $dataTransformer],


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Ref: https://github.com/sonata-project/SonataAdminBundle/issues/6624

PropertyAccesor was added to Pool in order to reuse it for performance reasons in https://github.com/sonata-project/SonataAdminBundle/pull/3488.

In https://github.com/symfony/symfony/pull/16838 cache was added to the component, so there is no need to reuse it thought the Pool service and it can be injected into the services.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `Pool::getPropertyAccessor()` method.
- Deprecated not passing and instance of `PropertyAccessor` as argument 1 to `Sonata\AdminBundle\Admin\AdminHelper` constructor.
- Deprecated not passing and instance of `PropertyAccessor` as argument 5 to `Sonata\AdminBundle\Action\SetObjectFieldValueAction` constructor.
- Deprecated not passing and instance of `PropertyAccessor` as argument 5 to `Sonata\AdminBundle\Twig\Extension\SonataAdminExtension` constructor.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
