### PR TITLE
[Twig] Split SonataAdminExtension

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,32 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.xx to 3.xx
+=========================
+
+### Sonata\AdminBundle\Twig\Extension\SonataAdminExtension
+
+- Deprecated `SonataAdminExtension::MOMENT_UNSUPPORTED_LOCALES` constant.
+- Deprecated `SonataAdminExtension::setXEditableTypeMapping()` method.
+- Deprecated `SonataAdminExtension::getXEditableType()` method.
+- Deprecated `SonataAdminExtension::getXEditableChoices()` method.
+- Deprecated `SonataAdminExtension::getCanonicalizedLocaleForMoment()` method in favor of
+  `CanonicalizerExtension::getCanonicalizedLocaleForMoment()`.
+- Deprecated `SonataAdminExtension::getCanonicalizedLocaleForSelect2()` method in favor of
+  `CanonicalizerExtension::getCanonicalizedLocaleForSelect2()`.
+- Deprecated `SonataAdminExtension::isGrantedAffirmative()` method in favor of
+  `SecurityExtension::isGrantedAffirmative()`.
+- Deprecated `SonataAdminExtension::renderListElement()` method in favor of
+  `RenderElementExtension::renderListElement()`.
+- Deprecated `SonataAdminExtension::renderViewElement()` method in favor of
+  `RenderElementExtension::renderViewElement()`.
+- Deprecated `SonataAdminExtension::renderViewElementCompare()` method in favor of
+  `RenderElementExtension::renderViewElementCompare()`.
+- Deprecated `SonataAdminExtension::renderRelationElement()` method in favor of
+  `RenderElementExtension::renderRelationElement()`.
+- Deprecated `SonataAdminExtension::getTemplate()` method.
+- Deprecated `SonataAdminExtension::getTemplateRegistry()` method.
+
 UPGRADE FROM 3.85 to 3.86
 =========================
 

--- a/src/Action/SetObjectFieldValueAction.php
+++ b/src/Action/SetObjectFieldValueAction.php
@@ -206,10 +206,11 @@ final class SetObjectFieldValueAction
 
         // render the widget
         // todo : fix this, the twig environment variable is not set inside the extension ...
+        // NEXT_MAJOR: Modify lines below to use RenderElementExtension instead of SonataAdminExtension
         $extension = $this->twig->getExtension(SonataAdminExtension::class);
         \assert($extension instanceof SonataAdminExtension);
 
-        $content = $extension->renderListElement($this->twig, $rootObject, $fieldDescription);
+        $content = $extension->renderListElement($this->twig, $rootObject, $fieldDescription, [], 'sonata_deprecation_mute');
 
         return new JsonResponse($content, Response::HTTP_OK);
     }

--- a/src/Action/SetObjectFieldValueAction.php
+++ b/src/Action/SetObjectFieldValueAction.php
@@ -210,6 +210,7 @@ final class SetObjectFieldValueAction
         $extension = $this->twig->getExtension(SonataAdminExtension::class);
         \assert($extension instanceof SonataAdminExtension);
 
+        // NEXT_MAJOR: Remove the last two arguments
         $content = $extension->renderListElement($this->twig, $rootObject, $fieldDescription, [], 'sonata_deprecation_mute');
 
         return new JsonResponse($content, Response::HTTP_OK);

--- a/src/Resources/config/twig.php
+++ b/src/Resources/config/twig.php
@@ -11,10 +11,13 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+use Sonata\AdminBundle\Twig\Extension\CanonicalizeExtension;
 use Sonata\AdminBundle\Twig\Extension\GroupExtension;
 use Sonata\AdminBundle\Twig\Extension\PaginationExtension;
+use Sonata\AdminBundle\Twig\Extension\SecurityExtension;
 use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
 use Sonata\AdminBundle\Twig\Extension\TemplateRegistryExtension;
+use Sonata\AdminBundle\Twig\Extension\XEditableExtension;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
 
@@ -50,9 +53,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->args([
                 new ReferenceConfigurator('sonata.admin.pool'),
                 (new ReferenceConfigurator('logger'))->nullOnInvalid(),
+                // NEXT_MAJOR: Remove next line.
                 new ReferenceConfigurator('translator'),
                 new ReferenceConfigurator('service_container'),
                 new ReferenceConfigurator('property_accessor'),
+                // NEXT_MAJOR: Remove next line.
                 new ReferenceConfigurator('security.authorization_checker'),
             ])
             ->call('setXEditableTypeMapping', [
@@ -75,5 +80,20 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         // NEXT_MAJOR: Remove this service.
         ->set('sonata.pagination.twig.extension', PaginationExtension::class)
             ->tag('twig.extension')
+
+        ->set('sonata.security.twig.extension', SecurityExtension::class)
+            ->tag('twig.extension')
+            ->args([
+                new ReferenceConfigurator('security.authorization_checker'),
+            ])
+
+        ->set('sonata.canonicalize.twig.extension', CanonicalizeExtension::class)
+            ->tag('twig.extension')
+
+        ->set('sonata.xeditable.twig.extension', XEditableExtension::class)
+            ->tag('twig.extension')
+            ->args([
+                new ReferenceConfigurator('translator'),
+            ])
     ;
 };

--- a/src/Resources/config/twig.php
+++ b/src/Resources/config/twig.php
@@ -62,6 +62,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ])
             ->call('setXEditableTypeMapping', [
                 '%sonata.admin.twig.extension.x_editable_type_mapping%',
+                'sonata_deprecation_mute',
             ])
 
         ->set('sonata.templates.twig.extension', TemplateRegistryExtension::class)
@@ -94,6 +95,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->tag('twig.extension')
             ->args([
                 new ReferenceConfigurator('translator'),
+                '%sonata.admin.twig.extension.x_editable_type_mapping%',
             ])
     ;
 };

--- a/src/Resources/config/twig.php
+++ b/src/Resources/config/twig.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 use Sonata\AdminBundle\Twig\Extension\CanonicalizeExtension;
 use Sonata\AdminBundle\Twig\Extension\GroupExtension;
 use Sonata\AdminBundle\Twig\Extension\PaginationExtension;
+use Sonata\AdminBundle\Twig\Extension\RenderElementExtension;
 use Sonata\AdminBundle\Twig\Extension\SecurityExtension;
 use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
 use Sonata\AdminBundle\Twig\Extension\TemplateRegistryExtension;
@@ -52,6 +53,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->tag('twig.extension')
             ->args([
                 new ReferenceConfigurator('sonata.admin.pool'),
+                // NEXT_MAJOR: Remove next line.
                 (new ReferenceConfigurator('logger'))->nullOnInvalid(),
                 // NEXT_MAJOR: Remove next line.
                 new ReferenceConfigurator('translator'),
@@ -99,6 +101,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->args([
                 new ReferenceConfigurator('translator'),
                 '%sonata.admin.twig.extension.x_editable_type_mapping%',
+            ])
+
+        ->set('sonata.renderElement.twig.extension', RenderElementExtension::class)
+            ->tag('twig.extension')
+            ->args([
+                new ReferenceConfigurator('property_accessor'),
+                new ReferenceConfigurator('service_container'),
+                (new ReferenceConfigurator('logger'))->nullOnInvalid(),
             ])
     ;
 };

--- a/src/Resources/config/twig.php
+++ b/src/Resources/config/twig.php
@@ -90,6 +90,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('sonata.canonicalize.twig.extension', CanonicalizeExtension::class)
             ->tag('twig.extension')
+            ->args([
+                new ReferenceConfigurator('request_stack'),
+            ])
 
         ->set('sonata.xeditable.twig.extension', XEditableExtension::class)
             ->tag('twig.extension')

--- a/src/Resources/config/twig.php
+++ b/src/Resources/config/twig.php
@@ -62,6 +62,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 // NEXT_MAJOR: Remove next line.
                 new ReferenceConfigurator('security.authorization_checker'),
             ])
+             // NEXT_MAJOR: Remove next call.
             ->call('setXEditableTypeMapping', [
                 '%sonata.admin.twig.extension.x_editable_type_mapping%',
                 'sonata_deprecation_mute',
@@ -103,7 +104,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 '%sonata.admin.twig.extension.x_editable_type_mapping%',
             ])
 
-        ->set('sonata.renderElement.twig.extension', RenderElementExtension::class)
+        ->set('sonata.render_element.twig.extension', RenderElementExtension::class)
             ->tag('twig.extension')
             ->args([
                 new ReferenceConfigurator('property_accessor'),

--- a/src/Twig/Extension/CanonicalizeExtension.php
+++ b/src/Twig/Extension/CanonicalizeExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Twig\Extension;
 
+use Symfony\Component\HttpFoundation\RequestStack;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 
@@ -25,6 +26,16 @@ final class CanonicalizeExtension extends AbstractExtension
         'nl' => ['nl', 'nl-be'],
         'fr' => ['fr', 'fr-ca', 'fr-ch'],
     ];
+
+    /**
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
 
     /**
      * @return TwigFunction[]
@@ -42,9 +53,9 @@ final class CanonicalizeExtension extends AbstractExtension
      * Returns a canonicalized locale for "moment" NPM library,
      * or `null` if the locale's language is "en", which doesn't require localization.
      */
-    public function getCanonicalizedLocaleForMoment(array $context): ?string
+    public function getCanonicalizedLocaleForMoment(): ?string
     {
-        $locale = strtolower(str_replace('_', '-', $context['app']->getRequest()->getLocale()));
+        $locale = strtolower(str_replace('_', '-', $this->requestStack->getCurrentRequest()->getLocale()));
 
         // "en" language doesn't require localization.
         if (('en' === $lang = substr($locale, 0, 2)) && !\in_array($locale, ['en-au', 'en-ca', 'en-gb', 'en-ie', 'en-nz'], true)) {
@@ -64,9 +75,9 @@ final class CanonicalizeExtension extends AbstractExtension
      * Returns a canonicalized locale for "select2" NPM library,
      * or `null` if the locale's language is "en", which doesn't require localization.
      */
-    public function getCanonicalizedLocaleForSelect2(array $context): ?string
+    public function getCanonicalizedLocaleForSelect2(): ?string
     {
-        $locale = str_replace('_', '-', $context['app']->getRequest()->getLocale());
+        $locale = str_replace('_', '-', $this->requestStack->getCurrentRequest()->getLocale());
 
         // "en" language doesn't require localization.
         if ('en' === $lang = substr($locale, 0, 2)) {

--- a/src/Twig/Extension/CanonicalizeExtension.php
+++ b/src/Twig/Extension/CanonicalizeExtension.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class CanonicalizeExtension extends AbstractExtension
+{
+    // @todo: there are more locales which are not supported by moment and they need to be translated/normalized/canonicalized here
+    private const MOMENT_UNSUPPORTED_LOCALES = [
+        'de' => ['de', 'de-at'],
+        'es' => ['es', 'es-do'],
+        'nl' => ['nl', 'nl-be'],
+        'fr' => ['fr', 'fr-ca', 'fr-ch'],
+    ];
+
+    /**
+     * @return TwigFunction[]
+     */
+    public function getFunctions(): array
+    {
+        return [
+            //NEXT_MAJOR: Uncomment lines below
+            //new TwigFunction('canonicalize_locale_for_moment', [$this, 'getCanonicalizedLocaleForMoment'], ['needs_context' => true]),
+            //new TwigFunction('canonicalize_locale_for_select2', [$this, 'getCanonicalizedLocaleForSelect2'], ['needs_context' => true]),
+        ];
+    }
+
+    /*
+     * Returns a canonicalized locale for "moment" NPM library,
+     * or `null` if the locale's language is "en", which doesn't require localization.
+     */
+    public function getCanonicalizedLocaleForMoment(array $context): ?string
+    {
+        $locale = strtolower(str_replace('_', '-', $context['app']->getRequest()->getLocale()));
+
+        // "en" language doesn't require localization.
+        if (('en' === $lang = substr($locale, 0, 2)) && !\in_array($locale, ['en-au', 'en-ca', 'en-gb', 'en-ie', 'en-nz'], true)) {
+            return null;
+        }
+
+        foreach (self::MOMENT_UNSUPPORTED_LOCALES as $language => $locales) {
+            if ($language === $lang && !\in_array($locale, $locales, true)) {
+                $locale = $language;
+            }
+        }
+
+        return $locale;
+    }
+
+    /**
+     * Returns a canonicalized locale for "select2" NPM library,
+     * or `null` if the locale's language is "en", which doesn't require localization.
+     */
+    public function getCanonicalizedLocaleForSelect2(array $context): ?string
+    {
+        $locale = str_replace('_', '-', $context['app']->getRequest()->getLocale());
+
+        // "en" language doesn't require localization.
+        if ('en' === $lang = substr($locale, 0, 2)) {
+            return null;
+        }
+
+        switch ($locale) {
+            case 'pt':
+                $locale = 'pt-PT';
+                break;
+            case 'ug':
+                $locale = 'ug-CN';
+                break;
+            case 'zh':
+                $locale = 'zh-CN';
+                break;
+            default:
+                if (!\in_array($locale, ['pt-BR', 'pt-PT', 'ug-CN', 'zh-CN', 'zh-TW'], true)) {
+                    $locale = $lang;
+                }
+        }
+
+        return $locale;
+    }
+}

--- a/src/Twig/Extension/CanonicalizeExtension.php
+++ b/src/Twig/Extension/CanonicalizeExtension.php
@@ -32,6 +32,9 @@ final class CanonicalizeExtension extends AbstractExtension
      */
     private $requestStack;
 
+    /**
+     * @internal This class should only be used through Twig
+     */
     public function __construct(RequestStack $requestStack)
     {
         $this->requestStack = $requestStack;
@@ -44,8 +47,8 @@ final class CanonicalizeExtension extends AbstractExtension
     {
         return [
             //NEXT_MAJOR: Uncomment lines below
-            //new TwigFunction('canonicalize_locale_for_moment', [$this, 'getCanonicalizedLocaleForMoment'], ['needs_context' => true]),
-            //new TwigFunction('canonicalize_locale_for_select2', [$this, 'getCanonicalizedLocaleForSelect2'], ['needs_context' => true]),
+            //new TwigFunction('canonicalize_locale_for_moment', [$this, 'getCanonicalizedLocaleForMoment']),
+            //new TwigFunction('canonicalize_locale_for_select2', [$this, 'getCanonicalizedLocaleForSelect2']),
         ];
     }
 

--- a/src/Twig/Extension/RenderElementExtension.php
+++ b/src/Twig/Extension/RenderElementExtension.php
@@ -44,8 +44,11 @@ final class RenderElementExtension extends AbstractExtension
      */
     private $propertyAccessor;
 
+    /**
+     * @internal This class should only be used through Twig
+     */
     public function __construct(
-        ?PropertyAccessorInterface $propertyAccessor = null,
+        PropertyAccessorInterface $propertyAccessor,
         ?ContainerInterface $templateRegistries = null,
         ?LoggerInterface $logger = null
     ) {
@@ -385,10 +388,7 @@ final class RenderElementExtension extends AbstractExtension
         return [$object, $value];
     }
 
-    /**
-     * NEXT MAJOR: Make this method private.
-     */
-    public function render(
+    private function render(
         FieldDescriptionInterface $fieldDescription,
         TemplateWrapper $template,
         array $parameters,

--- a/src/Twig/Extension/RenderElementExtension.php
+++ b/src/Twig/Extension/RenderElementExtension.php
@@ -30,12 +30,12 @@ use Twig\TwigFilter;
 final class RenderElementExtension extends AbstractExtension
 {
     /**
-     * @var LoggerInterface
+     * @var LoggerInterface|null
      */
-    protected $logger;
+    private $logger;
 
     /**
-     * @var ContainerInterface
+     * @var ContainerInterface|null
      */
     private $templateRegistries;
 
@@ -45,6 +45,8 @@ final class RenderElementExtension extends AbstractExtension
     private $propertyAccessor;
 
     /**
+     * NEXT_MAJOR: Make $templateRegistries mandatory.
+     *
      * @internal This class should only be used through Twig
      */
     public function __construct(
@@ -268,8 +270,9 @@ final class RenderElementExtension extends AbstractExtension
 
         if (null === $propertyPath) {
             // For BC kept associated_tostring option behavior
+            // NEXT_MAJOR Remove next line.
             $method = $fieldDescription->getOption('associated_tostring');
-
+            // NEXT_MAJOR: Remove the "if" part and leave the "else" part
             if ($method) {
                 @trigger_error(
                     'Option "associated_tostring" is deprecated since version 2.3 and will be removed in 4.0. Use "associated_property" instead.',
@@ -300,8 +303,9 @@ final class RenderElementExtension extends AbstractExtension
     }
 
     /**
-     * NEXT_MAJOR: Make this method protected
-     * Get template.
+     * NEXT_MAJOR: Make this method private.
+     *
+     * @internal This method will be private in the next major version
      *
      * @param string $defaultTemplate
      *
@@ -339,8 +343,6 @@ final class RenderElementExtension extends AbstractExtension
     }
 
     /**
-     * NEXT MAJOR: Make this method private.
-     *
      * Extracts the object and requested value from the $listElement.
      *
      * @param object|array $listElement
@@ -349,7 +351,7 @@ final class RenderElementExtension extends AbstractExtension
      *
      * @return array An array containing object and value
      */
-    public function getObjectAndValueFromListElement(
+    private function getObjectAndValueFromListElement(
         $listElement,
         FieldDescriptionInterface $fieldDescription
     ): array {

--- a/src/Twig/Extension/RenderElementExtension.php
+++ b/src/Twig/Extension/RenderElementExtension.php
@@ -1,0 +1,439 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Twig\Extension;
+
+use Psr\Log\LoggerInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Sonata\AdminBundle\Exception\NoValueException;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
+use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Twig\Environment;
+use Twig\Error\LoaderError;
+use Twig\Extension\AbstractExtension;
+use Twig\TemplateWrapper;
+use Twig\TwigFilter;
+
+final class RenderElementExtension extends AbstractExtension
+{
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * @var ContainerInterface
+     */
+    private $templateRegistries;
+
+    /**
+     * @var PropertyAccessorInterface
+     */
+    private $propertyAccessor;
+
+    public function __construct(
+        ?PropertyAccessorInterface $propertyAccessor = null,
+        ?ContainerInterface $templateRegistries = null,
+        ?LoggerInterface $logger = null
+    ) {
+        $this->propertyAccessor = $propertyAccessor;
+        $this->templateRegistries = $templateRegistries;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @return TwigFilter[]
+     */
+    public function getFilters(): array
+    {
+        return [
+            //NEXT_MAJOR: Uncomment lines below
+            /*
+            new TwigFilter(
+                'render_list_element',
+                [$this, 'renderListElement'],
+                [
+                    'is_safe' => ['html'],
+                    'needs_environment' => true,
+                ]
+            ),
+            new TwigFilter(
+                'render_view_element',
+                [$this, 'renderViewElement'],
+                [
+                    'is_safe' => ['html'],
+                    'needs_environment' => true,
+                ]
+            ),
+            new TwigFilter(
+                'render_view_element_compare',
+                [$this, 'renderViewElementCompare'],
+                [
+                    'is_safe' => ['html'],
+                    'needs_environment' => true,
+                ]
+            ),
+            new TwigFilter(
+                'render_relation_element',
+                [$this, 'renderRelationElement']
+            ),
+            */
+        ];
+    }
+
+    /**
+     * render a list element from the FieldDescription.
+     *
+     * @param object|array $listElement
+     * @param array        $params
+     *
+     * @return string
+     */
+    public function renderListElement(
+        Environment $environment,
+        $listElement,
+        FieldDescriptionInterface $fieldDescription,
+        $params = []
+    ) {
+        $template = $this->getTemplate(
+            $fieldDescription,
+            // NEXT_MAJOR: Remove this line and use commented line below instead
+            $fieldDescription->getAdmin()->getTemplate('base_list_field'),
+            //$this->getTemplateRegistry($fieldDescription->getAdmin()->getCode())->getTemplate('base_list_field'),
+            $environment
+        );
+
+        [$object, $value] = $this->getObjectAndValueFromListElement($listElement, $fieldDescription);
+
+        return $this->render($fieldDescription, $template, array_merge($params, [
+            'admin' => $fieldDescription->getAdmin(),
+            'object' => $object,
+            'value' => $value,
+            'field_description' => $fieldDescription,
+        ]), $environment);
+    }
+
+    /**
+     * render a view element.
+     *
+     * @param object $object
+     *
+     * @return string
+     */
+    public function renderViewElement(
+        Environment $environment,
+        FieldDescriptionInterface $fieldDescription,
+        $object
+    ) {
+        $template = $this->getTemplate(
+            $fieldDescription,
+            '@SonataAdmin/CRUD/base_show_field.html.twig',
+            $environment
+        );
+
+        try {
+            $value = $fieldDescription->getValue($object);
+        } catch (NoValueException $e) {
+            // NEXT_MAJOR: Remove the try catch in order to throw the NoValueException.
+            @trigger_error(
+                sprintf(
+                    'Accessing a non existing value for the field "%s" is deprecated'
+                    .' since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.',
+                    $fieldDescription->getName(),
+                ),
+                E_USER_DEPRECATED
+            );
+
+            $value = null;
+        }
+
+        return $this->render($fieldDescription, $template, [
+            'field_description' => $fieldDescription,
+            'object' => $object,
+            'value' => $value,
+            'admin' => $fieldDescription->getAdmin(),
+        ], $environment);
+    }
+
+    /**
+     * render a compared view element.
+     *
+     * @param mixed $baseObject
+     * @param mixed $compareObject
+     *
+     * @return string
+     */
+    public function renderViewElementCompare(
+        Environment $environment,
+        FieldDescriptionInterface $fieldDescription,
+        $baseObject,
+        $compareObject
+    ) {
+        $template = $this->getTemplate(
+            $fieldDescription,
+            '@SonataAdmin/CRUD/base_show_field.html.twig',
+            $environment
+        );
+
+        try {
+            $baseValue = $fieldDescription->getValue($baseObject);
+        } catch (NoValueException $e) {
+            // NEXT_MAJOR: Remove the try catch in order to throw the NoValueException.
+            @trigger_error(
+                sprintf(
+                    'Accessing a non existing value for the field "%s" is deprecated'
+                    .' since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.',
+                    $fieldDescription->getName(),
+                ),
+                E_USER_DEPRECATED
+            );
+
+            $baseValue = null;
+        }
+
+        try {
+            $compareValue = $fieldDescription->getValue($compareObject);
+        } catch (NoValueException $e) {
+            // NEXT_MAJOR: Remove the try catch in order to throw the NoValueException.
+            @trigger_error(
+                sprintf(
+                    'Accessing a non existing value for the field "%s" is deprecated'
+                    .' since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.',
+                    $fieldDescription->getName(),
+                ),
+                E_USER_DEPRECATED
+            );
+
+            $compareValue = null;
+        }
+
+        $baseValueOutput = $template->render([
+            'admin' => $fieldDescription->getAdmin(),
+            'field_description' => $fieldDescription,
+            'value' => $baseValue,
+            'object' => $baseObject,
+        ]);
+
+        $compareValueOutput = $template->render([
+            'field_description' => $fieldDescription,
+            'admin' => $fieldDescription->getAdmin(),
+            'value' => $compareValue,
+            'object' => $compareObject,
+        ]);
+
+        // Compare the rendered output of both objects by using the (possibly) overridden field block
+        $isDiff = $baseValueOutput !== $compareValueOutput;
+
+        return $this->render($fieldDescription, $template, [
+            'field_description' => $fieldDescription,
+            'value' => $baseValue,
+            'value_compare' => $compareValue,
+            'is_diff' => $isDiff,
+            'admin' => $fieldDescription->getAdmin(),
+            'object' => $baseObject,
+            'object_compare' => $compareObject,
+        ], $environment);
+    }
+
+    /**
+     * @param mixed $element
+     *
+     * @throws \RuntimeException
+     *
+     * @return mixed
+     */
+    public function renderRelationElement($element, FieldDescriptionInterface $fieldDescription)
+    {
+        if (!\is_object($element)) {
+            return $element;
+        }
+
+        $propertyPath = $fieldDescription->getOption('associated_property');
+
+        if (null === $propertyPath) {
+            // For BC kept associated_tostring option behavior
+            $method = $fieldDescription->getOption('associated_tostring');
+
+            if ($method) {
+                @trigger_error(
+                    'Option "associated_tostring" is deprecated since version 2.3 and will be removed in 4.0. Use "associated_property" instead.',
+                    E_USER_DEPRECATED
+                );
+            } else {
+                $method = '__toString';
+            }
+
+            if (!method_exists($element, $method)) {
+                throw new \RuntimeException(sprintf(
+                    'You must define an `associated_property` option or create a `%s::__toString` method'
+                    .' to the field option %s from service %s is ',
+                    \get_class($element),
+                    $fieldDescription->getName(),
+                    $fieldDescription->getAdmin()->getCode()
+                ));
+            }
+
+            return $element->{$method}();
+        }
+
+        if (\is_callable($propertyPath)) {
+            return $propertyPath($element);
+        }
+
+        return $this->propertyAccessor->getValue($element, $propertyPath);
+    }
+
+    /**
+     * NEXT_MAJOR: Make this method protected
+     * Get template.
+     *
+     * @param string $defaultTemplate
+     *
+     * @return TemplateWrapper
+     */
+    public function getTemplate(
+        FieldDescriptionInterface $fieldDescription,
+        $defaultTemplate,
+        Environment $environment
+    ) {
+        $templateName = $fieldDescription->getTemplate() ?: $defaultTemplate;
+
+        try {
+            $template = $environment->load($templateName);
+        } catch (LoaderError $e) {
+            @trigger_error(sprintf(
+                'Relying on default template loading on field template loading exception is deprecated since 3.1'
+                .' and will be removed in 4.0. A %s exception will be thrown instead',
+                LoaderError::class
+            ), E_USER_DEPRECATED);
+            $template = $environment->load($defaultTemplate);
+
+            if (null !== $this->logger) {
+                $this->logger->warning(sprintf(
+                    'An error occured trying to load the template "%s" for the field "%s",'
+                    .' the default template "%s" was used instead.',
+                    $templateName,
+                    $fieldDescription->getFieldName(),
+                    $defaultTemplate
+                ), ['exception' => $e]);
+            }
+        }
+
+        return $template;
+    }
+
+    /**
+     * NEXT MAJOR: Make this method private.
+     *
+     * Extracts the object and requested value from the $listElement.
+     *
+     * @param object|array $listElement
+     *
+     * @throws \TypeError when $listElement is not an object or an array with an object on offset 0
+     *
+     * @return array An array containing object and value
+     */
+    public function getObjectAndValueFromListElement(
+        $listElement,
+        FieldDescriptionInterface $fieldDescription
+    ): array {
+        if (\is_object($listElement)) {
+            $object = $listElement;
+        } elseif (\is_array($listElement)) {
+            if (!isset($listElement[0]) || !\is_object($listElement[0])) {
+                throw new \TypeError(sprintf('If argument 1 passed to %s() is an array it must contain an object at offset 0.', __METHOD__));
+            }
+
+            $object = $listElement[0];
+        } else {
+            throw new \TypeError(sprintf('Argument 1 passed to %s() must be an object or an array, %s given.', __METHOD__, \gettype($listElement)));
+        }
+
+        if (\is_array($listElement) && \array_key_exists($fieldDescription->getName(), $listElement)) {
+            $value = $listElement[$fieldDescription->getName()];
+        } else {
+            try {
+                $value = $fieldDescription->getValue($object);
+            } catch (NoValueException $e) {
+                // NEXT_MAJOR: throw the NoValueException.
+                @trigger_error(
+                    sprintf(
+                        'Accessing a non existing value for the field "%s" is deprecated'
+                        .' since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.',
+                        $fieldDescription->getName(),
+                    ),
+                    E_USER_DEPRECATED
+                );
+
+                $value = null;
+            }
+        }
+
+        return [$object, $value];
+    }
+
+    /**
+     * NEXT MAJOR: Make this method private.
+     */
+    public function render(
+        FieldDescriptionInterface $fieldDescription,
+        TemplateWrapper $template,
+        array $parameters,
+        Environment $environment
+    ): string {
+        $content = $template->render($parameters);
+
+        if ($environment->isDebug()) {
+            $commentTemplate = <<<'EOT'
+
+<!-- START
+    fieldName: %s
+    template: %s
+    compiled template: %s
+    -->
+    %s
+<!-- END - fieldName: %s -->
+EOT;
+
+            return sprintf(
+                $commentTemplate,
+                $fieldDescription->getFieldName(),
+                $fieldDescription->getTemplate(),
+                $template->getSourceContext()->getName(),
+                $content,
+                $fieldDescription->getFieldName()
+            );
+        }
+
+        return $content;
+    }
+
+    /**
+     * @throws ServiceCircularReferenceException
+     * @throws ServiceNotFoundException
+     */
+    private function getTemplateRegistry(string $adminCode): TemplateRegistryInterface
+    {
+        $serviceId = $adminCode.'.template_registry';
+        $templateRegistry = $this->templateRegistries->get($serviceId);
+
+        if ($templateRegistry instanceof TemplateRegistryInterface) {
+            return $templateRegistry;
+        }
+
+        throw new ServiceNotFoundException($serviceId);
+    }
+}

--- a/src/Twig/Extension/SecurityExtension.php
+++ b/src/Twig/Extension/SecurityExtension.php
@@ -26,6 +26,9 @@ final class SecurityExtension extends AbstractExtension
      */
     private $securityChecker;
 
+    /**
+     * @internal This class should only be used through Twig
+     */
     public function __construct(
         ?AuthorizationCheckerInterface $securityChecker = null
     ) {

--- a/src/Twig/Extension/SecurityExtension.php
+++ b/src/Twig/Extension/SecurityExtension.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Twig\Extension;
+
+use Symfony\Component\Security\Acl\Voter\FieldVote;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class SecurityExtension extends AbstractExtension
+{
+    /**
+     * @var AuthorizationCheckerInterface|null
+     */
+    private $securityChecker;
+
+    public function __construct(
+        ?AuthorizationCheckerInterface $securityChecker = null
+    ) {
+        $this->securityChecker = $securityChecker;
+    }
+
+    /**
+     * @return TwigFunction[]
+     */
+    public function getFunctions(): array
+    {
+        return [
+            //NEXT_MAJOR: Uncomment line below
+            //new TwigFunction('is_granted_affirmative', [$this, 'isGrantedAffirmative']),
+        ];
+    }
+
+    /**
+     * @param string|array $role
+     */
+    public function isGrantedAffirmative($role, ?object $object = null, ?string $field = null): bool
+    {
+        if (null === $this->securityChecker) {
+            return false;
+        }
+
+        if (null !== $field) {
+            $object = new FieldVote($object, $field);
+        }
+
+        if (!\is_array($role)) {
+            $role = [$role];
+        }
+
+        foreach ($role as $oneRole) {
+            try {
+                if ($this->securityChecker->isGranted($oneRole, $object)) {
+                    return true;
+                }
+            } catch (AuthenticationCredentialsNotFoundException $e) {
+                // empty on purpose
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -754,34 +754,4 @@ EOT;
 
         return $this->renderElementExtension->getTemplate($fieldDescription, $defaultTemplate, $$environment);
     }
-
-    /**
-     * NEXT_MAJOR: Remove this method
-     * Extracts the object and requested value from the $listElement.
-     *
-     * @param object|array $listElement
-     *
-     * @throws \TypeError when $listElement is not an object or an array with an object on offset 0
-     *
-     * @return array An array containing object and value
-     *
-     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0
-     */
-    private function getObjectAndValueFromListElement(
-        $listElement,
-        FieldDescriptionInterface $fieldDescription
-    ): array {
-        if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
-            @trigger_error(sprintf(
-                'The %s method is deprecated in favor of RenderElementExtension::getObjectAndValueFromListElement since version 3.x and will be removed in 4.0.',
-                __METHOD__
-            ), E_USER_DEPRECATED);
-        }
-
-        if (null === $this->renderElementExtension) {
-            $this->renderElementExtension = new RenderElementExtension($this->propertyAccessor, $this->templateRegistries, $this->logger);
-        }
-
-        return $this->renderElementExtension->getObjectAndValueFromListElement($listElement, $fieldDescription);
-    }
 }

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -23,6 +23,7 @@ use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Translation\TranslatorInterface as LegacyTranslationInterface;
@@ -669,10 +670,12 @@ class SonataAdminExtension extends AbstractExtension
         }
 
         if (null === $this->canonicalizeExtension) {
-            $this->canonicalizeExtension = new CanonicalizeExtension();
+            $requestStack = new RequestStack();
+            $requestStack->push($context['app']->getRequest());
+            $this->canonicalizeExtension = new CanonicalizeExtension($requestStack);
         }
 
-        return $this->canonicalizeExtension->getCanonicalizedLocaleForMoment($context);
+        return $this->canonicalizeExtension->getCanonicalizedLocaleForMoment();
     }
 
     /**
@@ -695,10 +698,12 @@ class SonataAdminExtension extends AbstractExtension
         }
 
         if (null === $this->canonicalizeExtension) {
-            $this->canonicalizeExtension = new CanonicalizeExtension();
+            $requestStack = new RequestStack();
+            $requestStack->push($context['app']->getRequest());
+            $this->canonicalizeExtension = new CanonicalizeExtension($requestStack);
         }
 
-        return $this->canonicalizeExtension->getCanonicalizedLocaleForSelect2($context);
+        return $this->canonicalizeExtension->getCanonicalizedLocaleForSelect2();
     }
 
     /**

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -388,12 +388,36 @@ class SonataAdminExtension extends AbstractExtension
         array $parameters,
         Environment $environment
     ) {
-        return $this->render(
-            $fieldDescription,
-            new TemplateWrapper($environment, $template),
-            $parameters,
-            $environment
-        );
+        @trigger_error(sprintf(
+            'The %s method is deprecated since version 3.33 and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
+        $content = $template->render($parameters);
+
+        if ($environment->isDebug()) {
+            $commentTemplate = <<<'EOT'
+
+<!-- START
+    fieldName: %s
+    template: %s
+    compiled template: %s
+    -->
+    %s
+<!-- END - fieldName: %s -->
+EOT;
+
+            return sprintf(
+                $commentTemplate,
+                $fieldDescription->getFieldName(),
+                $fieldDescription->getTemplate(),
+                $template->getSourceContext()->getName(),
+                $content,
+                $fieldDescription->getFieldName()
+            );
+        }
+
+        return $content;
     }
 
     /**
@@ -729,29 +753,6 @@ class SonataAdminExtension extends AbstractExtension
         }
 
         return $this->renderElementExtension->getTemplate($fieldDescription, $defaultTemplate, $$environment);
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     */
-    private function render(
-        FieldDescriptionInterface $fieldDescription,
-        TemplateWrapper $template,
-        array $parameters,
-        Environment $environment
-    ): string {
-        if ('sonata_deprecation_mute' !== (\func_get_args()[4] ?? null)) {
-            @trigger_error(sprintf(
-                'The %s method is deprecated in favor of RenderElementExtension::render since version 3.x and will be removed in 4.0.',
-                __METHOD__
-            ), E_USER_DEPRECATED);
-        }
-
-        if (null === $this->renderElementExtension) {
-            $this->renderElementExtension = new RenderElementExtension($this->propertyAccessor, $this->templateRegistries, $this->logger);
-        }
-
-        return $this->renderElementExtension->render($fieldDescription, $template, $parameters, $environment);
     }
 
     /**

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -24,9 +24,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
-use Symfony\Component\Security\Acl\Voter\FieldVote;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 use Symfony\Component\Translation\TranslatorInterface as LegacyTranslationInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
@@ -44,6 +42,11 @@ use Twig\TwigFunction;
  */
 class SonataAdminExtension extends AbstractExtension
 {
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0
+     */
     // @todo: there are more locales which are not supported by moment and they need to be translated/normalized/canonicalized here
     public const MOMENT_UNSUPPORTED_LOCALES = [
         'de' => ['de', 'de-at'],
@@ -68,7 +71,11 @@ class SonataAdminExtension extends AbstractExtension
     protected $translator;
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
      * @var string[]
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0
      */
     private $xEditableTypeMapping = [];
 
@@ -78,7 +85,11 @@ class SonataAdminExtension extends AbstractExtension
     private $templateRegistries;
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
      * @var AuthorizationCheckerInterface
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0
      */
     private $securityChecker;
 
@@ -88,7 +99,30 @@ class SonataAdminExtension extends AbstractExtension
     private $propertyAccessor;
 
     /**
-     * NEXT_MAJOR: Make $propertyAccessor mandatory.
+     * NEXT_MAJOR: Remove this property.
+     *
+     * @var XEditableExtension|null
+     */
+    private $xEditableExtension;
+
+    /**
+     * NEXT_MAJOR: Remove this property.
+     *
+     * @var SecurityExtension|null
+     */
+    private $securityExtension;
+
+    /**
+     * NEXT_MAJOR: Remove this property.
+     *
+     * @var CanonicalizeExtension|null
+     */
+    private $canonicalizeExtension;
+
+    /**
+     * NEXT_MAJOR: Remove @internal tag, $translator & $securityChecker parameters and make propertyAccessor mandatory.
+     *
+     * @internal
      */
     public function __construct(
         Pool $pool,
@@ -96,14 +130,14 @@ class SonataAdminExtension extends AbstractExtension
         $translator = null,
         ?ContainerInterface $templateRegistries = null,
         $propertyAccessorOrSecurityChecker = null,
-        ?AuthorizationCheckerInterface $securityChecker = null
+        ?AuthorizationCheckerInterface $securityChecker = null //NEXT_MAJOR: Remove this parameter
     ) {
         // NEXT_MAJOR: make the translator parameter required, move TranslatorInterface check to method signature
         // and remove this block
 
         if (null === $translator) {
             @trigger_error(
-                'The $translator parameter will be required fields with the 4.0 release.',
+                'The $translator parameter will be required field with the 4.0 release.',
                 E_USER_DEPRECATED
             );
         } else {
@@ -162,7 +196,7 @@ class SonataAdminExtension extends AbstractExtension
             $this->propertyAccessor = $pool->getPropertyAccessor();
             $this->securityChecker = $securityChecker;
         } else {
-            $this->securityChecker = $securityChecker;
+            $this->securityChecker = $securityChecker; //NEXT_MAJOR: Remove this property
             $this->propertyAccessor = $propertyAccessorOrSecurityChecker;
         }
 
@@ -210,10 +244,12 @@ class SonataAdminExtension extends AbstractExtension
                 'sonata_urlsafeid',
                 [$this, 'getUrlSafeIdentifier']
             ),
+            //NEXT_MAJOR remove this filter
             new TwigFilter(
                 'sonata_xeditable_type',
                 [$this, 'getXEditableType']
             ),
+            //NEXT_MAJOR remove this filter
             new TwigFilter(
                 'sonata_xeditable_choices',
                 [$this, 'getXEditableChoices']
@@ -222,7 +258,11 @@ class SonataAdminExtension extends AbstractExtension
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @return TwigFunction[]
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0
      */
     public function getFunctions()
     {
@@ -533,22 +573,46 @@ class SonataAdminExtension extends AbstractExtension
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @param string[] $xEditableTypeMapping
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0
      */
     public function setXEditableTypeMapping($xEditableTypeMapping)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s method is deprecated in favor of XEditableExtension::setXEditableTypeMapping since version 3.x and will be removed in 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         $this->xEditableTypeMapping = $xEditableTypeMapping;
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @return string|bool
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0
      */
     public function getXEditableType($type)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s method is deprecated in favor of XEditableExtension::getXEditableType since version 3.x and will be removed in 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         return $this->xEditableTypeMapping[$type] ?? false;
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * Return xEditable choices based on the field description choices options & catalogue options.
      * With the following choice options:
      *     ['Status1' => 'Alias1', 'Status2' => 'Alias2']
@@ -556,139 +620,102 @@ class SonataAdminExtension extends AbstractExtension
      *     [['value' => 'Status1', 'text' => 'Alias1'], ['value' => 'Status2', 'text' => 'Alias2']].
      *
      * @return array
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0
      */
     public function getXEditableChoices(FieldDescriptionInterface $fieldDescription)
     {
-        $choices = $fieldDescription->getOption('choices', []);
-        $catalogue = $fieldDescription->getOption('catalogue');
-        $xEditableChoices = [];
-        if (!empty($choices)) {
-            reset($choices);
-            $first = current($choices);
-            // the choices are already in the right format
-            if (\is_array($first) && \array_key_exists('value', $first) && \array_key_exists('text', $first)) {
-                $xEditableChoices = $choices;
-            } else {
-                foreach ($choices as $value => $text) {
-                    if ($catalogue) {
-                        if (null !== $this->translator) {
-                            $text = $this->translator->trans($text, [], $catalogue);
-                        // NEXT_MAJOR: Remove this check
-                        } elseif (method_exists($fieldDescription->getAdmin(), 'trans')) {
-                            $text = $fieldDescription->getAdmin()->trans($text, [], $catalogue);
-                        }
-                    }
-
-                    $xEditableChoices[] = [
-                        'value' => $value,
-                        'text' => $text,
-                    ];
-                }
-            }
+        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s method is deprecated in favor of XEditableExtension::getXEditableChoices since version 3.x and will be removed in 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
         }
 
-        if (false === $fieldDescription->getOption('required', true)
-            && false === $fieldDescription->getOption('multiple', false)
-        ) {
-            $xEditableChoices = array_merge([[
-                'value' => '',
-                'text' => '',
-            ]], $xEditableChoices);
+        if (null === $this->xEditableExtension) {
+            $this->xEditableExtension = new XEditableExtension($this->translator);
         }
 
-        return $xEditableChoices;
+        return $this->xEditableExtension->getXEditableChoices($fieldDescription);
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * Returns a canonicalized locale for "moment" NPM library,
      * or `null` if the locale's language is "en", which doesn't require localization.
      *
      * @return string|null
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0
      */
     final public function getCanonicalizedLocaleForMoment(array $context)
     {
-        $locale = strtolower(str_replace('_', '-', $context['app']->getRequest()->getLocale()));
-
-        // "en" language doesn't require localization.
-        if (('en' === $lang = substr($locale, 0, 2)) && !\in_array($locale, ['en-au', 'en-ca', 'en-gb', 'en-ie', 'en-nz'], true)) {
-            return null;
+        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s method is deprecated in favor of CanonicalizeExtension::getCanonicalizedLocaleForMoment since version 3.x and will be removed in 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
         }
 
-        foreach (self::MOMENT_UNSUPPORTED_LOCALES as $language => $locales) {
-            if ($language === $lang && !\in_array($locale, $locales, true)) {
-                $locale = $language;
-            }
+        if (null === $this->canonicalizeExtension) {
+            $this->canonicalizeExtension = new CanonicalizeExtension();
         }
 
-        return $locale;
+        return $this->canonicalizeExtension->getCanonicalizedLocaleForMoment($context);
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * Returns a canonicalized locale for "select2" NPM library,
      * or `null` if the locale's language is "en", which doesn't require localization.
      *
      * @return string|null
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0
      */
     final public function getCanonicalizedLocaleForSelect2(array $context)
     {
-        $locale = str_replace('_', '-', $context['app']->getRequest()->getLocale());
-
-        // "en" language doesn't require localization.
-        if ('en' === $lang = substr($locale, 0, 2)) {
-            return null;
+        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s method is deprecated in favor of CanonicalizeExtension::getCanonicalizedLocaleForSelect2 since version 3.x and will be removed in 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
         }
 
-        switch ($locale) {
-            case 'pt':
-                $locale = 'pt-PT';
-                break;
-            case 'ug':
-                $locale = 'ug-CN';
-                break;
-            case 'zh':
-                $locale = 'zh-CN';
-                break;
-            default:
-                if (!\in_array($locale, ['pt-BR', 'pt-PT', 'ug-CN', 'zh-CN', 'zh-TW'], true)) {
-                    $locale = $lang;
-                }
+        if (null === $this->canonicalizeExtension) {
+            $this->canonicalizeExtension = new CanonicalizeExtension();
         }
 
-        return $locale;
+        return $this->canonicalizeExtension->getCanonicalizedLocaleForSelect2($context);
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @param string|array $role
      * @param object|null  $object
      * @param string|null  $field
      *
      * @return bool
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0
      */
     public function isGrantedAffirmative($role, $object = null, $field = null)
     {
-        if (null === $this->securityChecker) {
-            return false;
+        if ('sonata_deprecation_mute' !== (\func_get_args()[3] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s method is deprecated in favor of SecurityExtension::isGrantedAffirmative since version 3.x and will be removed in 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
         }
 
-        if (null !== $field) {
-            $object = new FieldVote($object, $field);
+        if (null === $this->securityExtension) {
+            $this->securityExtension = new SecurityExtension($this->securityChecker);
         }
 
-        if (!\is_array($role)) {
-            $role = [$role];
-        }
-
-        foreach ($role as $oneRole) {
-            try {
-                if ($this->securityChecker->isGranted($oneRole, $object)) {
-                    return true;
-                }
-            } catch (AuthenticationCredentialsNotFoundException $e) {
-                // empty on purpose
-            }
-        }
-
-        return false;
+        return $this->securityExtension->isGrantedAffirmative($role, $object, $field);
     }
 
     /**

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -247,12 +247,16 @@ class SonataAdminExtension extends AbstractExtension
             //NEXT_MAJOR remove this filter
             new TwigFilter(
                 'sonata_xeditable_type',
-                [$this, 'getXEditableType']
+                function ($type) {
+                    return $this->getXEditableType($type, 'sonata_deprecation_mute');
+                }
             ),
             //NEXT_MAJOR remove this filter
             new TwigFilter(
                 'sonata_xeditable_choices',
-                [$this, 'getXEditableChoices']
+                function (FieldDescriptionInterface $fieldDescription) {
+                    return $this->getXEditableChoices($fieldDescription, 'sonata_deprecation_mute');
+                }
             ),
         ];
     }
@@ -267,9 +271,15 @@ class SonataAdminExtension extends AbstractExtension
     public function getFunctions()
     {
         return [
-            new TwigFunction('canonicalize_locale_for_moment', [$this, 'getCanonicalizedLocaleForMoment'], ['needs_context' => true]),
-            new TwigFunction('canonicalize_locale_for_select2', [$this, 'getCanonicalizedLocaleForSelect2'], ['needs_context' => true]),
-            new TwigFunction('is_granted_affirmative', [$this, 'isGrantedAffirmative']),
+            new TwigFunction('canonicalize_locale_for_moment', function (array $context) {
+                return $this->getCanonicalizedLocaleForMoment($context, 'sonata_deprecation_mute');
+            }, ['needs_context' => true]),
+            new TwigFunction('canonicalize_locale_for_select2', function (array $context) {
+                return $this->getCanonicalizedLocaleForSelect2($context, 'sonata_deprecation_mute');
+            }, ['needs_context' => true]),
+            new TwigFunction('is_granted_affirmative', function ($role, $object = null, $field = null) {
+                return $this->isGrantedAffirmative($role, $object, $field, 'sonata_deprecation_mute');
+            }),
         ];
     }
 
@@ -633,7 +643,7 @@ class SonataAdminExtension extends AbstractExtension
         }
 
         if (null === $this->xEditableExtension) {
-            $this->xEditableExtension = new XEditableExtension($this->translator);
+            $this->xEditableExtension = new XEditableExtension($this->translator, $this->xEditableTypeMapping);
         }
 
         return $this->xEditableExtension->getXEditableChoices($fieldDescription);

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -19,17 +19,13 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Exception\NoValueException;
-use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
-use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Translation\TranslatorInterface as LegacyTranslationInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
-use Twig\Error\LoaderError;
 use Twig\Extension\AbstractExtension;
 use Twig\Template;
 use Twig\TemplateWrapper;
@@ -62,6 +58,8 @@ class SonataAdminExtension extends AbstractExtension
     protected $pool;
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
      * @var LoggerInterface
      */
     protected $logger;
@@ -81,6 +79,8 @@ class SonataAdminExtension extends AbstractExtension
     private $xEditableTypeMapping = [];
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
      * @var ContainerInterface
      */
     private $templateRegistries;
@@ -121,13 +121,20 @@ class SonataAdminExtension extends AbstractExtension
     private $canonicalizeExtension;
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
+     * @var RenderElementExtension|null
+     */
+    private $renderElementExtension;
+
+    /**
      * NEXT_MAJOR: Remove @internal tag, $translator & $securityChecker parameters and make propertyAccessor mandatory.
      *
      * @internal
      */
     public function __construct(
         Pool $pool,
-        ?LoggerInterface $logger = null,
+        ?LoggerInterface $logger = null, //NEXT_MAJOR: Remove this parameter
         $translator = null,
         ?ContainerInterface $templateRegistries = null,
         $propertyAccessorOrSecurityChecker = null,
@@ -213,33 +220,83 @@ class SonataAdminExtension extends AbstractExtension
     public function getFilters()
     {
         return [
+            //NEXT_MAJOR remove this filter
             new TwigFilter(
                 'render_list_element',
-                [$this, 'renderListElement'],
+                function (
+                    Environment $environment,
+                    $listElement,
+                    FieldDescriptionInterface $fieldDescription,
+                    $params = []
+                ) {
+                    return $this->renderListElement(
+                        $environment,
+                        $listElement,
+                        $fieldDescription,
+                        $params,
+                        'sonata_deprecation_mute'
+                    );
+                },
                 [
                     'is_safe' => ['html'],
                     'needs_environment' => true,
                 ]
             ),
+            //NEXT_MAJOR remove this filter
             new TwigFilter(
                 'render_view_element',
-                [$this, 'renderViewElement'],
+                function (
+                    Environment $environment,
+                    FieldDescriptionInterface $fieldDescription,
+                    $object
+                ) {
+                    return $this->renderViewElement(
+                        $environment,
+                        $fieldDescription,
+                        $object,
+                        'sonata_deprecation_mute'
+                    );
+                },
                 [
                     'is_safe' => ['html'],
                     'needs_environment' => true,
                 ]
             ),
+            //NEXT_MAJOR remove this filter
             new TwigFilter(
                 'render_view_element_compare',
-                [$this, 'renderViewElementCompare'],
+                function (
+                    Environment $environment,
+                    FieldDescriptionInterface $fieldDescription,
+                    $baseObject,
+                    $compareObject
+                ) {
+                    return $this->renderViewElementCompare(
+                        $environment,
+                        $fieldDescription,
+                        $baseObject,
+                        $compareObject,
+                        'sonata_deprecation_mute'
+                    );
+                },
                 [
                     'is_safe' => ['html'],
                     'needs_environment' => true,
                 ]
             ),
+            //NEXT_MAJOR remove this filter
             new TwigFilter(
                 'render_relation_element',
-                [$this, 'renderRelationElement']
+                function (
+                    $element,
+                    FieldDescriptionInterface $fieldDescription
+                ) {
+                    return $this->renderRelationElement(
+                        $element,
+                        $fieldDescription,
+                        'sonata_deprecation_mute'
+                    );
+                }
             ),
             new TwigFilter(
                 'sonata_urlsafeid',
@@ -290,12 +347,15 @@ class SonataAdminExtension extends AbstractExtension
     }
 
     /**
+     * NEXT_MAJOR: Remove this method
      * render a list element from the FieldDescription.
      *
      * @param object|array $listElement
      * @param array        $params
      *
      * @return string
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0
      */
     public function renderListElement(
         Environment $environment,
@@ -303,22 +363,18 @@ class SonataAdminExtension extends AbstractExtension
         FieldDescriptionInterface $fieldDescription,
         $params = []
     ) {
-        $template = $this->getTemplate(
-            $fieldDescription,
-            // NEXT_MAJOR: Remove this line and use commented line below instead
-            $fieldDescription->getAdmin()->getTemplate('base_list_field'),
-            //$this->getTemplateRegistry($fieldDescription->getAdmin()->getCode())->getTemplate('base_list_field'),
-            $environment
-        );
+        if ('sonata_deprecation_mute' !== (\func_get_args()[4] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s method is deprecated in favor of RenderElementExtension::renderListElement since version 3.x and will be removed in 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
 
-        [$object, $value] = $this->getObjectAndValueFromListElement($listElement, $fieldDescription);
+        if (null === $this->renderElementExtension) {
+            $this->renderElementExtension = new RenderElementExtension($this->propertyAccessor, $this->templateRegistries, $this->logger);
+        }
 
-        return $this->render($fieldDescription, $template, array_merge($params, [
-            'admin' => $fieldDescription->getAdmin(),
-            'object' => $object,
-            'value' => $value,
-            'field_description' => $fieldDescription,
-        ]), $environment);
+        return $this->renderElementExtension->renderListElement($environment, $listElement, $fieldDescription, $params);
     }
 
     /**
@@ -393,54 +449,44 @@ class SonataAdminExtension extends AbstractExtension
     }
 
     /**
+     * NEXT_MAJOR: Remove this method
      * render a view element.
      *
      * @param object $object
      *
      * @return string
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0
      */
     public function renderViewElement(
         Environment $environment,
         FieldDescriptionInterface $fieldDescription,
         $object
     ) {
-        $template = $this->getTemplate(
-            $fieldDescription,
-            '@SonataAdmin/CRUD/base_show_field.html.twig',
-            $environment
-        );
-
-        try {
-            $value = $fieldDescription->getValue($object);
-        } catch (NoValueException $e) {
-            // NEXT_MAJOR: Remove the try catch in order to throw the NoValueException.
-            @trigger_error(
-                sprintf(
-                    'Accessing a non existing value for the field "%s" is deprecated'
-                    .' since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.',
-                    $fieldDescription->getName(),
-                ),
-                E_USER_DEPRECATED
-            );
-
-            $value = null;
+        if ('sonata_deprecation_mute' !== (\func_get_args()[3] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s method is deprecated in favor of RenderElementExtension::renderViewElement since version 3.x and will be removed in 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
         }
 
-        return $this->render($fieldDescription, $template, [
-            'field_description' => $fieldDescription,
-            'object' => $object,
-            'value' => $value,
-            'admin' => $fieldDescription->getAdmin(),
-        ], $environment);
+        if (null === $this->renderElementExtension) {
+            $this->renderElementExtension = new RenderElementExtension($this->propertyAccessor, $this->templateRegistries, $this->logger);
+        }
+
+        return $this->renderElementExtension->renderViewElement($environment, $fieldDescription, $object);
     }
 
     /**
+     * NEXT_MAJOR: Remove this method
      * render a compared view element.
      *
      * @param mixed $baseObject
      * @param mixed $compareObject
      *
      * @return string
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0
      */
     public function renderViewElementCompare(
         Environment $environment,
@@ -448,118 +494,44 @@ class SonataAdminExtension extends AbstractExtension
         $baseObject,
         $compareObject
     ) {
-        $template = $this->getTemplate(
-            $fieldDescription,
-            '@SonataAdmin/CRUD/base_show_field.html.twig',
-            $environment
-        );
-
-        try {
-            $baseValue = $fieldDescription->getValue($baseObject);
-        } catch (NoValueException $e) {
-            // NEXT_MAJOR: Remove the try catch in order to throw the NoValueException.
-            @trigger_error(
-                sprintf(
-                    'Accessing a non existing value for the field "%s" is deprecated'
-                    .' since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.',
-                    $fieldDescription->getName(),
-                ),
-                E_USER_DEPRECATED
-            );
-
-            $baseValue = null;
+        if ('sonata_deprecation_mute' !== (\func_get_args()[4] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s method is deprecated in favor of RenderElementExtension::renderViewElementCompare since version 3.x and will be removed in 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+        if (null === $this->renderElementExtension) {
+            $this->renderElementExtension = new RenderElementExtension($this->propertyAccessor, $this->templateRegistries, $this->logger);
         }
 
-        try {
-            $compareValue = $fieldDescription->getValue($compareObject);
-        } catch (NoValueException $e) {
-            // NEXT_MAJOR: Remove the try catch in order to throw the NoValueException.
-            @trigger_error(
-                sprintf(
-                    'Accessing a non existing value for the field "%s" is deprecated'
-                    .' since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.',
-                    $fieldDescription->getName(),
-                ),
-                E_USER_DEPRECATED
-            );
-
-            $compareValue = null;
-        }
-
-        $baseValueOutput = $template->render([
-            'admin' => $fieldDescription->getAdmin(),
-            'field_description' => $fieldDescription,
-            'value' => $baseValue,
-            'object' => $baseObject,
-        ]);
-
-        $compareValueOutput = $template->render([
-            'field_description' => $fieldDescription,
-            'admin' => $fieldDescription->getAdmin(),
-            'value' => $compareValue,
-            'object' => $compareObject,
-        ]);
-
-        // Compare the rendered output of both objects by using the (possibly) overridden field block
-        $isDiff = $baseValueOutput !== $compareValueOutput;
-
-        return $this->render($fieldDescription, $template, [
-            'field_description' => $fieldDescription,
-            'value' => $baseValue,
-            'value_compare' => $compareValue,
-            'is_diff' => $isDiff,
-            'admin' => $fieldDescription->getAdmin(),
-            'object' => $baseObject,
-            'object_compare' => $compareObject,
-        ], $environment);
+        return $this->renderElementExtension->renderViewElementCompare($environment, $fieldDescription, $baseObject, $compareObject);
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @param mixed $element
      *
      * @throws \RuntimeException
      *
      * @return mixed
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0
      */
     public function renderRelationElement($element, FieldDescriptionInterface $fieldDescription)
     {
-        if (!\is_object($element)) {
-            return $element;
+        if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s method is deprecated in favor of RenderElementExtension::renderRelationElement since version 3.x and will be removed in 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
         }
 
-        $propertyPath = $fieldDescription->getOption('associated_property');
-
-        if (null === $propertyPath) {
-            // For BC kept associated_tostring option behavior
-            $method = $fieldDescription->getOption('associated_tostring');
-
-            if ($method) {
-                @trigger_error(
-                    'Option "associated_tostring" is deprecated since version 2.3 and will be removed in 4.0. Use "associated_property" instead.',
-                    E_USER_DEPRECATED
-                );
-            } else {
-                $method = '__toString';
-            }
-
-            if (!method_exists($element, $method)) {
-                throw new \RuntimeException(sprintf(
-                    'You must define an `associated_property` option or create a `%s::__toString` method'
-                    .' to the field option %s from service %s is ',
-                    \get_class($element),
-                    $fieldDescription->getName(),
-                    $fieldDescription->getAdmin()->getCode()
-                ));
-            }
-
-            return $element->{$method}();
+        if (null === $this->renderElementExtension) {
+            $this->renderElementExtension = new RenderElementExtension($this->propertyAccessor, $this->templateRegistries, $this->logger);
         }
 
-        if (\is_callable($propertyPath)) {
-            return $propertyPath($element);
-        }
-
-        return $this->propertyAccessor->getValue($element, $propertyPath);
+        return $this->renderElementExtension->renderRelationElement($element, $fieldDescription);
     }
 
     /**
@@ -734,93 +706,56 @@ class SonataAdminExtension extends AbstractExtension
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * Get template.
      *
      * @param string $defaultTemplate
      *
      * @return TemplateWrapper
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0
      */
     protected function getTemplate(
         FieldDescriptionInterface $fieldDescription,
         $defaultTemplate,
         Environment $environment
     ) {
-        $templateName = $fieldDescription->getTemplate() ?: $defaultTemplate;
-
-        try {
-            $template = $environment->load($templateName);
-        } catch (LoaderError $e) {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[3] ?? null)) {
             @trigger_error(sprintf(
-                'Relying on default template loading on field template loading exception is deprecated since 3.1'
-                .' and will be removed in 4.0. A %s exception will be thrown instead',
-                LoaderError::class
+                'The %s method is deprecated in favor of RenderElementExtension::getTemplate since version 3.x and will be removed in 4.0.',
+                __METHOD__
             ), E_USER_DEPRECATED);
-            $template = $environment->load($defaultTemplate);
-
-            if (null !== $this->logger) {
-                $this->logger->warning(sprintf(
-                    'An error occured trying to load the template "%s" for the field "%s",'
-                    .' the default template "%s" was used instead.',
-                    $templateName,
-                    $fieldDescription->getFieldName(),
-                    $defaultTemplate
-                ), ['exception' => $e]);
-            }
         }
 
-        return $template;
+        return $this->renderElementExtension->getTemplate($fieldDescription, $defaultTemplate, $$environment);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     private function render(
         FieldDescriptionInterface $fieldDescription,
         TemplateWrapper $template,
         array $parameters,
         Environment $environment
     ): string {
-        $content = $template->render($parameters);
-
-        if ($environment->isDebug()) {
-            $commentTemplate = <<<'EOT'
-
-<!-- START
-    fieldName: %s
-    template: %s
-    compiled template: %s
-    -->
-    %s
-<!-- END - fieldName: %s -->
-EOT;
-
-            return sprintf(
-                $commentTemplate,
-                $fieldDescription->getFieldName(),
-                $fieldDescription->getTemplate(),
-                $template->getSourceContext()->getName(),
-                $content,
-                $fieldDescription->getFieldName()
-            );
+        if ('sonata_deprecation_mute' !== (\func_get_args()[4] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s method is deprecated in favor of RenderElementExtension::render since version 3.x and will be removed in 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
         }
 
-        return $content;
+        if (null === $this->renderElementExtension) {
+            $this->renderElementExtension = new RenderElementExtension($this->propertyAccessor, $this->templateRegistries, $this->logger);
+        }
+
+        return $this->renderElementExtension->render($fieldDescription, $template, $parameters, $environment);
     }
 
     /**
-     * @throws ServiceCircularReferenceException
-     * @throws ServiceNotFoundException
-     */
-    private function getTemplateRegistry(string $adminCode): TemplateRegistryInterface
-    {
-        $serviceId = $adminCode.'.template_registry';
-        $templateRegistry = $this->templateRegistries->get($serviceId);
-
-        if ($templateRegistry instanceof TemplateRegistryInterface) {
-            return $templateRegistry;
-        }
-
-        throw new ServiceNotFoundException($serviceId);
-    }
-
-    /**
+     * NEXT_MAJOR: Remove this method
      * Extracts the object and requested value from the $listElement.
      *
      * @param object|array $listElement
@@ -828,43 +763,24 @@ EOT;
      * @throws \TypeError when $listElement is not an object or an array with an object on offset 0
      *
      * @return array An array containing object and value
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0
      */
     private function getObjectAndValueFromListElement(
         $listElement,
         FieldDescriptionInterface $fieldDescription
     ): array {
-        if (\is_object($listElement)) {
-            $object = $listElement;
-        } elseif (\is_array($listElement)) {
-            if (!isset($listElement[0]) || !\is_object($listElement[0])) {
-                throw new \TypeError(sprintf('If argument 1 passed to %s() is an array it must contain an object at offset 0.', __METHOD__));
-            }
-
-            $object = $listElement[0];
-        } else {
-            throw new \TypeError(sprintf('Argument 1 passed to %s() must be an object or an array, %s given.', __METHOD__, \gettype($listElement)));
+        if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s method is deprecated in favor of RenderElementExtension::getObjectAndValueFromListElement since version 3.x and will be removed in 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
         }
 
-        if (\is_array($listElement) && \array_key_exists($fieldDescription->getName(), $listElement)) {
-            $value = $listElement[$fieldDescription->getName()];
-        } else {
-            try {
-                $value = $fieldDescription->getValue($object);
-            } catch (NoValueException $e) {
-                // NEXT_MAJOR: throw the NoValueException.
-                @trigger_error(
-                    sprintf(
-                        'Accessing a non existing value for the field "%s" is deprecated'
-                        .' since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.',
-                        $fieldDescription->getName(),
-                    ),
-                    E_USER_DEPRECATED
-                );
-
-                $value = null;
-            }
+        if (null === $this->renderElementExtension) {
+            $this->renderElementExtension = new RenderElementExtension($this->propertyAccessor, $this->templateRegistries, $this->logger);
         }
 
-        return [$object, $value];
+        return $this->renderElementExtension->getObjectAndValueFromListElement($listElement, $fieldDescription);
     }
 }

--- a/src/Twig/Extension/XEditableExtension.php
+++ b/src/Twig/Extension/XEditableExtension.php
@@ -32,6 +32,8 @@ final class XEditableExtension extends AbstractExtension
 
     /**
      * @param string[] $xEditableTypeMapping
+     *
+     * @internal This class should only be used through Twig
      */
     public function __construct(
         TranslatorInterface $translator,
@@ -67,6 +69,14 @@ final class XEditableExtension extends AbstractExtension
     public function getXEditableType(string $type)
     {
         return $this->xEditableTypeMapping[$type] ?? false;
+    }
+
+    /**
+     * @param string[] $xEditableTypeMapping
+     */
+    public function setXEditableTypeMapping($xEditableTypeMapping)
+    {
+        $this->xEditableTypeMapping = $xEditableTypeMapping;
     }
 
     /**

--- a/src/Twig/Extension/XEditableExtension.php
+++ b/src/Twig/Extension/XEditableExtension.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Twig\Extension;
+
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+final class XEditableExtension extends AbstractExtension
+{
+    /**
+     * @var string[]
+     */
+    private $xEditableTypeMapping = [];
+
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(
+        TranslatorInterface $translator
+    ) {
+        $this->translator = $translator;
+    }
+
+    /**
+     * @return TwigFilter[]
+     */
+    public function getFilters(): array
+    {
+        return [
+            //NEXT_MAJOR: Uncomment lines below
+            /*
+            new TwigFilter(
+                'sonata_xeditable_type',
+                [$this, 'getXEditableType']
+            ),
+            new TwigFilter(
+                'sonata_xeditable_choices',
+                [$this, 'getXEditableChoices']
+            ),
+            */
+        ];
+    }
+
+    /**
+     * @param string[] $xEditableTypeMapping
+     */
+    public function setXEditableTypeMapping(array $xEditableTypeMapping): void
+    {
+        $this->xEditableTypeMapping = $xEditableTypeMapping;
+    }
+
+    /**
+     * @return string|bool
+     */
+    public function getXEditableType(string $type)
+    {
+        return $this->xEditableTypeMapping[$type] ?? false;
+    }
+
+    /**
+     * Return xEditable choices based on the field description choices options & catalogue options.
+     * With the following choice options:
+     *     ['Status1' => 'Alias1', 'Status2' => 'Alias2']
+     * The method will return:
+     *     [['value' => 'Status1', 'text' => 'Alias1'], ['value' => 'Status2', 'text' => 'Alias2']].
+     */
+    public function getXEditableChoices(FieldDescriptionInterface $fieldDescription): array
+    {
+        $choices = $fieldDescription->getOption('choices', []);
+        $catalogue = $fieldDescription->getOption('catalogue');
+        $xEditableChoices = [];
+        if (!empty($choices)) {
+            reset($choices);
+            $first = current($choices);
+            // the choices are already in the right format
+            if (\is_array($first) && \array_key_exists('value', $first) && \array_key_exists('text', $first)) {
+                $xEditableChoices = $choices;
+            } else {
+                foreach ($choices as $value => $text) {
+                    if ($catalogue) {
+                        $text = $this->translator->trans($text, [], $catalogue);
+                    }
+
+                    $xEditableChoices[] = [
+                        'value' => $value,
+                        'text' => $text,
+                    ];
+                }
+            }
+        }
+
+        if (
+            false === $fieldDescription->getOption('required', true)
+            && false === $fieldDescription->getOption('multiple', false)
+        ) {
+            $xEditableChoices = array_merge([[
+                'value' => '',
+                'text' => '',
+            ]], $xEditableChoices);
+        }
+
+        return $xEditableChoices;
+    }
+}

--- a/src/Twig/Extension/XEditableExtension.php
+++ b/src/Twig/Extension/XEditableExtension.php
@@ -72,14 +72,6 @@ final class XEditableExtension extends AbstractExtension
     }
 
     /**
-     * @param string[] $xEditableTypeMapping
-     */
-    public function setXEditableTypeMapping($xEditableTypeMapping)
-    {
-        $this->xEditableTypeMapping = $xEditableTypeMapping;
-    }
-
-    /**
      * Return xEditable choices based on the field description choices options & catalogue options.
      * With the following choice options:
      *     ['Status1' => 'Alias1', 'Status2' => 'Alias2']

--- a/src/Twig/Extension/XEditableExtension.php
+++ b/src/Twig/Extension/XEditableExtension.php
@@ -30,10 +30,15 @@ final class XEditableExtension extends AbstractExtension
      */
     private $translator;
 
+    /**
+     * @param string[] $xEditableTypeMapping
+     */
     public function __construct(
-        TranslatorInterface $translator
+        TranslatorInterface $translator,
+        array $xEditableTypeMapping
     ) {
         $this->translator = $translator;
+        $this->xEditableTypeMapping = $xEditableTypeMapping;
     }
 
     /**
@@ -54,14 +59,6 @@ final class XEditableExtension extends AbstractExtension
             ),
             */
         ];
-    }
-
-    /**
-     * @param string[] $xEditableTypeMapping
-     */
-    public function setXEditableTypeMapping(array $xEditableTypeMapping): void
-    {
-        $this->xEditableTypeMapping = $xEditableTypeMapping;
     }
 
     /**

--- a/tests/Controller/HelperControllerTest.php
+++ b/tests/Controller/HelperControllerTest.php
@@ -224,7 +224,7 @@ class HelperControllerTest extends TestCase
         $container->set('sonata.post.admin.template_registry', $templateRegistry);
         $this->pool->method('getPropertyAccessor')->willReturn($propertyAccessor);
         $this->twig->method('getExtension')->with(SonataAdminExtension::class)->willReturn(
-            new SonataAdminExtension($pool, null, $translator, $container)
+            new SonataAdminExtension($pool, null, $translator, $container, $propertyAccessor)
         );
         $this->twig->method('load')->with('admin_template')->willReturn(new TemplateWrapper($this->twig, $template));
         $this->twig->method('isDebug')->willReturn(false);
@@ -280,7 +280,7 @@ class HelperControllerTest extends TestCase
         $this->admin->method('getModelManager')->willReturn($modelManager);
         $this->validator->method('validate')->with($object)->willReturn(new ConstraintViolationList([]));
         $this->twig->method('getExtension')->with(SonataAdminExtension::class)->willReturn(
-            new SonataAdminExtension($this->pool, null, $translator, $container)
+            new SonataAdminExtension($this->pool, null, $translator, $container, $propertyAccessor)
         );
         $this->twig->method('load')->with('field_template')->willReturn(new TemplateWrapper($this->twig, $template));
         $this->twig->method('isDebug')->willReturn(false);

--- a/tests/Twig/Extension/CanonicalizeExtensionTest.php
+++ b/tests/Twig/Extension/CanonicalizeExtensionTest.php
@@ -15,24 +15,29 @@ namespace Sonata\AdminBundle\Tests\Twig\Extension;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Twig\Extension\CanonicalizeExtension;
-use Symfony\Bridge\Twig\AppVariable;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
- * Test for SonataAdminExtension.
- *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
 final class CanonicalizeExtensionTest extends TestCase
 {
     /**
-     * @var SonataAdminExtension
+     * @var RequestStack
+     */
+    private $requestStack;
+
+    /**
+     * @var CanonicalizeExtension
      */
     private $twigExtension;
 
     protected function setUp(): void
     {
-        $this->twigExtension = new CanonicalizeExtension();
+        $this->requestStack = new RequestStack();
+        $this->requestStack->push(new Request());
+        $this->twigExtension = new CanonicalizeExtension($this->requestStack);
     }
 
     /**
@@ -40,7 +45,8 @@ final class CanonicalizeExtensionTest extends TestCase
      */
     public function testCanonicalizedLocaleForMoment(?string $expected, string $original): void
     {
-        $this->assertSame($expected, $this->twigExtension->getCanonicalizedLocaleForMoment($this->mockExtensionContext($original)));
+        $this->changeLocale($original);
+        $this->assertSame($expected, $this->twigExtension->getCanonicalizedLocaleForMoment());
     }
 
     /**
@@ -48,9 +54,13 @@ final class CanonicalizeExtensionTest extends TestCase
      */
     public function testCanonicalizedLocaleForSelect2(?string $expected, string $original): void
     {
-        $this->assertSame($expected, $this->twigExtension->getCanonicalizedLocaleForSelect2($this->mockExtensionContext($original)));
+        $this->changeLocale($original);
+        $this->assertSame($expected, $this->twigExtension->getCanonicalizedLocaleForSelect2());
     }
 
+    /**
+     * @return array<array{?string, string}>
+     */
     public function momentLocalesProvider(): array
     {
         return [
@@ -172,6 +182,9 @@ final class CanonicalizeExtensionTest extends TestCase
         ];
     }
 
+    /**
+     * @return array<array{?string, string}>
+     */
     public function select2LocalesProvider()
     {
         return [
@@ -227,13 +240,8 @@ final class CanonicalizeExtensionTest extends TestCase
         ];
     }
 
-    private function mockExtensionContext(string $locale): array
+    private function changeLocale(string $locale): void
     {
-        $request = $this->createMock(Request::class);
-        $request->method('getLocale')->willReturn($locale);
-        $appVariable = $this->createMock(AppVariable::class);
-        $appVariable->method('getRequest')->willReturn($request);
-
-        return ['app' => $appVariable];
+        $this->requestStack->getCurrentRequest()->setLocale($locale);
     }
 }

--- a/tests/Twig/Extension/CanonicalizeExtensionTest.php
+++ b/tests/Twig/Extension/CanonicalizeExtensionTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Twig\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Twig\Extension\CanonicalizeExtension;
+use Symfony\Bridge\Twig\AppVariable;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Test for SonataAdminExtension.
+ *
+ * @author Andrej Hudec <pulzarraider@gmail.com>
+ */
+final class CanonicalizeExtensionTest extends TestCase
+{
+    /**
+     * @var SonataAdminExtension
+     */
+    private $twigExtension;
+
+    protected function setUp(): void
+    {
+        $this->twigExtension = new CanonicalizeExtension();
+    }
+
+    /**
+     * @dataProvider momentLocalesProvider
+     */
+    public function testCanonicalizedLocaleForMoment(?string $expected, string $original): void
+    {
+        $this->assertSame($expected, $this->twigExtension->getCanonicalizedLocaleForMoment($this->mockExtensionContext($original)));
+    }
+
+    /**
+     * @dataProvider select2LocalesProvider
+     */
+    public function testCanonicalizedLocaleForSelect2(?string $expected, string $original): void
+    {
+        $this->assertSame($expected, $this->twigExtension->getCanonicalizedLocaleForSelect2($this->mockExtensionContext($original)));
+    }
+
+    public function momentLocalesProvider(): array
+    {
+        return [
+            ['af', 'af'],
+            ['ar-dz', 'ar-dz'],
+            ['ar', 'ar'],
+            ['ar-ly', 'ar-ly'],
+            ['ar-ma', 'ar-ma'],
+            ['ar-sa', 'ar-sa'],
+            ['ar-tn', 'ar-tn'],
+            ['az', 'az'],
+            ['be', 'be'],
+            ['bg', 'bg'],
+            ['bn', 'bn'],
+            ['bo', 'bo'],
+            ['br', 'br'],
+            ['bs', 'bs'],
+            ['ca', 'ca'],
+            ['cs', 'cs'],
+            ['cv', 'cv'],
+            ['cy', 'cy'],
+            ['da', 'da'],
+            ['de-at', 'de-at'],
+            ['de', 'de'],
+            ['de', 'de-de'],
+            ['dv', 'dv'],
+            ['el', 'el'],
+            [null, 'en'],
+            [null, 'en-us'],
+            ['en-au', 'en-au'],
+            ['en-ca', 'en-ca'],
+            ['en-gb', 'en-gb'],
+            ['en-ie', 'en-ie'],
+            ['en-nz', 'en-nz'],
+            ['eo', 'eo'],
+            ['es-do', 'es-do'],
+            ['es', 'es-ar'],
+            ['es', 'es-mx'],
+            ['es', 'es'],
+            ['et', 'et'],
+            ['eu', 'eu'],
+            ['fa', 'fa'],
+            ['fi', 'fi'],
+            ['fo', 'fo'],
+            ['fr-ca', 'fr-ca'],
+            ['fr-ch', 'fr-ch'],
+            ['fr', 'fr-fr'],
+            ['fr', 'fr'],
+            ['fy', 'fy'],
+            ['gd', 'gd'],
+            ['gl', 'gl'],
+            ['he', 'he'],
+            ['hi', 'hi'],
+            ['hr', 'hr'],
+            ['hu', 'hu'],
+            ['hy-am', 'hy-am'],
+            ['id', 'id'],
+            ['is', 'is'],
+            ['it', 'it'],
+            ['ja', 'ja'],
+            ['jv', 'jv'],
+            ['ka', 'ka'],
+            ['kk', 'kk'],
+            ['km', 'km'],
+            ['ko', 'ko'],
+            ['ky', 'ky'],
+            ['lb', 'lb'],
+            ['lo', 'lo'],
+            ['lt', 'lt'],
+            ['lv', 'lv'],
+            ['me', 'me'],
+            ['mi', 'mi'],
+            ['mk', 'mk'],
+            ['ml', 'ml'],
+            ['mr', 'mr'],
+            ['ms', 'ms'],
+            ['ms-my', 'ms-my'],
+            ['my', 'my'],
+            ['nb', 'nb'],
+            ['ne', 'ne'],
+            ['nl-be', 'nl-be'],
+            ['nl', 'nl'],
+            ['nl', 'nl-nl'],
+            ['nn', 'nn'],
+            ['pa-in', 'pa-in'],
+            ['pl', 'pl'],
+            ['pt-br', 'pt-br'],
+            ['pt', 'pt'],
+            ['ro', 'ro'],
+            ['ru', 'ru'],
+            ['se', 'se'],
+            ['si', 'si'],
+            ['sk', 'sk'],
+            ['sl', 'sl'],
+            ['sq', 'sq'],
+            ['sr-cyrl', 'sr-cyrl'],
+            ['sr', 'sr'],
+            ['ss', 'ss'],
+            ['sv', 'sv'],
+            ['sw', 'sw'],
+            ['ta', 'ta'],
+            ['te', 'te'],
+            ['tet', 'tet'],
+            ['th', 'th'],
+            ['tlh', 'tlh'],
+            ['tl-ph', 'tl-ph'],
+            ['tr', 'tr'],
+            ['tzl', 'tzl'],
+            ['tzm', 'tzm'],
+            ['tzm-latn', 'tzm-latn'],
+            ['uk', 'uk'],
+            ['uz', 'uz'],
+            ['vi', 'vi'],
+            ['x-pseudo', 'x-pseudo'],
+            ['yo', 'yo'],
+            ['zh-cn', 'zh-cn'],
+            ['zh-hk', 'zh-hk'],
+            ['zh-tw', 'zh-tw'],
+        ];
+    }
+
+    public function select2LocalesProvider()
+    {
+        return [
+            ['ar', 'ar'],
+            ['az', 'az'],
+            ['bg', 'bg'],
+            ['ca', 'ca'],
+            ['cs', 'cs'],
+            ['da', 'da'],
+            ['de', 'de'],
+            ['el', 'el'],
+            [null, 'en'],
+            ['es', 'es'],
+            ['et', 'et'],
+            ['eu', 'eu'],
+            ['fa', 'fa'],
+            ['fi', 'fi'],
+            ['fr', 'fr'],
+            ['gl', 'gl'],
+            ['he', 'he'],
+            ['hr', 'hr'],
+            ['hu', 'hu'],
+            ['id', 'id'],
+            ['is', 'is'],
+            ['it', 'it'],
+            ['ja', 'ja'],
+            ['ka', 'ka'],
+            ['ko', 'ko'],
+            ['lt', 'lt'],
+            ['lv', 'lv'],
+            ['mk', 'mk'],
+            ['ms', 'ms'],
+            ['nb', 'nb'],
+            ['nl', 'nl'],
+            ['pl', 'pl'],
+            ['pt-PT', 'pt'],
+            ['pt-BR', 'pt-BR'],
+            ['pt-PT', 'pt-PT'],
+            ['ro', 'ro'],
+            ['rs', 'rs'],
+            ['ru', 'ru'],
+            ['sk', 'sk'],
+            ['sv', 'sv'],
+            ['th', 'th'],
+            ['tr', 'tr'],
+            ['ug-CN', 'ug'],
+            ['ug-CN', 'ug-CN'],
+            ['uk', 'uk'],
+            ['vi', 'vi'],
+            ['zh-CN', 'zh'],
+            ['zh-CN', 'zh-CN'],
+            ['zh-TW', 'zh-TW'],
+        ];
+    }
+
+    private function mockExtensionContext(string $locale): array
+    {
+        $request = $this->createMock(Request::class);
+        $request->method('getLocale')->willReturn($locale);
+        $appVariable = $this->createMock(AppVariable::class);
+        $appVariable->method('getRequest')->willReturn($request);
+
+        return ['app' => $appVariable];
+    }
+}

--- a/tests/Twig/Extension/RenderElementExtensionTest.php
+++ b/tests/Twig/Extension/RenderElementExtensionTest.php
@@ -23,39 +23,36 @@ use Sonata\AdminBundle\Exception\NoValueException;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooToString;
 use Sonata\AdminBundle\Tests\Fixtures\StubFilesystemLoader;
+use Sonata\AdminBundle\Twig\Extension\RenderElementExtension;
 use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
+use Sonata\AdminBundle\Twig\Extension\XEditableExtension;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
-use Symfony\Bridge\Twig\AppVariable;
 use Symfony\Bridge\Twig\Extension\RoutingExtension;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyAccess\PropertyAccess;
-use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Loader\XmlFileLoader;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Translation\Loader\XliffFileLoader;
 use Symfony\Component\Translation\Translator;
-use Symfony\Component\Translation\TranslatorInterface as LegacyTranslatorInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 use Twig\Error\LoaderError;
 use Twig\Extra\String\StringExtension;
 
 /**
- * Test for SonataAdminExtension.
- *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class SonataAdminExtensionTest extends TestCase
+final class RenderElementExtensionTest extends TestCase
 {
     use ExpectDeprecationTrait;
 
     /**
-     * @var SonataAdminExtension
+     * @var RenderElementExtension
      */
     private $twigExtension;
 
@@ -95,11 +92,6 @@ class SonataAdminExtensionTest extends TestCase
     private $logger;
 
     /**
-     * @var string[]
-     */
-    private $xEditableTypeMapping;
-
-    /**
      * @var TranslatorInterface
      */
     private $translator;
@@ -115,11 +107,6 @@ class SonataAdminExtensionTest extends TestCase
     private $templateRegistry;
 
     /**
-     * @var AuthorizationCheckerInterface
-     */
-    private $securityChecker;
-
-    /**
      * @var PropertyAccessor
      */
     private $propertyAccessor;
@@ -128,12 +115,7 @@ class SonataAdminExtensionTest extends TestCase
     {
         date_default_timezone_set('Europe/London');
 
-        $container = new Container();
-
-        $this->pool = new Pool($container, ['sonata_admin_foo_service'], [], ['fooClass' => ['sonata_admin_foo_service']]);
-
-        $this->logger = $this->getMockForAbstractClass(LoggerInterface::class);
-        $this->xEditableTypeMapping = [
+        $xEditableTypeMapping = [
             'choice' => 'select',
             'boolean' => 'select',
             'text' => 'text',
@@ -150,6 +132,14 @@ class SonataAdminExtensionTest extends TestCase
             'url' => 'url',
         ];
 
+        $container = new Container();
+
+        $this->pool = new Pool($container, '', '');
+        $this->pool->setAdminServiceIds(['sonata_admin_foo_service']);
+        $this->pool->setAdminClasses(['fooClass' => ['sonata_admin_foo_service']]);
+
+        $this->logger = $this->getMockForAbstractClass(LoggerInterface::class);
+
         // translation extension
         $translator = new Translator('en');
         $translator->addLoader('xlf', new XliffFileLoader());
@@ -165,20 +155,7 @@ class SonataAdminExtensionTest extends TestCase
         $this->templateRegistry = $this->createStub(TemplateRegistryInterface::class);
         $this->container = new Container();
         $this->container->set('sonata_admin_foo_service.template_registry', $this->templateRegistry);
-
-        $this->securityChecker = $this->createStub(AuthorizationCheckerInterface::class);
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
-
-        $this->twigExtension = new SonataAdminExtension(
-            $this->pool,
-            $this->logger,
-            $this->translator,
-            $this->container,
-            $propertyAccessor,
-            $this->securityChecker
-        );
-
-        $this->twigExtension->setXEditableTypeMapping($this->xEditableTypeMapping, 'sonata_deprecation_mute');
 
         $request = $this->createMock(Request::class);
         $request->method('get')->with('_sonata_admin')->willReturn('sonata_admin_foo_service');
@@ -196,7 +173,38 @@ class SonataAdminExtensionTest extends TestCase
             'autoescape' => 'html',
             'optimizations' => 0,
         ]);
+
+        //NEXT_MAJOR: Remove follwing block
+        /**
+         * @var AuthorizationCheckerInterface
+         */
+        $securityChecker = $this->createStub(AuthorizationCheckerInterface::class);
+        $this->twigExtension = new SonataAdminExtension(
+            $this->pool,
+            $this->logger,
+            $this->translator,
+            $this->container,
+            $propertyAccessor,
+            $securityChecker
+        );
+        $this->twigExtension->setXEditableTypeMapping($xEditableTypeMapping, 'sonata_deprecation_mute');
         $this->environment->addExtension($this->twigExtension);
+        // block ends
+
+        //NEXT_MAJOR: Uncomment block below
+        /*
+        $this->twigExtension = new RenderElementExtension(
+            $propertyAccessor,
+            $this->container,
+            $this->logger,
+        );
+        $this->environment->addExtension($this->twigExtension);
+        // xeditable extension
+        $xEditableExtension = new XEditableExtension($translator, $xEditableTypeMapping);
+        $xEditableExtension->setXEditableTypeMapping($xEditableTypeMapping);
+        $this->environment->addExtension($xEditableExtension);
+        */
+
         $this->environment->addExtension(new TranslationExtension($translator));
         $this->environment->addExtension(new FakeTemplateRegistryExtension());
 
@@ -205,6 +213,7 @@ class SonataAdminExtensionTest extends TestCase
         $routeCollection = $xmlFileLoader->load('sonata_admin.xml');
 
         $xmlFileLoader = new XmlFileLoader(new FileLocator([sprintf('%s/../../Fixtures/Resources/config/routing', __DIR__)]));
+
         $testRouteCollection = $xmlFileLoader->load('routing.xml');
 
         $routeCollection->addCollection($testRouteCollection);
@@ -268,88 +277,12 @@ class SonataAdminExtensionTest extends TestCase
     }
 
     /**
-     * NEXT_MAJOR: Remove this method.
-     */
-    public function testConstructThrowsExceptionWithWrongPropertyAccessOrAuthorizationCheckerArgument(): void
-    {
-        $this->expectException(\TypeError::class);
-
-        new SonataAdminExtension(
-            $this->pool,
-            null,
-            $this->translator,
-            $this->container,
-            new \stdClass()
-        );
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
      * @group legacy
-     */
-    public function testConstructTriggersDeprecationWithAuthorizationCheckerArgument(): void
-    {
-        $this->expectDeprecation(sprintf(
-            'Passing an instance of "%s" as argument 5 for "%s::__construct()" is deprecated since'
-            .' sonata-project/admin-bundle 3.82 and will throw a \TypeError error in version 4.0. You MUST pass an instance'
-            .' of "%s" instead and pass an instance of "%s" as argument 6.',
-            AuthorizationCheckerInterface::class,
-            SonataAdminExtension::class,
-            PropertyAccessorInterface::class,
-            AuthorizationCheckerInterface::class
-        ));
-
-        new SonataAdminExtension(
-            $this->pool,
-            null,
-            $this->translator,
-            $this->container,
-            $this->securityChecker
-        );
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @group legacy
-     */
-    public function testConstructThrowsExceptionWithWrongTranslationArgument(): void
-    {
-        $this->expectException(\TypeError::class);
-
-        new SonataAdminExtension(
-            $this->pool,
-            null,
-            new \stdClass()
-        );
-    }
-
-    /**
-     * @doesNotPerformAssertions
-     * @group legacy
-     */
-    public function testConstructWithLegacyTranslator(): void
-    {
-        new SonataAdminExtension(
-            $this->pool,
-            null,
-            $this->createStub(LegacyTranslatorInterface::class)
-        );
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @group legacy
+     * @expectedDeprecation The Sonata\AdminBundle\Admin\AbstractAdmin::getTemplate method is deprecated (since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry services instead).
      * @dataProvider getRenderListElementTests
      */
     public function testRenderListElement(string $expected, string $type, $value, array $options): void
     {
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderListElement method is deprecated in favor of RenderElementExtension::renderListElement since version 3.x and will be removed in 4.0.');
-
-        $this->expectDeprecation('The Sonata\AdminBundle\Admin\AbstractAdmin::getTemplate method is deprecated (since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry services instead).');
-
         $this->admin
             ->method('getPersistentParameters')
             ->willReturn(['context' => 'foo']);
@@ -428,22 +361,19 @@ class SonataAdminExtensionTest extends TestCase
             $this->removeExtraWhitespace($this->twigExtension->renderListElement(
                 $this->environment,
                 $this->object,
-                $this->fieldDescription
+                $this->fieldDescription,
             ))
         );
     }
 
     /**
-     * NEXT_MAJOR: Remove this method.
+     * NEXT_MAJOR: Remove @expectedDeprecation.
      *
      * @group legacy
+     * @expectedDeprecation The Sonata\AdminBundle\Admin\AbstractAdmin::getTemplate method is deprecated (since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry services instead).
      */
     public function testRenderListElementWithAdditionalValuesInArray(): void
     {
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderListElement method is deprecated in favor of RenderElementExtension::renderListElement since version 3.x and will be removed in 4.0.');
-
-        $this->expectDeprecation('The Sonata\AdminBundle\Admin\AbstractAdmin::getTemplate method is deprecated (since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry services instead).');
-
         // NEXT_MAJOR: Remove this line
         $this->admin
             ->method('getTemplate')
@@ -468,16 +398,13 @@ class SonataAdminExtensionTest extends TestCase
     }
 
     /**
-     * NEXT_MAJOR: Remove this method.
+     * NEXT_MAJOR: Remove @expectedDeprecation.
      *
      * @group legacy
+     * @expectedDeprecation Accessing a non existing value is deprecated since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.
      */
     public function testRenderListElementWithNoValueException(): void
     {
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderListElement method is deprecated in favor of RenderElementExtension::renderListElement since version 3.x and will be removed in 4.0.');
-
-        $this->expectDeprecation('Accessing a non existing value is deprecated since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.');
-
         // NEXT_MAJOR: Remove this line
         $this->admin
             ->method('getTemplate')
@@ -504,8 +431,6 @@ class SonataAdminExtensionTest extends TestCase
     }
 
     /**
-     * NEXT_MAJOR: Remove this method.
-     *
      * @dataProvider getDeprecatedRenderListElementTests
      * @group legacy
      */
@@ -546,8 +471,6 @@ class SonataAdminExtensionTest extends TestCase
             ->method('getTemplate')
             ->willReturn('@SonataAdmin/CRUD/list_nonexistent_template.html.twig');
 
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderListElement method is deprecated in favor of RenderElementExtension::renderListElement since version 3.x and will be removed in 4.0.');
-
         $this->assertSame(
             $this->removeExtraWhitespace($expected),
             $this->removeExtraWhitespace($this->twigExtension->renderListElement(
@@ -559,27 +482,513 @@ class SonataAdminExtensionTest extends TestCase
     }
 
     /**
-     * NEXT_MAJOR: Remove this method.
+     * @group legacy
      */
-    public function getDeprecatedRenderListElementTests()
+    public function testRenderListElementNonExistentTemplate(): void
+    {
+        // NEXT_MAJOR: Remove this line
+        $this->admin->method('getTemplate')
+            ->with('base_list_field')
+            ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
+
+        $this->templateRegistry->method('getTemplate')->with('base_list_field')
+            ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
+
+        $this->fieldDescription->expects($this->once())
+            ->method('getValue')
+            ->willReturn('Foo');
+
+        $this->fieldDescription->expects($this->once())
+            ->method('getFieldName')
+            ->willReturn('Foo_name');
+
+        $this->fieldDescription->expects($this->exactly(2))
+            ->method('getType')
+            ->willReturn('nonexistent');
+
+        $this->fieldDescription->expects($this->once())
+            ->method('getTemplate')
+            ->willReturn('@SonataAdmin/CRUD/list_nonexistent_template.html.twig');
+
+        $this->logger->expects($this->once())
+            ->method('warning')
+            ->with(($this->stringStartsWith($this->removeExtraWhitespace(
+                'An error occured trying to load the template
+                "@SonataAdmin/CRUD/list_nonexistent_template.html.twig"
+                for the field "Foo_name", the default template
+                    "@SonataAdmin/CRUD/base_list_field.html.twig" was used
+                    instead.'
+            ))));
+
+        $this->twigExtension->renderListElement($this->environment, $this->object, $this->fieldDescription);
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testRenderListElementErrorLoadingTemplate(): void
+    {
+        $this->expectException(LoaderError::class);
+        $this->expectExceptionMessage('Unable to find template "@SonataAdmin/CRUD/base_list_nonexistent_field.html.twig"');
+
+        // NEXT_MAJOR: Remove this line
+        $this->admin->method('getTemplate')
+            ->with('base_list_field')
+            ->willReturn('@SonataAdmin/CRUD/base_list_nonexistent_field.html.twig');
+
+        $this->templateRegistry->method('getTemplate')->with('base_list_field')
+            ->willReturn('@SonataAdmin/CRUD/base_list_nonexistent_field.html.twig');
+
+        $this->fieldDescription->expects($this->once())
+            ->method('getTemplate')
+            ->willReturn('@SonataAdmin/CRUD/list_nonexistent_template.html.twig');
+
+        $this->twigExtension->renderListElement($this->environment, $this->object, $this->fieldDescription);
+
+        $this->templateRegistry->getTemplate('base_list_field')->shouldHaveBeenCalled();
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The Sonata\AdminBundle\Admin\AbstractAdmin::getTemplate method is deprecated (since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry services instead).
+     */
+    public function testRenderWithDebug(): void
+    {
+        $this->fieldDescription
+            ->method('getTemplate')
+            ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
+
+        $this->fieldDescription
+            ->method('getFieldName')
+            ->willReturn('fd_name');
+
+        $this->fieldDescription
+            ->method('getValue')
+            ->willReturn('foo');
+
+        $parameters = [
+            'admin' => $this->admin,
+            'value' => 'foo',
+            'field_description' => $this->fieldDescription,
+            'object' => $this->object,
+        ];
+
+        $this->environment->enableDebug();
+
+        $this->assertSame(
+            $this->removeExtraWhitespace(
+                <<<'EOT'
+<!-- START
+    fieldName: fd_name
+    template: @SonataAdmin/CRUD/base_list_field.html.twig
+    compiled template: @SonataAdmin/CRUD/base_list_field.html.twig
+-->
+    <td class="sonata-ba-list-field sonata-ba-list-field-" objectId="12345"> foo </td>
+<!-- END - fieldName: fd_name -->
+EOT
+            ),
+            $this->removeExtraWhitespace(
+                $this->twigExtension->renderListElement($this->environment, $this->object, $this->fieldDescription, $parameters)
+            )
+        );
+    }
+
+    /**
+     * @dataProvider getRenderViewElementTests
+     */
+    public function testRenderViewElement(string $expected, string $type, $value, array $options): void
+    {
+        $this->admin
+            ->method('getTemplate')
+            ->willReturn('@SonataAdmin/CRUD/base_show_field.html.twig');
+
+        $this->fieldDescription
+            ->method('getValue')
+            ->willReturn($value);
+
+        $this->fieldDescription
+            ->method('getType')
+            ->willReturn($type);
+
+        $this->fieldDescription
+            ->method('getOptions')
+            ->willReturn($options);
+
+        $this->fieldDescription
+            ->method('getTemplate')
+            ->willReturnCallback(static function () use ($type): ?string {
+                switch ($type) {
+                    case 'boolean':
+                        return '@SonataAdmin/CRUD/show_boolean.html.twig';
+                    case 'datetime':
+                        return '@SonataAdmin/CRUD/show_datetime.html.twig';
+                    case 'date':
+                        return '@SonataAdmin/CRUD/show_date.html.twig';
+                    case 'time':
+                        return '@SonataAdmin/CRUD/show_time.html.twig';
+                    case 'currency':
+                        return '@SonataAdmin/CRUD/show_currency.html.twig';
+                    case 'percent':
+                        return '@SonataAdmin/CRUD/show_percent.html.twig';
+                    case 'email':
+                        return '@SonataAdmin/CRUD/show_email.html.twig';
+                    case 'choice':
+                        return '@SonataAdmin/CRUD/show_choice.html.twig';
+                    case 'array':
+                        return '@SonataAdmin/CRUD/show_array.html.twig';
+                    case 'trans':
+                        return '@SonataAdmin/CRUD/show_trans.html.twig';
+                    case 'url':
+                        return '@SonataAdmin/CRUD/show_url.html.twig';
+                    case 'html':
+                        return '@SonataAdmin/CRUD/show_html.html.twig';
+                    default:
+                        return null;
+                }
+            });
+
+        $this->assertSame(
+            $this->removeExtraWhitespace($expected),
+            $this->removeExtraWhitespace(
+                $this->twigExtension->renderViewElement(
+                    $this->environment,
+                    $this->fieldDescription,
+                    $this->object
+                )
+            )
+        );
+    }
+
+    /**
+     * @group legacy
+     * @assertDeprecation Accessing a non existing value is deprecated since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.
+     *
+     * @dataProvider getRenderViewElementWithNoValueTests
+     */
+    public function testRenderViewElementWithNoValue(string $expected, string $type, array $options): void
+    {
+        $this->admin
+            ->method('getTemplate')
+            ->willReturn('@SonataAdmin/CRUD/base_show_field.html.twig');
+
+        $this->fieldDescription
+            ->method('getValue')
+            ->willThrowException(new NoValueException());
+
+        $this->fieldDescription
+            ->method('getType')
+            ->willReturn($type);
+
+        $this->fieldDescription
+            ->method('getOptions')
+            ->willReturn($options);
+
+        $this->fieldDescription
+            ->method('getTemplate')
+            ->willReturnCallback(static function () use ($type): ?string {
+                switch ($type) {
+                    case 'boolean':
+                        return '@SonataAdmin/CRUD/show_boolean.html.twig';
+                    case 'datetime':
+                        return '@SonataAdmin/CRUD/show_datetime.html.twig';
+                    case 'date':
+                        return '@SonataAdmin/CRUD/show_date.html.twig';
+                    case 'time':
+                        return '@SonataAdmin/CRUD/show_time.html.twig';
+                    case 'currency':
+                        return '@SonataAdmin/CRUD/show_currency.html.twig';
+                    case 'percent':
+                        return '@SonataAdmin/CRUD/show_percent.html.twig';
+                    case 'email':
+                        return '@SonataAdmin/CRUD/show_email.html.twig';
+                    case 'choice':
+                        return '@SonataAdmin/CRUD/show_choice.html.twig';
+                    case 'array':
+                        return '@SonataAdmin/CRUD/show_array.html.twig';
+                    case 'trans':
+                        return '@SonataAdmin/CRUD/show_trans.html.twig';
+                    case 'url':
+                        return '@SonataAdmin/CRUD/show_url.html.twig';
+                    case 'html':
+                        return '@SonataAdmin/CRUD/show_html.html.twig';
+                    default:
+                        return null;
+                }
+            });
+
+        $this->assertSame(
+            $this->removeExtraWhitespace($expected),
+            $this->removeExtraWhitespace(
+                $this->twigExtension->renderViewElement(
+                    $this->environment,
+                    $this->fieldDescription,
+                    $this->object
+                )
+            )
+        );
+    }
+
+    public function getRenderViewElementWithNoValueTests(): iterable
     {
         return [
+            // NoValueException
+            ['<th>Data</th> <td></td>', 'string', ['safe' => false]],
+            ['<th>Data</th> <td></td>', 'text', ['safe' => false]],
+            ['<th>Data</th> <td></td>', 'textarea', ['safe' => false]],
+            ['<th>Data</th> <td>&nbsp;</td>', 'datetime', []],
             [
-                '<td class="sonata-ba-list-field sonata-ba-list-field-nonexistent" objectId="12345"> Example </td>',
-                'Example',
+                '<th>Data</th> <td>&nbsp;</td>',
+                'datetime',
+                ['format' => 'd.m.Y H:i:s'],
+            ],
+            ['<th>Data</th> <td>&nbsp;</td>', 'date', []],
+            ['<th>Data</th> <td>&nbsp;</td>', 'date', ['format' => 'd.m.Y']],
+            ['<th>Data</th> <td>&nbsp;</td>', 'time', []],
+            ['<th>Data</th> <td></td>', 'number', ['safe' => false]],
+            ['<th>Data</th> <td></td>', 'integer', ['safe' => false]],
+            ['<th>Data</th> <td>&nbsp;</td>', 'percent', []],
+            ['<th>Data</th> <td>&nbsp;</td>', 'currency', ['currency' => 'EUR']],
+            ['<th>Data</th> <td>&nbsp;</td>', 'currency', ['currency' => 'GBP']],
+            ['<th>Data</th> <td> <ul></ul> </td>', 'array', ['safe' => false]],
+            [
+                '<th>Data</th> <td><span class="label label-danger">no</span></td>',
+                'boolean',
                 [],
             ],
             [
-                '<td class="sonata-ba-list-field sonata-ba-list-field-nonexistent" objectId="12345"> </td>',
-                null,
-                [],
+                '<th>Data</th> <td> </td>',
+                'trans',
+                ['safe' => false, 'catalogue' => 'SonataAdminBundle'],
+            ],
+            [
+                '<th>Data</th> <td></td>',
+                'choice',
+                ['safe' => false, 'choices' => []],
+            ],
+            [
+                '<th>Data</th> <td></td>',
+                'choice',
+                ['safe' => false, 'choices' => [], 'multiple' => true],
+            ],
+            ['<th>Data</th> <td>&nbsp;</td>', 'url', []],
+            [
+                '<th>Data</th> <td>&nbsp;</td>',
+                'url',
+                ['url' => 'http://example.com'],
+            ],
+            [
+                '<th>Data</th> <td>&nbsp;</td>',
+                'url',
+                ['route' => ['name' => 'sonata_admin_foo']],
             ],
         ];
     }
 
     /**
-     * NEXT_MAJOR: Remove this method.
+     * @dataProvider getRenderViewElementCompareTests
      */
+    public function testRenderViewElementCompare(string $expected, string $type, $value, array $options, ?string $objectName = null): void
+    {
+        $this->admin
+            ->method('getTemplate')
+            ->willReturn('@SonataAdmin/CRUD/base_show_compare.html.twig');
+
+        $this->fieldDescription
+            ->method('getValue')
+            ->willReturn($value);
+
+        $this->fieldDescription
+            ->method('getType')
+            ->willReturn($type);
+
+        $this->fieldDescription
+            ->method('getOptions')
+            ->willReturn($options);
+
+        $this->fieldDescription
+            ->method('getTemplate')
+            ->willReturnCallback(static function () use ($type, $options): ?string {
+                if (isset($options['template'])) {
+                    return $options['template'];
+                }
+
+                switch ($type) {
+                    case 'boolean':
+                        return '@SonataAdmin/CRUD/show_boolean.html.twig';
+                    case 'datetime':
+                        return '@SonataAdmin/CRUD/show_datetime.html.twig';
+                    case 'date':
+                        return '@SonataAdmin/CRUD/show_date.html.twig';
+                    case 'time':
+                        return '@SonataAdmin/CRUD/show_time.html.twig';
+                    case 'currency':
+                        return '@SonataAdmin/CRUD/show_currency.html.twig';
+                    case 'percent':
+                        return '@SonataAdmin/CRUD/show_percent.html.twig';
+                    case 'email':
+                        return '@SonataAdmin/CRUD/show_email.html.twig';
+                    case 'choice':
+                        return '@SonataAdmin/CRUD/show_choice.html.twig';
+                    case 'array':
+                        return '@SonataAdmin/CRUD/show_array.html.twig';
+                    case 'trans':
+                        return '@SonataAdmin/CRUD/show_trans.html.twig';
+                    case 'url':
+                        return '@SonataAdmin/CRUD/show_url.html.twig';
+                    case 'html':
+                        return '@SonataAdmin/CRUD/show_html.html.twig';
+                    default:
+                        return null;
+                }
+            });
+
+        $this->object->name = 'SonataAdmin';
+
+        $comparedObject = clone $this->object;
+
+        if (null !== $objectName) {
+            $comparedObject->name = $objectName;
+        }
+
+        $this->assertSame(
+            $this->removeExtraWhitespace($expected),
+            $this->removeExtraWhitespace(
+                $this->twigExtension->renderViewElementCompare(
+                    $this->environment,
+                    $this->fieldDescription,
+                    $this->object,
+                    $comparedObject
+                )
+            )
+        );
+    }
+
+    public function testRenderRelationElementNoObject(): void
+    {
+        $this->assertSame('foo', $this->twigExtension->renderRelationElement('foo', $this->fieldDescription));
+    }
+
+    public function testRenderRelationElementToString(): void
+    {
+        $this->fieldDescription->expects($this->exactly(2))
+            ->method('getOption')
+            ->willReturnCallback(static function ($value, $default = null) {
+                if ('associated_property' === $value) {
+                    return $default;
+                }
+            });
+
+        $element = new FooToString();
+        $this->assertSame('salut', $this->twigExtension->renderRelationElement($element, $this->fieldDescription));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testDeprecatedRelationElementToString(): void
+    {
+        $this->fieldDescription->expects($this->exactly(2))
+            ->method('getOption')
+            ->willReturnCallback(static function ($value, $default = null) {
+                if ('associated_tostring' === $value) {
+                    return '__toString';
+                }
+            });
+
+        $element = new FooToString();
+        $this->assertSame(
+            'salut',
+            $this->twigExtension->renderRelationElement($element, $this->fieldDescription)
+        );
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testRenderRelationElementCustomToString(): void
+    {
+        $this->fieldDescription->expects($this->exactly(2))
+            ->method('getOption')
+            ->willReturnCallback(static function ($value, $default = null) {
+                if ('associated_property' === $value) {
+                    return $default;
+                }
+
+                if ('associated_tostring' === $value) {
+                    return 'customToString';
+                }
+            });
+
+        $element = $this->getMockBuilder(\stdClass::class)
+            ->setMethods(['customToString'])
+            ->getMock();
+        $element
+            ->method('customToString')
+            ->willReturn('fooBar');
+
+        $this->assertSame('fooBar', $this->twigExtension->renderRelationElement($element, $this->fieldDescription));
+    }
+
+    /**
+     * @group legacy
+     */
+    public function testRenderRelationElementMethodNotExist(): void
+    {
+        $this->fieldDescription->expects($this->exactly(2))
+            ->method('getOption')
+
+            ->willReturnCallback(static function ($value, $default = null) {
+                if ('associated_tostring' === $value) {
+                    return 'nonExistedMethod';
+                }
+            });
+
+        $element = new \stdClass();
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('You must define an `associated_property` option or create a `stdClass::__toString');
+
+        $this->twigExtension->renderRelationElement($element, $this->fieldDescription);
+    }
+
+    public function testRenderRelationElementWithPropertyPath(): void
+    {
+        $this->fieldDescription->expects($this->once())
+            ->method('getOption')
+
+            ->willReturnCallback(static function ($value, $default = null) {
+                if ('associated_property' === $value) {
+                    return 'foo';
+                }
+            });
+
+        $element = new \stdClass();
+        $element->foo = 'bar';
+
+        $this->assertSame('bar', $this->twigExtension->renderRelationElement($element, $this->fieldDescription));
+    }
+
+    public function testRenderRelationElementWithClosure(): void
+    {
+        $this->fieldDescription->expects($this->once())
+            ->method('getOption')
+
+            ->willReturnCallback(static function ($value, $default = null) {
+                if ('associated_property' === $value) {
+                    return static function ($element): string {
+                        return sprintf('closure %s', $element->foo);
+                    };
+                }
+            });
+
+        $element = new \stdClass();
+        $element->foo = 'bar';
+
+        $this->assertSame(
+            'closure bar',
+            $this->twigExtension->renderRelationElement($element, $this->fieldDescription)
+        );
+    }
+
     public function getRenderListElementTests()
     {
         return [
@@ -1555,155 +1964,22 @@ EOT
         ];
     }
 
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @group legacy
-     */
-    public function testRenderListElementNonExistentTemplate(): void
+    public function getDeprecatedRenderListElementTests()
     {
-        // NEXT_MAJOR: Remove this line
-        $this->admin->method('getTemplate')
-            ->with('base_list_field')
-            ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
-
-        $this->templateRegistry->method('getTemplate')->with('base_list_field')
-            ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
-
-        $this->fieldDescription->expects($this->once())
-            ->method('getValue')
-            ->willReturn('Foo');
-
-        $this->fieldDescription->expects($this->once())
-            ->method('getFieldName')
-            ->willReturn('Foo_name');
-
-        $this->fieldDescription->expects($this->exactly(2))
-            ->method('getType')
-            ->willReturn('nonexistent');
-
-        $this->fieldDescription->expects($this->once())
-            ->method('getTemplate')
-            ->willReturn('@SonataAdmin/CRUD/list_nonexistent_template.html.twig');
-
-        $this->logger->expects($this->once())
-            ->method('warning')
-            ->with(($this->stringStartsWith($this->removeExtraWhitespace(
-                'An error occured trying to load the template
-                "@SonataAdmin/CRUD/list_nonexistent_template.html.twig"
-                for the field "Foo_name", the default template
-                    "@SonataAdmin/CRUD/base_list_field.html.twig" was used
-                    instead.'
-            ))));
-
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderListElement method is deprecated in favor of RenderElementExtension::renderListElement since version 3.x and will be removed in 4.0.');
-
-        $this->twigExtension->renderListElement($this->environment, $this->object, $this->fieldDescription);
+        return [
+            [
+                '<td class="sonata-ba-list-field sonata-ba-list-field-nonexistent" objectId="12345"> Example </td>',
+                'Example',
+                [],
+            ],
+            [
+                '<td class="sonata-ba-list-field sonata-ba-list-field-nonexistent" objectId="12345"> </td>',
+                null,
+                [],
+            ],
+        ];
     }
 
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @group legacy
-     */
-    public function testRenderListElementErrorLoadingTemplate(): void
-    {
-        $this->expectException(LoaderError::class);
-        $this->expectExceptionMessage('Unable to find template "@SonataAdmin/CRUD/base_list_nonexistent_field.html.twig"');
-
-        // NEXT_MAJOR: Remove this line
-        $this->admin->method('getTemplate')
-            ->with('base_list_field')
-            ->willReturn('@SonataAdmin/CRUD/base_list_nonexistent_field.html.twig');
-
-        $this->templateRegistry->method('getTemplate')->with('base_list_field')
-            ->willReturn('@SonataAdmin/CRUD/base_list_nonexistent_field.html.twig');
-
-        $this->fieldDescription->expects($this->once())
-            ->method('getTemplate')
-            ->willReturn('@SonataAdmin/CRUD/list_nonexistent_template.html.twig');
-
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderListElement method is deprecated in favor of RenderElementExtension::renderListElement since version 3.x and will be removed in 4.0.');
-
-        $this->twigExtension->renderListElement($this->environment, $this->object, $this->fieldDescription);
-
-        $this->templateRegistry->getTemplate('base_list_field')->shouldHaveBeenCalled();
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @group legacy
-     * @dataProvider getRenderViewElementTests
-     */
-    public function testRenderViewElement(string $expected, string $type, $value, array $options): void
-    {
-        $this->admin
-            ->method('getTemplate')
-            ->willReturn('@SonataAdmin/CRUD/base_show_field.html.twig');
-
-        $this->fieldDescription
-            ->method('getValue')
-            ->willReturn($value);
-
-        $this->fieldDescription
-            ->method('getType')
-            ->willReturn($type);
-
-        $this->fieldDescription
-            ->method('getOptions')
-            ->willReturn($options);
-
-        $this->fieldDescription
-            ->method('getTemplate')
-            ->willReturnCallback(static function () use ($type): ?string {
-                switch ($type) {
-                    case 'boolean':
-                        return '@SonataAdmin/CRUD/show_boolean.html.twig';
-                    case 'datetime':
-                        return '@SonataAdmin/CRUD/show_datetime.html.twig';
-                    case 'date':
-                        return '@SonataAdmin/CRUD/show_date.html.twig';
-                    case 'time':
-                        return '@SonataAdmin/CRUD/show_time.html.twig';
-                    case 'currency':
-                        return '@SonataAdmin/CRUD/show_currency.html.twig';
-                    case 'percent':
-                        return '@SonataAdmin/CRUD/show_percent.html.twig';
-                    case 'email':
-                        return '@SonataAdmin/CRUD/show_email.html.twig';
-                    case 'choice':
-                        return '@SonataAdmin/CRUD/show_choice.html.twig';
-                    case 'array':
-                        return '@SonataAdmin/CRUD/show_array.html.twig';
-                    case 'trans':
-                        return '@SonataAdmin/CRUD/show_trans.html.twig';
-                    case 'url':
-                        return '@SonataAdmin/CRUD/show_url.html.twig';
-                    case 'html':
-                        return '@SonataAdmin/CRUD/show_html.html.twig';
-                    default:
-                        return null;
-                }
-            });
-
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderViewElement method is deprecated in favor of RenderElementExtension::renderViewElement since version 3.x and will be removed in 4.0.');
-
-        $this->assertSame(
-            $this->removeExtraWhitespace($expected),
-            $this->removeExtraWhitespace(
-                $this->twigExtension->renderViewElement(
-                    $this->environment,
-                    $this->fieldDescription,
-                    $this->object
-                )
-            )
-        );
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     */
     public function getRenderViewElementTests()
     {
         return [
@@ -2205,1084 +2481,6 @@ EOT
         ];
     }
 
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @group legacy
-     * @assertDeprecation Accessing a non existing value for the field "fd_name" is deprecated since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.
-     *
-     * @dataProvider getRenderViewElementWithNoValueTests
-     */
-    public function testRenderViewElementWithNoValue(string $expected, string $type, array $options): void
-    {
-        $this->admin
-            ->method('getTemplate')
-            ->willReturn('@SonataAdmin/CRUD/base_show_field.html.twig');
-
-        $this->fieldDescription
-            ->method('getValue')
-            ->willThrowException(new NoValueException());
-
-        $this->fieldDescription
-            ->method('getType')
-            ->willReturn($type);
-
-        $this->fieldDescription
-            ->method('getOptions')
-            ->willReturn($options);
-
-        $this->fieldDescription
-            ->method('getTemplate')
-            ->willReturnCallback(static function () use ($type): ?string {
-                switch ($type) {
-                    case 'boolean':
-                        return '@SonataAdmin/CRUD/show_boolean.html.twig';
-                    case 'datetime':
-                        return '@SonataAdmin/CRUD/show_datetime.html.twig';
-                    case 'date':
-                        return '@SonataAdmin/CRUD/show_date.html.twig';
-                    case 'time':
-                        return '@SonataAdmin/CRUD/show_time.html.twig';
-                    case 'currency':
-                        return '@SonataAdmin/CRUD/show_currency.html.twig';
-                    case 'percent':
-                        return '@SonataAdmin/CRUD/show_percent.html.twig';
-                    case 'email':
-                        return '@SonataAdmin/CRUD/show_email.html.twig';
-                    case 'choice':
-                        return '@SonataAdmin/CRUD/show_choice.html.twig';
-                    case 'array':
-                        return '@SonataAdmin/CRUD/show_array.html.twig';
-                    case 'trans':
-                        return '@SonataAdmin/CRUD/show_trans.html.twig';
-                    case 'url':
-                        return '@SonataAdmin/CRUD/show_url.html.twig';
-                    case 'html':
-                        return '@SonataAdmin/CRUD/show_html.html.twig';
-                    default:
-                        return null;
-                }
-            });
-
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderViewElement method is deprecated in favor of RenderElementExtension::renderViewElement since version 3.x and will be removed in 4.0.');
-
-        $this->assertSame(
-            $this->removeExtraWhitespace($expected),
-            $this->removeExtraWhitespace(
-                $this->twigExtension->renderViewElement(
-                    $this->environment,
-                    $this->fieldDescription,
-                    $this->object
-                )
-            )
-        );
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     */
-    public function getRenderViewElementWithNoValueTests(): iterable
-    {
-        return [
-            // NoValueException
-            ['<th>Data</th> <td></td>', 'string', ['safe' => false]],
-            ['<th>Data</th> <td></td>', 'text', ['safe' => false]],
-            ['<th>Data</th> <td></td>', 'textarea', ['safe' => false]],
-            ['<th>Data</th> <td>&nbsp;</td>', 'datetime', []],
-            [
-                '<th>Data</th> <td>&nbsp;</td>',
-                'datetime',
-                ['format' => 'd.m.Y H:i:s'],
-            ],
-            ['<th>Data</th> <td>&nbsp;</td>', 'date', []],
-            ['<th>Data</th> <td>&nbsp;</td>', 'date', ['format' => 'd.m.Y']],
-            ['<th>Data</th> <td>&nbsp;</td>', 'time', []],
-            ['<th>Data</th> <td></td>', 'number', ['safe' => false]],
-            ['<th>Data</th> <td></td>', 'integer', ['safe' => false]],
-            ['<th>Data</th> <td>&nbsp;</td>', 'percent', []],
-            ['<th>Data</th> <td>&nbsp;</td>', 'currency', ['currency' => 'EUR']],
-            ['<th>Data</th> <td>&nbsp;</td>', 'currency', ['currency' => 'GBP']],
-            ['<th>Data</th> <td> <ul></ul> </td>', 'array', ['safe' => false]],
-            [
-                '<th>Data</th> <td><span class="label label-danger">no</span></td>',
-                'boolean',
-                [],
-            ],
-            [
-                '<th>Data</th> <td> </td>',
-                'trans',
-                ['safe' => false, 'catalogue' => 'SonataAdminBundle'],
-            ],
-            [
-                '<th>Data</th> <td></td>',
-                'choice',
-                ['safe' => false, 'choices' => []],
-            ],
-            [
-                '<th>Data</th> <td></td>',
-                'choice',
-                ['safe' => false, 'choices' => [], 'multiple' => true],
-            ],
-            ['<th>Data</th> <td>&nbsp;</td>', 'url', []],
-            [
-                '<th>Data</th> <td>&nbsp;</td>',
-                'url',
-                ['url' => 'http://example.com'],
-            ],
-            [
-                '<th>Data</th> <td>&nbsp;</td>',
-                'url',
-                ['route' => ['name' => 'sonata_admin_foo']],
-            ],
-        ];
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @group legacy
-     *
-     * @dataProvider getDeprecatedTextExtensionItems
-     */
-    public function testDeprecatedTextExtension(string $expected, string $type, $value, array $options): void
-    {
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderViewElement method is deprecated in favor of RenderElementExtension::renderViewElement since version 3.x and will be removed in 4.0.');
-
-        $this->expectDeprecation('The "truncate.preserve" option is deprecated since sonata-project/admin-bundle 3.65, to be removed in 4.0. Use "truncate.cut" instead. ("@SonataAdmin/CRUD/show_html.html.twig" at line %d).');
-
-        $this->expectDeprecation('The "truncate.separator" option is deprecated since sonata-project/admin-bundle 3.65, to be removed in 4.0. Use "truncate.ellipsis" instead. ("@SonataAdmin/CRUD/show_html.html.twig" at line %d).');
-
-        $loader = new StubFilesystemLoader([
-            sprintf('%s/../../../src/Resources/views/CRUD', __DIR__),
-        ]);
-        $loader->addPath(sprintf('%s/../../../src/Resources/views/', __DIR__), 'SonataAdmin');
-        $environment = new Environment($loader, [
-            'strict_variables' => true,
-            'cache' => false,
-            'autoescape' => 'html',
-            'optimizations' => 0,
-        ]);
-        $environment->addExtension($this->twigExtension);
-        $environment->addExtension(new TranslationExtension($this->translator));
-        $environment->addExtension(new StringExtension());
-
-        $this->admin
-            ->method('getTemplate')
-            ->willReturn('@SonataAdmin/CRUD/base_show_field.html.twig');
-
-        $this->fieldDescription
-            ->method('getValue')
-            ->willReturn($value);
-
-        $this->fieldDescription
-            ->method('getType')
-            ->willReturn($type);
-
-        $this->fieldDescription
-            ->method('getOptions')
-            ->willReturn($options);
-
-        $this->fieldDescription
-            ->method('getTemplate')
-            ->willReturn('@SonataAdmin/CRUD/show_html.html.twig');
-
-        $this->assertSame(
-            $this->removeExtraWhitespace($expected),
-            $this->removeExtraWhitespace(
-                $this->twigExtension->renderViewElement(
-                    $environment,
-                    $this->fieldDescription,
-                    $this->object
-                )
-            )
-        );
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     */
-    public function getDeprecatedTextExtensionItems(): iterable
-    {
-        yield 'default_separator' => [
-            '<th>Data</th> <td> Creating a Template for the Field... </td>',
-            'html',
-            '<p><strong>Creating a Template for the Field</strong> and form</p>',
-            ['truncate' => ['preserve' => true, 'separator' => '...']],
-        ];
-
-        yield 'custom_length' => [
-            '<th>Data</th> <td> Creating a Template[...] </td>',
-            'html',
-            '<p><strong>Creating a Template for the Field</strong> and form</p>',
-            [
-                'truncate' => [
-                    'length' => 20,
-                    'preserve' => true,
-                    'separator' => '[...]',
-                ],
-            ],
-        ];
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this test.
-     *
-     * @group legacy
-     */
-    public function testGetValueFromFieldDescription(): void
-    {
-        $object = new \stdClass();
-        $fieldDescription = $this->getMockForAbstractClass(FieldDescriptionInterface::class);
-
-        $fieldDescription
-            ->method('getValue')
-            ->willReturn('test123');
-
-        $this->assertSame('test123', $this->twigExtension->getValueFromFieldDescription($object, $fieldDescription));
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this test.
-     *
-     * @group legacy
-     */
-    public function testGetValueFromFieldDescriptionWithRemoveLoopException(): void
-    {
-        $object = $this->createMock(\ArrayAccess::class);
-        $fieldDescription = $this->getMockForAbstractClass(FieldDescriptionInterface::class);
-
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('remove the loop requirement');
-
-        $this->assertSame(
-            'anything',
-            $this->twigExtension->getValueFromFieldDescription($object, $fieldDescription, ['loop' => true])
-        );
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this test.
-     *
-     * @group legacy
-     * @expectedDeprecation Accessing a non existing value for the field "" is deprecated since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.
-     */
-    public function testGetValueFromFieldDescriptionWithNoValueException(): void
-    {
-        $object = new \stdClass();
-        $fieldDescription = $this->getMockForAbstractClass(FieldDescriptionInterface::class);
-
-        $fieldDescription
-            ->method('getValue')
-            ->willReturnCallback(static function (): void {
-                throw new NoValueException();
-            });
-
-        $fieldDescription
-            ->method('getAssociationAdmin')
-            ->willReturn(null);
-
-        $this->assertNull($this->twigExtension->getValueFromFieldDescription($object, $fieldDescription));
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this test.
-     *
-     * @group legacy
-     */
-    public function testGetValueFromFieldDescriptionWithNoValueExceptionNewAdminInstance(): void
-    {
-        $object = new \stdClass();
-        $fieldDescription = $this->getMockForAbstractClass(FieldDescriptionInterface::class);
-
-        $fieldDescription
-            ->method('getValue')
-            ->willReturnCallback(static function (): void {
-                throw new NoValueException();
-            });
-
-        $fieldDescription
-            ->method('getAssociationAdmin')
-            ->willReturn($this->admin);
-
-        $this->admin->expects($this->once())
-            ->method('getNewInstance')
-            ->willReturn('foo');
-
-        $this->assertSame('foo', $this->twigExtension->getValueFromFieldDescription($object, $fieldDescription));
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @group legacy
-     */
-    public function testOutput(): void
-    {
-        $this->fieldDescription
-            ->method('getTemplate')
-            ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
-
-        $this->fieldDescription
-            ->method('getFieldName')
-            ->willReturn('fd_name');
-
-        $this->environment->disableDebug();
-
-        $parameters = [
-            'admin' => $this->admin,
-            'value' => 'foo',
-            'field_description' => $this->fieldDescription,
-            'object' => $this->object,
-        ];
-
-        $template = $this->environment->load('@SonataAdmin/CRUD/base_list_field.html.twig')->unwrap();
-
-        $this->assertSame(
-            '<td class="sonata-ba-list-field sonata-ba-list-field-" objectId="12345"> foo </td>',
-            $this->removeExtraWhitespace($this->twigExtension->output(
-                $this->fieldDescription,
-                $template,
-                $parameters,
-                $this->environment
-            ))
-        );
-
-        $this->environment->enableDebug();
-
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::output method is deprecated since version 3.33 and will be removed in 4.0.');
-
-        $this->assertSame(
-            $this->removeExtraWhitespace(
-                <<<'EOT'
-<!-- START
-    fieldName: fd_name
-    template: @SonataAdmin/CRUD/base_list_field.html.twig
-    compiled template: @SonataAdmin/CRUD/base_list_field.html.twig
--->
-    <td class="sonata-ba-list-field sonata-ba-list-field-" objectId="12345"> foo </td>
-<!-- END - fieldName: fd_name -->
-EOT
-            ),
-            $this->removeExtraWhitespace(
-                $this->twigExtension->output($this->fieldDescription, $template, $parameters, $this->environment)
-            )
-        );
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @group legacy
-     */
-    public function testRenderWithDebug(): void
-    {
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderListElement method is deprecated in favor of RenderElementExtension::renderListElement since version 3.x and will be removed in 4.0.');
-
-        $this->expectDeprecation('The Sonata\AdminBundle\Admin\AbstractAdmin::getTemplate method is deprecated (since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry services instead).');
-
-        $this->fieldDescription
-            ->method('getTemplate')
-            ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
-
-        $this->fieldDescription
-            ->method('getFieldName')
-            ->willReturn('fd_name');
-
-        $this->fieldDescription
-            ->method('getValue')
-            ->willReturn('foo');
-
-        $parameters = [
-            'admin' => $this->admin,
-            'value' => 'foo',
-            'field_description' => $this->fieldDescription,
-            'object' => $this->object,
-        ];
-
-        $this->environment->enableDebug();
-
-        $this->assertSame(
-            $this->removeExtraWhitespace(
-                <<<'EOT'
-<!-- START
-    fieldName: fd_name
-    template: @SonataAdmin/CRUD/base_list_field.html.twig
-    compiled template: @SonataAdmin/CRUD/base_list_field.html.twig
--->
-    <td class="sonata-ba-list-field sonata-ba-list-field-" objectId="12345"> foo </td>
-<!-- END - fieldName: fd_name -->
-EOT
-            ),
-            $this->removeExtraWhitespace(
-                $this->twigExtension->renderListElement($this->environment, $this->object, $this->fieldDescription, $parameters)
-            )
-        );
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @group legacy
-     */
-    public function testRenderRelationElementNoObject(): void
-    {
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderRelationElement method is deprecated in favor of RenderElementExtension::renderRelationElement since version 3.x and will be removed in 4.0.');
-
-        $this->assertSame('foo', $this->twigExtension->renderRelationElement('foo', $this->fieldDescription));
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @group legacy
-     */
-    public function testRenderRelationElementToString(): void
-    {
-        $this->fieldDescription->expects($this->exactly(2))
-            ->method('getOption')
-            ->willReturnCallback(static function ($value, $default = null) {
-                if ('associated_property' === $value) {
-                    return $default;
-                }
-            });
-
-        $element = new FooToString();
-
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderRelationElement method is deprecated in favor of RenderElementExtension::renderRelationElement since version 3.x and will be removed in 4.0.');
-
-        $this->assertSame('salut', $this->twigExtension->renderRelationElement($element, $this->fieldDescription));
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @group legacy
-     */
-    public function testDeprecatedRelationElementToString(): void
-    {
-        $this->fieldDescription->expects($this->exactly(2))
-            ->method('getOption')
-            ->willReturnCallback(static function ($value, $default = null) {
-                if ('associated_tostring' === $value) {
-                    return '__toString';
-                }
-            });
-
-        $element = new FooToString();
-
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderRelationElement method is deprecated in favor of RenderElementExtension::renderRelationElement since version 3.x and will be removed in 4.0.');
-
-        $this->assertSame(
-            'salut',
-            $this->twigExtension->renderRelationElement($element, $this->fieldDescription)
-        );
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @group legacy
-     */
-    public function testRenderRelationElementCustomToString(): void
-    {
-        $this->fieldDescription->expects($this->exactly(2))
-            ->method('getOption')
-            ->willReturnCallback(static function ($value, $default = null) {
-                if ('associated_property' === $value) {
-                    return $default;
-                }
-
-                if ('associated_tostring' === $value) {
-                    return 'customToString';
-                }
-            });
-
-        $element = $this->getMockBuilder(\stdClass::class)
-            ->setMethods(['customToString'])
-            ->getMock();
-        $element
-            ->method('customToString')
-            ->willReturn('fooBar');
-
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderRelationElement method is deprecated in favor of RenderElementExtension::renderRelationElement since version 3.x and will be removed in 4.0.');
-
-        $this->assertSame('fooBar', $this->twigExtension->renderRelationElement($element, $this->fieldDescription));
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @group legacy
-     */
-    public function testRenderRelationElementMethodNotExist(): void
-    {
-        $this->fieldDescription->expects($this->exactly(2))
-            ->method('getOption')
-
-            ->willReturnCallback(static function ($value, $default = null) {
-                if ('associated_tostring' === $value) {
-                    return 'nonExistedMethod';
-                }
-            });
-
-        $element = new \stdClass();
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('You must define an `associated_property` option or create a `stdClass::__toString');
-
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderRelationElement method is deprecated in favor of RenderElementExtension::renderRelationElement since version 3.x and will be removed in 4.0.');
-
-        $this->twigExtension->renderRelationElement($element, $this->fieldDescription);
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @group legacy
-     */
-    public function testRenderRelationElementWithPropertyPath(): void
-    {
-        $this->fieldDescription->expects($this->once())
-            ->method('getOption')
-
-            ->willReturnCallback(static function ($value, $default = null) {
-                if ('associated_property' === $value) {
-                    return 'foo';
-                }
-            });
-
-        $element = new \stdClass();
-        $element->foo = 'bar';
-
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderRelationElement method is deprecated in favor of RenderElementExtension::renderRelationElement since version 3.x and will be removed in 4.0.');
-
-        $this->assertSame('bar', $this->twigExtension->renderRelationElement($element, $this->fieldDescription));
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @group legacy
-     */
-    public function testRenderRelationElementWithClosure(): void
-    {
-        $this->fieldDescription->expects($this->once())
-            ->method('getOption')
-
-            ->willReturnCallback(static function ($value, $default = null) {
-                if ('associated_property' === $value) {
-                    return static function ($element): string {
-                        return sprintf('closure %s', $element->foo);
-                    };
-                }
-            });
-
-        $element = new \stdClass();
-        $element->foo = 'bar';
-
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderRelationElement method is deprecated in favor of RenderElementExtension::renderRelationElement since version 3.x and will be removed in 4.0.');
-
-        $this->assertSame(
-            'closure bar',
-            $this->twigExtension->renderRelationElement($element, $this->fieldDescription)
-        );
-    }
-
-    public function testGetUrlsafeIdentifier(): void
-    {
-        $model = new \stdClass();
-
-        $pool = new Pool(
-            $this->container,
-            ['sonata_admin_foo_service'],
-            [],
-            [\stdClass::class => ['sonata_admin_foo_service']]
-        );
-
-        $this->admin->expects($this->once())
-            ->method('getUrlSafeIdentifier')
-            ->with($this->equalTo($model))
-            ->willReturn(1234567);
-
-        $this->container->set('sonata_admin_foo_service', $this->admin);
-
-        $twigExtension = new SonataAdminExtension(
-            $pool,
-            $this->logger,
-            $this->translator,
-            $this->container,
-            PropertyAccess::createPropertyAccessor()
-        );
-
-        $this->assertSame(1234567, $twigExtension->getUrlSafeIdentifier($model));
-    }
-
-    public function testGetUrlsafeIdentifier_GivenAdmin_Foo(): void
-    {
-        $model = new \stdClass();
-
-        $pool = new Pool(
-            $this->container,
-            [
-                'sonata_admin_foo_service',
-                'sonata_admin_bar_service',
-            ],
-            [],
-            [\stdClass::class => [
-                'sonata_admin_foo_service',
-                'sonata_admin_bar_service',
-            ]]
-        );
-
-        $this->admin->expects($this->once())
-            ->method('getUrlSafeIdentifier')
-            ->with($this->equalTo($model))
-            ->willReturn(1234567);
-
-        $this->adminBar->expects($this->never())
-            ->method('getUrlSafeIdentifier');
-
-        $twigExtension = new SonataAdminExtension(
-            $pool,
-            $this->logger,
-            $this->translator,
-            $this->container,
-            PropertyAccess::createPropertyAccessor()
-        );
-
-        $this->assertSame(1234567, $twigExtension->getUrlSafeIdentifier($model, $this->admin));
-    }
-
-    public function testGetUrlsafeIdentifier_GivenAdmin_Bar(): void
-    {
-        $model = new \stdClass();
-
-        $pool = new Pool(
-            $this->container,
-            ['sonata_admin_foo_service', 'sonata_admin_bar_service'],
-            [],
-            [\stdClass::class => [
-                'sonata_admin_foo_service',
-                'sonata_admin_bar_service',
-            ]]
-        );
-
-        $this->admin->expects($this->never())
-            ->method('getUrlSafeIdentifier');
-
-        $this->adminBar->expects($this->once())
-            ->method('getUrlSafeIdentifier')
-            ->with($this->equalTo($model))
-            ->willReturn(1234567);
-
-        $twigExtension = new SonataAdminExtension(
-            $pool,
-            $this->logger,
-            $this->translator,
-            $this->container,
-            PropertyAccess::createPropertyAccessor()
-        );
-
-        $this->assertSame(1234567, $twigExtension->getUrlSafeIdentifier($model, $this->adminBar));
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     */
-    public function xEditableChoicesProvider()
-    {
-        return [
-            'needs processing' => [
-                ['choices' => ['Status1' => 'Alias1', 'Status2' => 'Alias2']],
-                [
-                    ['value' => 'Status1', 'text' => 'Alias1'],
-                    ['value' => 'Status2', 'text' => 'Alias2'],
-                ],
-            ],
-            'already processed' => [
-                ['choices' => [
-                    ['value' => 'Status1', 'text' => 'Alias1'],
-                    ['value' => 'Status2', 'text' => 'Alias2'],
-                ]],
-                [
-                    ['value' => 'Status1', 'text' => 'Alias1'],
-                    ['value' => 'Status2', 'text' => 'Alias2'],
-                ],
-            ],
-            'not required' => [
-                [
-                    'required' => false,
-                    'choices' => ['' => '', 'Status1' => 'Alias1', 'Status2' => 'Alias2'],
-                ],
-                [
-                    ['value' => '', 'text' => ''],
-                    ['value' => 'Status1', 'text' => 'Alias1'],
-                    ['value' => 'Status2', 'text' => 'Alias2'],
-                ],
-            ],
-            'not required multiple' => [
-                [
-                    'required' => false,
-                    'multiple' => true,
-                    'choices' => ['Status1' => 'Alias1', 'Status2' => 'Alias2'],
-                ],
-                [
-                    ['value' => 'Status1', 'text' => 'Alias1'],
-                    ['value' => 'Status2', 'text' => 'Alias2'],
-                ],
-            ],
-        ];
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @dataProvider xEditablechoicesProvider
-     *
-     * @group legacy
-     */
-    public function testGetXEditableChoicesIsIdempotent(array $options, array $expectedChoices): void
-    {
-        $fieldDescription = $this->getMockForAbstractClass(FieldDescriptionInterface::class);
-        $fieldDescription
-            ->method('getOption')
-            ->withConsecutive(
-                ['choices', []],
-                ['catalogue'],
-                ['required'],
-                ['multiple']
-            )
-            ->will($this->onConsecutiveCalls(
-                $options['choices'],
-                'MyCatalogue',
-                $options['multiple'] ?? null
-            ));
-
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::getXEditableChoices method is deprecated in favor of XEditableExtension::getXEditableChoices since version 3.x and will be removed in 4.0.');
-
-        $this->assertSame($expectedChoices, $this->twigExtension->getXEditableChoices($fieldDescription));
-    }
-
-    public function select2LocalesProvider()
-    {
-        return [
-            ['ar', 'ar'],
-            ['az', 'az'],
-            ['bg', 'bg'],
-            ['ca', 'ca'],
-            ['cs', 'cs'],
-            ['da', 'da'],
-            ['de', 'de'],
-            ['el', 'el'],
-            [null, 'en'],
-            ['es', 'es'],
-            ['et', 'et'],
-            ['eu', 'eu'],
-            ['fa', 'fa'],
-            ['fi', 'fi'],
-            ['fr', 'fr'],
-            ['gl', 'gl'],
-            ['he', 'he'],
-            ['hr', 'hr'],
-            ['hu', 'hu'],
-            ['id', 'id'],
-            ['is', 'is'],
-            ['it', 'it'],
-            ['ja', 'ja'],
-            ['ka', 'ka'],
-            ['ko', 'ko'],
-            ['lt', 'lt'],
-            ['lv', 'lv'],
-            ['mk', 'mk'],
-            ['ms', 'ms'],
-            ['nb', 'nb'],
-            ['nl', 'nl'],
-            ['pl', 'pl'],
-            ['pt-PT', 'pt'],
-            ['pt-BR', 'pt-BR'],
-            ['pt-PT', 'pt-PT'],
-            ['ro', 'ro'],
-            ['rs', 'rs'],
-            ['ru', 'ru'],
-            ['sk', 'sk'],
-            ['sv', 'sv'],
-            ['th', 'th'],
-            ['tr', 'tr'],
-            ['ug-CN', 'ug'],
-            ['ug-CN', 'ug-CN'],
-            ['uk', 'uk'],
-            ['vi', 'vi'],
-            ['zh-CN', 'zh'],
-            ['zh-CN', 'zh-CN'],
-            ['zh-TW', 'zh-TW'],
-        ];
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @dataProvider select2LocalesProvider
-     *
-     * @group legacy
-     */
-    public function testCanonicalizedLocaleForSelect2(?string $expected, string $original): void
-    {
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::getCanonicalizedLocaleForSelect2 method is deprecated in favor of CanonicalizeExtension::getCanonicalizedLocaleForSelect2 since version 3.x and will be removed in 4.0.');
-
-        $this->assertSame($expected, $this->twigExtension->getCanonicalizedLocaleForSelect2($this->mockExtensionContext($original)));
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     */
-    public function momentLocalesProvider(): array
-    {
-        return [
-            ['af', 'af'],
-            ['ar-dz', 'ar-dz'],
-            ['ar', 'ar'],
-            ['ar-ly', 'ar-ly'],
-            ['ar-ma', 'ar-ma'],
-            ['ar-sa', 'ar-sa'],
-            ['ar-tn', 'ar-tn'],
-            ['az', 'az'],
-            ['be', 'be'],
-            ['bg', 'bg'],
-            ['bn', 'bn'],
-            ['bo', 'bo'],
-            ['br', 'br'],
-            ['bs', 'bs'],
-            ['ca', 'ca'],
-            ['cs', 'cs'],
-            ['cv', 'cv'],
-            ['cy', 'cy'],
-            ['da', 'da'],
-            ['de-at', 'de-at'],
-            ['de', 'de'],
-            ['de', 'de-de'],
-            ['dv', 'dv'],
-            ['el', 'el'],
-            [null, 'en'],
-            [null, 'en-us'],
-            ['en-au', 'en-au'],
-            ['en-ca', 'en-ca'],
-            ['en-gb', 'en-gb'],
-            ['en-ie', 'en-ie'],
-            ['en-nz', 'en-nz'],
-            ['eo', 'eo'],
-            ['es-do', 'es-do'],
-            ['es', 'es-ar'],
-            ['es', 'es-mx'],
-            ['es', 'es'],
-            ['et', 'et'],
-            ['eu', 'eu'],
-            ['fa', 'fa'],
-            ['fi', 'fi'],
-            ['fo', 'fo'],
-            ['fr-ca', 'fr-ca'],
-            ['fr-ch', 'fr-ch'],
-            ['fr', 'fr-fr'],
-            ['fr', 'fr'],
-            ['fy', 'fy'],
-            ['gd', 'gd'],
-            ['gl', 'gl'],
-            ['he', 'he'],
-            ['hi', 'hi'],
-            ['hr', 'hr'],
-            ['hu', 'hu'],
-            ['hy-am', 'hy-am'],
-            ['id', 'id'],
-            ['is', 'is'],
-            ['it', 'it'],
-            ['ja', 'ja'],
-            ['jv', 'jv'],
-            ['ka', 'ka'],
-            ['kk', 'kk'],
-            ['km', 'km'],
-            ['ko', 'ko'],
-            ['ky', 'ky'],
-            ['lb', 'lb'],
-            ['lo', 'lo'],
-            ['lt', 'lt'],
-            ['lv', 'lv'],
-            ['me', 'me'],
-            ['mi', 'mi'],
-            ['mk', 'mk'],
-            ['ml', 'ml'],
-            ['mr', 'mr'],
-            ['ms', 'ms'],
-            ['ms-my', 'ms-my'],
-            ['my', 'my'],
-            ['nb', 'nb'],
-            ['ne', 'ne'],
-            ['nl-be', 'nl-be'],
-            ['nl', 'nl'],
-            ['nl', 'nl-nl'],
-            ['nn', 'nn'],
-            ['pa-in', 'pa-in'],
-            ['pl', 'pl'],
-            ['pt-br', 'pt-br'],
-            ['pt', 'pt'],
-            ['ro', 'ro'],
-            ['ru', 'ru'],
-            ['se', 'se'],
-            ['si', 'si'],
-            ['sk', 'sk'],
-            ['sl', 'sl'],
-            ['sq', 'sq'],
-            ['sr-cyrl', 'sr-cyrl'],
-            ['sr', 'sr'],
-            ['ss', 'ss'],
-            ['sv', 'sv'],
-            ['sw', 'sw'],
-            ['ta', 'ta'],
-            ['te', 'te'],
-            ['tet', 'tet'],
-            ['th', 'th'],
-            ['tlh', 'tlh'],
-            ['tl-ph', 'tl-ph'],
-            ['tr', 'tr'],
-            ['tzl', 'tzl'],
-            ['tzm', 'tzm'],
-            ['tzm-latn', 'tzm-latn'],
-            ['uk', 'uk'],
-            ['uz', 'uz'],
-            ['vi', 'vi'],
-            ['x-pseudo', 'x-pseudo'],
-            ['yo', 'yo'],
-            ['zh-cn', 'zh-cn'],
-            ['zh-hk', 'zh-hk'],
-            ['zh-tw', 'zh-tw'],
-        ];
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @dataProvider momentLocalesProvider
-     *
-     * @group legacy
-     */
-    public function testCanonicalizedLocaleForMoment(?string $expected, string $original): void
-    {
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::getCanonicalizedLocaleForMoment method is deprecated in favor of CanonicalizeExtension::getCanonicalizedLocaleForMoment since version 3.x and will be removed in 4.0.');
-
-        $this->assertSame($expected, $this->twigExtension->getCanonicalizedLocaleForMoment($this->mockExtensionContext($original)));
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @group legacy
-     */
-    public function testIsGrantedAffirmative(): void
-    {
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::isGrantedAffirmative method is deprecated in favor of SecurityExtension::isGrantedAffirmative since version 3.x and will be removed in 4.0.');
-
-        $this->securityChecker
-            ->method('isGranted')
-            ->withConsecutive(
-                ['foo', null],
-                ['bar', null],
-                ['foo', null],
-                ['bar', null]
-            )
-            ->willReturnMap([
-                ['foo', null, false],
-                ['bar', null, true],
-            ]);
-
-        $this->assertTrue($this->twigExtension->isGrantedAffirmative(['foo', 'bar']));
-        $this->assertFalse($this->twigExtension->isGrantedAffirmative('foo'));
-        $this->assertTrue($this->twigExtension->isGrantedAffirmative('bar'));
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @group legacy
-     * @dataProvider getRenderViewElementCompareTests
-     */
-    public function testRenderViewElementCompare(string $expected, string $type, $value, array $options, ?string $objectName = null): void
-    {
-        $this->admin
-            ->method('getTemplate')
-            ->willReturn('@SonataAdmin/CRUD/base_show_compare.html.twig');
-
-        $this->fieldDescription
-            ->method('getValue')
-            ->willReturn($value);
-
-        $this->fieldDescription
-            ->method('getType')
-            ->willReturn($type);
-
-        $this->fieldDescription
-            ->method('getOptions')
-            ->willReturn($options);
-
-        $this->fieldDescription
-            ->method('getTemplate')
-            ->willReturnCallback(static function () use ($type, $options): ?string {
-                if (isset($options['template'])) {
-                    return $options['template'];
-                }
-
-                switch ($type) {
-                    case 'boolean':
-                        return '@SonataAdmin/CRUD/show_boolean.html.twig';
-                    case 'datetime':
-                        return '@SonataAdmin/CRUD/show_datetime.html.twig';
-                    case 'date':
-                        return '@SonataAdmin/CRUD/show_date.html.twig';
-                    case 'time':
-                        return '@SonataAdmin/CRUD/show_time.html.twig';
-                    case 'currency':
-                        return '@SonataAdmin/CRUD/show_currency.html.twig';
-                    case 'percent':
-                        return '@SonataAdmin/CRUD/show_percent.html.twig';
-                    case 'email':
-                        return '@SonataAdmin/CRUD/show_email.html.twig';
-                    case 'choice':
-                        return '@SonataAdmin/CRUD/show_choice.html.twig';
-                    case 'array':
-                        return '@SonataAdmin/CRUD/show_array.html.twig';
-                    case 'trans':
-                        return '@SonataAdmin/CRUD/show_trans.html.twig';
-                    case 'url':
-                        return '@SonataAdmin/CRUD/show_url.html.twig';
-                    case 'html':
-                        return '@SonataAdmin/CRUD/show_html.html.twig';
-                    default:
-                        return null;
-                }
-            });
-
-        $this->object->name = 'SonataAdmin';
-
-        $comparedObject = clone $this->object;
-
-        if (null !== $objectName) {
-            $comparedObject->name = $objectName;
-        }
-
-        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderViewElementCompare method is deprecated in favor of RenderElementExtension::renderViewElementCompare since version 3.x and will be removed in 4.0.');
-
-        $this->assertSame(
-            $this->removeExtraWhitespace($expected),
-            $this->removeExtraWhitespace(
-                $this->twigExtension->renderViewElementCompare(
-                    $this->environment,
-                    $this->fieldDescription,
-                    $this->object,
-                    $comparedObject
-                )
-            )
-        );
-    }
-
-    /**
-     * NEXT_MAJOR: Remove this method.
-     */
     public function getRenderViewElementCompareTests(): iterable
     {
         return [
@@ -3336,15 +2534,5 @@ EOT
             ' ',
             $string
         ));
-    }
-
-    private function mockExtensionContext(string $locale): array
-    {
-        $request = $this->createMock(Request::class);
-        $request->method('getLocale')->willReturn($locale);
-        $appVariable = $this->createMock(AppVariable::class);
-        $appVariable->method('getRequest')->willReturn($request);
-
-        return ['app' => $appVariable];
     }
 }

--- a/tests/Twig/Extension/SecurityExtensionTest.php
+++ b/tests/Twig/Extension/SecurityExtensionTest.php
@@ -18,8 +18,6 @@ use Sonata\AdminBundle\Twig\Extension\SecurityExtension;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
- * Test for SonataAdminExtension.
- *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
 final class SecurityExtensionTest extends TestCase

--- a/tests/Twig/Extension/SecurityExtensionTest.php
+++ b/tests/Twig/Extension/SecurityExtensionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Twig\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Twig\Extension\SecurityExtension;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+
+/**
+ * Test for SonataAdminExtension.
+ *
+ * @author Andrej Hudec <pulzarraider@gmail.com>
+ */
+final class SecurityExtensionTest extends TestCase
+{
+    public function testIsGrantedAffirmative(): void
+    {
+        $securityChecker = $this->createStub(AuthorizationCheckerInterface::class);
+        $twigExtension = new SecurityExtension($securityChecker);
+
+        $securityChecker
+            ->method('isGranted')
+            ->withConsecutive(
+                ['foo', null],
+                ['bar', null],
+                ['foo', null],
+                ['bar', null]
+            )
+            ->willReturnMap([
+                ['foo', null, false],
+                ['bar', null, true],
+            ]);
+
+        $this->assertTrue($twigExtension->isGrantedAffirmative(['foo', 'bar']));
+        $this->assertFalse($twigExtension->isGrantedAffirmative('foo'));
+        $this->assertTrue($twigExtension->isGrantedAffirmative('bar'));
+    }
+}

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -339,12 +339,17 @@ class SonataAdminExtensionTest extends TestCase
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @group legacy
-     * @expectedDeprecation The Sonata\AdminBundle\Admin\AbstractAdmin::getTemplate method is deprecated (since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry services instead).
      * @dataProvider getRenderListElementTests
      */
     public function testRenderListElement(string $expected, string $type, $value, array $options): void
     {
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderListElement method is deprecated in favor of RenderElementExtension::renderListElement since version 3.x and will be removed in 4.0.');
+
+        $this->expectDeprecation('The Sonata\AdminBundle\Admin\AbstractAdmin::getTemplate method is deprecated (since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry services instead).');
+
         $this->admin
             ->method('getPersistentParameters')
             ->willReturn(['context' => 'foo']);
@@ -429,13 +434,16 @@ class SonataAdminExtensionTest extends TestCase
     }
 
     /**
-     * NEXT_MAJOR: Remove @expectedDeprecation.
+     * NEXT_MAJOR: Remove this method.
      *
      * @group legacy
-     * @expectedDeprecation The Sonata\AdminBundle\Admin\AbstractAdmin::getTemplate method is deprecated (since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry services instead).
      */
     public function testRenderListElementWithAdditionalValuesInArray(): void
     {
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderListElement method is deprecated in favor of RenderElementExtension::renderListElement since version 3.x and will be removed in 4.0.');
+
+        $this->expectDeprecation('The Sonata\AdminBundle\Admin\AbstractAdmin::getTemplate method is deprecated (since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry services instead).');
+
         // NEXT_MAJOR: Remove this line
         $this->admin
             ->method('getTemplate')
@@ -460,13 +468,16 @@ class SonataAdminExtensionTest extends TestCase
     }
 
     /**
-     * NEXT_MAJOR: Remove @expectedDeprecation.
+     * NEXT_MAJOR: Remove this method.
      *
      * @group legacy
-     * @expectedDeprecation Accessing a non existing value for the field "fd_name" is deprecated since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.
      */
     public function testRenderListElementWithNoValueException(): void
     {
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderListElement method is deprecated in favor of RenderElementExtension::renderListElement since version 3.x and will be removed in 4.0.');
+
+        $this->expectDeprecation('Accessing a non existing value is deprecated since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.');
+
         // NEXT_MAJOR: Remove this line
         $this->admin
             ->method('getTemplate')
@@ -493,6 +504,8 @@ class SonataAdminExtensionTest extends TestCase
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @dataProvider getDeprecatedRenderListElementTests
      * @group legacy
      */
@@ -533,6 +546,8 @@ class SonataAdminExtensionTest extends TestCase
             ->method('getTemplate')
             ->willReturn('@SonataAdmin/CRUD/list_nonexistent_template.html.twig');
 
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderListElement method is deprecated in favor of RenderElementExtension::renderListElement since version 3.x and will be removed in 4.0.');
+
         $this->assertSame(
             $this->removeExtraWhitespace($expected),
             $this->removeExtraWhitespace($this->twigExtension->renderListElement(
@@ -543,6 +558,9 @@ class SonataAdminExtensionTest extends TestCase
         );
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function getDeprecatedRenderListElementTests()
     {
         return [
@@ -559,6 +577,9 @@ class SonataAdminExtensionTest extends TestCase
         ];
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function getRenderListElementTests()
     {
         return [
@@ -1535,6 +1556,8 @@ EOT
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @group legacy
      */
     public function testRenderListElementNonExistentTemplate(): void
@@ -1573,11 +1596,15 @@ EOT
                     instead.'
             ))));
 
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderListElement method is deprecated in favor of RenderElementExtension::renderListElement since version 3.x and will be removed in 4.0.');
+
         $this->twigExtension->renderListElement($this->environment, $this->object, $this->fieldDescription);
     }
 
     /**
-     * @group                    legacy
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @group legacy
      */
     public function testRenderListElementErrorLoadingTemplate(): void
     {
@@ -1596,12 +1623,17 @@ EOT
             ->method('getTemplate')
             ->willReturn('@SonataAdmin/CRUD/list_nonexistent_template.html.twig');
 
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderListElement method is deprecated in favor of RenderElementExtension::renderListElement since version 3.x and will be removed in 4.0.');
+
         $this->twigExtension->renderListElement($this->environment, $this->object, $this->fieldDescription);
 
         $this->templateRegistry->getTemplate('base_list_field')->shouldHaveBeenCalled();
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @group legacy
      * @dataProvider getRenderViewElementTests
      */
     public function testRenderViewElement(string $expected, string $type, $value, array $options): void
@@ -1655,6 +1687,8 @@ EOT
                 }
             });
 
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderViewElement method is deprecated in favor of RenderElementExtension::renderViewElement since version 3.x and will be removed in 4.0.');
+
         $this->assertSame(
             $this->removeExtraWhitespace($expected),
             $this->removeExtraWhitespace(
@@ -1667,6 +1701,9 @@ EOT
         );
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function getRenderViewElementTests()
     {
         return [
@@ -2169,6 +2206,8 @@ EOT
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @group legacy
      * @assertDeprecation Accessing a non existing value for the field "fd_name" is deprecated since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.
      *
@@ -2225,6 +2264,8 @@ EOT
                 }
             });
 
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderViewElement method is deprecated in favor of RenderElementExtension::renderViewElement since version 3.x and will be removed in 4.0.');
+
         $this->assertSame(
             $this->removeExtraWhitespace($expected),
             $this->removeExtraWhitespace(
@@ -2237,6 +2278,9 @@ EOT
         );
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function getRenderViewElementWithNoValueTests(): iterable
     {
         return [
@@ -2299,13 +2343,15 @@ EOT
      * @group legacy
      *
      * @dataProvider getDeprecatedTextExtensionItems
-     *
-     * @expectedDeprecation The "truncate.preserve" option is deprecated since sonata-project/admin-bundle 3.65, to be removed in 4.0. Use "truncate.cut" instead. ("@SonataAdmin/CRUD/show_html.html.twig" at line %d).
-     *
-     * @expectedDeprecation The "truncate.separator" option is deprecated since sonata-project/admin-bundle 3.65, to be removed in 4.0. Use "truncate.ellipsis" instead. ("@SonataAdmin/CRUD/show_html.html.twig" at line %d).
      */
     public function testDeprecatedTextExtension(string $expected, string $type, $value, array $options): void
     {
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderViewElement method is deprecated in favor of RenderElementExtension::renderViewElement since version 3.x and will be removed in 4.0.');
+
+        $this->expectDeprecation('The "truncate.preserve" option is deprecated since sonata-project/admin-bundle 3.65, to be removed in 4.0. Use "truncate.cut" instead. ("@SonataAdmin/CRUD/show_html.html.twig" at line %d).');
+
+        $this->expectDeprecation('The "truncate.separator" option is deprecated since sonata-project/admin-bundle 3.65, to be removed in 4.0. Use "truncate.ellipsis" instead. ("@SonataAdmin/CRUD/show_html.html.twig" at line %d).');
+
         $loader = new StubFilesystemLoader([
             sprintf('%s/../../../src/Resources/views/CRUD', __DIR__),
         ]);
@@ -2466,6 +2512,8 @@ EOT
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @group legacy
      */
     public function testOutput(): void
@@ -2500,6 +2548,9 @@ EOT
         );
 
         $this->environment->enableDebug();
+
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::render method is deprecated in favor of RenderElementExtension::render since version 3.x and will be removed in 4.0.');
+
         $this->assertSame(
             $this->removeExtraWhitespace(
                 <<<'EOT'
@@ -2519,11 +2570,16 @@ EOT
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @group legacy
-     * @expectedDeprecation The Sonata\AdminBundle\Admin\AbstractAdmin::getTemplate method is deprecated (since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry services instead).
      */
     public function testRenderWithDebug(): void
     {
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderListElement method is deprecated in favor of RenderElementExtension::renderListElement since version 3.x and will be removed in 4.0.');
+
+        $this->expectDeprecation('The Sonata\AdminBundle\Admin\AbstractAdmin::getTemplate method is deprecated (since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry services instead).');
+
         $this->fieldDescription
             ->method('getTemplate')
             ->willReturn('@SonataAdmin/CRUD/base_list_field.html.twig');
@@ -2563,11 +2619,23 @@ EOT
         );
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @group legacy
+     */
     public function testRenderRelationElementNoObject(): void
     {
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderRelationElement method is deprecated in favor of RenderElementExtension::renderRelationElement since version 3.x and will be removed in 4.0.');
+
         $this->assertSame('foo', $this->twigExtension->renderRelationElement('foo', $this->fieldDescription));
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @group legacy
+     */
     public function testRenderRelationElementToString(): void
     {
         $this->fieldDescription->expects($this->exactly(2))
@@ -2579,10 +2647,15 @@ EOT
             });
 
         $element = new FooToString();
+
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderRelationElement method is deprecated in favor of RenderElementExtension::renderRelationElement since version 3.x and will be removed in 4.0.');
+
         $this->assertSame('salut', $this->twigExtension->renderRelationElement($element, $this->fieldDescription));
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @group legacy
      */
     public function testDeprecatedRelationElementToString(): void
@@ -2596,6 +2669,9 @@ EOT
             });
 
         $element = new FooToString();
+
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderRelationElement method is deprecated in favor of RenderElementExtension::renderRelationElement since version 3.x and will be removed in 4.0.');
+
         $this->assertSame(
             'salut',
             $this->twigExtension->renderRelationElement($element, $this->fieldDescription)
@@ -2603,6 +2679,8 @@ EOT
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @group legacy
      */
     public function testRenderRelationElementCustomToString(): void
@@ -2626,10 +2704,14 @@ EOT
             ->method('customToString')
             ->willReturn('fooBar');
 
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderRelationElement method is deprecated in favor of RenderElementExtension::renderRelationElement since version 3.x and will be removed in 4.0.');
+
         $this->assertSame('fooBar', $this->twigExtension->renderRelationElement($element, $this->fieldDescription));
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @group legacy
      */
     public function testRenderRelationElementMethodNotExist(): void
@@ -2647,9 +2729,16 @@ EOT
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('You must define an `associated_property` option or create a `stdClass::__toString');
 
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderRelationElement method is deprecated in favor of RenderElementExtension::renderRelationElement since version 3.x and will be removed in 4.0.');
+
         $this->twigExtension->renderRelationElement($element, $this->fieldDescription);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @group legacy
+     */
     public function testRenderRelationElementWithPropertyPath(): void
     {
         $this->fieldDescription->expects($this->once())
@@ -2664,9 +2753,16 @@ EOT
         $element = new \stdClass();
         $element->foo = 'bar';
 
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderRelationElement method is deprecated in favor of RenderElementExtension::renderRelationElement since version 3.x and will be removed in 4.0.');
+
         $this->assertSame('bar', $this->twigExtension->renderRelationElement($element, $this->fieldDescription));
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @group legacy
+     */
     public function testRenderRelationElementWithClosure(): void
     {
         $this->fieldDescription->expects($this->once())
@@ -2682,6 +2778,8 @@ EOT
 
         $element = new \stdClass();
         $element->foo = 'bar';
+
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderRelationElement method is deprecated in favor of RenderElementExtension::renderRelationElement since version 3.x and will be removed in 4.0.');
 
         $this->assertSame(
             'closure bar',
@@ -3099,6 +3197,9 @@ EOT
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @group legacy
      * @dataProvider getRenderViewElementCompareTests
      */
     public function testRenderViewElementCompare(string $expected, string $type, $value, array $options, ?string $objectName = null): void
@@ -3164,6 +3265,8 @@ EOT
             $comparedObject->name = $objectName;
         }
 
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderViewElementCompare method is deprecated in favor of RenderElementExtension::renderViewElementCompare since version 3.x and will be removed in 4.0.');
+
         $this->assertSame(
             $this->removeExtraWhitespace($expected),
             $this->removeExtraWhitespace(
@@ -3177,6 +3280,9 @@ EOT
         );
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function getRenderViewElementCompareTests(): iterable
     {
         return [

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -476,7 +476,7 @@ class SonataAdminExtensionTest extends TestCase
     {
         $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderListElement method is deprecated in favor of RenderElementExtension::renderListElement since version 3.x and will be removed in 4.0.');
 
-        $this->expectDeprecation('Accessing a non existing value is deprecated since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.');
+        $this->expectDeprecation('Accessing a non existing value for the field "fd_name" is deprecated since sonata-project/admin-bundle 3.67 and will throw an exception in 4.0.');
 
         // NEXT_MAJOR: Remove this line
         $this->admin

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -177,7 +177,8 @@ class SonataAdminExtensionTest extends TestCase
             $propertyAccessor,
             $this->securityChecker
         );
-        $this->twigExtension->setXEditableTypeMapping($this->xEditableTypeMapping);
+
+        $this->twigExtension->setXEditableTypeMapping($this->xEditableTypeMapping, 'sonata_deprecation_mute');
 
         $request = $this->createMock(Request::class);
         $request->method('get')->with('_sonata_admin')->willReturn('sonata_admin_foo_service');
@@ -2786,6 +2787,9 @@ EOT
         $this->assertSame(1234567, $twigExtension->getUrlSafeIdentifier($model, $this->adminBar));
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function xEditableChoicesProvider()
     {
         return [
@@ -2832,7 +2836,11 @@ EOT
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @dataProvider xEditablechoicesProvider
+     *
+     * @group legacy
      */
     public function testGetXEditableChoicesIsIdempotent(array $options, array $expectedChoices): void
     {
@@ -2850,6 +2858,8 @@ EOT
                 'MyCatalogue',
                 $options['multiple'] ?? null
             ));
+
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::getXEditableChoices method is deprecated in favor of XEditableExtension::getXEditableChoices since version 3.x and will be removed in 4.0.');
 
         $this->assertSame($expectedChoices, $this->twigExtension->getXEditableChoices($fieldDescription));
     }
@@ -2910,13 +2920,22 @@ EOT
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @dataProvider select2LocalesProvider
+     *
+     * @group legacy
      */
     public function testCanonicalizedLocaleForSelect2(?string $expected, string $original): void
     {
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::getCanonicalizedLocaleForSelect2 method is deprecated in favor of CanonicalizeExtension::getCanonicalizedLocaleForSelect2 since version 3.x and will be removed in 4.0.');
+
         $this->assertSame($expected, $this->twigExtension->getCanonicalizedLocaleForSelect2($this->mockExtensionContext($original)));
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function momentLocalesProvider(): array
     {
         return [
@@ -3039,15 +3058,28 @@ EOT
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @dataProvider momentLocalesProvider
+     *
+     * @group legacy
      */
     public function testCanonicalizedLocaleForMoment(?string $expected, string $original): void
     {
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::getCanonicalizedLocaleForMoment method is deprecated in favor of CanonicalizeExtension::getCanonicalizedLocaleForMoment since version 3.x and will be removed in 4.0.');
+
         $this->assertSame($expected, $this->twigExtension->getCanonicalizedLocaleForMoment($this->mockExtensionContext($original)));
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @group legacy
+     */
     public function testIsGrantedAffirmative(): void
     {
+        $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::isGrantedAffirmative method is deprecated in favor of SecurityExtension::isGrantedAffirmative since version 3.x and will be removed in 4.0.');
+
         $this->securityChecker
             ->method('isGranted')
             ->withConsecutive(

--- a/tests/Twig/Extension/XEditableExtensionTest.php
+++ b/tests/Twig/Extension/XEditableExtensionTest.php
@@ -47,8 +47,7 @@ final class XEditableExtensionTest extends TestCase
             'url' => 'url',
         ];
 
-        $twigExtension = new XEditableExtension(new Translator('en'));
-        $twigExtension->setXEditableTypeMapping($xEditableTypeMapping);
+        $twigExtension = new XEditableExtension(new Translator('en'), $xEditableTypeMapping);
 
         $fieldDescription = $this->getMockForAbstractClass(FieldDescriptionInterface::class);
         $fieldDescription

--- a/tests/Twig/Extension/XEditableExtensionTest.php
+++ b/tests/Twig/Extension/XEditableExtensionTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Twig\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Sonata\AdminBundle\Twig\Extension\XEditableExtension;
+use Symfony\Component\Translation\Translator;
+
+/**
+ * Test for SonataAdminExtension.
+ *
+ * @author Andrej Hudec <pulzarraider@gmail.com>
+ */
+final class XEditableExtensionTest extends TestCase
+{
+    /**
+     * @dataProvider xEditablechoicesProvider
+     */
+    public function testGetXEditableChoicesIsIdempotent(array $options, array $expectedChoices): void
+    {
+        $xEditableTypeMapping = [
+            'choice' => 'select',
+            'boolean' => 'select',
+            'text' => 'text',
+            'textarea' => 'textarea',
+            'html' => 'textarea',
+            'email' => 'email',
+            'string' => 'text',
+            'smallint' => 'text',
+            'bigint' => 'text',
+            'integer' => 'number',
+            'decimal' => 'number',
+            'currency' => 'number',
+            'percent' => 'number',
+            'url' => 'url',
+        ];
+
+        $twigExtension = new XEditableExtension(new Translator('en'));
+        $twigExtension->setXEditableTypeMapping($xEditableTypeMapping);
+
+        $fieldDescription = $this->getMockForAbstractClass(FieldDescriptionInterface::class);
+        $fieldDescription
+            ->method('getOption')
+            ->withConsecutive(
+                ['choices', []],
+                ['catalogue'],
+                ['required'],
+                ['multiple']
+            )
+            ->will($this->onConsecutiveCalls(
+                $options['choices'],
+                'MyCatalogue',
+                $options['multiple'] ?? null
+            ));
+
+        $this->assertSame($expectedChoices, $twigExtension->getXEditableChoices($fieldDescription));
+    }
+
+    public function xEditableChoicesProvider()
+    {
+        return [
+            'needs processing' => [
+                ['choices' => ['Status1' => 'Alias1', 'Status2' => 'Alias2']],
+                [
+                    ['value' => 'Status1', 'text' => 'Alias1'],
+                    ['value' => 'Status2', 'text' => 'Alias2'],
+                ],
+            ],
+            'already processed' => [
+                ['choices' => [
+                    ['value' => 'Status1', 'text' => 'Alias1'],
+                    ['value' => 'Status2', 'text' => 'Alias2'],
+                ]],
+                [
+                    ['value' => 'Status1', 'text' => 'Alias1'],
+                    ['value' => 'Status2', 'text' => 'Alias2'],
+                ],
+            ],
+            'not required' => [
+                [
+                    'required' => false,
+                    'choices' => ['' => '', 'Status1' => 'Alias1', 'Status2' => 'Alias2'],
+                ],
+                [
+                    ['value' => '', 'text' => ''],
+                    ['value' => 'Status1', 'text' => 'Alias1'],
+                    ['value' => 'Status2', 'text' => 'Alias2'],
+                ],
+            ],
+            'not required multiple' => [
+                [
+                    'required' => false,
+                    'multiple' => true,
+                    'choices' => ['Status1' => 'Alias1', 'Status2' => 'Alias2'],
+                ],
+                [
+                    ['value' => 'Status1', 'text' => 'Alias1'],
+                    ['value' => 'Status2', 'text' => 'Alias2'],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/Twig/Extension/XEditableExtensionTest.php
+++ b/tests/Twig/Extension/XEditableExtensionTest.php
@@ -19,8 +19,6 @@ use Sonata\AdminBundle\Twig\Extension\XEditableExtension;
 use Symfony\Component\Translation\Translator;
 
 /**
- * Test for SonataAdminExtension.
- *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
 final class XEditableExtensionTest extends TestCase
@@ -67,6 +65,12 @@ final class XEditableExtensionTest extends TestCase
         $this->assertSame($expectedChoices, $twigExtension->getXEditableChoices($fieldDescription));
     }
 
+    /**
+     * @phpstan-return array<string, array{
+     *	array<string, mixed>,
+     *	array<array{value: string, text: string}>
+     * }>
+     */
     public function xEditableChoicesProvider()
     {
         return [


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6639.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `Sonata\AdminBundle\Twig\Extension\SecurityExtension`
- Added `Sonata\AdminBundle\Twig\Extension\CanonicalizeExtension`
- Added `Sonata\AdminBundle\Twig\Extension\XEditableExtension`
- Added `Sonata\AdminBundle\Twig\Extension\RenderElementExtension`
### Deprecated
- Deprecated `SonataAdminExtension::MOMENT_UNSUPPORTED_LOCALES` constant
- Deprecated `SonataAdminExtension::setXEditableTypeMapping()` method
- Deprecated `SonataAdminExtension::getXEditableType()` method
- Deprecated `SonataAdminExtension::getXEditableChoices()` method
- Deprecated `SonataAdminExtension::getCanonicalizedLocaleForMoment()` method
- Deprecated `SonataAdminExtension::getCanonicalizedLocaleForSelect2()` method
- Deprecated `SonataAdminExtension::isGrantedAffirmative()` method
- Deprecated `SonataAdminExtension::renderListElement()` method
- Deprecated `SonataAdminExtension::renderViewElement()` method
- Deprecated `SonataAdminExtension::renderViewElementCompare()` method
- Deprecated `SonataAdminExtension::renderRelationElement()` method
- Deprecated `SonataAdminExtension::getTemplate()` method
- Deprecated `SonataAdminExtension::getTemplateRegistry()` method
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
