### PR TITLE
Use sonata_config instead of admin_pool

### DIFF
--- a/src/Resources/views/Pager/base_links.html.twig
+++ b/src/Resources/views/Pager/base_links.html.twig
@@ -24,7 +24,7 @@ file that was distributed with this source code.
         {% endif %}
 
         {# Set the number of pages to display in the pager #}
-        {% for page in admin.datagrid.pager.getLinks(admin_pool.getOption('pager_links')) %}
+        {% for page in admin.datagrid.pager.getLinks(sonata_config.getOption('pager_links')) %}
             {% if page == admin.datagrid.pager.page %}
                 {# NEXT_MAJOR: Remove next line and uncomment the other one #}
                 <li class="active"><a href="{{ admin.generateUrl(action, sonata_pagination_parameters(admin, page)) }}">{{ page }}</a></li>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

See https://github.com/sonata-project/SonataAdminBundle/pull/6640#issuecomment-741618229

There was one use left that was not changed.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed using `admin_pool` to fetch an option instead of `sonata_config`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
