### PR TITLE
Add support for global admin extensions via config

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -235,6 +235,7 @@ Full Configuration Options
 
                 # Prototype
                 id:
+                    global: false
                     admins: []
                     excludes: []
                     implements: []

--- a/docs/reference/extensions.rst
+++ b/docs/reference/extensions.rst
@@ -80,6 +80,9 @@ Using ``config/packages/sonata_admin.yaml`` file has some advantages, it allows 
 extra options you can use to wire your extensions in a more dynamic way. This means you can change the behavior of all
 admins that manage a class of a specific type.
 
+global:
+    adds the extension to all admins.
+
 admins:
     specify one or more admin service ids to which the Extension should be added
 
@@ -115,6 +118,7 @@ priority:
         sonata_admin:
             extensions:
                 app.publish.extension:
+                    global: true
                     admins:
                         - app.admin.article
                     implements:

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -34,6 +34,14 @@
             <code>new ArrayCollection(\array_slice($this-&gt;results, 0, $this-&gt;getMaxPerPage()))</code>
         </InvalidPropertyAssignmentValue>
     </file>
+    <file src="src/DependencyInjection/Compiler/ExtensionCompilerPass.php">
+        <InvalidReturnStatement occurrences="1">
+            <code>$extensionMap</code>
+        </InvalidReturnStatement>
+        <InvalidReturnType occurrences="1">
+            <code>array&lt;string, array&lt;string, array&lt;string, array&lt;string, array&lt;string, string&gt;&gt;&gt;&gt;&gt;</code>
+        </InvalidReturnType>
+    </file>
     <file src="src/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php">
         <InvalidReturnType occurrences="2">
             <code>buildSecurityInformation</code>

--- a/src/DependencyInjection/Compiler/ExtensionCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ExtensionCompilerPass.php
@@ -177,11 +177,12 @@ class ExtensionCompilerPass implements CompilerPassInterface
     }
 
     /**
-     * @param array<string, array<string, array<string, string>>> $config
+     * @param array<string, array<string, array<string, string>|bool>> $config
      *
      * @return array<string, array<string, array<string, array<string, array<string, string>>>>> an array with the following structure.
      *
      * [
+     *     'global'     => ['<admin_id>'  => ['<extension_id>' => ['priority' => <int>]]],
      *     'excludes'   => ['<admin_id>'  => ['<extension_id>' => ['priority' => <int>]]],
      *     'admins'     => ['<admin_id>'  => ['<extension_id>' => ['priority' => <int>]]],
      *     'implements' => ['<interface>' => ['<extension_id>' => ['priority' => <int>]]],
@@ -193,6 +194,7 @@ class ExtensionCompilerPass implements CompilerPassInterface
     protected function flattenExtensionConfiguration(array $config)
     {
         $extensionMap = [
+            'global' => [],
             'excludes' => [],
             'admins' => [],
             'implements' => [],
@@ -202,6 +204,12 @@ class ExtensionCompilerPass implements CompilerPassInterface
         ];
 
         foreach ($config as $extension => $options) {
+            if (true === $options['global']) {
+                $options['global'] = [$extension];
+            } else {
+                $options['global'] = [];
+            }
+
             $optionsMap = array_intersect_key($options, $extensionMap);
 
             foreach ($optionsMap as $key => $value) {
@@ -244,6 +252,8 @@ class ExtensionCompilerPass implements CompilerPassInterface
         $classReflection = new \ReflectionClass($class);
 
         switch ($type) {
+            case 'global':
+                return true;
             case 'instanceof':
                 $subjectReflection = new \ReflectionClass($subject);
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -516,7 +516,7 @@ CASESENSITIVE;
 
                 ->arrayNode('extensions')
                 ->useAttributeAsKey('id')
-                ->defaultValue(['admins' => [], 'excludes' => [], 'implements' => [], 'extends' => [], 'instanceof' => [], 'uses' => []])
+                ->defaultValue([])
                     ->prototype('array')
                         ->fixXmlConfig('admin')
                         ->fixXmlConfig('exclude')
@@ -524,6 +524,7 @@ CASESENSITIVE;
                         ->fixXmlConfig('extend')
                         ->fixXmlConfig('use')
                         ->children()
+                            ->booleanNode('global')->defaultValue(false)->end()
                             ->arrayNode('admins')
                                 ->prototype('scalar')->end()
                             ->end()

--- a/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -75,12 +75,7 @@ class ExtensionCompilerPassTest extends TestCase
         $this->assertTrue($container->hasParameter(sprintf('%s.extension.map', $this->root)));
         $this->assertIsArray($extensionMap = $container->getParameter(sprintf('%s.extension.map', $this->root)));
 
-        $this->assertArrayHasKey('admins', $extensionMap);
-        $this->assertArrayHasKey('excludes', $extensionMap);
-        $this->assertArrayHasKey('implements', $extensionMap);
-        $this->assertArrayHasKey('extends', $extensionMap);
-        $this->assertArrayHasKey('instanceof', $extensionMap);
-        $this->assertArrayHasKey('uses', $extensionMap);
+        $this->assertSame([], $extensionMap);
     }
 
     /**
@@ -106,6 +101,7 @@ class ExtensionCompilerPassTest extends TestCase
         $this->assertArrayHasKey('instanceof', $extensionMap);
         $this->assertArrayHasKey('uses', $extensionMap);
 
+        $this->assertEmpty($extensionMap['global']);
         $this->assertEmpty($extensionMap['admins']);
         $this->assertEmpty($extensionMap['excludes']);
         $this->assertEmpty($extensionMap['implements']);
@@ -245,6 +241,7 @@ class ExtensionCompilerPassTest extends TestCase
         $extensionsPass->process($container);
         $container->compile();
 
+        $this->assertTrue($container->hasDefinition('sonata_extension_global'));
         $this->assertTrue($container->hasDefinition('sonata_extension_publish'));
         $this->assertTrue($container->hasDefinition('sonata_extension_history'));
         $this->assertTrue($container->hasDefinition('sonata_extension_order'));
@@ -255,6 +252,7 @@ class ExtensionCompilerPassTest extends TestCase
         $this->assertTrue($container->hasDefinition('sonata_article_admin'));
         $this->assertTrue($container->hasDefinition('sonata_news_admin'));
 
+        $globalExtension = $container->get('sonata_extension_global');
         $securityExtension = $container->get('sonata_extension_security');
         $publishExtension = $container->get('sonata_extension_publish');
         $historyExtension = $container->get('sonata_extension_history');
@@ -263,28 +261,31 @@ class ExtensionCompilerPassTest extends TestCase
 
         $def = $container->get('sonata_post_admin');
         $extensions = $def->getExtensions();
-        $this->assertCount(4, $extensions);
+        $this->assertCount(5, $extensions);
 
         $this->assertSame($historyExtension, $extensions[0]);
         $this->assertSame($publishExtension, $extensions[2]);
         $this->assertSame($securityExtension, $extensions[3]);
+        $this->assertSame($globalExtension, $extensions[4]);
 
         $def = $container->get('sonata_article_admin');
         $extensions = $def->getExtensions();
-        $this->assertCount(5, $extensions);
+        $this->assertCount(6, $extensions);
 
         $this->assertSame($filterExtension, $extensions[0]);
         $this->assertSame($securityExtension, $extensions[1]);
         $this->assertSame($publishExtension, $extensions[2]);
         $this->assertSame($orderExtension, $extensions[4]);
+        $this->assertSame($globalExtension, $extensions[5]);
 
         $def = $container->get('sonata_news_admin');
         $extensions = $def->getExtensions();
-        $this->assertCount(5, $extensions);
+        $this->assertCount(6, $extensions);
         $this->assertSame($historyExtension, $extensions[0]);
-        $this->assertSame($securityExtension, $extensions[1]);
-        $this->assertSame($filterExtension, $extensions[2]);
+        $this->assertSame($securityExtension, $extensions[2]);
+        $this->assertSame($filterExtension, $extensions[3]);
         $this->assertSame($orderExtension, $extensions[4]);
+        $this->assertSame($globalExtension, $extensions[5]);
     }
 
     /**
@@ -308,13 +309,14 @@ class ExtensionCompilerPassTest extends TestCase
         $container->compile();
     }
 
-    /**
-     * @return array
-     */
-    protected function getConfig()
+    protected function getConfig(): array
     {
         $config = [
             'extensions' => [
+                'sonata_extension_global' => [
+                    'global' => true,
+                    'priority' => -255,
+                ],
                 'sonata_extension_publish' => [
                     'admins' => ['sonata_post_admin'],
                     'implements' => [Publishable::class],
@@ -418,6 +420,10 @@ class ExtensionCompilerPassTest extends TestCase
         // Add admin extension definition's
         $extensionClass = \get_class($this->createMock(AdminExtensionInterface::class));
 
+        $container
+            ->register('sonata_extension_global')
+            ->setPublic(true)
+            ->setClass($extensionClass);
         $container
             ->register('sonata_extension_publish')
             ->setPublic(true)


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Is is now possible to register a global admin extension via the configuration. This was only possible for tags.

The next step (new PR) is to allow all extension configuration for tags.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this feature is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Add support for global admin extensions via config
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
