### PR TITLE
Deprecate field name setter from FieldDescriptionInterface

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,23 @@
 UPGRADE 3.x
 ===========
 
+### Sonata\AdminBundle\Admin\BaseFieldDescription
+
+Method `__construct()` has been updated to receive the field name as argument 6:
+
+```php
+public function __construct(
+    ?string $name = null,
+    array $options = [],
+    array $fieldMapping = [],
+    array $associationMapping = [],
+    array $parentAssociationMappings = [],
+    ?string $fieldName = null
+) {
+```
+
+Deprecated `Sonata\AdminBundle\Admin\BaseFieldDescription::setFieldName()`.
+
 UPGRADE FROM 3.82 to 3.83
 =========================
 

--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -137,14 +137,15 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
     private static $fieldGetters = [];
 
     /**
-     * NEXT_MAJOR: Remove the null default value and restrict param type to `string`.
+     * NEXT_MAJOR: Remove the null default value for $name and restrict param type to `string`.
      */
     public function __construct(
         ?string $name = null,
         array $options = [],
         array $fieldMapping = [],
         array $associationMapping = [],
-        array $parentAssociationMappings = []
+        array $parentAssociationMappings = [],
+        ?string $fieldName = null
     ) {
         // NEXT_MAJOR: Remove this check and keep the else part.
         if (null === $name) {
@@ -155,6 +156,15 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
             ), E_USER_DEPRECATED);
         } else {
             $this->setName($name);
+
+            if (null === $fieldName) {
+                // NEXT_MAJOR: Remove this line and uncomment the following.
+                $fieldName = substr(strrchr('.'.$name, '.'), 1);
+//                $fieldName = $name;
+            }
+
+            // NEXT_MAJOR: Remove 'sonata_deprecation_mute' and the phpstan-ignore.
+            $this->setFieldName($fieldName, 'sonata_deprecation_mute');
         }
 
         $this->setOptions($options);
@@ -177,8 +187,19 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
     // abstract protected function setAssociationMapping(array $associationMapping): void;
     // abstract protected function setParentAssociationMappings(array $parentAssociationMappings): void;
 
+    /**
+     * NEXT_MAJOR: Change the visibility to private.
+     */
     public function setFieldName($fieldName)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s() method is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will become private in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         $this->fieldName = $fieldName;
     }
 
@@ -191,8 +212,9 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
     {
         $this->name = $name;
 
+        // NEXT_MAJOR: Remove this code since the field name will be set in the construct.
         if (!$this->getFieldName()) {
-            $this->setFieldName(substr(strrchr('.'.$name, '.'), 1));
+            $this->setFieldName(substr(strrchr('.'.$name, '.'), 1), 'sonata_deprecation_mute');
         }
     }
 

--- a/src/Admin/FieldDescriptionInterface.php
+++ b/src/Admin/FieldDescriptionInterface.php
@@ -24,6 +24,10 @@ namespace Sonata\AdminBundle\Admin;
 interface FieldDescriptionInterface
 {
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.
+     *
      * set the field name.
      *
      * @param string $fieldName

--- a/tests/Admin/BaseFieldDescriptionTest.php
+++ b/tests/Admin/BaseFieldDescriptionTest.php
@@ -27,6 +27,16 @@ class BaseFieldDescriptionTest extends TestCase
 {
     use ExpectDeprecationTrait;
 
+    public function testConstruct(): void
+    {
+        $description = new FieldDescription('foo.bar');
+
+        $this->assertSame('foo.bar', $description->getName());
+        // NEXT_MAJOR: Remove this line and uncomment the following
+        $this->assertSame('bar', $description->getFieldName());
+//        $this->assertSame('foo.bar', $description->getFieldName());
+    }
+
     public function testConstructingWithMapping(): void
     {
         $fieldMapping = ['field_name' => 'fieldName'];
@@ -39,11 +49,13 @@ class BaseFieldDescriptionTest extends TestCase
             $fieldMapping,
             $associationMapping,
             $parentAssociationMapping,
+            'bar'
         );
 
         $this->assertSame($fieldMapping, $description->getFieldMapping());
         $this->assertSame($associationMapping, $description->getAssociationMapping());
         $this->assertSame($parentAssociationMapping, $description->getParentAssociationMappings());
+        $this->assertSame('bar', $description->getFieldName());
     }
 
     public function testSetName(): void


### PR DESCRIPTION
## Subject

Similar to https://github.com/sonata-project/SonataAdminBundle/pull/6648

IMHO: the fieldName should be immutable.
And I don't see usage of the `setFieldName` method.

I am targeting this branch, because BC.

## Changelog
```markdown
### Added
- one argument to `BaseFieldDescription::construct()` to set the field name.

### Deprecated
- `FieldDescriptionInterface::setFieldMapping()`
- `BaseFieldDescription::setFieldMapping()`
```
