### PR TITLE
Rename ProxyQueryInterface param and improve phpdoc

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -58,12 +58,12 @@ Empty values are passed to datagrid filters. If you have custom datagrid filters
 
 ```php
 ->add('with_open_comments', CallbackFilter::class, [
-    'callback' => static function (ProxyQueryInterface $queryBuilder, string $alias, string $field, array $value): bool {
+    'callback' => static function (ProxyQueryInterface $query, string $alias, string $field, array $value): bool {
         if (!$value['value']) {
             return false;
         }
 
-        $queryBuilder
+        $query
             ->leftJoin(sprintf('%s.comments', $alias), 'c')
             ->andWhere('c.moderation = :moderation')
             ->setParameter('moderation', CommentModeration::APPROVED);

--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -357,10 +357,10 @@ Configuring the default ordering column can be achieved by overriding the
             protected function configureQuery(ProxyQueryInterface $query): ProxyQueryInterface
             {
                 $rootAlias = current($query->getRootAliases());
-            
+
                 $query->addOrderBy($rootAlias.'.author', 'ASC');
                 $query->addOrderBy($rootAlias.'.createdAt', 'ASC');
-                
+
                 return $query;
             }
 
@@ -541,17 +541,17 @@ If you have the **SonataDoctrineORMAdminBundle** installed you can use the
                 ]);
         }
 
-        public function getFullTextFilter($queryBuilder, $alias, $field, $value)
+        public function getFullTextFilter($query, $alias, $field, $value)
         {
             if (!$value['value']) {
                 return false;
             }
 
             // Use `andWhere` instead of `where` to prevent overriding existing `where` conditions
-            $queryBuilder->andWhere($queryBuilder->expr()->orX(
-                $queryBuilder->expr()->like($alias.'.username', $queryBuilder->expr()->literal('%' . $value['value'] . '%')),
-                $queryBuilder->expr()->like($alias.'.firstName', $queryBuilder->expr()->literal('%' . $value['value'] . '%')),
-                $queryBuilder->expr()->like($alias.'.lastName', $queryBuilder->expr()->literal('%' . $value['value'] . '%'))
+            $query->andWhere($query->expr()->orX(
+                $query->expr()->like($alias.'.username', $query->expr()->literal('%' . $value['value'] . '%')),
+                $query->expr()->like($alias.'.firstName', $query->expr()->literal('%' . $value['value'] . '%')),
+                $query->expr()->like($alias.'.lastName', $query->expr()->literal('%' . $value['value'] . '%'))
             ));
 
             return true;
@@ -567,7 +567,7 @@ type of your condition(s)::
 
     final class UserAdmin extends Sonata\UserBundle\Admin\Model\UserAdmin
     {
-        public function getFullTextFilter($queryBuilder, $alias, $field, $value)
+        public function getFullTextFilter($query, $alias, $field, $value)
         {
             if (!$value['value']) {
                 return;
@@ -575,7 +575,7 @@ type of your condition(s)::
 
             $operator = $value['type'] == EqualType::TYPE_IS_EQUAL ? '=' : '!=';
 
-            $queryBuilder
+            $query
                 ->andWhere($alias.'.username '.$operator.' :username')
                 ->setParameter('username', $value['value'])
             ;

--- a/docs/reference/form_types.rst
+++ b/docs/reference/form_types.rst
@@ -61,7 +61,7 @@ The available options are:
   string to designate which field to use for the choice values.
 
 ``query``
-  defaults to ``null``. You can set this to a QueryBuilder instance in order to
+  defaults to ``null``. You can set this to a ProxyQueryInterface instance in order to
   define a custom query for retrieving the available options.
 
 ``template``
@@ -272,9 +272,9 @@ The available options are:
               'property' => 'title',
               'callback' => static function (AdminInterface $admin, string $property, $value): void {
                   $datagrid = $admin->getDatagrid();
-                  $queryBuilder = $datagrid->getQuery();
-                  $queryBuilder
-                      ->andWhere($queryBuilder->getRootAlias() . '.foo=:barValue')
+                  $query = $datagrid->getQuery();
+                  $query
+                      ->andWhere($query->getRootAlias() . '.foo=:barValue')
                       ->setParameter('barValue', $admin->getRequest()->get('bar'))
                   ;
                   $datagrid->setValue($property, null, $value);

--- a/src/Datagrid/SimplePager.php
+++ b/src/Datagrid/SimplePager.php
@@ -99,12 +99,12 @@ class SimplePager extends Pager
     /**
      * {@inheritdoc}
      *
-     * @throws \RuntimeException the QueryBuilder is uninitialized
+     * @throws \RuntimeException the query is uninitialized
      */
     public function init()
     {
         if (!$this->getQuery()) {
-            throw new \RuntimeException('Uninitialized QueryBuilder');
+            throw new \RuntimeException('Uninitialized query');
         }
         $this->resetIterator();
 

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -33,19 +33,19 @@ interface FilterInterface
      *
      * @param string  $alias
      * @param string  $field
-     * @param mixed[] $value
+     * @param mixed[] $data
      *
-     * @phpstan array{type?: string, value?: mixed} $value
+     * @phpstan array{type?: string, value?: mixed} $data
      */
-    public function filter(ProxyQueryInterface $query, $alias, $field, $value);
+    public function filter(ProxyQueryInterface $query, $alias, $field, $data);
 
     /**
      * @param ProxyQueryInterface $query
-     * @param mixed[]             $value
+     * @param mixed[]             $filterData
      *
-     * @phpstan array{type?: string, value?: mixed} $value
+     * @phpstan array{type?: string, value?: mixed} $filterData
      */
-    public function apply($query, $value);
+    public function apply($query, $filterData);
 
     /**
      * Returns the filter name.

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -29,17 +29,21 @@ interface FilterInterface
      *
      * @deprecated since sonata-project/admin-bundle 3.78, to be removed with 4.0
      *
-     * Apply the filter to the QueryBuilder instance.
+     * Apply the filter to the ProxyQueryInterface instance.
      *
      * @param string  $alias
      * @param string  $field
      * @param mixed[] $value
+     *
+     * @phpstan array{type?: string, value?: mixed} $value
      */
-    public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $value);
+    public function filter(ProxyQueryInterface $query, $alias, $field, $value);
 
     /**
-     * @param mixed $query
-     * @param mixed $value
+     * @param ProxyQueryInterface $query
+     * @param mixed[]             $value
+     *
+     * @phpstan array{type?: string, value?: mixed} $value
      */
     public function apply($query, $value);
 

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -102,7 +102,7 @@ interface ModelManagerInterface extends DatagridManagerInterface
      *
      * @phpstan-param class-string $class
      */
-    public function batchDelete($class, ProxyQueryInterface $queryProxy);
+    public function batchDelete($class, ProxyQueryInterface $query);
 
     /**
      * NEXT_MAJOR: Remove this method.

--- a/tests/Fixtures/Filter/FooFilter.php
+++ b/tests/Fixtures/Filter/FooFilter.php
@@ -21,7 +21,7 @@ class FooFilter extends Filter
     /**
      * NEXT_MAJOR: Remove this method.
      */
-    public function filter(ProxyQueryInterface $queryBuilder, $alias, $field, $value): void
+    public function filter(ProxyQueryInterface $query, $alias, $field, $value): void
     {
     }
 


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.
I think it's pedantic.

We should always call the `ProxyQueryInterface` param the same way ; and most of the time it's called `$query`.
Even if the method `filter` is deprecated, the param shouldn't be called `$queryBuilder` then.

I also improve the `phpdoc` for
```
public function apply($query, $value);
```
and I'm wondering if we shouldn't use a better name than `$value`, since it's an array with this shape
```
array{type?: string, value?: mixed}
```

`$filter` ? `$data` ? Keeping this way ?
