### PR TITLE
Deprecate AbstractFilter value property

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -29,6 +29,29 @@ Argument 2 of `Sonata\AdminBundle\Model\ModelManagerInterface::createQuery()` me
 - `Sonata\AdminBundle\Admin\Pool::getOption()` method has been deprecated.
   Use `Sonata\AdminBundle\SonataConfiguration::getOption()` instead.
 
+### Sonata\AdminBundle\Filter\Filter
+
+Deprecate `Sonata\AdminBundle\Filter\Filter::setValue()` and `Sonata\AdminBundle\Filter\Filter::getValue()`
+without replacement.
+
+The implementation of the method `Sonata\AdminBundle\Filter\Filter::isActive()` will change from
+```
+public function isActive()
+{
+    $values = $this->value;
+
+    return isset($values['value']) && false !== $values['value'] && '' !== $values['value'];
+}
+```
+to
+```
+public function isActive()
+{
+    return $this->active;
+}
+```
+in next major. Currently we are supporting both properties so you SHOULD start using `$this->active`.
+
 ### Sonata\AdminBundle\Admin\FieldDescriptionInterface
 
 The following methods have been deprecated from the interface and will be added as abstract methods to

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -26,7 +26,11 @@ abstract class Filter implements FilterInterface
     protected $name;
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
      * @var mixed|null
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
      */
     protected $value;
 
@@ -39,6 +43,11 @@ abstract class Filter implements FilterInterface
      * @var string
      */
     protected $condition;
+
+    /**
+     * @var bool
+     */
+    private $active = false;
 
     public function initialize($name, array $options = [])
     {
@@ -181,32 +190,46 @@ abstract class Filter implements FilterInterface
     }
 
     /**
-     * Set value.
+     * NEXT_MAJOR: Remove this method.
      *
      * @param mixed $value
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
      */
     public function setValue($value)
     {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.',
+            __METHOD__,
+        ), E_USER_DEPRECATED);
+
         $this->value = $value;
     }
 
     /**
-     * Get value.
+     * NEXT_MAJOR: Remove this method.
      *
      * @return mixed
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
      */
     public function getValue()
     {
+        @trigger_error(sprintf(
+            'Method %s() is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.',
+            __METHOD__,
+        ), E_USER_DEPRECATED);
+
         return $this->value;
     }
 
     public function isActive()
     {
-        $values = $this->getValue();
+        $values = $this->value;
 
-        return isset($values['value'])
-            && false !== $values['value']
-            && '' !== $values['value'];
+        // NEXT_MAJOR: Change for `return $this->active;`
+        return $this->active
+            || isset($values['value']) && false !== $values['value'] && '' !== $values['value'];
     }
 
     public function setCondition($condition)
@@ -222,5 +245,10 @@ abstract class Filter implements FilterInterface
     public function getTranslationDomain()
     {
         return $this->getOption('translation_domain');
+    }
+
+    protected function setActive(bool $active): void
+    {
+        $this->active = $active;
     }
 }

--- a/tests/Filter/FilterTest.php
+++ b/tests/Filter/FilterTest.php
@@ -50,11 +50,21 @@ class FilterTest extends TestCase
 
         $this->assertSame('default', $filter->getOption('fake', 'default'));
 
-        $filter->setValue(42);
-        $this->assertSame(42, $filter->getValue());
-
         $filter->setCondition('>');
         $this->assertSame('>', $filter->getCondition());
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
+    public function testFilterLegacyMethod(): void
+    {
+        $filter = new FooFilter();
+
+        $filter->setValue(42);
+        $this->assertSame(42, $filter->getValue());
     }
 
     public function testGetFieldOption(): void
@@ -111,13 +121,24 @@ class FilterTest extends TestCase
         $filter->getFieldName();
     }
 
+    public function testIsActive(): void
+    {
+        $filter = new FooFilter();
+        $this->assertFalse($filter->isActive());
+
+        $filter->callSetActive(true);
+        $this->assertTrue($filter->isActive());
+    }
+
     /**
      * @dataProvider isActiveData
      *
      * @param $expected
      * @param $value
+     *
+     * @group legacy
      */
-    public function testIsActive(bool $expected, array $value): void
+    public function testDeprecatedIsActive(bool $expected, array $value): void
     {
         $filter = new FooFilter();
         $filter->setValue($value);

--- a/tests/Fixtures/Filter/FooFilter.php
+++ b/tests/Fixtures/Filter/FooFilter.php
@@ -29,6 +29,11 @@ class FooFilter extends Filter
     {
     }
 
+    public function callSetActive(bool $active): void
+    {
+        $this->setActive($active);
+    }
+
     public function getDefaultOptions()
     {
         return [


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

I discovered that our persistence bundle override the `isActive` method
https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/src/Filter/Filter.php#L37
https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/blob/3.x/src/Filter/Filter.php#L43

And the `setValue`/`getValue` are not used.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `Sonata\AdminBundle\Filter\Filter::active` property.

### Deprecated
- `Sonata\AdminBundle\Filter\Filter::getValue()`
- `Sonata\AdminBundle\Filter\Filter::setValue()`
```