### PR TITLE
Fix incorrect object passed to the view when rendering the history compare action

### DIFF
--- a/src/Resources/views/CRUD/base_show_field.html.twig
+++ b/src/Resources/views/CRUD/base_show_field.html.twig
@@ -42,6 +42,7 @@ file that was distributed with this source code.
     {% apply spaceless %}
         {% if(value_compare is defined) %}
             {% set value = value_compare %}
+            {% set object = object_compare %}
             <td>{{ block('field') }}</td>
         {% endif %}
     {% endapply %}

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -447,6 +447,7 @@ class SonataAdminExtension extends AbstractExtension
             'is_diff' => $isDiff,
             'admin' => $fieldDescription->getAdmin(),
             'object' => $baseObject,
+            'object_compare' => $compareObject,
         ], $environment);
     }
 

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -3119,7 +3119,7 @@ EOT
             ['<th>Data</th> <td>Example</td><td>Example</td>', 'text', 'Example', ['safe' => false]],
             ['<th>Data</th> <td>Example</td><td>Example</td>', 'textarea', 'Example', ['safe' => false]],
             ['<th>Data</th> <td>SonataAdmin<br/>Example</td><td>SonataAdmin<br/>Example</td>', 'virtual_field', 'Example', ['template' => 'custom_show_field.html.twig', 'safe' => false, 'SonataAdmin']],
-            ['<th class="diff">Data</th> <td>SonataAdmin<br/>Example</td><td>SonataAdmin<br/>Example</td>', 'virtual_field', 'Example', ['template' => 'custom_show_field.html.twig', 'safe' => false], 'sonata-project/admin-bundle'],
+            ['<th class="diff">Data</th> <td>SonataAdmin<br/>Example</td><td>sonata-project/admin-bundle<br/>Example</td>', 'virtual_field', 'Example', ['template' => 'custom_show_field.html.twig', 'safe' => false], 'sonata-project/admin-bundle'],
             [
                 '<th>Data</th> <td><time datetime="2020-05-27T09:11:12+00:00" title="2020-05-27T09:11:12+00:00"> May 27, 2020 10:11 </time></td>'
                 .'<td><time datetime="2020-05-27T09:11:12+00:00" title="2020-05-27T09:11:12+00:00"> May 27, 2020 10:11 </time></td>',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Currently, when rendering the entity compare view in the history action, only the current (first) entity object will be passed to the view, even when it is going to render the value of the comparing (secondary) entity object. This means that the `field` block of the show field template will receive the first entity (the base object) along with the secondary value (value to compare) when the secondary value is going to be rendered. This can cause problem if the template does not solely rely on the value but also the object for the correct output. This PR fixes this.

I am targeting this branch, because it is backward-compatible. Note that after applying the patch, the block `field_compare` in template `base_show_field.html.twig` will assume the the existence of the `object_compare` variable. This may cause compatibility problem. But given that 
  - `SonataAdminExtension` class is annotated `@final`, and
  - The [documentation](https://sonata-project.org/bundles/doctrine-orm-admin/3-x/doc/reference/audit.html) states that  _show_field views should extend @SonataAdmin/CRUD/base_show_field.html.twig and **should not contain a field_compare block**_

I think it is still reasonable to say that the patch won't break BC. Otherwise I'd suggest `base_show_field.html.twig` to be changed to something like this:

```twig
            {% if(object_compare is defined) %}
                {% set object = object_compare %}
            {% endif %}
```

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Incorrect object being passed to the view when rendering the history compare action
```