### PR TITLE
Unchanged filters params

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -871,14 +871,19 @@ abstract class AbstractAdmin implements AdminInterface, DomainObjectInterface, A
     {
     }
 
-    public function getFilterParameters()
+    final public function getDefaultFilterParameters(): array
     {
-        $parameters = array_merge(
+        return array_merge(
             $this->getModelManager()->getDefaultSortValues($this->getClass()), // NEXT_MAJOR: Remove this line.
             $this->datagridValues, // NEXT_MAJOR: Remove this line.
             $this->getDefaultSortValues(),
             $this->getDefaultFilterValues()
         );
+    }
+
+    public function getFilterParameters()
+    {
+        $parameters = $this->getDefaultFilterParameters();
 
         // build the values array
         if ($this->hasRequest()) {

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -541,7 +541,7 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      *
      * @return array<string, mixed>
      */
-    // public function getDefaultFilterParameters();
+    // public function getDefaultFilterParameters(): array;
 
     /**
      * Return array of filter parameters.

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -44,6 +44,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  * @method string                          getSearchResultLink(object $object)
  * @method void                            showMosaicButton(bool $isShown)
  * @method bool                            isDefaultFilter(string $name)                                         // NEXT_MAJOR: Remove this
+ * @method array                           getDefaultFilterParameters()                                          // NEXT_MAJOR: Remove this
  * @method bool                            isCurrentRoute(string $name, ?string $adminCode)
  * @method bool                            canAccessObject(string $action, object $object)
  * @method mixed                           getPersistentParameter(string $name)
@@ -532,6 +533,15 @@ interface AdminInterface extends AccessRegistryInterface, FieldDescriptionRegist
      * @param bool   $allElements
      */
     public function preBatchAction($actionName, ProxyQueryInterface $query, array &$idx, $allElements);
+
+    /**
+     * Return array of default filter parameters.
+     *
+     * NEXT_MAJOR: uncomment this method
+     *
+     * @return array<string, mixed>
+     */
+    // public function getDefaultFilterParameters();
 
     /**
      * Return array of filter parameters.

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -32,7 +32,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @method array                           configureActionButtons(string $action, ?object $object = null)
  * @method string                          getSearchResultLink(object $object)
- * @method array                           getDefaultFilterParameters()                                          // NEXT_MAJOR: Remove this
+ * @method array                           getDefaultFilterParameters()                                    // NEXT_MAJOR: Remove this
  * @method bool                            isCurrentRoute(string $name, ?string $adminCode)
  * @method bool                            canAccessObject(string $action, object $object)
  * @method mixed                           getPersistentParameter(string $name)

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -32,7 +32,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @method array                           configureActionButtons(string $action, ?object $object = null)
  * @method string                          getSearchResultLink(object $object)
- * @method array                           getDefaultFilterParameters()                                    // NEXT_MAJOR: Remove this
+ * @method array                           getDefaultFilterParameters()
  * @method bool                            isCurrentRoute(string $name, ?string $adminCode)
  * @method bool                            canAccessObject(string $action, object $object)
  * @method mixed                           getPersistentParameter(string $name)

--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -322,7 +322,29 @@ var Admin = {
         });
 
         jQuery('.sonata-filter-form', subject).on('submit', function () {
-            jQuery(this).find('[sonata-filter="true"]:hidden :input').val('');
+            var $form = jQuery(this);
+            $form.find('[sonata-filter="true"]:hidden :input').val('');
+
+            if (! this.dataset.defaultValues) {
+                return;
+            }
+
+            var defaultValues = $.param({'filter': JSON.parse(this.dataset.defaultValues)}).split('&'),
+                submittedValues = $form.serialize().split('&');
+
+            // Compare default and submitted filter values in keyValue representation. (keyValue ex: filter[publish][value][end]=2020-12-12)
+            // Allow submit next values: non default & non empty values because empty values equals not present.
+            var changedValues = submittedValues.filter(function (keyValue) {
+                return defaultValues.indexOf(keyValue) === -1 && keyValue.split('=')[1] !== '';
+            });
+
+            // Disable all inputs and enabled only needed
+            $form.find('[name*=filter]').attr('disabled', 'disabled');
+            changedValues
+                .map(function (keyValue) { return decodeURIComponent(keyValue.split('=')[0]); })
+                .forEach(function (key) {
+                    $form.find('[name="' + key + '"]').removeAttr('disabled');
+                });
         });
 
         /* Advanced filters */

--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -325,7 +325,7 @@ var Admin = {
             var $form = jQuery(this);
             $form.find('[sonata-filter="true"]:hidden :input').val('');
 
-            if (! this.dataset.defaultValues) {
+            if (!this.dataset.defaultValues) {
                 return;
             }
 

--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -332,13 +332,13 @@ var Admin = {
             var defaultValues = $.param({'filter': JSON.parse(this.dataset.defaultValues)}).split('&'),
                 submittedValues = $form.serialize().split('&');
 
-            // Compare default and submitted filter values in keyValue representation. (keyValue ex: filter[publish][value][end]=2020-12-12)
-            // Allow submit next values: non default & non empty values because empty values equals not present.
+            // Compare default and submitted filter values in `keyValue` representation. (`keyValue` ex: "filter[publish][value][end]=2020-12-12")
+            // Only allow to submit non default and non empty values, because empty values means they are not present.
             var changedValues = submittedValues.filter(function (keyValue) {
                 return defaultValues.indexOf(keyValue) === -1 && keyValue.split('=')[1] !== '';
             });
 
-            // Disable all inputs and enabled only needed
+            // Disable all inputs and enable only the required ones
             $form.find('[name*=filter]').attr('disabled', 'disabled');
             changedValues
                 .map(function (keyValue) { return decodeURIComponent(keyValue.split('=')[0]); })

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -283,7 +283,16 @@ file that was distributed with this source code.
         <div class="col-xs-12 col-md-12 sonata-filters-box" style="display: {{ admin.datagrid.hasDisplayableFilters ? 'block' : 'none' }}" id="filter-container-{{ admin.uniqid() }}">
             <div class="box box-primary" >
                 <div class="box-body">
-                    <form class="sonata-filter-form form-horizontal {{ admin.isChild and 1 == admin.datagrid.filters|length ? 'hide' : '' }}" action="{{ admin.generateUrl('list') }}" method="GET" role="form">
+                    <form
+                        class="sonata-filter-form form-horizontal {{ admin.isChild and 1 == admin.datagrid.filters|length ? 'hide' : '' }}"
+                        action="{{ admin.generateUrl('list') }}"
+                        method="GET"
+                        role="form"
+                        {# NEXT_MAJOR: Remove condition #}
+                        {% if attribute(admin, 'getDefaultFilterParameters') is defined %}
+                            data-default-values="{{ admin.defaultFilterParameters|json_encode }}"
+                        {% endif %}
+                    >
                         {{ form_errors(form) }}
 
                         <div class="row">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject


I am targeting this branch, because created new feature for SonataAdminBundle: **Only changed filters will be submitted. Made admin`s urls shorter as possible.**

Closes #6642.

## Changelog

```markdown
### Added
- Added `AbstractAdmin::getDefaultFilterParameters()` to get default filter parameters.

### Changed
- Only changed (non default, non empty) filters will be submitted.
```

<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Fix anoter submit ways(pagination, batch??).
-->
