### PR TITLE
Fix - Variable "admin" does not exist.

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -131,7 +131,7 @@ This code manages the many-to-[one|many] association field popup
 
                 // populate the popup container
                 field_dialog_content_{{ id }}.html(html);
-                {% if admin.label is not empty %}
+                {% if admin is defined and admin.label is not empty %}
                     field_dialog_title_{{ id }}.html("{{ associationadmin.label|trans({}, associationadmin.translationdomain) }}");
                 {% endif %}
 
@@ -170,7 +170,7 @@ This code manages the many-to-[one|many] association field popup
 
                 // populate the popup container
                 field_dialog_content_{{ id }}.html(html);
-                {% if admin.label is not empty %}
+                {% if admin is defined and admin.label is not empty %}
                     field_dialog_title_{{ id }}.html("{{ associationadmin.label|trans({}, associationadmin.translationdomain) }}");
                 {% endif %}
 
@@ -212,7 +212,7 @@ This code manages the many-to-[one|many] association field popup
 
                 // populate the popup container
                 field_dialog_content_{{ id }}.html(html);
-                {% if admin.label is not empty %}
+                {% if admin is defined and admin.label is not empty %}
                     field_dialog_title_{{ id }}.html("{{ associationadmin.label|trans({}, associationadmin.translationdomain) }}");
                 {% endif %}
 

--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -131,7 +131,7 @@ This code manages the many-to-[one|many] association field popup
 
                 // populate the popup container
                 field_dialog_content_{{ id }}.html(html);
-                {% if admin is defined and admin.label is not empty %}
+                {% if associationadmin.label is not empty %}
                     field_dialog_title_{{ id }}.html("{{ associationadmin.label|trans({}, associationadmin.translationdomain) }}");
                 {% endif %}
 
@@ -170,7 +170,7 @@ This code manages the many-to-[one|many] association field popup
 
                 // populate the popup container
                 field_dialog_content_{{ id }}.html(html);
-                {% if admin is defined and admin.label is not empty %}
+                {% if associationadmin.label is not empty %}
                     field_dialog_title_{{ id }}.html("{{ associationadmin.label|trans({}, associationadmin.translationdomain) }}");
                 {% endif %}
 
@@ -212,7 +212,7 @@ This code manages the many-to-[one|many] association field popup
 
                 // populate the popup container
                 field_dialog_content_{{ id }}.html(html);
-                {% if admin is defined and admin.label is not empty %}
+                {% if associationadmin.label is not empty %}
                     field_dialog_title_{{ id }}.html("{{ associationadmin.label|trans({}, associationadmin.translationdomain) }}");
                 {% endif %}
 


### PR DESCRIPTION
## Subject

After updating to 3.84 I found some Twig runtime error related to missing "admin" variable. Probably one extra check will fix the issue or someone with more experience can suggest better solution.


I am targeting this branch, because of BC.


## Changelog

```markdown
### Fixed
Variable "admin" does not exist in `CRUD/Association/edit_many_script.html.twig`
```

