### PR TITLE
Add RouteCollectionInterface

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,44 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.xx to 3.xx
+=========================
+
+### `RouteCollection` now implements `RouteCollectionInterface`
+
+In 4.0, `AbstractAdmin::configureRoutes` and `AdminExtensionInterface::configureRoutes` will receive a
+`RouteCollectionInterface` instance instead of a `RouteCollection` instance, you can update your code before ugprading
+to 4.0.
+
+Before:
+```php
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Route\RouteCollection;
+
+final class MyAdmin extends AbstractAdmin
+{
+    protected function configureRoutes(RouteCollection $collection): void
+    {
+        $collection->add('my_route');
+    }
+}
+```
+
+After:
+```php
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Route\RouteCollectionInterface;
+
+final class MyAdmin extends AbstractAdmin
+{
+    protected function configureRoutes(RouteCollectionInterface $collection): void
+    {
+        $collection->add('my_route');
+    }
+}
+```
+This only will work with PHP >= 7.4, where fully support to contravariance was added.
+
 UPGRADE FROM 3.82 to 3.83
 =========================
 

--- a/src/Route/RouteCollection.php
+++ b/src/Route/RouteCollection.php
@@ -20,7 +20,7 @@ use Symfony\Component\Routing\Route;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class RouteCollection
+class RouteCollection implements RouteCollectionInterface
 {
     /**
      * @var array<string, Route|callable():Route>

--- a/src/Route/RouteCollectionInterface.php
+++ b/src/Route/RouteCollectionInterface.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Route;
+
+use Symfony\Component\Routing\Route;
+
+/**
+ * @author Jordi Sala <jordism91@gmail.com>
+ */
+interface RouteCollectionInterface
+{
+    /**
+     * @param string $name
+     * @param string $pattern   Pattern (will be automatically combined with @see $this->baseRoutePattern and $name
+     * @param string $host
+     * @param string $condition
+     *
+     * @return RouteCollection
+     */
+    public function add(
+        $name,
+        $pattern = null,
+        array $defaults = [],
+        array $requirements = [],
+        array $options = [],
+        $host = '',
+        array $schemes = [],
+        array $methods = [],
+        $condition = ''
+    );
+
+    /**
+     * @return string
+     */
+    public function getCode(string $name);
+
+    /**
+     * @return $this
+     */
+    public function addCollection(RouteCollection $collection);
+
+    /**
+     * @return Route[]
+     */
+    public function getElements();
+
+    /**
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function has($name);
+
+    public function hasCached(string $name): bool;
+
+    /**
+     * @param string $name
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return Route
+     */
+    public function get($name);
+
+    /**
+     * @return $this
+     */
+    public function remove(string $name);
+
+    /**
+     * @throws \InvalidArgumentException
+     *
+     * @return $this
+     */
+    public function restore(string $name);
+
+    /**
+     * Remove all routes except routes in $routeList.
+     *
+     * @param string[]|string $routeList
+     *
+     * @return $this
+     */
+    public function clearExcept($routeList);
+
+    /**
+     * @return $this
+     */
+    public function clear();
+
+    /**
+     * Converts a word into the format required for a controller action. By instance,
+     * the argument "list_something" returns "listSomething" if the associated controller is not an action itself,
+     * otherwise, it will return "listSomethingAction".
+     *
+     * @return string
+     */
+    public function actionify(string $action);
+
+    /**
+     * @return string
+     */
+    public function getBaseCodeRoute();
+
+    /**
+     * @return string
+     */
+    public function getBaseControllerName();
+
+    /**
+     * @return string
+     */
+    public function getBaseRouteName();
+
+    /**
+     * @return string
+     */
+    public function getBaseRoutePattern();
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Related https://github.com/sonata-project/SonataAdminBundle/issues/6698

This interface was added in 4.x branch, this commit imports it removing type and return declarations to make it compatible with `RouteCollection` which implements this interface.

In sonata 4 `AbstractAdmin::configureRoutes()` method receives a `RouteCollectionInterface`, importing this interface in 3.x would allow users to update their code and define this method as in 4, easing the upgrading process.

This would only work for users with PHP >= 7.4 because contravariance was fully support since that version, to me this is fine, but we could remove `AbstractAdmin::configureRoutes()` and `AdminExtensionInterface::configureRoutes()` methods and add some `method_exists` checks and reintroduce these methods in `4.x` branch.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6698.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `RouteCollectionInterface` imported from `4.x` to ease upgrading process.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
