### PR TITLE
Remove passing admin_pool to twig templates in next major version

### DIFF
--- a/src/Action/DashboardAction.php
+++ b/src/Action/DashboardAction.php
@@ -79,6 +79,7 @@ final class DashboardAction
             'base_template' => $request->isXmlHttpRequest() ?
                 $this->templateRegistry->getTemplate('ajax') :
                 $this->templateRegistry->getTemplate('layout'),
+            // NEXT_MAJOR: Remove next line.
             'admin_pool' => $this->pool,
             'blocks' => $blocks,
         ];

--- a/src/Action/SearchAction.php
+++ b/src/Action/SearchAction.php
@@ -79,6 +79,7 @@ final class SearchAction
                     $this->templateRegistry->getTemplate('ajax') :
                     $this->templateRegistry->getTemplate('layout'),
                 'breadcrumbs_builder' => $this->breadcrumbsBuilder,
+                // NEXT_MAJOR: Remove next line.
                 'admin_pool' => $this->pool,
                 'query' => $request->get('q'),
                 'groups' => $this->pool->getDashboardGroups(),

--- a/src/Block/AdminListBlockService.php
+++ b/src/Block/AdminListBlockService.php
@@ -125,6 +125,7 @@ class AdminListBlockService extends AbstractBlockService
         return $this->renderPrivateResponse($this->templateRegistry->getTemplate('list_block'), [
             'block' => $blockContext->getBlock(),
             'settings' => $settings,
+            // NEXT_MAJOR: Remove next line.
             'admin_pool' => $this->pool,
             'groups' => $visibleGroups,
         ], $response);

--- a/src/Block/AdminSearchBlockService.php
+++ b/src/Block/AdminSearchBlockService.php
@@ -169,6 +169,7 @@ class AdminSearchBlockService extends AbstractBlockService
         return $this->renderPrivateResponse($admin->getTemplate('search_result_block'), [
             'block' => $blockContext->getBlock(),
             'settings' => $blockContext->getSettings(),
+            // NEXT_MAJOR: Remove next line.
             'admin_pool' => $this->pool,
             'pager' => $pager,
             'admin' => $admin,

--- a/src/Block/AdminStatsBlockService.php
+++ b/src/Block/AdminStatsBlockService.php
@@ -108,6 +108,7 @@ class AdminStatsBlockService extends AbstractBlockService
         return $this->renderPrivateResponse($blockContext->getTemplate(), [
             'block' => $blockContext->getBlock(),
             'settings' => $blockContext->getSettings(),
+            // NEXT_MAJOR: Remove next line.
             'admin_pool' => $this->pool,
             'admin' => $admin,
             'pager' => $datagrid->getPager(),

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1080,6 +1080,7 @@ class CRUDController implements ContainerAwareInterface
 
         $parameters['admin'] = $parameters['admin'] ?? $this->admin;
         $parameters['base_template'] = $parameters['base_template'] ?? $this->getBaseTemplate();
+        // NEXT_MAJOR: Remove next line.
         $parameters['admin_pool'] = $this->get('sonata.admin.pool');
 
         return $parameters;

--- a/tests/Action/SearchActionTest.php
+++ b/tests/Action/SearchActionTest.php
@@ -64,6 +64,7 @@ class SearchActionTest extends TestCase
         $this->twig->method('render')->with('search.html.twig', [
             'base_template' => 'layout.html.twig',
             'breadcrumbs_builder' => $this->breadcrumbsBuilder,
+            // NEXT_MAJOR: Remove next line.
             'admin_pool' => $this->pool,
             'query' => 'some search',
             'groups' => [],

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -535,6 +535,7 @@ class CRUDControllerTest extends TestCase
         );
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
         $this->assertSame('@FooAdmin/foo.html.twig', $this->template);
     }
@@ -550,6 +551,7 @@ class CRUDControllerTest extends TestCase
         $this->assertSame('bar', $responseResult->headers->get('X-foo'));
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
         $this->assertSame('@FooAdmin/foo.html.twig', $this->template);
     }
@@ -567,6 +569,7 @@ class CRUDControllerTest extends TestCase
         );
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
         $this->assertSame('bar', $this->parameters['foo']);
         $this->assertSame('@FooAdmin/foo.html.twig', $this->template);
@@ -586,6 +589,7 @@ class CRUDControllerTest extends TestCase
         );
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/ajax_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
         $this->assertSame('bar', $this->parameters['foo']);
         $this->assertSame('@FooAdmin/foo.html.twig', $this->template);
@@ -658,6 +662,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('list', $this->parameters['action']);
@@ -822,6 +827,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('show', $this->parameters['action']);
@@ -972,6 +978,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('delete', $this->parameters['action']);
@@ -1062,6 +1069,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('delete', $this->parameters['action']);
@@ -1320,6 +1328,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('delete', $this->parameters['action']);
@@ -1473,6 +1482,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('edit', $this->parameters['action']);
@@ -1594,6 +1604,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('edit', $this->parameters['action']);
@@ -1755,6 +1766,7 @@ class CRUDControllerTest extends TestCase
         $this->assertInstanceOf(Response::class, $response = $this->controller->editAction(null));
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/ajax_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
         $this->assertSame('edit', $this->parameters['action']);
         $this->assertInstanceOf(FormView::class, $this->parameters['form']);
@@ -1822,6 +1834,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('edit', $this->parameters['action']);
@@ -1876,6 +1889,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('edit', $this->parameters['action']);
@@ -2018,6 +2032,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('create', $this->parameters['action']);
@@ -2212,6 +2227,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('create', $this->parameters['action']);
@@ -2281,6 +2297,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('create', $this->parameters['action']);
@@ -2463,6 +2480,7 @@ class CRUDControllerTest extends TestCase
         $this->assertInstanceOf(Response::class, $response = $this->controller->createAction());
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/ajax_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
         $this->assertSame('create', $this->parameters['action']);
         $this->assertInstanceOf(FormView::class, $this->parameters['form']);
@@ -2521,6 +2539,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('create', $this->parameters['action']);
@@ -2690,6 +2709,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('history', $this->parameters['action']);
@@ -2837,6 +2857,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('acl', $this->parameters['action']);
@@ -2926,6 +2947,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('acl', $this->parameters['action']);
@@ -3178,6 +3200,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('show', $this->parameters['action']);
@@ -3398,6 +3421,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('show', $this->parameters['action']);
@@ -3651,6 +3675,7 @@ class CRUDControllerTest extends TestCase
 
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
+        // NEXT_MAJOR: Remove next line.
         $this->assertSame($this->pool, $this->parameters['admin_pool']);
 
         $this->assertSame('list', $this->parameters['action']);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Since `sonata-project/admin-bundle` 3.83, `Pool` is just used as an Admin registry, before this, `admin_pool` was used to access to global options from Twig, but now there is a global Twig `sonata_config` variable to access to those options.

Here are the usages of `admin_pool`: https://github.com/sonata-project/SonataAdminBundle/search?p=1&q=admin_pool

So there is no need to pass an instance of `Pool` to Twig templates anymore, the pool is not supposed to be used in templates.

What I don't know is in which file should I add that in `4.0` these variables are not going to be available, just in the changelog when removing those lines in `4.x` branch?
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.
