### PR TITLE
Inject a ServiceLocator to Pool instead of container

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "doctrine/persistence": "^1.3.6 || ^2.0",
         "knplabs/knp-menu": "^3.1",
         "knplabs/knp-menu-bundle": "^3.0",
+        "psr/container": "^1.0",
         "sonata-project/block-bundle": "^4.0",
         "sonata-project/doctrine-extensions": "^1.8",
         "sonata-project/exporter": "^2.1",

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -13,8 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Admin;
 
+use Psr\Container\ContainerInterface;
 use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @psalm-type Group = array{

--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -48,7 +48,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set('sonata.admin.pool', Pool::class)
             ->public()
             ->args([
-                new ReferenceConfigurator('service_container'),
+                null, // admin service locator
             ])
 
         ->alias(Pool::class, 'sonata.admin.pool')


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

The ServiceLocator will only have admin services and there is no need to make admin services public anymore.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6624.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Admin services are not made public anymore.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
