### PR TITLE
Fix iterating over children in form builder

### DIFF
--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -102,9 +102,14 @@ class AdminHelper
      */
     public function getChildFormBuilder(FormBuilderInterface $formBuilder, $elementId)
     {
-        foreach (new FormBuilderIterator($formBuilder) as $name => $formBuilder) {
+        $iterator = new \RecursiveIteratorIterator(
+            new FormBuilderIterator($formBuilder),
+            \RecursiveIteratorIterator::SELF_FIRST
+        );
+
+        foreach ($iterator as $name => $currentFormBuilder) {
             if ($name === $elementId) {
-                return $formBuilder;
+                return $currentFormBuilder;
             }
         }
 

--- a/src/Util/FormBuilderIterator.php
+++ b/src/Util/FormBuilderIterator.php
@@ -38,7 +38,7 @@ class FormBuilderIterator extends \RecursiveArrayIterator
     protected $keys = [];
 
     /**
-     * @var bool|string
+     * @var string
      */
     protected $prefix;
 
@@ -48,13 +48,18 @@ class FormBuilderIterator extends \RecursiveArrayIterator
     protected $iterator;
 
     /**
-     * @param bool $prefix
+     * NEXT_MAJOR: Change argument 2 to ?string $prefix = null.
+     *
+     * @param string|false $prefix
      */
     public function __construct(FormBuilderInterface $formBuilder, $prefix = false)
     {
         parent::__construct();
         $this->formBuilder = $formBuilder;
-        $this->prefix = $prefix ?: $formBuilder->getName();
+        // NEXT_MAJOR: Remove next line.
+        $this->prefix = \is_string($prefix) ? $prefix : $formBuilder->getName();
+        // NEXT_MAJOR: Uncomment next line.
+        // $this->prefix = $prefix ?? $formBuilder->getName();
         $this->iterator = new \ArrayIterator(self::getKeys($formBuilder));
     }
 
@@ -87,7 +92,7 @@ class FormBuilderIterator extends \RecursiveArrayIterator
 
     public function getChildren()
     {
-        return new self($this->formBuilder->get($this->iterator->current()), $this->current());
+        return new self($this->formBuilder->get($this->iterator->current()), $this->key());
     }
 
     public function hasChildren()

--- a/src/Util/FormBuilderIterator.php
+++ b/src/Util/FormBuilderIterator.php
@@ -52,10 +52,20 @@ class FormBuilderIterator extends \RecursiveArrayIterator
      *
      * @param string|false $prefix
      */
-    public function __construct(FormBuilderInterface $formBuilder, $prefix = false)
+    public function __construct(FormBuilderInterface $formBuilder, $prefix = null)
     {
         parent::__construct();
         $this->formBuilder = $formBuilder;
+
+        // NEXT_MAJOR: Remove this block.
+        if (null !== $prefix && !\is_string($prefix)) {
+            @trigger_error(sprintf(
+                'Passing other type than string or null as argument 2 for method %s() is deprecated since'
+                .' sonata-project/admin-bundle 3.x. It will accept only string and null in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         // NEXT_MAJOR: Remove next line.
         $this->prefix = \is_string($prefix) ? $prefix : $formBuilder->getName();
         // NEXT_MAJOR: Uncomment next line.

--- a/tests/Admin/AdminHelperTest.php
+++ b/tests/Admin/AdminHelperTest.php
@@ -89,6 +89,21 @@ class AdminHelperTest extends TestCase
         $this->assertInstanceOf(FormBuilder::class, $this->helper->getChildFormBuilder($formBuilder, 'test_elementId'));
     }
 
+    public function testGetGrandChildFormBuilder(): void
+    {
+        $formFactory = $this->createMock(FormFactoryInterface::class);
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $formBuilder = new FormBuilder('parent', \stdClass::class, $eventDispatcher, $formFactory);
+        $childFormBuilder = new FormBuilder('child', \stdClass::class, $eventDispatcher, $formFactory);
+        $grandchildFormBuilder = new FormBuilder('grandchild', \stdClass::class, $eventDispatcher, $formFactory);
+
+        $formBuilder->add($childFormBuilder);
+        $childFormBuilder->add($grandchildFormBuilder);
+
+        $this->assertInstanceOf(FormBuilder::class, $this->helper->getChildFormBuilder($formBuilder, 'parent_child_grandchild'));
+    }
+
     public function testGetChildFormView(): void
     {
         $formView = new FormView();

--- a/tests/Admin/AdminHelperTest.php
+++ b/tests/Admin/AdminHelperTest.php
@@ -91,8 +91,8 @@ class AdminHelperTest extends TestCase
 
     public function testGetGrandChildFormBuilder(): void
     {
-        $formFactory = $this->createMock(FormFactoryInterface::class);
-        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $formFactory = $this->createStub(FormFactoryInterface::class);
+        $eventDispatcher = $this->createStub(EventDispatcherInterface::class);
 
         $formBuilder = new FormBuilder('parent', \stdClass::class, $eventDispatcher, $formFactory);
         $childFormBuilder = new FormBuilder('child', \stdClass::class, $eventDispatcher, $formFactory);

--- a/tests/Admin/AdminHelperTest.php
+++ b/tests/Admin/AdminHelperTest.php
@@ -77,8 +77,8 @@ class AdminHelperTest extends TestCase
 
     public function testGetChildFormBuilder(): void
     {
-        $formFactory = $this->createMock(FormFactoryInterface::class);
-        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $formFactory = $this->createStub(FormFactoryInterface::class);
+        $eventDispatcher = $this->createStub(EventDispatcherInterface::class);
 
         $formBuilder = new FormBuilder('test', \stdClass::class, $eventDispatcher, $formFactory);
 
@@ -235,7 +235,7 @@ class AdminHelperTest extends TestCase
     {
         $helper = new AdminHelper($this->propertyAccessor);
 
-        $admin = $this->createMock(AdminInterface::class);
+        $admin = $this->createStub(AdminInterface::class);
         $admin
             ->method('getClass')
             ->willReturn(Foo::class);
@@ -252,7 +252,7 @@ class AdminHelperTest extends TestCase
             'isOwningSide' => false,
         ];
 
-        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
+        $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
         $fieldDescription->method('getAssociationAdmin')->willReturn($associationAdmin);
         $fieldDescription->method('getAssociationMapping')->willReturn($associationMapping);
         $fieldDescription->method('getParentAssociationMappings')->willReturn([]);
@@ -267,7 +267,7 @@ class AdminHelperTest extends TestCase
                 'bar' => $fieldDescription,
             ]);
 
-        $request = $this->createMock(Request::class);
+        $request = $this->createStub(Request::class);
         $request
             ->method('get')
             ->willReturn([
@@ -285,7 +285,7 @@ class AdminHelperTest extends TestCase
 
         $admin
             ->method('getRequest')
-            ->will($this->onConsecutiveCalls($request, $request, $request, null, $request, $request, $request, $request, null, $request));
+            ->willReturnOnConsecutiveCalls($request, $request, $request, null, $request, $request, $request, $request, null, $request);
 
         $foo = $this->createMock(Foo::class);
         $admin
@@ -303,9 +303,9 @@ class AdminHelperTest extends TestCase
 
         $foo->expects($this->atLeastOnce())->method('addBar')->with($bar);
 
-        $dataMapper = $this->createMock(DataMapperInterface::class);
-        $formFactory = $this->createMock(FormFactoryInterface::class);
-        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dataMapper = $this->createStub(DataMapperInterface::class);
+        $formFactory = $this->createStub(FormFactoryInterface::class);
+        $eventDispatcher = $this->createStub(EventDispatcherInterface::class);
         $formBuilder = new FormBuilder('test', \get_class($foo), $eventDispatcher, $formFactory);
         $childFormBuilder = new FormBuilder('bar', \stdClass::class, $eventDispatcher, $formFactory);
         $childFormBuilder->setCompound(true);
@@ -343,21 +343,21 @@ class AdminHelperTest extends TestCase
     {
         $admin = $this->createMock(AdminInterface::class);
         $object = $this->getMockBuilder(\stdClass::class)
-            ->setMethods(['getSubObject'])
+            ->addMethods(['getSubObject'])
             ->getMock();
 
         $subObject = $this->getMockBuilder(\stdClass::class)
-            ->setMethods(['getAnd'])
+            ->addMethods(['getAnd'])
             ->getMock();
         $sub2Object = $this->getMockBuilder(\stdClass::class)
-            ->setMethods(['getMore'])
+            ->addMethods(['getMore'])
             ->getMock();
         $sub3Object = $this->getMockBuilder(\stdClass::class)
-            ->setMethods(['getFinalData'])
+            ->addMethods(['getFinalData'])
             ->getMock();
-        $dataMapper = $this->createMock(DataMapperInterface::class);
-        $formFactory = $this->createMock(FormFactoryInterface::class);
-        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dataMapper = $this->createStub(DataMapperInterface::class);
+        $formFactory = $this->createStub(FormFactoryInterface::class);
+        $eventDispatcher = $this->createStub(EventDispatcherInterface::class);
         $formBuilder = new FormBuilder('test', \get_class($object), $eventDispatcher, $formFactory);
         $childFormBuilder = new FormBuilder('subObject', \get_class($subObject), $eventDispatcher, $formFactory);
 

--- a/tests/Util/FormBuilderIteratorTest.php
+++ b/tests/Util/FormBuilderIteratorTest.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Tests\Util;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Util\FormBuilderIterator;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilder;
@@ -25,6 +26,8 @@ use Symfony\Component\Form\FormFactoryInterface;
  */
 class FormBuilderIteratorTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     /**
      * @var EventDispatcherInterface
      */
@@ -68,5 +71,20 @@ class FormBuilderIteratorTest extends TestCase
         $this->builder->add('name', TextType::class);
         $iterator = new FormBuilderIterator($this->builder);
         $this->assertTrue($iterator->hasChildren());
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
+    public function testTriggersADeprecationWithWrongPrefixType(): void
+    {
+        $this->expectDeprecation('Passing other type than string or null as argument 2 for method Sonata\AdminBundle\Util\FormBuilderIterator::__construct() is deprecated since sonata-project/admin-bundle 3.x. It will accept only string and null in version 4.0.');
+
+        $this->builder->add('name', TextType::class);
+        $iterator = new FormBuilderIterator($this->builder, new \stdClass());
+
+        $this->assertSame($iterator->key(), 'name_name');
     }
 }

--- a/tests/Util/FormBuilderIteratorTest.php
+++ b/tests/Util/FormBuilderIteratorTest.php
@@ -45,8 +45,8 @@ class FormBuilderIteratorTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->dispatcher = $this->getMockForAbstractClass(EventDispatcherInterface::class);
-        $this->factory = $this->getMockForAbstractClass(FormFactoryInterface::class);
+        $this->dispatcher = $this->createStub(EventDispatcherInterface::class);
+        $this->factory = $this->createStub(FormFactoryInterface::class);
         $this->builder = new FormBuilder('name', null, $this->dispatcher, $this->factory);
         $this->factory->method('createNamedBuilder')->willReturn($this->builder);
     }

--- a/tests/Util/FormBuilderIteratorTest.php
+++ b/tests/Util/FormBuilderIteratorTest.php
@@ -44,7 +44,7 @@ class FormBuilderIteratorTest extends TestCase
     {
         $this->dispatcher = $this->getMockForAbstractClass(EventDispatcherInterface::class);
         $this->factory = $this->getMockForAbstractClass(FormFactoryInterface::class);
-        $this->builder = new TestFormBuilder('name', null, $this->dispatcher, $this->factory);
+        $this->builder = new FormBuilder('name', null, $this->dispatcher, $this->factory);
         $this->factory->method('createNamedBuilder')->willReturn($this->builder);
     }
 
@@ -60,6 +60,7 @@ class FormBuilderIteratorTest extends TestCase
         $this->builder->add('name', TextType::class);
         $iterator = new FormBuilderIterator($this->builder);
         $this->assertInstanceOf(\get_class($iterator), $iterator->getChildren());
+        $this->assertSame('name_name', $iterator->key());
     }
 
     public function testHasChildren(): void
@@ -68,8 +69,4 @@ class FormBuilderIteratorTest extends TestCase
         $iterator = new FormBuilderIterator($this->builder);
         $this->assertTrue($iterator->hasChildren());
     }
-}
-
-class TestFormBuilder extends FormBuilder
-{
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Triggered by https://github.com/sonata-project/SonataAdminBundle/pull/6689#discussion_r540314983

`AdminHelper::getChildFormBuilder()` method was iterating only over the first level of form builder. It is needed a
`RecursiveIteratorIterator` for a tree traversal as `AdminHelper::getChildFormView()` method does.

It also fixes FormBuilderIterator prefix property when traversing children, now the current prefix is passed to the
children to create its key.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated passing other type than `string` or `null` as argument 2 constructing `FormBuilderIterator`.
### Fixed
- Fixed iterating over children names in `AdminHelper::getChildFormBuilder` recursively.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->

When merging with `4.x`, https://github.com/sonata-project/SonataAdminBundle/pull/6533/files#diff-743b4f55ec26cc7163d9150b5f5e8f1b40a0fbd4338f84b36dc2067ab3507b98L88 should be reverted (add `$this->key()` argument).

PS: The variable change from `$formBuilder` to `$currentFormBuilder` is because `$formBuilder` is the name of the parameter in the function.