### PR TITLE
Move getter from TaggedAdminInterface to AdminInterface

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -159,7 +159,7 @@ parameters:
 
         -
             # will be fixed in v4. Currently BC break
-            message: "#^Method Sonata\\\\AdminBundle\\\\Translator\\\\Extractor\\\\JMSTranslatorBundle\\\\AdminExtractor\\:\\:buildSecurityInformation\\(\\) should return array\\<string, mixed\\> but return statement is missing\\.$#"
+            message: "#^Method Sonata\\\\AdminBundle\\\\Translator\\\\Extractor\\\\JMSTranslatorBundle\\\\AdminExtractor\\:\\:buildSecurityInformation\\(\\) should return array\\<string, array<string>\\> but return statement is missing\\.$#"
             count: 1
             path: src/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php
 

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -525,7 +525,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function initialize()
     {
@@ -2122,7 +2122,7 @@ EOT;
         if (null === $this->classnameLabel) {
             // NEXT_MAJOR: Remove this deprecation and uncomment the following exception
             @trigger_error(sprintf(
-                'Calling %s() when no classname label is set is deprecated since sonata-project/admin-bundle 3.x'
+                'Calling %s() when no classname label is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
             ), E_USER_DEPRECATED);

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1177,12 +1177,12 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
 
     public function generateUrl($name, array $parameters = [], $referenceType = RoutingUrlGeneratorInterface::ABSOLUTE_PATH)
     {
-        return $this->routeGenerator->generateUrl($this, $name, $parameters, $referenceType);
+        return $this->getRouteGenerator()->generateUrl($this, $name, $parameters, $referenceType);
     }
 
     public function generateMenuUrl($name, array $parameters = [], $referenceType = RoutingUrlGeneratorInterface::ABSOLUTE_PATH)
     {
-        return $this->routeGenerator->generateMenuUrl($this, $name, $parameters, $referenceType);
+        return $this->getRouteGenerator()->generateMenuUrl($this, $name, $parameters, $referenceType);
     }
 
     final public function setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry): void

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2587,11 +2587,6 @@ EOT;
         return new Metadata($this->toString($object));
     }
 
-    public function getListModes()
-    {
-        return $this->listModes;
-    }
-
     public function setListMode($mode)
     {
         if (!$this->hasRequest()) {

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -52,7 +52,6 @@ use Symfony\Component\HttpFoundation\Request;
  * @method void                            defineFormBuilder(FormBuilderInterface $formBuilder)
  *
  * @phpstan-template T of object
- * @phpstan-extends TaggedAdminInterface<T>
  * @phpstan-extends AccessRegistryInterface<T>
  * @phpstan-extends UrlGeneratorInterface<T>
  * @phpstan-extends LifecycleHookProviderInterface<T>

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -382,7 +382,7 @@ interface AdminInterface extends TaggedAdminInterface, AccessRegistryInterface, 
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-admin/admin-bundle 3.x
+     * @deprecated since sonata-admin/admin-bundle 3.84
      *
      * @return void
      */

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -699,11 +699,6 @@ interface AdminInterface extends TaggedAdminInterface, AccessRegistryInterface, 
     public function getObjectMetadata($object);
 
     /**
-     * @return array<string, array<string, mixed>>
-     */
-    public function getListModes();
-
-    /**
      * Check the current request is given route or not.
      *
      * NEXT_MAJOR: uncomment this method

--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -47,7 +47,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this property.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * @var int
      */
@@ -56,7 +56,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this property.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * @var array<string, mixed>
      */
@@ -65,7 +65,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this property.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * @var int
      */
@@ -74,7 +74,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this property.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * @var mixed bool|int
      */
@@ -88,7 +88,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this property.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * Used by iterator interface
      *
@@ -99,7 +99,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this property.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * Used by iterator interface
      *
@@ -115,7 +115,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this property.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * @var string[]
      */
@@ -132,7 +132,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * Returns the current pager's max link.
      *
@@ -141,7 +141,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     public function getCurrentMaxLink()
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -151,7 +151,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * Returns the current pager's max record limit.
      *
@@ -160,7 +160,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     public function getMaxRecordLimit()
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -170,7 +170,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * Sets the current pager's max record limit.
      *
@@ -179,7 +179,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     public function setMaxRecordLimit($limit)
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -228,7 +228,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * Returns the current cursor.
      *
@@ -237,7 +237,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     public function getCursor()
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -247,7 +247,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * Sets the current cursor.
      *
@@ -256,7 +256,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     public function setCursor($pos)
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -274,7 +274,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * Returns an object by cursor position.
      *
@@ -285,7 +285,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     public function getObjectByCursor($pos)
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -297,7 +297,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * Returns the current object.
      *
@@ -306,7 +306,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     public function getCurrent()
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -316,7 +316,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * Returns the next object.
      *
@@ -325,7 +325,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     public function getNext()
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -339,7 +339,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * Returns the previous object.
      *
@@ -348,7 +348,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     public function getPrevious()
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -362,7 +362,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * Returns the first index on the current page.
      *
@@ -371,7 +371,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     public function getFirstIndex()
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -401,7 +401,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * Returns the last index on the current page.
      *
@@ -410,7 +410,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     public function getLastIndex()
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -556,7 +556,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * Returns the current pager's parameter holder.
      *
@@ -565,7 +565,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     public function getParameters()
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -575,7 +575,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * Returns a parameter.
      *
@@ -587,7 +587,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     public function getParameter($name, $default = null)
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -597,7 +597,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * Checks whether a parameter has been set.
      *
@@ -608,7 +608,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     public function hasParameter($name)
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -618,7 +618,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * Sets a parameter.
      *
@@ -628,7 +628,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     public function setParameter($name, $value)
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -638,12 +638,12 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      */
     public function current()
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -657,12 +657,12 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      */
     public function key()
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -676,12 +676,12 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      */
     public function next()
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -698,12 +698,12 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      */
     public function rewind()
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -720,12 +720,12 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      */
     public function valid()
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -739,12 +739,12 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x, use getNbResults instead
+     * @deprecated since sonata-project/admin-bundle 3.84, use getNbResults instead
      */
     public function count()
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -754,12 +754,12 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      */
     public function serialize()
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -772,12 +772,12 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      */
     public function unserialize($serialized)
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -791,14 +791,14 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * @return string[]
      */
     public function getCountColumn()
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -808,14 +808,14 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * @return string[]
      */
     public function setCountColumn(array $countColumn)
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -863,7 +863,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * Returns true if the properties used for iteration have been initialized.
      *
@@ -872,7 +872,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     protected function isIteratorInitialized()
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 
@@ -882,7 +882,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * Loads data into properties used for iteration.
      *
@@ -892,7 +892,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     {
         if ('sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
             @trigger_error(sprintf(
-                'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
                 __METHOD__
             ), E_USER_DEPRECATED);
         }
@@ -904,7 +904,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * Empties properties used for iteration.
      *
@@ -914,7 +914,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     {
         if ('sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
             @trigger_error(sprintf(
-                'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
                 __METHOD__
             ), E_USER_DEPRECATED);
         }
@@ -926,7 +926,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      *
      * Retrieve the object for a certain offset.
      *
@@ -937,7 +937,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     protected function retrieveObject($offset)
     {
         @trigger_error(sprintf(
-            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
             __METHOD__
         ), E_USER_DEPRECATED);
 

--- a/src/Datagrid/PagerInterface.php
+++ b/src/Datagrid/PagerInterface.php
@@ -18,17 +18,17 @@ namespace Sonata\AdminBundle\Datagrid;
  *
  * NEXT_MAJOR: Remove these comments and uncomment corresponding methods.
  *
- * @method int                 getPage()
- * @method int                 getFirstPage()
- * @method int                 getLastPage()
- * @method int                 getNextPage()
- * @method int                 getPreviousPage()
- * @method bool                isFirstPage()
- * @method bool                isLastPage()
- * @method int                 getNbResults()
- * @method array               getLinks(?int $nbLinks = null)
- * @method bool                haveToPaginate()
- * @method ProxyQueryInterface getQuery()
+ * @method int                      getPage()
+ * @method int                      getFirstPage()
+ * @method int                      getLastPage()
+ * @method int                      getNextPage()
+ * @method int                      getPreviousPage()
+ * @method bool                     isFirstPage()
+ * @method bool                     isLastPage()
+ * @method int                      getNbResults()
+ * @method array                    getLinks(?int $nbLinks = null)
+ * @method bool                     haveToPaginate()
+ * @method ProxyQueryInterface|null getQuery()
  */
 interface PagerInterface
 {
@@ -78,7 +78,7 @@ interface PagerInterface
 //    public function isLastPage(): bool;
 
 //    NEXT_MAJOR: uncomment this method in 4.0
-//    public function getQuery(): ProxyQueryInterface;
+//    public function getQuery(): ?ProxyQueryInterface;
 
     /**
      * @param ProxyQueryInterface $query

--- a/src/Datagrid/SimplePager.php
+++ b/src/Datagrid/SimplePager.php
@@ -159,13 +159,13 @@ class SimplePager extends Pager
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.x
+     * @deprecated since sonata-project/admin-bundle 3.84
      */
     protected function resetIterator()
     {
         if ('sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
             @trigger_error(sprintf(
-                'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                'The method "%s()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.',
                 __METHOD__
             ), E_USER_DEPRECATED);
         }

--- a/src/DependencyInjection/Admin/AbstractTaggedAdmin.php
+++ b/src/DependencyInjection/Admin/AbstractTaggedAdmin.php
@@ -227,7 +227,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
         if (!\is_string($baseControllerName)) {
             @trigger_error(sprintf(
                 'Passing other type than string as argument 3 for method %s() is deprecated since'
-                .' sonata-project/admin-bundle 3.x. It will accept only string in version 4.0.',
+                .' sonata-project/admin-bundle 3.84. It will accept only string in version 4.0.',
                 __METHOD__
             ), E_USER_DEPRECATED);
         }
@@ -237,7 +237,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     abstract public function initialize();
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function setLabel($label)
     {
@@ -245,7 +245,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function getLabel()
     {
@@ -262,7 +262,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function getListModes()
     {
@@ -270,7 +270,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function setPagerType($pagerType)
     {
@@ -278,7 +278,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      *
      * @return string
      */
@@ -288,7 +288,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function setManagerType($type)
     {
@@ -296,14 +296,14 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function getManagerType()
     {
         if (null === $this->managerType) {
             // NEXT_MAJOR: Remove this deprecation and uncomment the following exception
             @trigger_error(sprintf(
-                'Calling %s() when no manager type is set is deprecated since sonata-project/admin-bundle 3.x'
+                'Calling %s() when no manager type is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
             ), E_USER_DEPRECATED);
@@ -317,7 +317,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function setSecurityInformation(array $information)
     {
@@ -325,7 +325,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function getSecurityInformation()
     {
@@ -333,7 +333,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function setFilterPersister(?FilterPersisterInterface $filterPersister = null)
     {
@@ -357,7 +357,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function setModelManager(ModelManagerInterface $modelManager)
     {
@@ -365,14 +365,14 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function getModelManager()
     {
         if (null === $this->modelManager) {
             // NEXT_MAJOR: Remove this deprecation and uncomment the following exception
             @trigger_error(sprintf(
-                'Calling %s() when no model manager is set is deprecated since sonata-project/admin-bundle 3.x'
+                'Calling %s() when no model manager is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
             ), E_USER_DEPRECATED);
@@ -386,7 +386,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function setDataSource(DataSourceInterface $dataSource)
     {
@@ -401,7 +401,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
         if (null === $this->dataSource) {
             // NEXT_MAJOR: Remove this deprecation and uncomment the following exception
             @trigger_error(sprintf(
-                'Calling %s() when no data source is set is deprecated since sonata-project/admin-bundle 3.x'
+                'Calling %s() when no data source is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
             ), E_USER_DEPRECATED);
@@ -415,7 +415,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function setFormContractor(FormContractorInterface $formBuilder)
     {
@@ -423,14 +423,14 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function getFormContractor()
     {
         if (null === $this->formContractor) {
             // NEXT_MAJOR: Remove this deprecation and uncomment the following exception
             @trigger_error(sprintf(
-                'Calling %s() when no form contractor is set is deprecated since sonata-project/admin-bundle 3.x'
+                'Calling %s() when no form contractor is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
             ), E_USER_DEPRECATED);
@@ -444,7 +444,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function setShowBuilder(ShowBuilderInterface $showBuilder)
     {
@@ -452,14 +452,14 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function getShowBuilder()
     {
         if (null === $this->showBuilder) {
             // NEXT_MAJOR: Remove this deprecation and uncomment the following exception
             @trigger_error(sprintf(
-                'Calling %s() when no show builder is set is deprecated since sonata-project/admin-bundle 3.x'
+                'Calling %s() when no show builder is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
             ), E_USER_DEPRECATED);
@@ -473,7 +473,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function setListBuilder(ListBuilderInterface $listBuilder)
     {
@@ -481,14 +481,14 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function getListBuilder()
     {
         if (null === $this->listBuilder) {
             // NEXT_MAJOR: Remove this deprecation and uncomment the following exception
             @trigger_error(sprintf(
-                'Calling %s() when no list build is set is deprecated since sonata-project/admin-bundle 3.x'
+                'Calling %s() when no list build is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
             ), E_USER_DEPRECATED);
@@ -502,7 +502,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function setDatagridBuilder(DatagridBuilderInterface $datagridBuilder)
     {
@@ -510,14 +510,14 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function getDatagridBuilder()
     {
         if (null === $this->datagridBuilder) {
             // NEXT_MAJOR: Remove this deprecation and uncomment the following exception
             @trigger_error(sprintf(
-                'Calling %s() when no datagrid builder is set is deprecated since sonata-project/admin-bundle 3.x'
+                'Calling %s() when no datagrid builder is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
             ), E_USER_DEPRECATED);
@@ -546,7 +546,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
         if (null === $this->translator) {
             // NEXT_MAJOR: Remove this deprecation and uncomment the following exception
             @trigger_error(sprintf(
-                'Calling %s() when no translator is set is deprecated since sonata-project/admin-bundle 3.x'
+                'Calling %s() when no translator is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
             ), E_USER_DEPRECATED);
@@ -560,7 +560,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function setConfigurationPool(Pool $configurationPool)
     {
@@ -568,7 +568,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function getConfigurationPool()
     {
@@ -576,7 +576,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
             // NEXT_MAJOR: Remove this deprecation and uncomment the following exception
             if ('sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
                 @trigger_error(sprintf(
-                    'Calling %s() when no pool is set is deprecated since sonata-project/admin-bundle 3.x'
+                    'Calling %s() when no pool is set is deprecated since sonata-project/admin-bundle 3.84'
                     .' and will throw a LogicException in 4.0',
                     __METHOD__,
                 ), E_USER_DEPRECATED);
@@ -591,7 +591,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function setRouteGenerator(RouteGeneratorInterface $routeGenerator)
     {
@@ -599,14 +599,14 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function getRouteGenerator()
     {
         if (null === $this->routeGenerator) {
             // NEXT_MAJOR: Remove this deprecation and uncomment the following exception
             @trigger_error(sprintf(
-                'Calling %s() when no route generator is set is deprecated since sonata-project/admin-bundle 3.x'
+                'Calling %s() when no route generator is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
             ), E_USER_DEPRECATED);
@@ -653,7 +653,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function setSecurityHandler(SecurityHandlerInterface $securityHandler)
     {
@@ -661,14 +661,14 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function getSecurityHandler()
     {
         if (null === $this->securityHandler) {
             // NEXT_MAJOR: Remove this deprecation and uncomment the following exception
             @trigger_error(sprintf(
-                'Calling %s() when no security handler is set is deprecated since sonata-project/admin-bundle 3.x'
+                'Calling %s() when no security handler is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
             ), E_USER_DEPRECATED);
@@ -682,7 +682,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function setMenuFactory(FactoryInterface $menuFactory)
     {
@@ -690,14 +690,14 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function getMenuFactory()
     {
         if (null === $this->menuFactory) {
             // NEXT_MAJOR: Remove this deprecation and uncomment the following exception
             @trigger_error(sprintf(
-                'Calling %s() when no security handler is set is deprecated since sonata-project/admin-bundle 3.x'
+                'Calling %s() when no security handler is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
             ), E_USER_DEPRECATED);
@@ -711,7 +711,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function setRouteBuilder(RouteBuilderInterface $routeBuilder)
     {
@@ -719,14 +719,14 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function getRouteBuilder()
     {
         if (null === $this->routeBuilder) {
             // NEXT_MAJOR: Remove this deprecation and uncomment the following exception
             @trigger_error(sprintf(
-                'Calling %s() when no route builder is set is deprecated since sonata-project/admin-bundle 3.x'
+                'Calling %s() when no route builder is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
             ), E_USER_DEPRECATED);
@@ -740,7 +740,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function setLabelTranslatorStrategy(LabelTranslatorStrategyInterface $labelTranslatorStrategy)
     {
@@ -748,14 +748,14 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
-     * @final since sonata-admin/admin-bundle 3.x
+     * @final since sonata-admin/admin-bundle 3.84
      */
     public function getLabelTranslatorStrategy()
     {
         if (null === $this->labelTranslatorStrategy) {
             // NEXT_MAJOR: Remove this deprecation and uncomment the following exception
             @trigger_error(sprintf(
-                'Calling %s() when no label translator strategy is set is deprecated since sonata-project/admin-bundle 3.x'
+                'Calling %s() when no label translator strategy is set is deprecated since sonata-project/admin-bundle 3.84'
                 .' and will throw a LogicException in 4.0',
                 __METHOD__,
             ), E_USER_DEPRECATED);

--- a/src/DependencyInjection/Admin/AbstractTaggedAdmin.php
+++ b/src/DependencyInjection/Admin/AbstractTaggedAdmin.php
@@ -264,6 +264,14 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     /**
      * @final since sonata-admin/admin-bundle 3.x
      */
+    public function getListModes()
+    {
+        return $this->listModes;
+    }
+
+    /**
+     * @final since sonata-admin/admin-bundle 3.x
+     */
     public function setPagerType($pagerType)
     {
         $this->pagerType = $pagerType;

--- a/src/DependencyInjection/Admin/AbstractTaggedAdmin.php
+++ b/src/DependencyInjection/Admin/AbstractTaggedAdmin.php
@@ -68,6 +68,8 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
 
     /**
      * @var array<string, array<string, string>>
+     *
+     * @phpstan-var array{list: array{class: string}, mosaic: array{class: string}}
      */
     protected $listModes = [
         'list' => ['class' => 'fa fa-list fa-fw'],
@@ -318,6 +320,8 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
 
     /**
      * @final since sonata-admin/admin-bundle 3.84
+     *
+     * @param array<string, string[]> $information
      */
     public function setSecurityInformation(array $information)
     {
@@ -326,6 +330,8 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
 
     /**
      * @final since sonata-admin/admin-bundle 3.84
+     *
+     * @return array<string, string[]>
      */
     public function getSecurityInformation()
     {

--- a/src/DependencyInjection/Admin/AbstractTaggedAdmin.php
+++ b/src/DependencyInjection/Admin/AbstractTaggedAdmin.php
@@ -32,7 +32,6 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @phpstan-template T of object
- * @phpstan-implements TaggedAdminInterface<T>
  */
 abstract class AbstractTaggedAdmin implements TaggedAdminInterface
 {

--- a/src/DependencyInjection/Admin/TaggedAdminInterface.php
+++ b/src/DependencyInjection/Admin/TaggedAdminInterface.php
@@ -41,8 +41,6 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  *     - The first and third argument are automatically injected by the AddDependencyCallsCompilerPass.
  *     - The second one is used as a reference of the Admin in the Pool, with the `setAdminClasses` call.
  *
- * @phpstan-template T of object
- *
  * @method void                          initialize()
  * @method void                          setLabel(?string $label)
  * @method void                          showMosaicButton(bool $isShown)

--- a/src/DependencyInjection/Admin/TaggedAdminInterface.php
+++ b/src/DependencyInjection/Admin/TaggedAdminInterface.php
@@ -120,6 +120,8 @@ interface TaggedAdminInterface
      * NEXT_MAJOR: Uncomment this method.
      *
      * Set the roles and permissions per role.
+     *
+     * @param array<string, string[]> $information
      */
 //    public function setSecurityInformation(array $information): void;
 

--- a/src/DependencyInjection/Admin/TaggedAdminInterface.php
+++ b/src/DependencyInjection/Admin/TaggedAdminInterface.php
@@ -92,6 +92,11 @@ interface TaggedAdminInterface
 //    public function showMosaicButton(bool $isShown): void;
 
     /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function getListModes();
+
+    /**
      * NEXT_MAJOR: Uncomment this method.
      */
 //    public function setPagerType(string $pagerType): void;

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -30,7 +30,7 @@ abstract class Filter implements FilterInterface
      *
      * @var mixed|null
      *
-     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * @deprecated since sonata-project/admin-bundle 3.84, to be removed in 4.0.
      */
     protected $value;
 
@@ -194,12 +194,12 @@ abstract class Filter implements FilterInterface
      *
      * @param mixed $value
      *
-     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * @deprecated since sonata-project/admin-bundle 3.84, to be removed in 4.0.
      */
     public function setValue($value)
     {
         @trigger_error(sprintf(
-            'Method %s() is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.',
+            'Method %s() is deprecated since sonata-project/admin-bundle 3.84 and will be removed in version 4.0.',
             __METHOD__,
         ), E_USER_DEPRECATED);
 
@@ -211,12 +211,12 @@ abstract class Filter implements FilterInterface
      *
      * @return mixed
      *
-     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * @deprecated since sonata-project/admin-bundle 3.84, to be removed in 4.0.
      */
     public function getValue()
     {
         @trigger_error(sprintf(
-            'Method %s() is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.',
+            'Method %s() is deprecated since sonata-project/admin-bundle 3.84 and will be removed in version 4.0.',
             __METHOD__,
         ), E_USER_DEPRECATED);
 

--- a/src/Security/Handler/AclSecurityHandlerInterface.php
+++ b/src/Security/Handler/AclSecurityHandlerInterface.php
@@ -86,7 +86,8 @@ interface AclSecurityHandlerInterface extends SecurityHandlerInterface
      *
      * NEXT_MAJOR: change signature to `addObjectClassAces(MutableAclInterface $acl, array $roleInformation = []): void`.
      *
-     * @param MutableAclInterface $acl
+     * @param MutableAclInterface     $acl
+     * @param array<string, string[]> $roleInformation
      *
      * @return void
      */

--- a/src/Security/Handler/SecurityHandlerInterface.php
+++ b/src/Security/Handler/SecurityHandlerInterface.php
@@ -36,7 +36,7 @@ interface SecurityHandlerInterface
     public function getBaseRole(AdminInterface $admin);
 
     /**
-     * @return array<string, mixed>
+     * @return array<string, string[]>
      */
     public function buildSecurityInformation(AdminInterface $admin);
 

--- a/src/Util/AdminObjectAclData.php
+++ b/src/Util/AdminObjectAclData.php
@@ -321,7 +321,7 @@ class AdminObjectAclData
     }
 
     /**
-     * @return array
+     * @return array<string, string[]>
      */
     public function getSecurityInformation()
     {

--- a/src/Util/FormBuilderIterator.php
+++ b/src/Util/FormBuilderIterator.php
@@ -61,7 +61,7 @@ class FormBuilderIterator extends \RecursiveArrayIterator
         if (null !== $prefix && !\is_string($prefix)) {
             @trigger_error(sprintf(
                 'Passing other type than string or null as argument 2 for method %s() is deprecated since'
-                .' sonata-project/admin-bundle 3.x. It will accept only string and null in version 4.0.',
+                .' sonata-project/admin-bundle 3.84. It will accept only string and null in version 4.0.',
                 __METHOD__
             ), E_USER_DEPRECATED);
         }

--- a/src/Util/FormViewIterator.php
+++ b/src/Util/FormViewIterator.php
@@ -42,6 +42,9 @@ class FormViewIterator implements \RecursiveIterator
         return \count($this->current()->children) > 0;
     }
 
+    /**
+     * @return FormView
+     */
     public function current()
     {
         return $this->iterator->current();

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -107,7 +107,7 @@ class PagerTest extends TestCase
      */
     public function testGetCurrentMaxLink(): void
     {
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getCurrentMaxLink()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getCurrentMaxLink()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->assertSame(1, $this->pager->getCurrentMaxLink());
 
         $this->pager->getLinks();
@@ -129,7 +129,7 @@ class PagerTest extends TestCase
      */
     public function testGetMaxRecordLimit(): void
     {
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getMaxRecordLimit()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getMaxRecordLimit()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->assertFalse($this->pager->getMaxRecordLimit());
 
         $this->pager->setMaxRecordLimit(99);
@@ -152,7 +152,7 @@ class PagerTest extends TestCase
      */
     public function testCount(): void
     {
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::count()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::count()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->assertSame(0, $this->pager->count());
 
         $this->callMethod($this->pager, 'setNbResults', [100]);
@@ -175,10 +175,10 @@ class PagerTest extends TestCase
      */
     public function testGetCountColumn(): void
     {
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getCountColumn()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getCountColumn()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->assertSame(['id'], $this->pager->getCountColumn());
 
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::setCountColumn()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::setCountColumn()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->pager->setCountColumn(['foo']);
         $this->assertSame(['foo'], $this->pager->getCountColumn());
     }
@@ -190,14 +190,14 @@ class PagerTest extends TestCase
      */
     public function testParameters(): void
     {
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getParameter()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getParameter()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->assertNull($this->pager->getParameter('foo', null));
         $this->assertSame('bar', $this->pager->getParameter('foo', 'bar'));
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::hasParameter()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::hasParameter()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->assertFalse($this->pager->hasParameter('foo'));
         $this->assertSame([], $this->pager->getParameters());
 
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::setParameter()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::setParameter()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->pager->setParameter('foo', 'foo_value');
 
         $this->assertTrue($this->pager->hasParameter('foo'));
@@ -332,7 +332,7 @@ class PagerTest extends TestCase
         $this->assertSame($object3, $value);
         $this->assertSame($expectedObjects, $values);
 
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::valid()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::valid()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->assertFalse($this->pager->valid());
 
         $this->callMethod($this->pager, 'resetIterator');
@@ -350,7 +350,7 @@ class PagerTest extends TestCase
             ->method('getResults')
             ->willReturn([]);
 
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::valid()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::valid()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->assertFalse($this->pager->valid());
     }
 
@@ -365,7 +365,7 @@ class PagerTest extends TestCase
             ->method('getResults')
             ->willReturn([]);
 
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::next()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::next()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->assertFalse($this->pager->next());
     }
 
@@ -380,7 +380,7 @@ class PagerTest extends TestCase
             ->method('getResults')
             ->willReturn([123 => new \stdClass()]);
 
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::key()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::key()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->assertSame(123, $this->pager->key());
     }
 
@@ -397,7 +397,7 @@ class PagerTest extends TestCase
             ->method('getResults')
             ->willReturn([$object]);
 
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::current()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::current()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->assertSame($object, $this->pager->current());
     }
 
@@ -408,7 +408,7 @@ class PagerTest extends TestCase
      */
     public function testGetCursor(): void
     {
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getCursor()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getCursor()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->assertSame(1, $this->pager->getCursor());
 
         $this->pager->setCursor(0);
@@ -474,9 +474,9 @@ class PagerTest extends TestCase
 
         $this->pager->setQuery($query);
 
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getObjectByCursor()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getObjectByCursor()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->assertSame($object1, $this->pager->getObjectByCursor(1));
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getCursor()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getCursor()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->assertSame(1, $this->pager->getCursor());
 
         $id = 1;
@@ -527,7 +527,7 @@ class PagerTest extends TestCase
      */
     public function testGetFirstIndex(): void
     {
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getFirstIndex()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getFirstIndex()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->assertSame(1, $this->pager->getFirstIndex());
 
         $this->pager->setMaxPerPage(0);
@@ -550,7 +550,7 @@ class PagerTest extends TestCase
      */
     public function testGetLastIndex(): void
     {
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getLastIndex()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getLastIndex()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->assertSame(0, $this->pager->getLastIndex());
 
         $this->pager->setMaxPerPage(0);
@@ -578,7 +578,7 @@ class PagerTest extends TestCase
      */
     public function testGetNext(): void
     {
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getNext()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getNext()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->assertNull($this->pager->getNext());
 
         $object1 = new \stdClass();
@@ -642,7 +642,7 @@ class PagerTest extends TestCase
      */
     public function testGetPrevious(): void
     {
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getPrevious()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::getPrevious()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->assertNull($this->pager->getPrevious());
 
         $object1 = new \stdClass();
@@ -707,7 +707,7 @@ class PagerTest extends TestCase
     public function testSerialize(): void
     {
         $pagerClone = clone $this->pager;
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::serialize()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::serialize()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $data = $this->pager->serialize();
         $this->assertNotEmpty($data);
 
@@ -746,7 +746,7 @@ class PagerTest extends TestCase
             ->willReturn([]);
         $this->pager->current();
 
-        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::unserialize()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
+        $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::unserialize()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->pager->unserialize(serialize($serialized));
 
         $this->assertSame(7, $this->pager->getMaxPerPage());

--- a/tests/Util/FormBuilderIteratorTest.php
+++ b/tests/Util/FormBuilderIteratorTest.php
@@ -80,7 +80,7 @@ class FormBuilderIteratorTest extends TestCase
      */
     public function testTriggersADeprecationWithWrongPrefixType(): void
     {
-        $this->expectDeprecation('Passing other type than string or null as argument 2 for method Sonata\AdminBundle\Util\FormBuilderIterator::__construct() is deprecated since sonata-project/admin-bundle 3.x. It will accept only string and null in version 4.0.');
+        $this->expectDeprecation('Passing other type than string or null as argument 2 for method Sonata\AdminBundle\Util\FormBuilderIterator::__construct() is deprecated since sonata-project/admin-bundle 3.84. It will accept only string and null in version 4.0.');
 
         $this->builder->add('name', TextType::class);
         $iterator = new FormBuilderIterator($this->builder, new \stdClass());


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC. Because the TaggedAdminInterface is not released.
After the merge, I will edit the previous changelog.

Moving `getListModes` to `AbstractTaggedAdmin` is consistent with others changes and allow to restrict the visibility of the `listModes` property to private in nextMajor.

I also
- Update the 3.x comments since I'm fixing conflicts
- Fix some issues I find during the merge from 3.x into master

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `AbstractTaggedAdmin::getListModes()`.
- Added `TaggedAdminInterface::getListModes()`.
```