### PR TITLE
Fix form label in next major

### DIFF
--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -93,9 +93,7 @@ class FormMapper extends BaseGroupedMapper
             $type = CollectionType::class;
         }
 
-        $label = $fieldName;
-
-        $group = $this->addFieldToCurrentGroup($label);
+        $group = $this->addFieldToCurrentGroup($fieldName);
 
         // Try to autodetect type
         if ($name instanceof FormBuilderInterface && null === $type) {
@@ -124,10 +122,11 @@ class FormMapper extends BaseGroupedMapper
         }
 
         if ($name instanceof FormBuilderInterface) {
+            $child = $name;
             $type = null;
             $options = [];
         } else {
-            $name = $fieldDescription->getName();
+            $child = $fieldDescription->getName();
 
             // Note that the builder var is actually the formContractor:
             $options = array_replace_recursive(
@@ -142,7 +141,17 @@ class FormMapper extends BaseGroupedMapper
             }
 
             if (!isset($options['label'])) {
-                $options['label'] = $this->admin->getLabelTranslatorStrategy()->getLabel($name, 'form', 'label');
+                /*
+                 * NEXT_MAJOR: Replace $child by $name in the next line.
+                 * And add the following BC-break in the upgrade note:
+                 *
+                 * The form label are now correctly using the label translator strategy
+                 * for field with `.` (which won't be replaced by `__`). For instance,
+                 * with the underscore label strategy, the label `foo.barBaz` was
+                 * previously `form.label_foo__bar_baz` and now is `form.label_foo_bar_baz`
+                 * to be consistent with others labels like `show.label_foo_bar_baz`.
+                 */
+                $options['label'] = $this->admin->getLabelTranslatorStrategy()->getLabel($child, 'form', 'label');
             }
 
             // NEXT_MAJOR: Remove this block.
@@ -162,7 +171,7 @@ class FormMapper extends BaseGroupedMapper
         }
 
         $this->admin->addFormFieldDescription($fieldName, $fieldDescription);
-        $this->formBuilder->add($name, $type, $options);
+        $this->formBuilder->add($child, $type, $options);
 
         return $this;
     }


### PR DESCRIPTION
Pedantic.

Currently, with
```
->add('foo.barBaz`)
```
and the label underscore strategy.

The show label is `show.label_foo_bar_baz`.
The form label is `form.label_foo__bar_baz`.

The issue is that for the form, `.` are forbidden and replaced by `__`.
But we should use the given name for the label, instead of the new sanitized one.

This will add consistency in next major. I don't fix it in 3.x to avoid people to rewrite every label.