### PR TITLE
Deprecate DateOperatorType::TYPE_NULL and TYPE_NOT_NULL

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,10 @@ UPGRADE 3.x
 UPGRADE FROM 3.xx to 3.xx
 =========================
 
+### Deprecated `DateOperatorType::TYPE_NULL` and `DateOperatorType::TYPE_NOT_NULL`
+
+We recommend using a specific filter for null values instead.
+
 ### Sonata\AdminBundle\Twig\Extension\SonataAdminExtension
 
 - Deprecated `SonataAdminExtension::MOMENT_UNSUPPORTED_LOCALES` constant.

--- a/src/Form/Type/Operator/DateOperatorType.php
+++ b/src/Form/Type/Operator/DateOperatorType.php
@@ -25,7 +25,13 @@ final class DateOperatorType extends AbstractType
     public const TYPE_EQUAL = 3;
     public const TYPE_LESS_EQUAL = 4;
     public const TYPE_LESS_THAN = 5;
+    /**
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0
+     */
     public const TYPE_NULL = 6;
+    /**
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed with 4.0
+     */
     public const TYPE_NOT_NULL = 7;
 
     /**
@@ -41,6 +47,7 @@ final class DateOperatorType extends AbstractType
                 'label_date_type_greater_than' => self::TYPE_GREATER_THAN,
                 'label_date_type_less_equal' => self::TYPE_LESS_EQUAL,
                 'label_date_type_less_than' => self::TYPE_LESS_THAN,
+                // NEXT_MAJOR: Remove the two following lines and remove all the translations.
                 'label_date_type_null' => self::TYPE_NULL,
                 'label_date_type_not_null' => self::TYPE_NOT_NULL,
             ],


### PR DESCRIPTION
## Subject

I recommend deprecating these two constants. 
The UX is weird because you can still provide a value when you selected these types.
I recommend instead using a specific filter for null values like the `NullFilter` of DoctrineORMAdminBundle.

I am targeting this branch, because BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecate `DateOperatorType::TYPE_NULL` and `DateOperatorType::TYPE_NOT_NULL`
```

