### PR TITLE
Introduce SonataConfiguration class

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,31 @@ UPGRADE 3.x
 UPGRADE FROM 3.xx to 3.xx
 =========================
 
+### Deprecated `admin_pool` parameter in `sonata.admin.dashboard.top` and `sonata.admin.dashboard.bottom` block events.
+
+This parameter will be removed in 4.0. If you are using it, you SHOULD inject `Pool` service instead.
+
+### Deprecated global Twig `sonata_admin` variable
+
+This variable has been deprecated in favor of `sonata_config` variable.
+
+### Sonata\AdminBundle\Twig\GlobalVariables
+
+This class has been deprecated without replacement.
+
+### Sonata\AdminBundle\Model\ModelManagerInterface
+
+Argument 2 of `Sonata\AdminBundle\Model\ModelManagerInterface::createQuery()` method has been removed.
+
+### Sonata\AdminBundle\Admin\Pool
+
+- `Sonata\AdminBundle\Admin\Pool::getTitle()` method has been deprecated.
+  Use `Sonata\AdminBundle\SonataConfiguration::getTitle()` instead.
+- `Sonata\AdminBundle\Admin\Pool::getTitleLogo()` method has been deprecated.
+  Use `Sonata\AdminBundle\SonataConfiguration::getLogo()` instead.
+- `Sonata\AdminBundle\Admin\Pool::getOption()` method has been deprecated.
+  Use `Sonata\AdminBundle\SonataConfiguration::getOption()` instead.
+
 ### Sonata\AdminBundle\Admin\FieldDescriptionInterface
 
 The following methods have been deprecated from the interface and will be added as abstract methods to

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Admin;
 
+use Sonata\AdminBundle\SonataConfiguration;
 use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
@@ -60,16 +61,28 @@ class Pool
     protected $assets = [];
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, will be dropped in 4.0.
+     *
      * @var string
      */
     protected $title;
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, will be dropped in 4.0.
+     *
      * @var string
      */
     protected $titleLogo;
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, will be dropped in 4.0.
+     *
      * @var array
      */
     protected $options = [];
@@ -92,6 +105,7 @@ class Pool
 
     /**
      * NEXT_MAJOR: Remove $propertyAccessor argument.
+     * NEXT_MAJOR: Remove $title, $logoTitle and $options.
      *
      * @param string $title
      * @param string $logoTitle
@@ -532,22 +546,48 @@ class Pool
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, will be dropped in 4.0.
+     *
      * @return string
      */
     public function getTitleLogo()
     {
+        @trigger_error(sprintf(
+            'The "%s" method is deprecated since version 3.x and will be removed in 4.0.'
+            .' Use "%s::getTitle()" instead.',
+            SonataConfiguration::class,
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $this->titleLogo;
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, will be dropped in 4.0.
+     *
      * @return string
      */
     public function getTitle()
     {
+        @trigger_error(sprintf(
+            'The "%s" method is deprecated since version 3.x and will be removed in 4.0.'
+            .' Use "%s::getLogo()" instead.',
+            SonataConfiguration::class,
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $this->title;
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, will be dropped in 4.0.
+     *
      * @param string $name
      * @param mixed  $default
      *
@@ -555,6 +595,13 @@ class Pool
      */
     public function getOption($name, $default = null)
     {
+        @trigger_error(sprintf(
+            'The "%s" method is deprecated since version 3.x and will be removed in 4.0.'
+            .' Use "%s::getOption()" instead.',
+            SonataConfiguration::class,
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         if (isset($this->options[$name])) {
             return $this->options[$name];
         }

--- a/src/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
@@ -27,6 +27,8 @@ class GlobalVariablesCompilerPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         $container->getDefinition('twig')
+            ->addMethodCall('addGlobal', ['sonata_config', new Reference('sonata.admin.configuration')])
+            // NEXT_MAJOR: Remove next line.
             ->addMethodCall('addGlobal', ['sonata_admin', new Reference('sonata.admin.twig.global')]);
     }
 }

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -92,10 +92,16 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         $config['options']['role_super_admin'] = $config['security']['role_super_admin'];
         $config['options']['search'] = $config['search'];
 
+        // NEXT_MAJOR: Remove this Pool configuration.
         $pool = $container->getDefinition('sonata.admin.pool');
         $pool->replaceArgument(1, $config['title']);
         $pool->replaceArgument(2, $config['title_logo']);
         $pool->replaceArgument(3, $config['options']);
+
+        $sonataConfiguration = $container->getDefinition('sonata.admin.configuration');
+        $sonataConfiguration->replaceArgument(0, $config['title']);
+        $sonataConfiguration->replaceArgument(1, $config['title_logo']);
+        $sonataConfiguration->replaceArgument(2, $config['options']);
 
         if (false === $config['options']['lock_protection']) {
             $container->removeDefinition('sonata.admin.lock.extension');

--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -27,6 +27,7 @@ use Sonata\AdminBundle\Model\AuditManager;
 use Sonata\AdminBundle\Model\AuditManagerInterface;
 use Sonata\AdminBundle\Route\AdminPoolLoader;
 use Sonata\AdminBundle\Search\SearchHandler;
+use Sonata\AdminBundle\SonataConfiguration;
 use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
 use Sonata\AdminBundle\Templating\TemplateRegistry;
 use Sonata\AdminBundle\Translator\BCLabelTranslatorStrategy;
@@ -60,6 +61,15 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ])
 
         ->alias(Pool::class, 'sonata.admin.pool')
+
+        ->set('sonata.admin.configuration', SonataConfiguration::class)
+            ->args([
+                '',
+                '',
+                [],
+            ])
+
+        ->alias(SonataConfiguration::class, 'sonata.admin.configuration')
 
         ->set('sonata.admin.route_loader', AdminPoolLoader::class)
             ->public()
@@ -213,6 +223,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->public()
             ->tag('sonata.admin.extension', ['global' => true])
 
+        // NEXT_MAJOR: Remove this service definition and alias.
         ->set('sonata.admin.twig.global', GlobalVariables::class)
             ->public()
             ->args([

--- a/src/Resources/config/twig.php
+++ b/src/Resources/config/twig.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+use Sonata\AdminBundle\Twig\Extension\GroupExtension;
 use Sonata\AdminBundle\Twig\Extension\PaginationExtension;
 use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
 use Sonata\AdminBundle\Twig\Extension\TemplateRegistryExtension;
@@ -64,6 +65,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ReferenceConfigurator('sonata.admin.global_template_registry'),
                 new ReferenceConfigurator('service_container'),
             ])
+
+        ->set('sonata.admin.group.extension', GroupExtension::class)
+        ->tag('twig.extension')
+        ->args([
+            new ReferenceConfigurator('sonata.admin.pool'),
+        ])
 
         // NEXT_MAJOR: Remove this service.
         ->set('sonata.pagination.twig.extension', PaginationExtension::class)

--- a/src/Resources/views/Block/block_admin_list.html.twig
+++ b/src/Resources/views/Block/block_admin_list.html.twig
@@ -13,7 +13,7 @@ file that was distributed with this source code.
 
 {% block block %}
     {% for group in groups %}
-        {% set display = group.roles is empty or is_granted(sonata_admin.adminPool.getOption('role_super_admin')) or group.roles|filter(role => is_granted(role))|length > 0 %}
+        {% set display = group.roles is empty or is_granted(sonata_config.getOption('role_super_admin')) or group.roles|filter(role => is_granted(role))|length > 0 %}
 
         {% if display %}
             <div class="box">

--- a/src/Resources/views/CRUD/base_acl.html.twig
+++ b/src/Resources/views/CRUD/base_acl.html.twig
@@ -19,9 +19,9 @@ file that was distributed with this source code.
 
 {% block form %}
     {% block form_acl_roles %}
-        {{ acl.render_form(aclRolesForm, permissions, 'td_role', admin, sonata_admin.adminPool, object) }}
+        {{ acl.render_form(aclRolesForm, permissions, 'td_role', admin, sonata_config, object) }}
     {% endblock %}
     {% block form_acl_users %}
-        {{ acl.render_form(aclUsersForm, permissions, 'td_username', admin, sonata_admin.adminPool, object) }}
+        {{ acl.render_form(aclUsersForm, permissions, 'td_username', admin, sonata_config, object) }}
     {% endblock %}
 {% endblock %}

--- a/src/Resources/views/CRUD/base_acl_macro.html.twig
+++ b/src/Resources/views/CRUD/base_acl_macro.html.twig
@@ -9,12 +9,12 @@ file that was distributed with this source code.
 
 #}
 
-{% macro render_form(form, permissions, td_type, admin, admin_pool, object) %}
+{% macro render_form(form, permissions, td_type, admin, admin_configuration, object) %}
     <form class="form-horizontal"
           action="{{ admin.generateUrl('acl', {'id': admin.id(object), 'uniqid': admin.uniqid, 'subclass': app.request.get('subclass')}) }}"
           {% if form.vars.multipart %} enctype="multipart/form-data"{% endif %}
           method="POST"
-            {% if not admin_pool.getOption('html5_validate') %}novalidate="novalidate"{% endif %}
+            {% if not admin_configuration.getOption('html5_validate') %}novalidate="novalidate"{% endif %}
             >
 
         {{ include('@SonataAdmin/Helper/render_form_dismissable_errors.html.twig') }}

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -10,13 +10,13 @@
         </div>
     {% else %}
         <form
-              {% if sonata_admin.adminPool.getOption('form_type') == 'horizontal' %}class="form-horizontal"{% endif %}
+              {% if sonata_config.getOption('form_type') == 'horizontal' %}class="form-horizontal"{% endif %}
               role="form"
               {# NEXT_MAJOR: remove default filter #}
               action="{% block sonata_form_action_url %}{{ admin.generateUrl(url, {'id': objectId|default(admin.id(object)), 'uniqid': admin.uniqid, 'subclass': app.request.get('subclass')}) }}{% endblock %}"
               {% if form.vars.multipart %} enctype="multipart/form-data"{% endif %}
               method="POST"
-              {% if not sonata_admin.adminPool.getOption('html5_validate') %}novalidate="novalidate"{% endif %}
+              {% if not sonata_config.getOption('html5_validate') %}novalidate="novalidate"{% endif %}
               {% block sonata_form_attributes %}{% endblock %}
               >
 

--- a/src/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
+++ b/src/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
@@ -30,7 +30,7 @@ This template can be customized to match your needs. You should only extends the
 
                             <div class="mosaic-inner-box-default">
                                 {% block sonata_mosaic_background %}
-                                    {% set metaImage = meta.isImageAvailable is defined and not meta.isImageAvailable ? sonata_admin.mosaicBackground : meta.image %}
+                                    {% set metaImage = meta.isImageAvailable is defined and not meta.isImageAvailable ? sonata_config.getOption('mosaic_background') : meta.image %}
                                     {% if not (metaImage starts with 'data:') %}
                                         {% set metaImage = asset(metaImage) %}
                                     {% endif %}

--- a/src/Resources/views/Core/add_block.html.twig
+++ b/src/Resources/views/Core/add_block.html.twig
@@ -1,10 +1,7 @@
 {% block user_block %}
-    {% set items_per_column = sonata_admin.adminPool.getOption('dropdown_number_groups_per_colums') %}
-    {% set groups = [] %}
+    {% set items_per_column = sonata_config.getOption('dropdown_number_groups_per_colums') %}
 
-    {% for group in sonata_admin.adminPool.dashboardgroups|filter(group => group.items|filter(admin => admin.hasRoute('create') and admin.hasAccess('create'))|length > 0) %}
-        {% set groups = [group]|merge(groups) %}
-    {% endfor %}
+    {% set groups = get_sonata_dashboard_groups_with_creatable_admins() %}
 
     {% set column_count = (groups|length / items_per_column)|round(0, 'ceil') %}
 
@@ -12,7 +9,7 @@
         {% if column_count > 1 %}style="width: {{ column_count*140 }}px;"{% endif %}
     >
         {% for group in groups|reverse %}
-            {% set display = group.roles is empty or is_granted(sonata_admin.adminPool.getOption('role_admin')) or group.roles|filter(role => is_granted(role))|length > 0 %}
+            {% set display = group.roles is empty or is_granted(sonata_config.getOption('role_admin')) or group.roles|filter(role => is_granted(role))|length > 0 %}
 
             {% if loop.first %}
                 {% set render_first_element = true %}

--- a/src/Resources/views/Core/dashboard.html.twig
+++ b/src/Resources/views/Core/dashboard.html.twig
@@ -50,7 +50,8 @@ file that was distributed with this source code.
         {% endif %}
     {% endfor %}
 
-    {{ sonata_block_render_event('sonata.admin.dashboard.top', { 'admin_pool': sonata_admin.adminPool }) }}
+    {# NEXT_MAJOR: Remove the admin_pool argument #}
+    {{ sonata_block_render_event('sonata.admin.dashboard.top', { 'admin_pool': sonata_admin.adminPool('sonata_deprecation_mute') }) }}
 
     {% if has_top %}
         <div class="row">
@@ -125,6 +126,7 @@ file that was distributed with this source code.
         </div>
     {% endif %}
 
-    {{ sonata_block_render_event('sonata.admin.dashboard.bottom', { 'admin_pool': sonata_admin.adminPool }) }}
+    {# NEXT_MAJOR: Remove the admin_pool argument #}
+    {{ sonata_block_render_event('sonata.admin.dashboard.bottom', { 'admin_pool': sonata_admin.adminPool('sonata_deprecation_mute') }) }}
 
 {% endblock %}

--- a/src/Resources/views/Core/search.html.twig
+++ b/src/Resources/views/Core/search.html.twig
@@ -20,7 +20,7 @@ file that was distributed with this source code.
         {% set count = 0 %}
         <div class="row" data-masonry='{ "itemSelector": ".search-box-item" }'>
         {% for group in groups %}
-            {% set display = group.roles is empty or is_granted(sonata_admin.adminPool.getOption('role_super_admin')) or group.roles|filter(role => is_granted(role))|length > 0 %}
+            {% set display = group.roles is empty or is_granted(sonata_config.getOption('role_super_admin')) or group.roles|filter(role => is_granted(role))|length > 0 %}
 
             {% if display %}
                 {% for admin in group.items %}

--- a/src/Resources/views/Menu/sonata_menu.html.twig
+++ b/src/Resources/views/Menu/sonata_menu.html.twig
@@ -9,7 +9,7 @@
 {% block item %}
     {%- if item.displayed -%}
         {#- check role of the group #}
-        {%- set display = item.extra('roles') is empty or is_granted(sonata_admin.adminPool.getOption('role_super_admin')) or item.extra('roles')|filter(role => is_granted(role))|length > 0 -%}
+        {%- set display = item.extra('roles') is empty or is_granted(sonata_config.getOption('role_super_admin')) or item.extra('roles')|filter(role => is_granted(role))|length > 0 -%}
     {%- endif -%}
 
     {%- if item.displayed and display|default -%}

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -21,9 +21,9 @@ file that was distributed with this source code.
 {% set _actions = block('actions') is defined ? block('actions')|trim : null %}
 {% set _navbar_title = block('navbar_title') is defined ? block('navbar_title')|trim : null %}
 {% set _list_filters_actions = block('list_filters_actions') is defined ? block('list_filters_actions')|trim : null -%}
-{% set _skin = sonata_admin.adminPool.getOption('skin') %}
-{% set _use_select2 = sonata_admin.adminPool.getOption('use_select2') %}
-{% set _use_icheck = sonata_admin.adminPool.getOption('use_icheck') %}
+{% set _skin = sonata_config.getOption('skin') %}
+{% set _use_select2 = sonata_config.getOption('use_select2') %}
+{% set _use_icheck = sonata_config.getOption('use_icheck') %}
 
 <!DOCTYPE html>
 <html {% block html_attributes %}class="no-js"{% endblock %}>
@@ -37,11 +37,11 @@ file that was distributed with this source code.
         <meta data-sonata-admin='{{ {
             config: {
                 SKIN: _skin,
-                CONFIRM_EXIT: sonata_admin.adminPool.getOption('confirm_exit'),
+                CONFIRM_EXIT: sonata_config.getOption('confirm_exit'),
                 USE_SELECT2: _use_select2,
                 USE_ICHECK: _use_icheck,
-                USE_STICKYFORMS: sonata_admin.adminPool.getOption('use_stickyforms'),
-                DEBUG: sonata_admin.adminPool.getOption('js_debug'),
+                USE_STICKYFORMS: sonata_config.getOption('use_stickyforms'),
+                DEBUG: sonata_config.getOption('js_debug'),
             },
             translations: {
                 CONFIRM_EXIT: 'confirm_exit'|trans({}, 'SonataAdminBundle'),
@@ -50,7 +50,7 @@ file that was distributed with this source code.
         >
 
         {% block stylesheets %}
-            {% for stylesheet in sonata_admin.adminPool.getOption('stylesheets', []) %}
+            {% for stylesheet in sonata_config.getOption('stylesheets', []) %}
                 <link rel="stylesheet" href="{{ asset(stylesheet) }}">
             {% endfor %}
         {% endblock %}
@@ -60,7 +60,7 @@ file that was distributed with this source code.
             {% endblock %}
 
             {% block sonata_javascript_pool %}
-                {% for javascript in sonata_admin.adminPool.getOption('javascripts', []) %}
+                {% for javascript in sonata_config.getOption('javascripts', []) %}
                     <script src="{{ asset(javascript) }}"></script>
                 {% endfor %}
             {% endblock %}
@@ -76,7 +76,7 @@ file that was distributed with this source code.
             {% endif %}
 
             {# localize select2 #}
-            {% if sonata_admin.adminPool.getOption('use_select2') %}
+            {% if sonata_config.getOption('use_select2') %}
                 {% set localeForSelect2 = canonicalize_locale_for_select2() %}
                 {% if localeForSelect2 %}
                     <script src="{{ asset('bundles/sonatacore/vendor/select2/select2_locale_' ~ localeForSelect2 ~ '.js') }}"></script>
@@ -139,11 +139,11 @@ file that was distributed with this source code.
                 {% block logo %}
                     {% apply spaceless %}
                         <a class="logo" href="{{ path('sonata_admin_dashboard') }}">
-                            {% if 'single_image' == sonata_admin.adminPool.getOption('title_mode') or 'both' == sonata_admin.adminPool.getOption('title_mode') %}
-                                <img src="{{ asset(sonata_admin.adminPool.titlelogo) }}" alt="{{ sonata_admin.adminPool.title }}">
+                            {% if 'single_image' == sonata_config.getOption('title_mode') or 'both' == sonata_config.getOption('title_mode') %}
+                                <img src="{{ asset(sonata_config.logo) }}" alt="{{ sonata_config.title }}">
                             {% endif %}
-                            {% if 'single_text' == sonata_admin.adminPool.getOption('title_mode') or 'both' == sonata_admin.adminPool.getOption('title_mode') %}
-                                <span>{{ sonata_admin.adminPool.title }}</span>
+                            {% if 'single_text' == sonata_config.getOption('title_mode') or 'both' == sonata_config.getOption('title_mode') %}
+                                <span>{{ sonata_config.title }}</span>
                             {% endif %}
                         </a>
                     {% endapply %}
@@ -199,7 +199,7 @@ file that was distributed with this source code.
                         </div>
 
                         {% block sonata_top_nav_menu %}
-                            {% if app.user and is_granted(sonata_admin.adminPool.getOption('role_admin')) %}
+                            {% if app.user and is_granted(sonata_config.getOption('role_admin')) %}
                                 <div class="navbar-custom-menu">
                                     <ul class="nav navbar-nav">
                                         {% block sonata_top_nav_menu_add_block %}
@@ -235,7 +235,7 @@ file that was distributed with this source code.
                     <section class="sidebar">
                         {% block sonata_side_nav %}
                             {% block sonata_sidebar_search %}
-                                {% if sonata_admin.adminPool.getOption('search') %}
+                                {% if sonata_config.getOption('search') %}
                                     <form action="{{ path('sonata_admin_search') }}" method="GET" class="sidebar-form" role="search">
                                         <div class="input-group custom-search-form">
                                             <input type="text" name="q" value="{{ app.request.get('q') }}" class="form-control" placeholder="{{ 'search_placeholder'|trans({}, 'SonataAdminBundle') }}">
@@ -369,7 +369,7 @@ file that was distributed with this source code.
         {% endblock sonata_wrapper %}
     </div>
 
-    {% if sonata_admin.adminPool.getOption('use_bootlint') %}
+    {% if sonata_config.getOption('use_bootlint') %}
         {% block bootlint %}
             {# Bootlint - https://github.com/twbs/bootlint#in-the-browser #}
             <script type="text/javascript">

--- a/src/SonataConfiguration.php
+++ b/src/SonataConfiguration.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle;
+
+/**
+ * @psalm-type SonataConfigurationOptions = array{
+ *  confirm_exit: bool,
+ *  default_group: string,
+ *  default_icon: string,
+ *  default_label_catalogue: string,
+ *  dropdown_number_groups_per_colums: int,
+ *  form_type: string,
+ *  html5_validate: bool,
+ *  javascripts: list<string>,
+ *  js_debug: bool,
+ *  legacy_twig_text_extension: bool,
+ *  lock_protection: bool,
+ *  mosaic_background: string,
+ *  pager_links: ?int,
+ *  role_admin: string,
+ *  role_super_admin: string,
+ *  search: bool,
+ *  skin: string,
+ *  sort_admins: bool,
+ *  stylesheets: list<string>,
+ *  title_mode: 'single_text'|'single_image'|'both',
+ *  use_bootlint: bool,
+ *  use_icheck: bool,
+ *  use_select2: bool,
+ *  use_stickyforms: bool
+ * }
+ */
+final class SonataConfiguration
+{
+    /**
+     * @var string
+     */
+    private $title;
+
+    /**
+     * @var string
+     */
+    private $logo;
+
+    /**
+     * @var array
+     * @psalm-var SonataConfigurationOptions $options
+     * @phpstan-var array<string, mixed>
+     */
+    private $options;
+
+    /**
+     * @var array
+     * @psalm-param SonataConfigurationOptions $options
+     * @phpstan-param array<string, mixed> $options
+     */
+    public function __construct(string $title, string $logo, array $options)
+    {
+        $this->title = $title;
+        $this->logo = $logo;
+        $this->options = $options;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getLogo(): string
+    {
+        return $this->logo;
+    }
+
+    /**
+     * @param mixed $default
+     *
+     * @return mixed
+     */
+    public function getOption(string $name, $default = null)
+    {
+        return $this->options[$name] ?? $default;
+    }
+}

--- a/src/Twig/Extension/GroupExtension.php
+++ b/src/Twig/Extension/GroupExtension.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Twig\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class GroupExtension extends AbstractExtension
+{
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @internal
+     */
+    public function __construct(Pool $pool)
+    {
+        $this->pool = $pool;
+    }
+
+    /**
+     * @return TwigFunction[]
+     */
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('get_sonata_dashboard_groups_with_creatable_admins', [$this, 'getDashboardGroupsWithCreatableAdmins']),
+        ];
+    }
+
+    /**
+     * @phpstan-return array{array{
+     *  roles: list<string>,
+     *  icon: string,
+     *  label: string,
+     *  label_catalogue: string,
+     *  items: AdminInterface[]
+     * }}
+     */
+    public function getDashboardGroupsWithCreatableAdmins(): array
+    {
+        $groups = [];
+
+        foreach ($this->pool->getDashboardGroups() as $group) {
+            $filteredGroups = array_filter($group['items'], static function (AdminInterface $admin) {
+                return $admin->hasRoute('create') && $admin->hasAccess('create');
+            });
+
+            if (\count($filteredGroups) > 0) {
+                $groups[] = $group;
+            }
+        }
+
+        return $groups;
+    }
+}

--- a/src/Twig/GlobalVariables.php
+++ b/src/Twig/GlobalVariables.php
@@ -20,6 +20,10 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 /**
  * @final since sonata-project/admin-bundle 3.52
  *
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @deprecated since sonata-project/admin-bundle 3.x, will be removed in 4.0.
+ *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class GlobalVariables
@@ -74,6 +78,13 @@ class GlobalVariables
      */
     public function getAdminPool()
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
+            @trigger_error(sprintf(
+                'Method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         return $this->adminPool;
     }
 
@@ -87,6 +98,11 @@ class GlobalVariables
      */
     public function url($code, $action, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
+        @trigger_error(sprintf(
+            'Method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         [$action, $code] = $this->getCodeAction($code, $action);
 
         return $this->getAdminPool()->getAdminByAdminCode($code)->generateUrl($action, $parameters, $referenceType);
@@ -103,6 +119,11 @@ class GlobalVariables
      */
     public function objectUrl($code, $action, $object, $parameters = [], $referenceType = UrlGeneratorInterface::ABSOLUTE_PATH)
     {
+        @trigger_error(sprintf(
+            'Method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         [$action, $code] = $this->getCodeAction($code, $action);
 
         return $this->getAdminPool()->getAdminByAdminCode($code)->generateObjectUrl($action, $object, $parameters, $referenceType);
@@ -110,6 +131,12 @@ class GlobalVariables
 
     public function getMosaicBackground(): ?string
     {
+        @trigger_error(sprintf(
+            'Method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.'
+            .' Use "sonata_config.getOption(\'mosaic_background\')" instead.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return $this->mosaicBackground;
     }
 

--- a/tests/Admin/PoolTest.php
+++ b/tests/Admin/PoolTest.php
@@ -36,6 +36,7 @@ class PoolTest extends TestCase
     protected function setUp(): void
     {
         $this->container = new Container();
+        // NEXT_MAJOR: Only pass the container to Pool: "new Pool($this->container)".
         $this->pool = new Pool($this->container, 'Sonata Admin', '/path/to/pic.png', ['foo' => 'bar']);
     }
 
@@ -535,16 +536,31 @@ class PoolTest extends TestCase
         $this->assertSame($templates, $this->pool->getTemplates());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetTitleLogo(): void
     {
         $this->assertSame('/path/to/pic.png', $this->pool->getTitleLogo());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetTitle(): void
     {
         $this->assertSame('Sonata Admin', $this->pool->getTitle());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetOption(): void
     {
         $this->assertSame('bar', $this->pool->getOption('foo'));
@@ -552,6 +568,11 @@ class PoolTest extends TestCase
         $this->assertNull($this->pool->getOption('non_existent_option'));
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testOptionDefault(): void
     {
         $this->assertSame([], $this->pool->getOption('nonexistantarray', []));

--- a/tests/SonataConfigurationTest.php
+++ b/tests/SonataConfigurationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\SonataConfiguration;
+
+final class SonataConfigurationTest extends TestCase
+{
+    /**
+     * @var SonataConfiguration
+     */
+    private $configuration;
+
+    protected function setUp(): void
+    {
+        $this->configuration = new SonataConfiguration('title', '/path/to/logo.png', [
+            'html5_validate' => true,
+            'lock_protection' => false,
+        ]);
+    }
+
+    public function testGetTitle(): void
+    {
+        $this->assertSame('title', $this->configuration->getTitle());
+    }
+
+    public function testGetLogo(): void
+    {
+        $this->assertSame('/path/to/logo.png', $this->configuration->getLogo());
+    }
+
+    public function testGetOption(): void
+    {
+        $this->assertTrue($this->configuration->getOption('html5_validate'));
+        $this->assertFalse($this->configuration->getOption('lock_protection'));
+    }
+
+    public function testGetOptionDefault(): void
+    {
+        $this->assertSame('group', $this->configuration->getOption('default_group', 'group'));
+    }
+}

--- a/tests/Twig/Extension/GroupExtensionTest.php
+++ b/tests/Twig/Extension/GroupExtensionTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Twig\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Twig\Extension\GroupExtension;
+use Symfony\Component\DependencyInjection\Container;
+
+final class GroupExtensionTest extends TestCase
+{
+    /**
+     * @var GroupExtension
+     */
+    private $twigExtension;
+
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    /**
+     * @var Container
+     */
+    private $container;
+
+    protected function setUp(): void
+    {
+        $this->container = new Container();
+        $this->pool = new Pool($this->container, '', '');
+        $this->twigExtension = new GroupExtension($this->pool);
+    }
+
+    public function testGetDashboardGroupsWithCreatableAdmins(): void
+    {
+        $adminNonCreatable = $this->createMock(AbstractAdmin::class);
+        $adminCreatable = $this->createMock(AbstractAdmin::class);
+
+        $this->container->set('sonata_admin_non_creatable', $adminNonCreatable);
+        $this->container->set('sonata_admin_creatable', $adminCreatable);
+        $this->pool->setAdminServiceIds(['sonata_admin_non_creatable', 'sonata_admin_creatable']);
+
+        $adminCreatable
+            ->method('showIn')
+            ->with(AbstractAdmin::CONTEXT_DASHBOARD)
+            ->willReturn(true);
+
+        $adminCreatable
+            ->method('hasRoute')
+            ->with('create')
+            ->willReturn(true);
+
+        $adminCreatable
+            ->method('hasAccess')
+            ->with('create')
+            ->willReturn(true);
+
+        $adminNonCreatable
+            ->method('hasAccess')
+            ->with('create')
+            ->willReturn(false);
+
+        $this->pool->setAdminGroups([
+            'group_without_creatable' => [
+                'items' => [
+                    'itemKey' => ['admin' => 'sonata_admin_non_creatable'],
+                ],
+            ],
+            'group_with_creatable' => [
+                'items' => [
+                    'itemKey' => ['admin' => 'sonata_admin_creatable'],
+                ],
+            ],
+        ]);
+
+        $this->assertSame([
+            [
+                'items' => [
+                    'itemKey' => $adminCreatable,
+                ],
+            ],
+        ], $this->twigExtension->getDashboardGroupsWithCreatableAdmins());
+    }
+}

--- a/tests/Twig/GlobalVariablesTest.php
+++ b/tests/Twig/GlobalVariablesTest.php
@@ -22,6 +22,10 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * @author Ahmet Akbana <ahmetakbana@gmail.com>
+ *
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @group legacy
  */
 class GlobalVariablesTest extends TestCase
 {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Part of https://github.com/sonata-project/SonataAdminBundle/issues/6624

This class (I wasn't sure in which folder should go) will handle configuration for sonata which is currently holded by Pool class.

It adds a global twig `sonata_config` variable in order to replace the current `sonata_admin` variable whose name could mislead to think that is some kind of admin.

`sonata_admin` is registered as global twig variable in:

https://github.com/sonata-project/SonataAdminBundle/blob/ea9f3a47bee1d47e6ee74d53cb3103747ec326ec/src/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php#L27-L31

https://github.com/sonata-project/SonataAdminBundle/blob/ea9f3a47bee1d47e6ee74d53cb3103747ec326ec/src/Resources/config/core.php#L216-L223

All `GlobalVariables` methods have been deprecated:
 - `url` and `objectUrl` were added in https://github.com/sonata-project/SonataAdminBundle/commit/964853c9e145f1e1e985f96abbc24bb0a7e29853, I haven't found any use, this is usually done though the `AdminInterface::generateUrl` and `AdminInterface::generateObjectUrl`.
- `getAdminPool` shouldn't be used in twig, it still has one usage, I'll comment later.
- `getMosaicBackground` has been replaced by `SonataConfiguration::getOption('mosaic_background')`.

I added a `GroupExtension` Twig extension in order to handle some logic that was done in twig directly.
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `SonataConfiguration` class to handle sonata global configuration.
- Added global Twig `sonata_config` to access global configuration from Twig.
### Deprecated
- Deprecated `Pool::getTitle()` method.
- Deprecated `Pool::getTitleLogo()` method.
- Deprecated `Pool::getOption()` method.
- Deprecated global Twig `sonata_admin` variable.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

The only thing left is in `dashboard.html.twig` where there are a couple of calls:

https://github.com/sonata-project/SonataAdminBundle/blob/ea9f3a47bee1d47e6ee74d53cb3103747ec326ec/src/Resources/views/Core/dashboard.html.twig#L53

https://github.com/sonata-project/SonataAdminBundle/blob/ea9f3a47bee1d47e6ee74d53cb3103747ec326ec/src/Resources/views/Core/dashboard.html.twig#L128

which I haven't used, but I guess someone using this event could inject the `Pool` service in the listener directly.
