### PR TITLE
Remove public access for getFieldValue

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,10 @@ UPGRADE 3.x
 UPGRADE FROM 3.xx to 3.xx
 =========================
 
+### Deprecated `FieldDescriptionInterface::getFieldValue()`
+
+`BaseFieldDescription::getFieldValue()` will become protected.
+
 ### `RouteCollection` now implements `RouteCollectionInterface`
 
 In 4.0, `AbstractAdmin::configureRoutes` and `AdminExtensionInterface::configureRoutes` will receive a

--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -381,6 +381,16 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         return null !== $this->associationAdmin;
     }
 
+    /**
+     * NEXT_MAJOR: Change the visibility to protected.
+     *
+     * @param object|null $object
+     * @param string      $fieldName
+     *
+     * @throws NoValueException
+     *
+     * @return mixed
+     */
     public function getFieldValue($object, $fieldName)
     {
         if ($this->isVirtual() || null === $object) {

--- a/src/Admin/FieldDescriptionInterface.php
+++ b/src/Admin/FieldDescriptionInterface.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Admin;
 
+use Sonata\AdminBundle\Exception\NoValueException;
+
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
@@ -228,7 +230,9 @@ interface FieldDescriptionInterface
      *
      * @param object $object
      *
-     * @return bool|mixed
+     * @throws NoValueException if the value cannot be determined
+     *
+     * @return mixed
      */
     public function getValue($object);
 
@@ -314,6 +318,10 @@ interface FieldDescriptionInterface
     public function getSortParentAssociationMapping();
 
     /**
+     * NEXT_MAJOR: Remove this method from the interface.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     *
      * @param object|null $object
      * @param string      $fieldName
      *


### PR DESCRIPTION
## Subject

When working on an issue of SonataDoctrineORMAdminBundle, I discovered that `getFieldValue` was in the interface, but to me it's a method implemented in BaseFieldDescription to help the `getValue` implementation.

So I propose to restrict the visibility of this method.

I am targeting this branch, because BC.

## Changelog

```markdown
### Deprecated
- `FieldDescriptionInterface::getFieldValue()`
```