### PR TITLE
Deprecate some Pool methods related to groups and fix array shapes

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -28,6 +28,7 @@ Argument 2 of `Sonata\AdminBundle\Model\ModelManagerInterface::createQuery()` me
   Use `Sonata\AdminBundle\SonataConfiguration::getLogo()` instead.
 - `Sonata\AdminBundle\Admin\Pool::getOption()` method has been deprecated.
   Use `Sonata\AdminBundle\SonataConfiguration::getOption()` instead.
+- `Sonata\AdminBundle\Admin\Pool::getGroups()` method has been deprecated.
 
 ### Sonata\AdminBundle\Admin\FieldDescriptionInterface
 

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -29,6 +29,8 @@ Argument 2 of `Sonata\AdminBundle\Model\ModelManagerInterface::createQuery()` me
 - `Sonata\AdminBundle\Admin\Pool::getOption()` method has been deprecated.
   Use `Sonata\AdminBundle\SonataConfiguration::getOption()` instead.
 - `Sonata\AdminBundle\Admin\Pool::getGroups()` method has been deprecated.
+- `Sonata\AdminBundle\Admin\Pool::hasGroup()` method has been deprecated.
+- `Sonata\AdminBundle\Admin\Pool::getAdminsByGroup()` method has been deprecated.
 
 ### Sonata\AdminBundle\Admin\FieldDescriptionInterface
 

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -182,6 +182,10 @@ class Pool
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.
+     *
      * Returns whether an admin group exists or not.
      *
      * @param string $group
@@ -190,6 +194,11 @@ class Pool
      */
     public function hasGroup($group)
     {
+        @trigger_error(sprintf(
+            'Method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         return isset($this->adminGroups[$group]);
     }
 
@@ -237,6 +246,10 @@ class Pool
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.
+     *
      * Returns all admins related to the given $group.
      *
      * @param string $group
@@ -247,6 +260,11 @@ class Pool
      */
     public function getAdminsByGroup($group)
     {
+        @trigger_error(sprintf(
+            'Method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         if (!isset($this->adminGroups[$group])) {
             throw new \InvalidArgumentException(sprintf('Group "%s" not found in admin pool.', $group));
         }

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -153,8 +153,20 @@ class Pool
         $this->propertyAccessor = $propertyAccessor;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.
+     *
+     * @return array
+     */
     public function getGroups()
     {
+        @trigger_error(sprintf(
+            'Method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         $groups = $this->adminGroups;
 
         foreach ($this->adminGroups as $name => $adminGroup) {

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -38,6 +38,23 @@ class Pool
 
     /**
      * @var array
+     * @phpstan-var array<string, array{
+     *  label: string,
+     *  label_catalogue: string,
+     *  icon: string,
+     *  item_adds: array,
+     *  items: array<array-key, array{
+     *      admin?: string,
+     *      label?: string,
+     *      roles: list<string>,
+     *      route?: string,
+     *      router_absolute: bool,
+     *      route_params: array<string, string>
+     *  }>,
+     *  keep_open: bool,
+     *  on_top: bool,
+     *  roles: list<string>
+     * }>
      */
     protected $adminGroups = [];
 
@@ -136,9 +153,6 @@ class Pool
         $this->propertyAccessor = $propertyAccessor;
     }
 
-    /**
-     * @return array<string, array<string, AdminInterface>>
-     */
     public function getGroups()
     {
         $groups = $this->adminGroups;
@@ -166,6 +180,16 @@ class Pool
 
     /**
      * @return array
+     * @phpstan-return array<string, array{
+     *  label: string,
+     *  label_catalogue: string,
+     *  icon: string,
+     *  item_adds: array,
+     *  items: array<array-key, AdminInterface>,
+     *  keep_open: bool,
+     *  on_top: bool,
+     *  roles: list<string>
+     * }>
      */
     public function getDashboardGroups()
     {
@@ -449,6 +473,24 @@ class Pool
     }
 
     /**
+     * @phpstan-param array<string, array{
+     *  label: string,
+     *  label_catalogue: string,
+     *  icon: string,
+     *  item_adds: array,
+     *  items: array<array-key, array{
+     *      admin?: string,
+     *      label?: string,
+     *      roles: list<string>,
+     *      route?: string,
+     *      router_absolute: bool,
+     *      route_params: array<string, string>
+     *  }>,
+     *  keep_open: bool,
+     *  on_top: bool,
+     *  roles: list<string>
+     * }> $adminGroups
+     *
      * @return void
      */
     public function setAdminGroups(array $adminGroups)

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -20,6 +20,24 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
+ * @psalm-type Group = array{
+ *  label: string,
+ *  label_catalogue: string,
+ *  icon: string,
+ *  item_adds: array,
+ *  items: array<array-key, array{
+ *      admin?: string,
+ *      label?: string,
+ *      roles: list<string>,
+ *      route?: string,
+ *      router_absolute: bool,
+ *      route_params: array<string, string>
+ *  }>,
+ *  keep_open: bool,
+ *  on_top: bool,
+ *  roles: list<string>
+ * }
+ *
  * @final since sonata-project/admin-bundle 3.52
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -38,23 +56,8 @@ class Pool
 
     /**
      * @var array
-     * @phpstan-var array<string, array{
-     *  label: string,
-     *  label_catalogue: string,
-     *  icon: string,
-     *  item_adds: array,
-     *  items: array<array-key, array{
-     *      admin?: string,
-     *      label?: string,
-     *      roles: list<string>,
-     *      route?: string,
-     *      router_absolute: bool,
-     *      route_params: array<string, string>
-     *  }>,
-     *  keep_open: bool,
-     *  on_top: bool,
-     *  roles: list<string>
-     * }>
+     * @phpstan-var array<string, array<string, mixed>>
+     * @psalm-var array<string, Group>
      */
     protected $adminGroups = [];
 
@@ -485,23 +488,8 @@ class Pool
     }
 
     /**
-     * @phpstan-param array<string, array{
-     *  label: string,
-     *  label_catalogue: string,
-     *  icon: string,
-     *  item_adds: array,
-     *  items: array<array-key, array{
-     *      admin?: string,
-     *      label?: string,
-     *      roles: list<string>,
-     *      route?: string,
-     *      router_absolute: bool,
-     *      route_params: array<string, string>
-     *  }>,
-     *  keep_open: bool,
-     *  on_top: bool,
-     *  roles: list<string>
-     * }> $adminGroups
+     * @phpstan-param array<string, array<string, mixed>> $adminGroups
+     * @psalm-param array<string, Group> $adminGroups
      *
      * @return void
      */

--- a/src/Twig/Extension/GroupExtension.php
+++ b/src/Twig/Extension/GroupExtension.php
@@ -44,13 +44,16 @@ final class GroupExtension extends AbstractExtension
     }
 
     /**
-     * @phpstan-return array{array{
-     *  roles: list<string>,
-     *  icon: string,
+     * @phpstan-return array<array{
      *  label: string,
      *  label_catalogue: string,
-     *  items: AdminInterface[]
-     * }}
+     *  icon: string,
+     *  item_adds: array,
+     *  items: AdminInterface[],
+     *  keep_open: bool,
+     *  on_top: bool,
+     *  roles: list<string>
+     * }>
      */
     public function getDashboardGroupsWithCreatableAdmins(): array
     {

--- a/tests/Admin/PoolTest.php
+++ b/tests/Admin/PoolTest.php
@@ -65,11 +65,18 @@ class PoolTest extends TestCase
         $this->assertArrayHasKey('sonata.user.admin.group1', $result['adminGroup1']);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testHasGroup(): void
     {
         $this->pool->setAdminGroups([
             'adminGroup1' => [],
         ]);
+
+        $this->expectDeprecation('Method "Sonata\AdminBundle\Admin\Pool::hasGroup()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.');
 
         $this->assertTrue($this->pool->hasGroup('adminGroup1'));
         $this->assertFalse($this->pool->hasGroup('adminGroup2'));
@@ -113,26 +120,43 @@ class PoolTest extends TestCase
         $this->assertSame($adminGroup1, $groups['adminGroup1']['items']['itemKey']);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetAdminsByGroupWhenGroupNotSet(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
-
         $this->pool->setAdminGroups([
                 'adminGroup1' => [],
             ]);
 
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->pool->getAdminsByGroup('adminGroup2');
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetAdminsByGroupWhenGroupIsEmpty(): void
     {
         $this->pool->setAdminGroups([
                 'adminGroup1' => [],
             ]);
 
+        $this->expectDeprecation('Method "Sonata\AdminBundle\Admin\Pool::getAdminsByGroup()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.');
+
         $this->assertSame([], $this->pool->getAdminsByGroup('adminGroup1'));
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetAdminsByGroup(): void
     {
         $this->container->set('sonata.admin1', $this->createMock(AdminInterface::class));
@@ -152,6 +176,8 @@ class PoolTest extends TestCase
                 'items' => [$this->getItemArray('sonata.admin3')],
             ],
         ]);
+
+        $this->expectDeprecation('Method "Sonata\AdminBundle\Admin\Pool::getAdminsByGroup()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.');
 
         $this->assertCount(2, $this->pool->getAdminsByGroup('adminGroup1'));
         $this->assertCount(1, $this->pool->getAdminsByGroup('adminGroup2'));

--- a/tests/Admin/PoolTest.php
+++ b/tests/Admin/PoolTest.php
@@ -18,11 +18,14 @@ use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class PoolTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @var Container
      */
@@ -40,6 +43,11 @@ class PoolTest extends TestCase
         $this->pool = new Pool($this->container, 'Sonata Admin', '/path/to/pic.png', ['foo' => 'bar']);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @group legacy
+     */
     public function testGetGroups(): void
     {
         $this->container->set('sonata.user.admin.group1', $this->createMock(AdminInterface::class));
@@ -49,6 +57,8 @@ class PoolTest extends TestCase
         $this->pool->setAdminGroups([
             'adminGroup1' => ['sonata.user.admin.group1' => []],
         ]);
+
+        $this->expectDeprecation('Method "Sonata\AdminBundle\Admin\Pool::getGroups()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.');
 
         $result = $this->pool->getGroups();
         $this->assertArrayHasKey('adminGroup1', $result);


### PR DESCRIPTION
I was trying to manual merge `3.x`, but phpstan failed because the array specified in `GroupExtension` is different from https://github.com/sonata-project/SonataAdminBundle/blob/8c0d58a24e4e02dba56eea168d1e3564d4ac5c85/src/Admin/Pool.php#L108-L111
So I added more specific info.

~Not sure if should be `pedantic` or if I should add a changelog.~

~While doing this I found that `Pool::getGroups()` method maybe it's not used because the code doesn't make sense with the current groups.~ https://github.com/sonata-project/SonataAdminBundle/pull/6659#issuecomment-739559129

- [x] Check if `Pool::getGroups()` is used.

I am targeting this branch, because this is BC.

## Changelog

```markdown
### Deprecated
- Deprecated `Pool::getGroups()` method.
- Deprecated `Pool::hasGroup()` method.
- Deprecated `Pool::getAdminsByGroup()` method.
```