### PR TITLE
Added default_controller configuration option

### DIFF
--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -451,4 +451,19 @@ by overriding ``checkAccess`` function::
         }
     }
 
+Use your own custom controller as default
+-----------------------------------------
+
+By default, ``CRUDController`` is the controller used when no controller has been specified. You can modify this by
+adding the following in the configuration:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/sonata_admin.yaml
+
+        sonata_admin:
+            default_controller: App\Controller\DefaultCRUDController
+
 .. _`Core's documentation`: https://sonata-project.org/bundles/core/master/doc/reference/form_types.html#sonata-type-translatable-choice

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -70,6 +70,7 @@ Full Configuration Options
             title: 'Sonata Admin'
             title_logo: bundles/sonataadmin/logo_title.png
             search: true
+            default_controller: Sonata\AdminBundle\Controller\CRUDController
             options:
                 html5_validate: true
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -85,9 +85,11 @@
         </UndefinedGlobalVariable>
     </file>
     <file src="src/Resources/skeleton/AdminController.tpl.php">
-        <UndefinedGlobalVariable occurrences="2">
+        <UndefinedGlobalVariable occurrences="4">
             <code>$namespace</code>
             <code>$class_name</code>
+            <code>$default_controller</code>
+            <code>$default_controller_short_name</code>
         </UndefinedGlobalVariable>
     </file>
     <!--will be removed in v4. Currently BC break-->

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -73,25 +73,6 @@
         </UndefinedClass>
         <UnrecognizedStatement occurrences="1"/>
     </file>
-    <!-- ignore template files-->
-    <file src="src/Resources/skeleton/Admin.tpl.php">
-        <UndefinedGlobalVariable occurrences="6">
-            <code>$namespace</code>
-            <code>$class_name</code>
-            <code>$fields</code>
-            <code>$fields</code>
-            <code>$fields</code>
-            <code>$fields</code>
-        </UndefinedGlobalVariable>
-    </file>
-    <file src="src/Resources/skeleton/AdminController.tpl.php">
-        <UndefinedGlobalVariable occurrences="4">
-            <code>$namespace</code>
-            <code>$class_name</code>
-            <code>$default_controller</code>
-            <code>$default_controller_short_name</code>
-        </UndefinedGlobalVariable>
-    </file>
     <!--will be removed in v4. Currently BC break-->
     <file src="src/Twig/Extension/StringExtension.php">
         <UndefinedClass occurrences="2">

--- a/psalm.xml
+++ b/psalm.xml
@@ -3,7 +3,7 @@
     <projectFiles>
         <directory name="src"/>
         <ignoreFiles>
-            <file name="src/Resources/skeleton"/>
+            <directory name="src/Resources/skeleton"/>
             <directory name="vendor"/>
         </ignoreFiles>
     </projectFiles>

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\DependencyInjection\Compiler;
 
 use Doctrine\Inflector\InflectorFactory;
-use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\AdminBundle\Datagrid\Pager;
 use Sonata\AdminBundle\DependencyInjection\Admin\TaggedAdminInterface;
 use Sonata\AdminBundle\Templating\TemplateRegistry;
@@ -50,6 +49,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
         $groupDefaults = $admins = $classes = [];
 
         $pool = $container->getDefinition('sonata.admin.pool');
+        $defaultController = $container->getParameter('sonata.admin.configuration.default_controller');
 
         $defaultValues = [
             'group' => $container->getParameter('sonata.admin.configuration.default_group'),
@@ -71,7 +71,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
                 $this->replaceDefaultArguments([
                     0 => $id,
-                    2 => CRUDController::class,
+                    2 => $defaultController,
                 ], $definition, $parentDefinition);
                 $this->applyConfigurationFromAttribute($definition, $attributes);
                 $this->applyDefaults($container, $id, $attributes);

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\DependencyInjection;
 
+use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\AdminBundle\Util\BCDeprecationParameters;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
@@ -116,6 +117,12 @@ CASESENSITIVE;
                             ->info($caseSensitiveInfo)
                         ->end()
                     ->end()
+                ->end()
+
+                ->scalarNode('default_controller')
+                    ->defaultValue(CRUDController::class)
+                    ->cannotBeEmpty()
+                    ->info('Name of the controller class to be used as a default in admin definitions')
                 ->end()
 
                 ->arrayNode('breadcrumbs')

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -111,6 +111,7 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         $container->setParameter('sonata.admin.configuration.global_search.case_sensitive', $config['global_search']['case_sensitive']);
         $container->setParameter('sonata.admin.configuration.templates', $config['templates']);
         $container->setParameter('sonata.admin.configuration.admin_services', $config['admin_services']);
+        $container->setParameter('sonata.admin.configuration.default_controller', $config['default_controller']);
         $container->setParameter('sonata.admin.configuration.dashboard_groups', $config['dashboard']['groups']);
         $container->setParameter('sonata.admin.configuration.dashboard_blocks', $config['dashboard']['blocks']);
         $container->setParameter('sonata.admin.configuration.sort_admins', $config['options']['sort_admins']);

--- a/src/Maker/AdminMaker.php
+++ b/src/Maker/AdminMaker.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Maker;
 
 use Sonata\AdminBundle\Command\Validators;
+use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\AdminBundle\Manipulator\ServicesManipulator;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
@@ -21,6 +22,7 @@ use Symfony\Bundle\MakerBundle\DependencyBuilder;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\InputConfiguration;
 use Symfony\Bundle\MakerBundle\Maker\AbstractMaker;
+use Symfony\Bundle\MakerBundle\Str;
 use Symfony\Bundle\MakerBundle\Util\ClassNameDetails;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -71,14 +73,23 @@ final class AdminMaker extends AbstractMaker
     private $modelManager;
 
     /**
+     * @var string
+     */
+    private $defaultController;
+
+    /**
+     * NEXT_MAJOR: Make $defaultController mandatory.
+     *
      * @param string                               $projectDirectory
      * @param array<string, ModelManagerInterface> $modelManagers
      */
-    public function __construct($projectDirectory, array $modelManagers = [])
+    public function __construct($projectDirectory, array $modelManagers = [], ?string $defaultController = null)
     {
         $this->projectDirectory = $projectDirectory;
         $this->availableModelManagers = $modelManagers;
         $this->skeletonDirectory = sprintf('%s/../Resources/skeleton', __DIR__);
+        // NEXT_MAJOR: Remove the CRUDController part.
+        $this->defaultController = $defaultController ?? CRUDController::class;
     }
 
     public static function getCommandName(): string
@@ -237,7 +248,10 @@ final class AdminMaker extends AbstractMaker
         $generator->generateClass(
             $controllerClassFullName,
             sprintf('%s/AdminController.tpl.php', $this->skeletonDirectory),
-            []
+            [
+                'default_controller' => $this->defaultController,
+                'default_controller_short_name' => Str::getShortClassName($this->defaultController),
+            ]
         );
         $generator->writeChanges();
         $io->writeln(sprintf(

--- a/src/Resources/config/makers.php
+++ b/src/Resources/config/makers.php
@@ -24,6 +24,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->args([
                 '%kernel.project_dir%',
                 [],
+                '%sonata.admin.configuration.default_controller%',
             ])
     ;
 };

--- a/src/Resources/skeleton/AdminController.tpl.php
+++ b/src/Resources/skeleton/AdminController.tpl.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace <?= $namespace ?>;
 
-use Sonata\AdminBundle\Controller\CRUDController;
+use <?= $default_controller ?>;
 
-final class <?= $class_name ?> extends CRUDController
+final class <?= $class_name ?> extends <?= $default_controller_short_name ?>
 {
 
 }

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -21,6 +21,7 @@ use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
 use Sonata\AdminBundle\Route\RoutesCache;
+use Sonata\AdminBundle\Tests\Fixtures\Controller\FooAdminController;
 use Sonata\BlockBundle\DependencyInjection\SonataBlockExtension;
 use Sonata\DoctrinePHPCRAdminBundle\Route\PathInfoBuilderSlashes;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
@@ -565,6 +566,24 @@ class AddDependencyCallsCompilerPassTest extends TestCase
         $this->assertSame('extra_argument_2', $definition->getArgument(3));
     }
 
+    public function testDefaultControllerCanBeChanged(): void
+    {
+        $container = $this->getContainer();
+
+        $config = $this->config;
+        $config['default_controller'] = FooAdminController::class;
+
+        $this->extension->load([$config], $container);
+
+        $compilerPass = new AddDependencyCallsCompilerPass();
+
+        $compilerPass->process($container);
+        $container->compile();
+
+        $definition = $container->getDefinition('sonata_without_controller');
+        $this->assertSame(FooAdminController::class, $definition->getArgument(2));
+    }
+
     /**
      * @return array
      */
@@ -761,6 +780,11 @@ class AddDependencyCallsCompilerPassTest extends TestCase
             ->setClass(MockAdmin::class)
             ->setArguments(['', ReportTwo::class, CRUDController::class])
             ->addTag('sonata.admin', ['group' => 'sonata_report_two_group', 'manager_type' => 'orm', 'show_mosaic_button' => true]);
+        $container
+            ->register('sonata_without_controller')
+            ->setClass(MockAdmin::class)
+            ->setArguments(['', ReportTwo::class, ''])
+            ->addTag('sonata.admin', ['group' => 'sonata_report_two_group', 'manager_type' => 'orm']);
 
         // translator
         $container

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -14,7 +14,9 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\DependencyInjection;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\AdminBundle\DependencyInjection\Configuration;
+use Sonata\AdminBundle\Tests\Fixtures\Controller\FooAdminController;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Config\Definition\Exception\InvalidTypeException;
 use Symfony\Component\Config\Definition\Processor;
@@ -294,6 +296,22 @@ class ConfigurationTest extends TestCase
 
         $this->assertSame([], $config['assets']['remove_stylesheets']);
         $this->assertSame([], $config['assets']['remove_javascripts']);
+    }
+
+    public function testDefaultControllerIsCRUDController(): void
+    {
+        $config = $this->process([]);
+
+        $this->assertSame(CRUDController::class, $config['default_controller']);
+    }
+
+    public function testSettingDefaultController(): void
+    {
+        $config = $this->process([[
+            'default_controller' => FooAdminController::class,
+        ]]);
+
+        $this->assertSame(FooAdminController::class, $config['default_controller']);
     }
 
     /**

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -145,6 +145,7 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
         $this->assertContainerBuilderHasParameter('sonata.admin.configuration.default_group');
         $this->assertContainerBuilderHasParameter('sonata.admin.configuration.default_label_catalogue');
         $this->assertContainerBuilderHasParameter('sonata.admin.configuration.default_icon');
+        $this->assertContainerBuilderHasParameter('sonata.admin.configuration.default_controller');
     }
 
     public function testExtraStylesheetsGetAdded(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This is a follow-up of https://github.com/sonata-project/SonataAdminBundle/pull/5307.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `default_controller` to configure the default controlled used by the admins.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
