### PR TITLE
Fix to use Twig sonata_config

### DIFF
--- a/src/Resources/views/Pager/base_links.html.twig
+++ b/src/Resources/views/Pager/base_links.html.twig
@@ -20,7 +20,7 @@ file that was distributed with this source code.
         {% endif %}
 
         {# Set the number of pages to display in the pager #}
-        {% for page in admin.datagrid.pager.getLinks(admin_pool.getOption('pager_links')) %}
+        {% for page in admin.datagrid.pager.getLinks(sonata_config.getOption('pager_links')) %}
             {% if page == admin.datagrid.pager.page %}
                 <li class="active"><a href="{{ admin.generateUrl(action, admin.datagrid.paginationparameters(page)) }}">{{ page }}</a></li>
             {% else %}


### PR DESCRIPTION
## Subject

Fix using the sonata_config in base_links.html.twig

I am targeting this branch, because of BC.

### Fixed
Neither the property "getOption" nor one of the methods "getOption()", "getgetOption()"/"isgetOption()"/"hasgetOption()" or "__call()" exist and have public access in class "Sonata\AdminBundle\Admin\Pool".

