### PR TITLE
Use instance of SearchHandler in tests

### DIFF
--- a/tests/Action/SearchActionTest.php
+++ b/tests/Action/SearchActionTest.php
@@ -46,7 +46,7 @@ class SearchActionTest extends TestCase
         ]);
 
         $this->breadcrumbsBuilder = $this->createMock(BreadcrumbsBuilderInterface::class);
-        $this->searchHandler = $this->createMock(SearchHandler::class);
+        $this->searchHandler = new SearchHandler(true);
         $this->twig = $this->createStub(Environment::class);
 
         $this->action = new SearchAction(
@@ -74,7 +74,10 @@ class SearchActionTest extends TestCase
 
     public function testAjaxCall(): void
     {
-        $admin = new CleanAdmin('code', 'class', 'controller');
+        $adminCode = 'code';
+
+        $this->searchHandler->configureAdminSearch([$adminCode => false]);
+        $admin = new CleanAdmin($adminCode, 'class', 'controller');
         $this->container->set('foo', $admin);
         $this->pool->setAdminServiceIds(['foo']);
         $request = new Request(['admin' => 'foo']);

--- a/tests/Action/SearchActionTest.php
+++ b/tests/Action/SearchActionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\Action;
 
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Action\SearchAction;
 use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
@@ -26,13 +27,36 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
 
-class SearchActionTest extends TestCase
+final class SearchActionTest extends TestCase
 {
+    /**
+     * @var Container
+     */
     private $container;
+
+    /**
+     * @var Pool
+     */
     private $pool;
+
+    /**
+     * @var SearchHandler
+     */
     private $searchHandler;
+
+    /**
+     * @var SearchAction
+     */
     private $action;
+
+    /**
+     * @var Stub&Environment
+     */
     private $twig;
+
+    /**
+     * @var Stub&BreadcrumbsBuilderInterface
+     */
     private $breadcrumbsBuilder;
 
     protected function setUp(): void
@@ -45,7 +69,7 @@ class SearchActionTest extends TestCase
             'layout' => 'layout.html.twig',
         ]);
 
-        $this->breadcrumbsBuilder = $this->createMock(BreadcrumbsBuilderInterface::class);
+        $this->breadcrumbsBuilder = $this->createStub(BreadcrumbsBuilderInterface::class);
         $this->searchHandler = new SearchHandler(true);
         $this->twig = $this->createStub(Environment::class);
 

--- a/tests/Block/AdminSearchBlockServiceTest.php
+++ b/tests/Block/AdminSearchBlockServiceTest.php
@@ -25,7 +25,7 @@ use Twig\Environment;
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
  */
-class AdminSearchBlockServiceTest extends BlockServiceTestCase
+final class AdminSearchBlockServiceTest extends BlockServiceTestCase
 {
     use ExpectDeprecationTrait;
 
@@ -101,7 +101,7 @@ class AdminSearchBlockServiceTest extends BlockServiceTestCase
             ->willReturn($adminCode);
 
         $blockService = new AdminSearchBlockService(
-            $this->createMock(Environment::class),
+            $this->createStub(Environment::class),
             $this->pool,
             $this->searchHandler,
             'show'

--- a/tests/Block/AdminSearchBlockServiceTest.php
+++ b/tests/Block/AdminSearchBlockServiceTest.php
@@ -44,7 +44,7 @@ class AdminSearchBlockServiceTest extends BlockServiceTestCase
         parent::setUp();
 
         $this->pool = $this->createMock(Pool::class);
-        $this->searchHandler = $this->createMock(SearchHandler::class);
+        $this->searchHandler = new SearchHandler(true);
     }
 
     public function testDefaultSettings(): void
@@ -93,7 +93,12 @@ class AdminSearchBlockServiceTest extends BlockServiceTestCase
 
     public function testGlobalSearchReturnsEmptyWhenFiltersAreDisabled(): void
     {
+        $adminCode = 'code';
+
         $admin = $this->createMock(AbstractAdmin::class);
+        $admin
+            ->method('getCode')
+            ->willReturn($adminCode);
 
         $blockService = new AdminSearchBlockService(
             $this->createMock(Environment::class),
@@ -103,7 +108,7 @@ class AdminSearchBlockServiceTest extends BlockServiceTestCase
         );
         $blockContext = $this->getBlockContext($blockService);
 
-        $this->searchHandler->expects(self::once())->method('search')->willReturn(false);
+        $this->searchHandler->configureAdminSearch([$adminCode => false]);
         $this->pool->expects(self::once())->method('getAdminByAdminCode')->willReturn($admin);
         $admin->expects(self::once())->method('checkAccess')->with('list')->willReturn(true);
 


### PR DESCRIPTION
Following https://github.com/sonata-project/SonataAdminBundle/pull/6705

Apparently after this, only `Pool` and `AdminHelper` are the ones remaining from https://github.com/sonata-project/SonataAdminBundle/pull/6543#issue-510215361