### PR TITLE
deprecate PagerInterface::getNbResults() in favour of countResults()

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,13 +4,13 @@ UPGRADE 3.x
 UPGRADE FROM 3.85 to 3.86
 =========================
 
-### Deprecated
-- `PagerInterface::getNbResults()`
-- `PagerInterface::setNbResults(...)`
-- `PagerInterface::$nbResults`
+### Sonata\AdminBundle\Datagrid\PagerInterface
 
-The method `PagerInterface::getNbResults()` was deprecated in favour of a new method `PagerInterface::countResults()`.
-Not implementing this new method is deprecated and will throw an error on 4.0.
+Deprecated `getNbResults()` method in favor of `countResults()`.
+
+### Sonata\AdminBundle\Datagrid\Pager and Sonata\AdminBundle\Datagrid\SimplePager
+
+Deprecated `$nbResults` property, `getNbResults()` and `setNbResults()` methods.
 
 UPGRADE FROM 3.83 to 3.84
 =========================

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,17 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.85 to 3.86
+=========================
+
+### Deprecated
+- `PagerInterface::getNbResults()`
+- `PagerInterface::setNbResults(...)`
+- `PagerInterface::$nbResults`
+
+The method `PagerInterface::getNbResults()` was deprecated in favour of a new method `PagerInterface::countResults()`.
+Not implementing this new method is deprecated and will throw an error on 4.0.
+
 UPGRADE FROM 3.83 to 3.84
 =========================
 

--- a/src/Action/SearchAction.php
+++ b/src/Action/SearchAction.php
@@ -114,7 +114,15 @@ final class SearchAction
                 ];
             }
             $page = (int) $pager->getPage();
-            $total = (int) $pager->getNbResults();
+            if (method_exists($pager, 'countResults')) {
+                $total = (int) $pager->countResults();
+            } else {
+                @trigger_error(sprintf(
+                    'Not implementing "%s::countResults()" is deprecated since sonata-project/admin-bundle 3.86 and will fail in 4.0.',
+                    'Sonata\AdminBundle\Datagrid\PagerInterface'
+                ), E_USER_DEPRECATED);
+                $total = (int) $pager->getNbResults();
+            }
         }
 
         $response = new JsonResponse([

--- a/src/Action/SearchAction.php
+++ b/src/Action/SearchAction.php
@@ -114,6 +114,8 @@ final class SearchAction
                 ];
             }
             $page = (int) $pager->getPage();
+
+            // NEXT_MAJOR: remove the existence check and the else part
             if (method_exists($pager, 'countResults')) {
                 $total = (int) $pager->countResults();
             } else {

--- a/src/Action/SearchAction.php
+++ b/src/Action/SearchAction.php
@@ -115,7 +115,7 @@ final class SearchAction
             }
             $page = (int) $pager->getPage();
 
-            // NEXT_MAJOR: remove the existence check and the else part
+            // NEXT_MAJOR: remove the existence check and just use $pager->countResults() without casting to int
             if (method_exists($pager, 'countResults')) {
                 $total = (int) $pager->countResults();
             } else {

--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -40,7 +40,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     protected $lastPage = 1;
 
     /**
-     * NEXT_MAJOR: Remove this property and add a private "countResults" property.
+     * NEXT_MAJOR: Remove this property.
      *
      * @deprecated since sonata-project/admin-bundle 3.86
      *
@@ -226,7 +226,19 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      */
     public function haveToPaginate()
     {
-        return $this->getMaxPerPage() && $this->countResults() > $this->getMaxPerPage();
+        // NEXT_MAJOR: remove the existence check and the else part
+        if (method_exists($this, 'countResults')) {
+            $countResults = (int) $this->countResults();
+        } else {
+            @trigger_error(sprintf(
+                'Not implementing "%s::countResults()" is deprecated since sonata-project/admin-bundle 3.86 and will fail in 4.0.',
+                'Sonata\AdminBundle\Datagrid\PagerInterface'
+            ), E_USER_DEPRECATED);
+
+            $countResults = (int) $this->getNbResults();
+        }
+
+        return $this->getMaxPerPage() && $countResults > $this->getMaxPerPage();
     }
 
     /**
@@ -458,11 +470,6 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
             __METHOD__
         ), E_USER_DEPRECATED);
 
-        return $this->countResults();
-    }
-
-    public function countResults(): int
-    {
         return $this->nbResults;
     }
 
@@ -766,7 +773,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
             __METHOD__
         ), E_USER_DEPRECATED);
 
-        return $this->countResults();
+        return $this->nbResults;
     }
 
     /**

--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -40,6 +40,10 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     protected $lastPage = 1;
 
     /**
+     * NEXT_MAJOR: Remove this property and add a private "countResults" property.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.86
+     *
      * @var int
      */
     protected $nbResults = 0;

--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -773,7 +773,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
             __METHOD__
         ), E_USER_DEPRECATED);
 
-        return $this->nbResults;
+        return $this->getNbResults();
     }
 
     /**

--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -445,6 +445,8 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * @deprecated since sonata-project/admin-bundle 3.86, use countResults instead
      *
      * @return int
@@ -852,6 +854,8 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     }
 
     /**
+     * NEXT_MAJOR: remove this method.
+     *
      * @param int $nb
      *
      * @deprecated since sonata-project/admin-bundle 3.86

--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -222,7 +222,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      */
     public function haveToPaginate()
     {
-        return $this->getMaxPerPage() && $this->getNbResults() > $this->getMaxPerPage();
+        return $this->getMaxPerPage() && $this->countResults() > $this->getMaxPerPage();
     }
 
     /**
@@ -441,9 +441,21 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     }
 
     /**
+     * @deprecated since sonata-project/admin-bundle 3.86, use countResults instead
+     *
      * @return int
      */
     public function getNbResults()
+    {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.86 and will be removed in 4.0. Use countResults() instead.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
+        return $this->countResults();
+    }
+
+    public function countResults(): int
     {
         return $this->nbResults;
     }
@@ -739,7 +751,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle 3.84, use getNbResults instead
+     * @deprecated since sonata-project/admin-bundle 3.84, use countResults instead
      */
     public function count()
     {
@@ -748,7 +760,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
             __METHOD__
         ), E_USER_DEPRECATED);
 
-        return $this->getNbResults();
+        return $this->countResults();
     }
 
     /**
@@ -838,10 +850,17 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
     /**
      * @param int $nb
      *
+     * @deprecated since sonata-project/admin-bundle 3.86
+     *
      * @return void
      */
     protected function setNbResults($nb)
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.86 and will be removed in 4.0.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
         $this->nbResults = $nb;
     }
 

--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -226,7 +226,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      */
     public function haveToPaginate()
     {
-        // NEXT_MAJOR: remove the existence check and the else part
+        // NEXT_MAJOR: remove the existence check and just use $pager->countResults() without casting to int
         if (method_exists($this, 'countResults')) {
             $countResults = (int) $this->countResults();
         } else {

--- a/src/Datagrid/PagerInterface.php
+++ b/src/Datagrid/PagerInterface.php
@@ -26,6 +26,7 @@ namespace Sonata\AdminBundle\Datagrid;
  * @method bool                     isFirstPage()
  * @method bool                     isLastPage()
  * @method int                      getNbResults()
+ * @method int                      countResults()
  * @method array                    getLinks(?int $nbLinks = null)
  * @method bool                     haveToPaginate()
  * @method ProxyQueryInterface|null getQuery()
@@ -99,7 +100,7 @@ interface PagerInterface
     public function getResults();
 
 //    NEXT_MAJOR: uncomment this method in 4.0
-//    public function getNbResults(): int;
+//    public function countResults(): int;
 
 //    NEXT_MAJOR: uncomment this method 4.0
 //    /**

--- a/src/Datagrid/SimplePager.php
+++ b/src/Datagrid/SimplePager.php
@@ -65,6 +65,16 @@ class SimplePager extends Pager
 
     public function getNbResults()
     {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.86 and will be removed in 4.0. Use countResults() instead.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
+        return $this->countResults();
+    }
+
+    public function countResults(): int
+    {
         $n = ($this->getLastPage() - 1) * $this->getMaxPerPage();
         if ($this->getLastPage() === $this->getPage()) {
             return $n + $this->thresholdCount;

--- a/src/Datagrid/SimplePager.php
+++ b/src/Datagrid/SimplePager.php
@@ -63,6 +63,9 @@ class SimplePager extends Pager
         $this->setThreshold($threshold);
     }
 
+    /**
+     * NEXT_MAJOR: remove this method.
+     */
     public function getNbResults()
     {
         @trigger_error(sprintf(

--- a/src/Resources/views/Block/block_search_result.html.twig
+++ b/src/Resources/views/Block/block_search_result.html.twig
@@ -31,8 +31,8 @@ file that was distributed with this source code.
                 </h3>
 
                 <div class="box-tools pull-right">
-                    {% if pager and pager.getNbResults() > 0 %}
-                        <span class="badge">{{ pager.getNbResults() }}</span>
+                    {% if pager and (pager.countResults is defined ? pager.countResults() : pager.getNbResults()) > 0 %}
+                        <span class="badge">{{ pager.countResults is defined ? pager.countResults() : pager.getNbResults() }}</span>
                     {% elseif admin.hasRoute('create') and admin.hasAccess('create') %}
                         <a href="{{ admin.generateUrl('create') }}" class="btn btn-box-tool">
                             <i class="fa fa-plus" aria-hidden="true"></i>

--- a/src/Resources/views/Block/block_search_result.html.twig
+++ b/src/Resources/views/Block/block_search_result.html.twig
@@ -31,8 +31,10 @@ file that was distributed with this source code.
                 </h3>
 
                 <div class="box-tools pull-right">
-                    {% if pager and (pager.countResults is defined ? pager.countResults() : pager.getNbResults()) > 0 %}
-                        <span class="badge">{{ pager.countResults is defined ? pager.countResults() : pager.getNbResults() }}</span>
+                    {# NEXT_MAJOR: remove the attribute check and just use .countResults() #}
+                    {% if pager and (attribute(pager, 'countResults') is defined ? pager.countResults() : pager.getNbResults()) > 0 %}
+                        {# NEXT_MAJOR: remove the attribute check and just use .countResults() #}
+                        <span class="badge">{{ (attribute(pager, 'countResults') is defined ? pager.countResults() : pager.getNbResults()) }}</span>
                     {% elseif admin.hasRoute('create') and admin.hasAccess('create') %}
                         <a href="{{ admin.generateUrl('create') }}" class="btn btn-box-tool">
                             <i class="fa fa-plus" aria-hidden="true"></i>

--- a/src/Resources/views/Block/block_stats.html.twig
+++ b/src/Resources/views/Block/block_stats.html.twig
@@ -17,10 +17,12 @@ file that was distributed with this source code.
     <!-- small box -->
     <div class="small-box {{ settings.color }}">
         <div class="inner">
-            <h3>{{ pager.countResults is defined ? pager.countResults() : pager.getNbResults() }}</h3>
+            {# NEXT_MAJOR: remove the attribute check and just use .countResults() #}
+            <h3>{{ attribute(pager, 'countResults') is defined ? pager.countResults() : pager.getNbResults() }}</h3>
             <p>
                 {% if translation_domain %}
-                    {{ settings.text|trans({'%count%': pager.countResults is defined ? pager.countResults() : pager.getNbResults()}, translation_domain) }}
+                    {# NEXT_MAJOR: remove the attribute check and just use .countResults() #}
+                    {{ settings.text|trans({'%count%': attribute(pager, 'countResults') is defined ? pager.countResults() : pager.getNbResults()}, translation_domain) }}
                 {% else %}
                     {{ settings.text }}
                 {% endif %}

--- a/src/Resources/views/Block/block_stats.html.twig
+++ b/src/Resources/views/Block/block_stats.html.twig
@@ -17,10 +17,10 @@ file that was distributed with this source code.
     <!-- small box -->
     <div class="small-box {{ settings.color }}">
         <div class="inner">
-            <h3>{{ pager.getNbResults() }}</h3>
+            <h3>{{ pager.countResults is defined ? pager.countResults() : pager.getNbResults() }}</h3>
             <p>
                 {% if translation_domain %}
-                    {{ settings.text|trans({'%count%': pager.getNbResults()}, translation_domain) }}
+                    {{ settings.text|trans({'%count%': pager.countResults is defined ? pager.countResults() : pager.getNbResults()}, translation_domain) }}
                 {% else %}
                     {{ settings.text }}
                 {% endif %}

--- a/tests/App/Datagrid/Pager.php
+++ b/tests/App/Datagrid/Pager.php
@@ -100,7 +100,9 @@ final class Pager implements PagerInterface
         return $this->repository->all();
     }
 
-    // NEXT_MAJOR: remove this method
+    /**
+     * NEXT_MAJOR: remove this method.
+     */
     public function getNbResults(): int
     {
         return $this->countResults();

--- a/tests/App/Datagrid/Pager.php
+++ b/tests/App/Datagrid/Pager.php
@@ -100,7 +100,7 @@ final class Pager implements PagerInterface
         return $this->repository->all();
     }
 
-    public function getNbResults()
+    public function countResults(): int
     {
         return \count($this->getResults());
     }

--- a/tests/App/Datagrid/Pager.php
+++ b/tests/App/Datagrid/Pager.php
@@ -100,6 +100,12 @@ final class Pager implements PagerInterface
         return $this->repository->all();
     }
 
+    // NEXT_MAJOR: remove this method
+    public function getNbResults(): int
+    {
+        return $this->countResults();
+    }
+
     public function countResults(): int
     {
         return \count($this->getResults());

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -136,11 +136,14 @@ class PagerTest extends TestCase
         $this->assertSame(99, $this->pager->getMaxRecordLimit());
     }
 
+    /**
+     * @group legacy
+     */
     public function testGetNbResults(): void
     {
         $this->assertSame(0, $this->pager->getNbResults());
 
-        $this->callMethod($this->pager, 'setNbResults', [100]);
+        $this->setProperty($this->pager, 'nbResults', 100);
 
         $this->assertSame(100, $this->pager->getNbResults());
     }
@@ -155,7 +158,7 @@ class PagerTest extends TestCase
         $this->expectDeprecation('The method "Sonata\AdminBundle\Datagrid\Pager::count()" is deprecated since sonata-project/admin-bundle 3.84 and will be removed in 4.0.');
         $this->assertSame(0, $this->pager->count());
 
-        $this->callMethod($this->pager, 'setNbResults', [100]);
+        $this->setProperty($this->pager, 'nbResults', 100);
 
         $this->assertSame(100, $this->pager->count());
     }
@@ -293,7 +296,7 @@ class PagerTest extends TestCase
         $this->pager->setMaxPerPage(10);
         $this->assertFalse($this->pager->haveToPaginate());
 
-        $this->callMethod($this->pager, 'setNbResults', [100]);
+        $this->setProperty($this->pager, 'nbResults', 100);
         $this->assertTrue($this->pager->haveToPaginate());
     }
 
@@ -417,7 +420,7 @@ class PagerTest extends TestCase
         $this->pager->setCursor(300);
         $this->assertSame(0, $this->pager->getCursor());
 
-        $this->callMethod($this->pager, 'setNbResults', [100]);
+        $this->setProperty($this->pager, 'nbResults', 100);
 
         $this->pager->setCursor(5);
         $this->assertSame(5, $this->pager->getCursor());
@@ -442,7 +445,7 @@ class PagerTest extends TestCase
         $object3 = new \stdClass();
         $object3->foo = 'bar3';
 
-        $this->callMethod($this->pager, 'setNbResults', [3]);
+        $this->setProperty($this->pager, 'nbResults', 3);
 
         $query = $this->createMock(ProxyQueryInterface::class);
 
@@ -557,7 +560,7 @@ class PagerTest extends TestCase
         $this->pager->setPage(0);
         $this->assertSame(0, $this->pager->getLastIndex());
 
-        $this->callMethod($this->pager, 'setNbResults', [100]);
+        $this->setProperty($this->pager, 'nbResults', 100);
 
         $this->assertSame(100, $this->pager->getLastIndex());
 
@@ -590,7 +593,7 @@ class PagerTest extends TestCase
         $object3 = new \stdClass();
         $object3->foo = 'bar3';
 
-        $this->callMethod($this->pager, 'setNbResults', [3]);
+        $this->setProperty($this->pager, 'nbResults', 3);
 
         $query = $this->createMock(ProxyQueryInterface::class);
 
@@ -654,7 +657,7 @@ class PagerTest extends TestCase
         $object3 = new \stdClass();
         $object3->foo = 'bar3';
 
-        $this->callMethod($this->pager, 'setNbResults', [3]);
+        $this->setProperty($this->pager, 'nbResults', 3);
 
         $query = $this->createMock(ProxyQueryInterface::class);
 
@@ -769,5 +772,13 @@ class PagerTest extends TestCase
         $method->setAccessible(true);
 
         return $method->invokeArgs($obj, $args);
+    }
+
+    private function setProperty(object $obj, string $name, $value)
+    {
+        $class = new \ReflectionClass($obj);
+        $property = $class->getProperty($name);
+        $property->setAccessible(true);
+        $property->setValue($obj, $value);
     }
 }

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -308,9 +308,7 @@ class PagerTest extends TestCase
 
         $this->pager->expects($this->once())
             ->method('countResults')
-            ->willReturnCallback(static function () {
-                return 100;
-            })
+            ->willReturn(100)
         ;
 
         $this->assertTrue($this->pager->haveToPaginate());

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -137,7 +137,7 @@ class PagerTest extends TestCase
     }
 
     /**
-     * NEXT_MAJOR: Remove this test.
+     * NEXT_MAJOR: Remove this test and the setProperty method.
      *
      * @group legacy
      */
@@ -291,6 +291,11 @@ class PagerTest extends TestCase
         $this->assertSame([45, 46, 47, 48, 49, 50], $this->pager->getLinks());
     }
 
+    /**
+     * NEXT_MAJOR: remove legacy group.
+     *
+     * @group legacy
+     */
     public function testHaveToPaginate(): void
     {
         $this->assertFalse($this->pager->haveToPaginate());

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -137,6 +137,8 @@ class PagerTest extends TestCase
     }
 
     /**
+     * NEXT_MAJOR: Remove this test.
+     *
      * @group legacy
      */
     public function testGetNbResults(): void

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -791,7 +791,7 @@ class PagerTest extends TestCase
     /**
      * NEXT_MAJOR: remove this method.
      */
-    private function setProperty(object $obj, string $name, $value)
+    private function setProperty(object $obj, string $name, $value): void
     {
         $class = new \ReflectionClass($obj);
         $property = $class->getProperty($name);

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -137,7 +137,7 @@ class PagerTest extends TestCase
     }
 
     /**
-     * NEXT_MAJOR: Remove this test and the setProperty method.
+     * NEXT_MAJOR: Remove this test.
      *
      * @group legacy
      */
@@ -781,6 +781,9 @@ class PagerTest extends TestCase
         return $method->invokeArgs($obj, $args);
     }
 
+    /**
+     * NEXT_MAJOR: remove this method.
+     */
     private function setProperty(object $obj, string $name, $value)
     {
         $class = new \ReflectionClass($obj);

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -32,7 +32,15 @@ class PagerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->pager = $this->getMockForAbstractClass(Pager::class);
+        $this->pager = $this->getMockForAbstractClass(
+            Pager::class,
+            [],
+            '',
+            true,
+            true,
+            true,
+            ['countResults']
+        );
     }
 
     /**
@@ -291,11 +299,6 @@ class PagerTest extends TestCase
         $this->assertSame([45, 46, 47, 48, 49, 50], $this->pager->getLinks());
     }
 
-    /**
-     * NEXT_MAJOR: remove legacy group.
-     *
-     * @group legacy
-     */
     public function testHaveToPaginate(): void
     {
         $this->assertFalse($this->pager->haveToPaginate());
@@ -303,7 +306,13 @@ class PagerTest extends TestCase
         $this->pager->setMaxPerPage(10);
         $this->assertFalse($this->pager->haveToPaginate());
 
-        $this->setProperty($this->pager, 'nbResults', 100);
+        $this->pager->expects($this->once())
+            ->method('countResults')
+            ->willReturnCallback(static function () {
+                return 100;
+            })
+        ;
+
         $this->assertTrue($this->pager->haveToPaginate());
     }
 

--- a/tests/Datagrid/SimplePagerTest.php
+++ b/tests/Datagrid/SimplePagerTest.php
@@ -115,7 +115,7 @@ class SimplePagerTest extends TestCase
         $this->pager->setQuery($this->proxyQuery);
         $this->pager->init();
         $this->assertSame(1, $this->pager->getLastPage());
-        $this->assertSame(0, $this->pager->getNbResults());
+        $this->assertSame(0, $this->pager->countResults());
     }
 
     public function testInitNoQuery(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6710

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `PagerInterface::countResults`

### Deprecated
- `PagerInterface::getNbResults()` in favour of `countResults()`
- `PagerInterface::setNbResults(...)`
- `PagerInterface::$nbResults`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
