### PR TITLE
Disable sorting for an associated_property callable

### DIFF
--- a/src/Datagrid/ListMapper.php
+++ b/src/Datagrid/ListMapper.php
@@ -86,7 +86,7 @@ class ListMapper extends BaseMapper
         // Default sort on "associated_property"
         if (isset($fieldDescriptionOptions['associated_property'])) {
             if (!isset($fieldDescriptionOptions['sortable'])) {
-                $fieldDescriptionOptions['sortable'] = true;
+                $fieldDescriptionOptions['sortable'] = !\is_callable($fieldDescriptionOptions['associated_property']);
             }
             if (!isset($fieldDescriptionOptions['sort_parent_association_mappings'])) {
                 $fieldDescriptionOptions['sort_parent_association_mappings'] = [[

--- a/tests/Datagrid/ListMapperTest.php
+++ b/tests/Datagrid/ListMapperTest.php
@@ -337,6 +337,32 @@ class ListMapperTest extends TestCase
         $this->assertSame('fooSortFieldMapping', $fieldManualSort->getOption('sort_field_mapping'));
     }
 
+    public function testCallableAssociationPropertyCannotBeSortable(): void
+    {
+        $this->listMapper->add(
+            'fooNameNotSortable',
+            null,
+            [
+                'associated_property' => static function ($value) {
+                    return (string) $value;
+                },
+            ]
+        );
+        $this->listMapper->add(
+            'fooNameSortable',
+            null,
+            [
+                'associated_property' => 'fooProperty',
+            ]
+        );
+
+        $fieldSortable = $this->listMapper->get('fooNameSortable');
+        $fieldNotSortable = $this->listMapper->get('fooNameNotSortable');
+
+        $this->assertTrue($fieldSortable->getOption('sortable'));
+        $this->assertFalse($fieldNotSortable->getOption('sortable'));
+    }
+
     public function testKeys(): void
     {
         $fieldDescription1 = $this->getFieldDescriptionMock('fooName1', 'fooLabel1');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Related to https://github.com/sonata-project/SonataAdminBundle/issues/6649

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6649.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed disallowing sorting in a field defined with a closure in `associated_property`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
