### PR TITLE
Make Pool immutable

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -20,6 +20,15 @@ They have been moved to `Sonata\AdminBundle\Admin\FieldDescriptionInterface`.
 
 Deprecated `configure()` method for configuring the associated admin, you MUST call `configureAdmin()` method instead.
 
+### Sonata\AdminBundle\Admin\Pool
+
+- `Sonata\AdminBundle\Admin\Pool::setAdminServiceIds()` method has been deprecated. You MUST pass service ids as
+  argument 2 to the constructor.
+- `Sonata\AdminBundle\Admin\Pool::setAdminGroups()` method has been deprecated. You MUST pass admin groups as
+  argument 3 to the constructor.
+- `Sonata\AdminBundle\Admin\Pool::setAdminClasses()` method has been deprecated. You MUST pass admin classes as
+  argument 4 to the constructor.
+
 UPGRADE FROM 3.83 to 3.84
 =========================
 

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -125,23 +125,61 @@ class Pool
 
     /**
      * NEXT_MAJOR: Remove $propertyAccessor argument.
-     * NEXT_MAJOR: Remove $title, $logoTitle and $options.
+     * NEXT_MAJOR: Rename $titleOrAdminServiceIds to $adminServices, $logoTitleOrAdminGroups to $adminGroups and
+     * $optionsOrAdminClasses to $adminClasses and add "array" type declaration.
      *
-     * @param string $title
-     * @param string $logoTitle
-     * @param array  $options
+     * @param string|array $titleOrAdminServiceIds
+     * @param string|array $logoTitleOrAdminGroups
+     * @param array        $optionsOrAdminClasses
      */
     public function __construct(
         ContainerInterface $container,
-        $title,
-        $logoTitle,
-        $options = [],
+        $titleOrAdminServiceIds = [],
+        $logoTitleOrAdminGroups = [],
+        $optionsOrAdminClasses = [],
         ?PropertyAccessorInterface $propertyAccessor = null
     ) {
         $this->container = $container;
-        $this->title = $title;
-        $this->titleLogo = $logoTitle;
-        $this->options = $options;
+
+        // NEXT_MAJOR: Uncomment the following lines
+        // $this->adminServiceIds = $titleOrAdminServiceIds;
+        // $this->adminGroups = $logoTitleOrAdminGroups;
+        // $this->adminClasses = $optionsOrAdminClasses;
+
+        // NEXT_MAJOR: Remove this block.
+        if (\is_array($titleOrAdminServiceIds)) {
+            $this->adminServiceIds = $titleOrAdminServiceIds;
+        } else {
+            @trigger_error(sprintf(
+                'Passing other type than array as argument 2 to "%s()" is deprecated since'
+                .' sonata-project/admin-bundle 3.x and will throw "%s" exception in 4.0.',
+                __METHOD__,
+                \TypeError::class
+            ), E_USER_DEPRECATED);
+
+            $this->title = $titleOrAdminServiceIds;
+        }
+
+        // NEXT_MAJOR: Remove this block.
+        if (\is_array($logoTitleOrAdminGroups)) {
+            $this->adminGroups = $logoTitleOrAdminGroups;
+        } else {
+            @trigger_error(sprintf(
+                'Passing other type than array as argument 3 to "%s()" is deprecated since'
+                .' sonata-project/admin-bundle 3.x and will throw "%s" exception in 4.0.',
+                __METHOD__,
+                \TypeError::class
+            ), E_USER_DEPRECATED);
+
+            $this->titleLogo = $logoTitleOrAdminGroups;
+        }
+
+        // NEXT_MAJOR: Remove this block.
+        if (\is_array($titleOrAdminServiceIds) && \is_array($logoTitleOrAdminGroups)) {
+            $this->adminClasses = $optionsOrAdminClasses;
+        } else {
+            $this->options = $optionsOrAdminClasses;
+        }
 
         // NEXT_MAJOR: Remove this block.
         if (null !== $propertyAccessor) {
@@ -154,6 +192,18 @@ class Pool
 
         // NEXT_MAJOR: Remove next line.
         $this->propertyAccessor = $propertyAccessor;
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @internal
+     */
+    public function setDeprecatedPropertiesForBC(string $title, string $titleLogo, array $options): void
+    {
+        $this->title = $title;
+        $this->titleLogo = $titleLogo;
+        $this->options = $options;
     }
 
     /**
@@ -506,6 +556,11 @@ class Pool
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, will be dropped in 4.0. Pass $adminGroups as argument 3
+     * to the __construct method instead.
+     *
      * @phpstan-param array<string, array<string, mixed>> $adminGroups
      * @psalm-param array<string, Group> $adminGroups
      *
@@ -513,6 +568,13 @@ class Pool
      */
     public function setAdminGroups(array $adminGroups)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
+            @trigger_error(sprintf(
+                'Method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         $this->adminGroups = $adminGroups;
     }
 
@@ -525,10 +587,22 @@ class Pool
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, will be dropped in 4.0. Pass $adminGroups as argument 2
+     * to the __construct method instead.
+     *
      * @return void
      */
     public function setAdminServiceIds(array $adminServiceIds)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
+            @trigger_error(sprintf(
+                'Method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         $this->adminServiceIds = $adminServiceIds;
     }
 
@@ -541,6 +615,11 @@ class Pool
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, will be dropped in 4.0. Pass $adminGroups as argument 4
+     * to the __construct method instead.
+     *
      * @param array<string, string[]> $adminClasses
      *
      * @phpstan-param array<class-string, string[]> $adminClasses
@@ -549,6 +628,13 @@ class Pool
      */
     public function setAdminClasses(array $adminClasses)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
+            @trigger_error(sprintf(
+                'Method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.',
+                __METHOD__
+            ), E_USER_DEPRECATED);
+        }
+
         $this->adminClasses = $adminClasses;
     }
 

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -209,9 +209,14 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
             $groups = $groupDefaults;
         }
 
-        $pool->addMethodCall('setAdminServiceIds', [$admins]);
-        $pool->addMethodCall('setAdminGroups', [$groups]);
-        $pool->addMethodCall('setAdminClasses', [$classes]);
+        // NEXT_MAJOR: Remove the following 3 lines
+        $pool->addMethodCall('setAdminServiceIds', [$admins, 'sonata_deprecation_mute']);
+        $pool->addMethodCall('setAdminGroups', [$groups, 'sonata_deprecation_mute']);
+        $pool->addMethodCall('setAdminClasses', [$classes, 'sonata_deprecation_mute']);
+
+        $pool->replaceArgument(1, [$admins]);
+        $pool->replaceArgument(2, [$groups]);
+        $pool->replaceArgument(3, [$classes]);
 
         $routeLoader = $container->getDefinition('sonata.admin.route_loader');
         $routeLoader->replaceArgument(1, $admins);

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -97,6 +97,11 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         $pool->replaceArgument(1, $config['title']);
         $pool->replaceArgument(2, $config['title_logo']);
         $pool->replaceArgument(3, $config['options']);
+        $pool->addMethodCall('setDeprecatedPropertiesForBC', [
+            $config['title'],
+            $config['title_logo'],
+            $config['options'],
+        ]);
 
         $sonataConfiguration = $container->getDefinition('sonata.admin.configuration');
         $sonataConfiguration->replaceArgument(0, $config['title']);

--- a/tests/Action/AppendFormFieldElementActionTest.php
+++ b/tests/Action/AppendFormFieldElementActionTest.php
@@ -21,6 +21,7 @@ use Sonata\AdminBundle\Admin\AdminHelper;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
@@ -58,10 +59,11 @@ final class AppendFormFieldElementActionTest extends TestCase
     protected function setUp(): void
     {
         $this->twig = $this->createStub(Environment::class);
-        $this->pool = $this->createStub(Pool::class);
         $this->admin = $this->createMock(AbstractAdmin::class);
-        $this->pool->method('getInstance')->willReturn($this->admin);
         $this->admin->expects($this->once())->method('setRequest');
+        $container = new Container();
+        $container->set('sonata.post.admin', $this->admin);
+        $this->pool = new Pool($container, ['sonata.post.admin']);
         $this->helper = $this->createStub(AdminHelper::class);
         $this->action = new AppendFormFieldElementAction(
             $this->twig,

--- a/tests/Action/DashboardActionTest.php
+++ b/tests/Action/DashboardActionTest.php
@@ -41,7 +41,7 @@ class DashboardActionTest extends TestCase
 
         $this->templateRegistry = $this->createStub(MutableTemplateRegistryInterface::class);
 
-        $pool = new Pool($container, 'title', 'logo.png');
+        $pool = new Pool($container);
         $pool->setTemplateRegistry($this->templateRegistry);
 
         $twig = $this->createMock(Environment::class);

--- a/tests/Action/RetrieveAutocompleteItemsActionTest.php
+++ b/tests/Action/RetrieveAutocompleteItemsActionTest.php
@@ -24,6 +24,7 @@ use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Datagrid\Pager;
 use Sonata\AdminBundle\Object\MetadataInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Filter\FooFilter;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormConfigInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -51,8 +52,9 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
     {
         $this->admin = $this->createMock(AbstractAdmin::class);
         $this->admin->expects($this->once())->method('setRequest');
-        $this->pool = $this->createStub(Pool::class);
-        $this->pool->method('getInstance')->willReturn($this->admin);
+        $container = new Container();
+        $container->set('foo.admin', $this->admin);
+        $this->pool = new Pool($container, ['foo.admin']);
         $this->action = new RetrieveAutocompleteItemsAction($this->pool);
     }
 

--- a/tests/Action/RetrieveFormFieldElementActionTest.php
+++ b/tests/Action/RetrieveFormFieldElementActionTest.php
@@ -20,6 +20,7 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminHelper;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormRenderer;
@@ -60,8 +61,9 @@ final class RetrieveFormFieldElementActionTest extends TestCase
         $this->twig = $this->createStub(Environment::class);
         $this->admin = $this->createMock(AbstractAdmin::class);
         $this->admin->expects($this->once())->method('setRequest');
-        $this->pool = $this->createStub(Pool::class);
-        $this->pool->method('getInstance')->willReturn($this->admin);
+        $container = new Container();
+        $container->set('sonata.post.admin', $this->admin);
+        $this->pool = new Pool($container, ['sonata.post.admin']);
         $this->helper = $this->createStub(AdminHelper::class);
         $this->action = new RetrieveFormFieldElementAction(
             $this->twig,

--- a/tests/Action/SearchActionTest.php
+++ b/tests/Action/SearchActionTest.php
@@ -62,8 +62,8 @@ final class SearchActionTest extends TestCase
     protected function setUp(): void
     {
         $this->container = new Container();
+        $this->pool = new Pool($this->container, ['foo']);
 
-        $this->pool = new Pool($this->container, 'title', 'logo.png');
         $templateRegistry = new TemplateRegistry([
             'search' => 'search.html.twig',
             'layout' => 'layout.html.twig',
@@ -104,7 +104,6 @@ final class SearchActionTest extends TestCase
         $this->searchHandler->configureAdminSearch([$adminCode => false]);
         $admin = new CleanAdmin($adminCode, 'class', 'controller');
         $this->container->set('foo', $admin);
-        $this->pool->setAdminServiceIds(['foo']);
         $request = new Request(['admin' => 'foo']);
         $request->headers->set('X-Requested-With', 'XMLHttpRequest');
 

--- a/tests/Action/SetObjectFieldValueActionTest.php
+++ b/tests/Action/SetObjectFieldValueActionTest.php
@@ -77,15 +77,22 @@ final class SetObjectFieldValueActionTest extends TestCase
      */
     private $propertyAccessor;
 
+    /**
+     * @var string
+     */
+    private $adminCode;
+
     protected function setUp(): void
     {
         $this->twig = new Environment(new ArrayLoader([
             'admin_template' => 'renderedTemplate',
             'field_template' => 'renderedTemplate',
         ]));
-        $this->pool = $this->createStub(Pool::class);
+        $this->adminCode = 'sonata.post.admin';
         $this->admin = $this->createMock(AbstractAdmin::class);
-        $this->pool->method('getInstance')->willReturn($this->admin);
+        $container = new Container();
+        $container->set($this->adminCode, $this->admin);
+        $this->pool = new Pool($container, [$this->adminCode]);
         $this->admin->expects($this->once())->method('setRequest');
         $this->validator = $this->createStub(ValidatorInterface::class);
         $this->modelManager = $this->createStub(ModelManagerInterface::class);
@@ -105,7 +112,7 @@ final class SetObjectFieldValueActionTest extends TestCase
     {
         $object = new Foo();
         $request = new Request([
-            'code' => 'sonata.post.admin',
+            'code' => $this->adminCode,
             'objectId' => 42,
             'field' => 'enabled',
             'value' => 1,
@@ -113,13 +120,12 @@ final class SetObjectFieldValueActionTest extends TestCase
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
-        $pool = $this->createStub(Pool::class);
         $translator = $this->createStub(TranslatorInterface::class);
         $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
         $container = new Container();
 
         $this->admin->method('getObject')->with(42)->willReturn($object);
-        $this->admin->method('getCode')->willReturn('sonata.post.admin');
+        $this->admin->method('getCode')->willReturn($this->adminCode);
         $this->admin->method('hasAccess')->with('edit', $object)->willReturn(true);
         $this->admin->method('getListFieldDescription')->with('enabled')->willReturn($fieldDescription);
         $this->admin->expects($this->once())->method('update')->with($object);
@@ -128,7 +134,7 @@ final class SetObjectFieldValueActionTest extends TestCase
         $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $container->set('sonata.post.admin.template_registry', $templateRegistry);
         $this->twig->addExtension(new SonataAdminExtension(
-            $pool,
+            new Pool(new Container()),
             null,
             $translator,
             $container,
@@ -172,7 +178,7 @@ final class SetObjectFieldValueActionTest extends TestCase
     {
         $object = new Bafoo();
         $request = new Request([
-            'code' => 'sonata.post.admin',
+            'code' => $this->adminCode,
             'objectId' => 42,
             'field' => 'dateProp',
             'value' => '2020-12-12',
@@ -180,13 +186,12 @@ final class SetObjectFieldValueActionTest extends TestCase
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
-        $pool = $this->createStub(Pool::class);
         $translator = $this->createStub(TranslatorInterface::class);
         $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
         $container = new Container();
 
         $this->admin->method('getObject')->with(42)->willReturn($object);
-        $this->admin->method('getCode')->willReturn('sonata.post.admin');
+        $this->admin->method('getCode')->willReturn($this->adminCode);
         $this->admin->method('hasAccess')->with('edit', $object)->willReturn(true);
         $this->admin->method('getListFieldDescription')->with('dateProp')->willReturn($fieldDescription);
         $this->admin->expects($this->once())->method('update')->with($object);
@@ -195,7 +200,7 @@ final class SetObjectFieldValueActionTest extends TestCase
         $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $container->set('sonata.post.admin.template_registry', $templateRegistry);
         $this->twig->addExtension(new SonataAdminExtension(
-            $pool,
+            new Pool(new Container()),
             null,
             $translator,
             $container,
@@ -231,7 +236,7 @@ final class SetObjectFieldValueActionTest extends TestCase
         $object = new Baz();
         $associationObject = new Bar();
         $request = new Request([
-            'code' => 'sonata.post.admin',
+            'code' => $this->adminCode,
             'objectId' => 42,
             'field' => 'bar',
             'value' => 1,
@@ -247,7 +252,7 @@ final class SetObjectFieldValueActionTest extends TestCase
         $container = new Container();
 
         $this->admin->method('getObject')->with(42)->willReturn($object);
-        $this->admin->method('getCode')->willReturn('sonata.post.admin');
+        $this->admin->method('getCode')->willReturn($this->adminCode);
         $this->admin->method('hasAccess')->with('edit', $object)->willReturn(true);
         $this->admin->method('getListFieldDescription')->with('bar')->willReturn($fieldDescription);
         $this->admin->method('getClass')->willReturn(\get_class($object));
@@ -290,7 +295,7 @@ final class SetObjectFieldValueActionTest extends TestCase
         $object = new Baz();
         $object->setBar($bar);
         $request = new Request([
-            'code' => 'sonata.post.admin',
+            'code' => $this->adminCode,
             'objectId' => 42,
             'field' => 'bar.enabled',
             'value' => 1,
@@ -322,7 +327,7 @@ final class SetObjectFieldValueActionTest extends TestCase
     {
         $object = new StatusMultiple();
         $request = new Request([
-            'code' => 'sonata.post.admin',
+            'code' => $this->adminCode,
             'objectId' => 42,
             'field' => 'status',
             'value' => [1, 2],
@@ -330,13 +335,12 @@ final class SetObjectFieldValueActionTest extends TestCase
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
-        $pool = $this->createStub(Pool::class);
         $translator = $this->createStub(TranslatorInterface::class);
         $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
         $container = new Container();
 
         $this->admin->method('getObject')->with(42)->willReturn($object);
-        $this->admin->method('getCode')->willReturn('sonata.post.admin');
+        $this->admin->method('getCode')->willReturn($this->adminCode);
         $this->admin->method('hasAccess')->with('edit', $object)->willReturn(true);
         $this->admin->method('getListFieldDescription')->with('status')->willReturn($fieldDescription);
         $this->admin->expects($this->once())->method('update')->with($object);
@@ -345,7 +349,7 @@ final class SetObjectFieldValueActionTest extends TestCase
         $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $container->set('sonata.post.admin.template_registry', $templateRegistry);
         $this->twig->addExtension(new SonataAdminExtension(
-            $pool,
+            new Pool(new Container()),
             null,
             $translator,
             $container,
@@ -374,7 +378,7 @@ final class SetObjectFieldValueActionTest extends TestCase
     {
         $object = new Foo();
         $request = new Request([
-            'code' => 'sonata.post.admin',
+            'code' => $this->adminCode,
             'objectId' => 42,
             'field' => 'enabled',
             'value' => 'yes',
@@ -388,13 +392,12 @@ final class SetObjectFieldValueActionTest extends TestCase
         });
 
         $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
-        $pool = $this->createStub(Pool::class);
         $translator = $this->createStub(TranslatorInterface::class);
         $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
         $container = new Container();
 
         $this->admin->method('getObject')->with(42)->willReturn($object);
-        $this->admin->method('getCode')->willReturn('sonata.post.admin');
+        $this->admin->method('getCode')->willReturn($this->adminCode);
         $this->admin->method('hasAccess')->with('edit', $object)->willReturn(true);
         $this->admin->method('getListFieldDescription')->with('enabled')->willReturn($fieldDescription);
         $this->admin->expects($this->once())->method('update')->with($object);
@@ -403,7 +406,7 @@ final class SetObjectFieldValueActionTest extends TestCase
         $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $container->set('sonata.post.admin.template_registry', $templateRegistry);
         $this->twig->addExtension(new SonataAdminExtension(
-            $pool,
+            new Pool(new Container()),
             null,
             $translator,
             $container,
@@ -431,7 +434,7 @@ final class SetObjectFieldValueActionTest extends TestCase
     {
         $object = new Foo();
         $request = new Request([
-            'code' => 'sonata.post.admin',
+            'code' => $this->adminCode,
             'objectId' => 42,
             'field' => 'enabled',
             'value' => 'yes',
@@ -448,13 +451,12 @@ final class SetObjectFieldValueActionTest extends TestCase
         });
 
         $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
-        $pool = $this->createStub(Pool::class);
         $translator = $this->createStub(TranslatorInterface::class);
         $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
         $container = new Container();
 
         $this->admin->method('getObject')->with(42)->willReturn($object);
-        $this->admin->method('getCode')->willReturn('sonata.post.admin');
+        $this->admin->method('getCode')->willReturn($this->adminCode);
         $this->admin->method('hasAccess')->with('edit', $object)->willReturn(true);
         $this->admin->method('getListFieldDescription')->with('enabled')->willReturn($fieldDescription);
         $this->admin->expects($this->once())->method('update')->with($object);
@@ -463,7 +465,7 @@ final class SetObjectFieldValueActionTest extends TestCase
         $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $container->set('sonata.post.admin.template_registry', $templateRegistry);
         $this->twig->addExtension(new SonataAdminExtension(
-            $pool,
+            new Pool(new Container()),
             null,
             $translator,
             $container,

--- a/tests/Admin/AdminHelperTest.php
+++ b/tests/Admin/AdminHelperTest.php
@@ -61,7 +61,7 @@ class AdminHelperTest extends TestCase
      */
     public function testDeprecatedConstructingWithoutPropertyAccessor(): void
     {
-        $pool = new Pool(new Container(), 'title', 'logo.png');
+        $pool = new Pool(new Container());
 
         $this->expectDeprecation(sprintf(
             'Passing an instance of "%s" as argument 1 for "%s::__construct()" is deprecated since'

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -555,7 +555,7 @@ class AdminTest extends TestCase
         );
 
         $container = new Container();
-        $pool = new Pool($container, 'Sonata Admin', '/path/to/pic.png');
+        $pool = new Pool($container);
 
         $pathInfo = new PathInfoBuilder($this->createMock(AuditManagerInterface::class));
         $postAdmin = new PostAdmin('sonata.post.admin.post', $objFqn, 'Sonata\NewsBundle\Controller\PostAdminController');

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -83,7 +83,6 @@ use Symfony\Component\Form\FormRegistry;
 use Symfony\Component\Form\ResolvedFormTypeFactory;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -1062,9 +1061,7 @@ class AdminTest extends TestCase
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
-        $pool = $this->getMockBuilder(Pool::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $pool = new Pool(new Container());
 
         $admin->setConfigurationPool($pool);
         $this->assertSame($pool, $admin->getConfigurationPool());
@@ -1614,14 +1611,6 @@ class AdminTest extends TestCase
         $request = $this->createStub(Request::class);
         $tagAdmin->setRequest($request);
 
-        $configurationPool = $this->getMockBuilder(Pool::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $configurationPool->method('getPropertyAccessor')->willReturn(PropertyAccess::createPropertyAccessor());
-
-        $tagAdmin->setConfigurationPool($configurationPool);
-
         $tag = $tagAdmin->getNewInstance();
 
         $this->assertSame($post, $tag->getPost());
@@ -1649,14 +1638,6 @@ class AdminTest extends TestCase
 
         $request = $this->createStub(Request::class);
         $postCategoryAdmin->setRequest($request);
-
-        $configurationPool = $this->getMockBuilder(Pool::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $configurationPool->method('getPropertyAccessor')->willReturn(PropertyAccess::createPropertyAccessor());
-
-        $postCategoryAdmin->setConfigurationPool($configurationPool);
 
         $postCategory = $postCategoryAdmin->getNewInstance();
 
@@ -1692,14 +1673,6 @@ class AdminTest extends TestCase
 
         $request = $this->createStub(Request::class);
         $tagAdmin->setRequest($request);
-
-        $configurationPool = $this->getMockBuilder(Pool::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $configurationPool->method('getPropertyAccessor')->willReturn(PropertyAccess::createPropertyAccessor());
-
-        $tagAdmin->setConfigurationPool($configurationPool);
 
         $tag = $tagAdmin->getNewInstance();
 

--- a/tests/Admin/BreadcrumbsBuilderTest.php
+++ b/tests/Admin/BreadcrumbsBuilderTest.php
@@ -53,9 +53,7 @@ class BreadcrumbsBuilderTest extends TestCase
         $modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
         $routeGenerator = $this->getMockForAbstractClass(RouteGeneratorInterface::class);
         $container = new Container();
-        $pool = $this->getMockBuilder(Pool::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $pool = new Pool($container);
 
         $menu
             ->method('addChild')
@@ -79,10 +77,6 @@ class BreadcrumbsBuilderTest extends TestCase
         $commentAdmin->setCurrentChild(true);
 
         $container->setParameter('sonata.admin.configuration.breadcrumbs', []);
-
-        $pool
-            ->method('getContainer')
-            ->willReturn($container);
 
         $postAdmin->setConfigurationPool($pool);
         $postAdmin->setMenuFactory($menuFactory);
@@ -218,9 +212,7 @@ class BreadcrumbsBuilderTest extends TestCase
         $routeGenerator = $this->getMockForAbstractClass(RouteGeneratorInterface::class);
         $modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
         $container = new Container();
-        $pool = $this->getMockBuilder(Pool::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $pool = new Pool($container);
 
         $postAdmin = new PostAdmin('sonata.post.admin.post', DummySubject::class, 'Sonata\NewsBundle\Controller\PostAdminController');
         $commentAdmin = new CommentAdmin('sonata.post.admin.comment', Comment::class, 'Sonata\NewsBundle\Controller\CommentAdminController');
@@ -271,10 +263,6 @@ class BreadcrumbsBuilderTest extends TestCase
             ->willReturn($menu);
 
         $container->setParameter('sonata.admin.configuration.breadcrumbs', []);
-
-        $pool
-            ->method('getContainer')
-            ->willReturn($container);
 
         $postAdmin->setConfigurationPool($pool);
 

--- a/tests/Admin/PoolTest.php
+++ b/tests/Admin/PoolTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\Admin;
 
-use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
@@ -191,10 +190,11 @@ class PoolTest extends TestCase
             'someclass' => ['sonata.user.admin.group1', 'sonata.user.admin.group2'],
         ]);
 
-        $this->expectException(\RuntimeException::class);
-
         $this->assertTrue($pool->hasAdminByClass('someclass'));
         $this->assertFalse($pool->hasSingleAdminByClass('someclass'));
+
+        $this->expectException(\RuntimeException::class);
+
         $pool->getAdminByClass('someclass');
     }
 
@@ -337,18 +337,11 @@ class PoolTest extends TestCase
         $adminMock->expects($this->never())
             ->method('hasChild');
 
-        /** @var MockObject|Pool $poolMock */
-        $poolMock = $this->getMockBuilder(Pool::class)
-            ->setConstructorArgs([$this->container, 'Sonata', '/path/to/logo.png'])
-            ->disableOriginalClone()
-            ->setMethodsExcept(['getAdminByAdminCode'])
-            ->getMock();
-        $poolMock->expects($this->never())
-            ->method('getInstance');
+        $pool = new Pool($this->container, [$adminId]);
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Root admin code must contain a valid admin reference, empty string given.');
-        $poolMock->getAdminByAdminCode($adminId);
+        $pool->getAdminByAdminCode($adminId);
     }
 
     public function getEmptyRootAdminServiceNames()

--- a/tests/Block/AdminListBlockServiceTest.php
+++ b/tests/Block/AdminListBlockServiceTest.php
@@ -18,6 +18,7 @@ use Sonata\AdminBundle\Block\AdminListBlockService;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Block\FakeBlockService;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
+use Symfony\Component\DependencyInjection\Container;
 use Twig\Environment;
 
 /**
@@ -29,7 +30,7 @@ class AdminListBlockServiceTest extends BlockServiceTestCase
     {
         $blockService = new AdminListBlockService(
             $this->createStub(Environment::class),
-            $this->createStub(Pool::class),
+            new Pool(new Container()),
             $this->createStub(TemplateRegistryInterface::class)
         );
         $blockContext = $this->getBlockContext($blockService);
@@ -46,7 +47,7 @@ class AdminListBlockServiceTest extends BlockServiceTestCase
     {
         $blockService = new FakeBlockService(
             $this->createStub(Environment::class),
-            $this->createStub(Pool::class),
+            new Pool(new Container()),
             $this->createStub(TemplateRegistryInterface::class)
         );
         $blockContext = $this->getBlockContext($blockService);

--- a/tests/Block/AdminStatsBlockServiceTest.php
+++ b/tests/Block/AdminStatsBlockServiceTest.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Tests\Block;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Block\AdminStatsBlockService;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
+use Symfony\Component\DependencyInjection\Container;
 use Twig\Environment;
 
 /**
@@ -32,7 +33,7 @@ class AdminStatsBlockServiceTest extends BlockServiceTestCase
     {
         parent::setUp();
 
-        $this->pool = $this->createMock(Pool::class);
+        $this->pool = new Pool(new Container());
     }
 
     public function testDefaultSettings(): void

--- a/tests/Command/DeprecatedGenerateObjectAclCommandTest.php
+++ b/tests/Command/DeprecatedGenerateObjectAclCommandTest.php
@@ -53,7 +53,7 @@ final class DeprecatedGenerateObjectAclCommandTest extends TestCase
 
     public function testExecuteWithDeprecatedDoctrineService(): void
     {
-        $pool = new Pool($this->container, '', '');
+        $pool = new Pool($this->container);
 
         $registry = $this->createStub(RegistryInterface::class);
         $this->expectDeprecation('Passing a third argument to Sonata\AdminBundle\Command\GenerateObjectAclCommand::__construct() is deprecated since sonata-project/admin-bundle 3.77.');
@@ -71,7 +71,7 @@ final class DeprecatedGenerateObjectAclCommandTest extends TestCase
 
     public function testExecuteWithEmptyManipulators(): void
     {
-        $pool = new Pool($this->container, '', '');
+        $pool = new Pool($this->container);
 
         $registry = $this->createStub(ManagerRegistry::class);
         $this->expectDeprecation('Passing a third argument to Sonata\AdminBundle\Command\GenerateObjectAclCommand::__construct() is deprecated since sonata-project/admin-bundle 3.77.');
@@ -198,7 +198,7 @@ final class DeprecatedGenerateObjectAclCommandTest extends TestCase
 
     public function testExecuteWithDeprecatedUserModelNotation(): void
     {
-        $pool = new Pool($this->container, '', '');
+        $pool = new Pool($this->container);
 
         $registry = $this->createStub(ManagerRegistry::class);
         $this->expectDeprecation('Passing a third argument to Sonata\AdminBundle\Command\GenerateObjectAclCommand::__construct() is deprecated since sonata-project/admin-bundle 3.77.');
@@ -223,7 +223,7 @@ final class DeprecatedGenerateObjectAclCommandTest extends TestCase
 
     public function testExecuteWithDeprecatedUserModelNotationAndWithoutDoctrineService(): void
     {
-        $pool = new Pool($this->container, '', '');
+        $pool = new Pool($this->container);
 
         $command = new GenerateObjectAclCommand($pool, []);
 
@@ -249,7 +249,7 @@ final class DeprecatedGenerateObjectAclCommandTest extends TestCase
 
     public function testExecuteWithDeprecatedUserModelNotationAndInternalSetter(): void
     {
-        $pool = new Pool($this->container, '', '');
+        $pool = new Pool($this->container);
 
         $registry = $this->createStub(ManagerRegistry::class);
         $command = new GenerateObjectAclCommand($pool, []);

--- a/tests/Command/ExplainAdminCommandTest.php
+++ b/tests/Command/ExplainAdminCommandTest.php
@@ -145,8 +145,7 @@ class ExplainAdminCommandTest extends TestCase
 
         $container->set('acme.admin.foo', $this->admin);
 
-        $pool = new Pool($container, '', '');
-        $pool->setAdminServiceIds(['acme.admin.foo', 'acme.admin.bar']);
+        $pool = new Pool($container, ['acme.admin.foo', 'acme.admin.bar']);
 
         $this->validatorFactory = $this->createMock(MetadataFactoryInterface::class);
 

--- a/tests/Command/GenerateObjectAclCommandTest.php
+++ b/tests/Command/GenerateObjectAclCommandTest.php
@@ -47,7 +47,7 @@ class GenerateObjectAclCommandTest extends TestCase
 
     public function testExecuteWithDeprecatedDoctrineService(): void
     {
-        $pool = new Pool($this->container, '', '');
+        $pool = new Pool($this->container);
 
         $command = new GenerateObjectAclCommand($pool, []);
 
@@ -63,7 +63,7 @@ class GenerateObjectAclCommandTest extends TestCase
 
     public function testExecuteWithEmptyManipulators(): void
     {
-        $pool = new Pool($this->container, '', '');
+        $pool = new Pool($this->container);
 
         $command = new GenerateObjectAclCommand($pool, []);
 

--- a/tests/Command/GenerateObjectAclCommandTest.php
+++ b/tests/Command/GenerateObjectAclCommandTest.php
@@ -80,11 +80,11 @@ class GenerateObjectAclCommandTest extends TestCase
     public function testExecuteWithManipulatorNotFound(): void
     {
         $admin = $this->createStub(AbstractAdmin::class);
-        $pool = $this->createStub(Pool::class);
+        $container = new Container();
+        $container->set('acme.admin.foo', $admin);
+        $pool = new Pool($container, ['acme.admin.foo']);
 
         $admin->method('getManagerType')->willReturn('bar');
-        $pool->method('getAdminServiceIds')->willReturn(['acme.admin.foo']);
-        $pool->method('getInstance')->willReturn($admin);
 
         $aclObjectManipulators = [
             'bar' => new \stdClass(),
@@ -105,11 +105,11 @@ class GenerateObjectAclCommandTest extends TestCase
     public function testExecuteWithManipulatorNotObjectAclManipulatorInterface(): void
     {
         $admin = $this->createStub(AbstractAdmin::class);
-        $pool = $this->createStub(Pool::class);
+        $container = new Container();
+        $container->set('acme.admin.foo', $admin);
+        $pool = new Pool($container, ['acme.admin.foo']);
 
         $admin->method('getManagerType')->willReturn('bar');
-        $pool->method('getAdminServiceIds')->willReturn(['acme.admin.foo']);
-        $pool->method('getInstance')->willReturn($admin);
 
         $aclObjectManipulators = [
             'sonata.admin.manipulator.acl.object.bar' => new \stdClass(),
@@ -130,11 +130,11 @@ class GenerateObjectAclCommandTest extends TestCase
     public function testExecuteWithManipulator(): void
     {
         $admin = $this->createStub(AbstractAdmin::class);
-        $pool = $this->createStub(Pool::class);
+        $container = new Container();
+        $container->set('acme.admin.foo', $admin);
+        $pool = new Pool($container, ['acme.admin.foo']);
 
         $admin->method('getManagerType')->willReturn('bar');
-        $pool->method('getAdminServiceIds')->willReturn(['acme.admin.foo']);
-        $pool->method('getInstance')->willReturn($admin);
 
         $manipulator = $this->createMock(ObjectAclManipulatorInterface::class);
         $manipulator->expects($this->once())->method('batchConfigureAcls')
@@ -157,19 +157,13 @@ class GenerateObjectAclCommandTest extends TestCase
     public function testExecuteWithUserModel(): void
     {
         $admin = $this->createStub(AbstractAdmin::class);
-        $pool = $this->createStub(Pool::class);
+        $container = new Container();
+        $container->set('acme.admin.foo', $admin);
+        $pool = new Pool($container, ['acme.admin.foo']);
 
         $admin
             ->method('getManagerType')
             ->willReturn('bar');
-
-        $pool
-            ->method('getAdminServiceIds')
-            ->willReturn(['acme.admin.foo']);
-
-        $pool
-            ->method('getInstance')
-            ->willReturn($admin);
 
         $manipulator = $this->createMock(ObjectAclManipulatorInterface::class);
         $manipulator

--- a/tests/Command/ListAdminCommandTest.php
+++ b/tests/Command/ListAdminCommandTest.php
@@ -45,8 +45,7 @@ class ListAdminCommandTest extends TestCase
         $container->set('acme.admin.foo', $admin1);
         $container->set('acme.admin.bar', $admin2);
 
-        $pool = new Pool($container, '', '');
-        $pool->setAdminServiceIds(['acme.admin.foo', 'acme.admin.bar']);
+        $pool = new Pool($container, ['acme.admin.foo', 'acme.admin.bar']);
         $command = new ListAdminCommand($pool);
 
         $application->add($command);

--- a/tests/Command/SetupAclCommandTest.php
+++ b/tests/Command/SetupAclCommandTest.php
@@ -42,8 +42,7 @@ class SetupAclCommandTest extends TestCase
 
     public function testExecute(): void
     {
-        $pool = new Pool($this->container, '', '');
-        $pool->setAdminServiceIds(['acme.admin.foo']);
+        $pool = new Pool($this->container, ['acme.admin.foo']);
 
         $command = new SetupAclCommand($pool, $this->createMock(AdminAclManipulatorInterface::class));
 
@@ -60,8 +59,7 @@ class SetupAclCommandTest extends TestCase
     public function testExecuteWithException1(): void
     {
         $this->container->set('acme.admin.foo', null);
-        $pool = new Pool($this->container, '', '');
-        $pool->setAdminServiceIds(['acme.admin.foo']);
+        $pool = new Pool($this->container, ['acme.admin.foo']);
 
         $command = new SetupAclCommand($pool, $this->createMock(AdminAclManipulatorInterface::class));
 

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -179,8 +179,7 @@ class CRUDControllerTest extends TestCase
         $this->httpMethodParameterOverride = Request::getHttpMethodParameterOverride();
         $this->container = new Container();
         $this->request = new Request();
-        $this->pool = new Pool($this->container, 'title', 'logo.png');
-        $this->pool->setAdminServiceIds(['foo.admin']);
+        $this->pool = new Pool($this->container, ['foo.admin']);
         $this->request->attributes->set('_sonata_admin', 'foo.admin');
         $this->admin = $this->getMockBuilder(AbstractAdmin::class)
             ->disableOriginalConstructor()

--- a/tests/Controller/CoreControllerTest.php
+++ b/tests/Controller/CoreControllerTest.php
@@ -41,7 +41,7 @@ class CoreControllerTest extends TestCase
             ['layout', 'layout.html'],
         ]);
 
-        $pool = new Pool($container, 'title', 'logo.png');
+        $pool = new Pool($container);
         $pool->setTemplateRegistry($templateRegistry);
 
         $twig = $this->createMock(Environment::class);
@@ -82,7 +82,7 @@ class CoreControllerTest extends TestCase
         ]);
         $breadcrumbsBuilder = $this->createStub(BreadcrumbsBuilderInterface::class);
 
-        $pool = new Pool($container, 'title', 'logo.png');
+        $pool = new Pool($container);
         $pool->setTemplateRegistry($templateRegistry);
 
         $twig = $this->createMock(Environment::class);

--- a/tests/DependencyInjection/Compiler/ObjectAclManipulatorCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ObjectAclManipulatorCompilerPassTest.php
@@ -18,6 +18,7 @@ use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Command\GenerateObjectAclCommand;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ObjectAclManipulatorCompilerPass;
 use Sonata\AdminBundle\Util\ObjectAclManipulator;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -62,7 +63,7 @@ class ObjectAclManipulatorCompilerPassTest extends TestCase
 
     private function createContainer(): ContainerBuilder
     {
-        $pool = $this->createStub(Pool::class);
+        $pool = new Pool(new Container());
         $container = new ContainerBuilder();
         $container
             ->register(GenerateObjectAclCommand::class)

--- a/tests/Mapper/BaseGroupedMapperTest.php
+++ b/tests/Mapper/BaseGroupedMapperTest.php
@@ -56,7 +56,7 @@ class BaseGroupedMapperTest extends TestCase
 
         $container = new Container();
         $container->setParameter('sonata.admin.configuration.translate_group_label', '');
-        $configurationPool = new Pool($container, 'myTitle', 'myLogoTitle');
+        $configurationPool = new Pool($container);
 
         $admin
             ->method('getConfigurationPool')

--- a/tests/Menu/Provider/GroupMenuProviderTest.php
+++ b/tests/Menu/Provider/GroupMenuProviderTest.php
@@ -24,13 +24,14 @@ use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Menu\Provider\GroupMenuProvider;
+use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class GroupMenuProviderTest extends TestCase
 {
     /**
-     * @var MockObject|Pool
+     * @var Pool
      */
     private $pool;
     /**
@@ -47,14 +48,16 @@ class GroupMenuProviderTest extends TestCase
      */
     private $checker;
 
+    /**
+     * @var Container
+     */
+    private $container;
+
     protected function setUp(): void
     {
-        $this->pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
-        $this->checker = $this
-            ->getMockBuilder(AuthorizationCheckerInterface::class)
-            ->setMethods(['isGranted'])
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->container = new Container();
+        $this->pool = new Pool($this->container, ['sonata_admin_foo_service', 'sonata_admin_absolute_url']);
+        $this->checker = $this->createStub(AuthorizationCheckerInterface::class);
 
         $this->factory = new MenuFactory();
 
@@ -93,10 +96,7 @@ class GroupMenuProviderTest extends TestCase
     {
         $provider = new GroupMenuProvider($this->factory, $this->pool);
 
-        $this->pool
-            ->method('getInstance')
-            ->with($this->equalTo('sonata_admin_foo_service'))
-            ->willReturn($this->getAdminMock());
+        $this->container->set('sonata_admin_foo_service', $this->getAdminMock());
 
         $menu = $provider->get(
             'providerFoo',
@@ -131,10 +131,7 @@ class GroupMenuProviderTest extends TestCase
      */
     public function testGetMenuProviderWithCheckerGrantedGroupRoles(array $adminGroups): void
     {
-        $this->pool
-            ->method('getInstance')
-            ->with($this->equalTo('sonata_admin_foo_service'))
-            ->willReturn($this->getAdminMock());
+        $this->container->set('sonata_admin_foo_service', $this->getAdminMock());
 
         $this->checker
             ->method('isGranted')
@@ -252,10 +249,7 @@ class GroupMenuProviderTest extends TestCase
      */
     public function testGetMenuProviderWithAdmin(array $adminGroups): void
     {
-        $this->pool
-            ->method('getInstance')
-            ->with($this->equalTo('sonata_admin_foo_service'))
-            ->willReturn($this->getAdminMock());
+        $this->container->set('sonata_admin_foo_service', $this->getAdminMock());
 
         $this->checker
             ->method('isGranted')
@@ -297,10 +291,7 @@ class GroupMenuProviderTest extends TestCase
      */
     public function testGetKnpMenuWithListRoute(array $adminGroups): void
     {
-        $this->pool
-            ->method('getInstance')
-            ->with($this->equalTo('sonata_admin_foo_service'))
-            ->willReturn($this->getAdminMock(false));
+        $this->container->set('sonata_admin_foo_service', $this->getAdminMock(false));
 
         $this->checker
             ->method('isGranted')
@@ -325,10 +316,7 @@ class GroupMenuProviderTest extends TestCase
      */
     public function testGetKnpMenuWithGrantedList(array $adminGroups): void
     {
-        $this->pool
-            ->method('getInstance')
-            ->with($this->equalTo('sonata_admin_foo_service'))
-            ->willReturn($this->getAdminMock(true, false));
+        $this->container->set('sonata_admin_foo_service', $this->getAdminMock(true, false));
 
         $this->checker
             ->method('isGranted')
@@ -353,10 +341,7 @@ class GroupMenuProviderTest extends TestCase
      */
     public function testGetMenuProviderOnTopOptions(array $adminGroupsOnTopOption): void
     {
-        $this->pool
-            ->method('getInstance')
-            ->with($this->equalTo('sonata_admin_foo_service'))
-            ->willReturn($this->getAdminMock(true, false));
+        $this->container->set('sonata_admin_foo_service', $this->getAdminMock(true, false));
 
         $menu = $this->provider->get(
             'providerFoo',
@@ -375,10 +360,7 @@ class GroupMenuProviderTest extends TestCase
      */
     public function testGetMenuProviderKeepOpenOption(array $adminGroups): void
     {
-        $this->pool
-            ->method('getInstance')
-            ->with($this->equalTo('sonata_admin_foo_service'))
-            ->willReturn($this->getAdminMock());
+        $this->container->set('sonata_admin_foo_service', $this->getAdminMock());
 
         $this->checker
             ->method('isGranted')
@@ -404,10 +386,7 @@ class GroupMenuProviderTest extends TestCase
      */
     public function testRootMenuItemUrl(string $expectedUrl, array $item): void
     {
-        $this->pool
-            ->method('getInstance')
-            ->with($this->equalTo('sonata_admin_absolute_url'))
-            ->willReturn($this->getAdminMock());
+        $this->container->set('sonata_admin_absolute_url', $this->getAdminMock());
 
         $this->checker
             ->method('isGranted')

--- a/tests/Route/AdminPoolLoaderTest.php
+++ b/tests/Route/AdminPoolLoaderTest.php
@@ -30,7 +30,7 @@ class AdminPoolLoaderTest extends TestCase
     public function testSupports(): void
     {
         $container = new Container();
-        $pool = new Pool($container, 'title', 'logoTitle');
+        $pool = new Pool($container);
 
         $adminPoolLoader = new AdminPoolLoader($pool, ['foo_admin', 'bar_admin'], $container);
 
@@ -41,8 +41,7 @@ class AdminPoolLoaderTest extends TestCase
     public function testLoad(): void
     {
         $container = new Container();
-        $pool = new Pool($container, 'title', 'logoTitle');
-        $pool->setAdminServiceIds(['foo_admin', 'bar_admin']);
+        $pool = new Pool($container, ['foo_admin', 'bar_admin']);
 
         $adminPoolLoader = new AdminPoolLoader($pool, ['foo_admin', 'bar_admin'], $container);
 

--- a/tests/Route/RoutesCacheWarmUpTest.php
+++ b/tests/Route/RoutesCacheWarmUpTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Route\RoutesCache;
 use Sonata\AdminBundle\Route\RoutesCacheWarmUp;
+use Symfony\Component\DependencyInjection\Container;
 
 class RoutesCacheWarmUpTest extends TestCase
 {
@@ -28,7 +29,7 @@ class RoutesCacheWarmUpTest extends TestCase
     protected function setUp(): void
     {
         $routesCache = $this->getMockBuilder(RoutesCache::class)->disableOriginalConstructor()->getMock();
-        $pool = $this->getMockBuilder(Pool::class)->disableOriginalConstructor()->getMock();
+        $pool = new Pool(new Container());
 
         $this->routesCacheWarmUp = new RoutesCacheWarmUp($routesCache, $pool);
     }

--- a/tests/Translator/Extractor/AdminExtractorTest.php
+++ b/tests/Translator/Extractor/AdminExtractorTest.php
@@ -57,9 +57,7 @@ final class AdminExtractorTest extends TestCase
         $container->set('foo_admin', $this->fooAdmin);
         $container->set('bar_admin', $this->barAdmin);
 
-        $this->pool = new Pool($container, 'title', 'logo_title');
-        $this->pool->setAdminServiceIds(['foo_admin', 'bar_admin']);
-        $this->pool->setAdminGroups(['group' => [
+        $this->pool = new Pool($container, ['foo_admin', 'bar_admin'], ['group' => [
             'label_catalogue' => 'admin_domain',
         ]]);
 

--- a/tests/Twig/Extension/GroupExtensionTest.php
+++ b/tests/Twig/Extension/GroupExtensionTest.php
@@ -21,36 +21,28 @@ use Symfony\Component\DependencyInjection\Container;
 
 final class GroupExtensionTest extends TestCase
 {
-    /**
-     * @var GroupExtension
-     */
-    private $twigExtension;
-
-    /**
-     * @var Pool
-     */
-    private $pool;
-
-    /**
-     * @var Container
-     */
-    private $container;
-
-    protected function setUp(): void
-    {
-        $this->container = new Container();
-        $this->pool = new Pool($this->container, '', '');
-        $this->twigExtension = new GroupExtension($this->pool);
-    }
-
     public function testGetDashboardGroupsWithCreatableAdmins(): void
     {
+        $container = new Container();
+        $pool = new Pool($container, ['sonata_admin_non_creatable', 'sonata_admin_creatable'], [
+            'group_without_creatable' => [
+                'items' => [
+                    'itemKey' => ['admin' => 'sonata_admin_non_creatable'],
+                ],
+            ],
+            'group_with_creatable' => [
+                'items' => [
+                    'itemKey' => ['admin' => 'sonata_admin_creatable'],
+                ],
+            ],
+        ]);
+        $twigExtension = new GroupExtension($pool);
+
         $adminNonCreatable = $this->createMock(AbstractAdmin::class);
         $adminCreatable = $this->createMock(AbstractAdmin::class);
 
-        $this->container->set('sonata_admin_non_creatable', $adminNonCreatable);
-        $this->container->set('sonata_admin_creatable', $adminCreatable);
-        $this->pool->setAdminServiceIds(['sonata_admin_non_creatable', 'sonata_admin_creatable']);
+        $container->set('sonata_admin_non_creatable', $adminNonCreatable);
+        $container->set('sonata_admin_creatable', $adminCreatable);
 
         $adminCreatable
             ->method('showIn')
@@ -72,25 +64,12 @@ final class GroupExtensionTest extends TestCase
             ->with('create')
             ->willReturn(false);
 
-        $this->pool->setAdminGroups([
-            'group_without_creatable' => [
-                'items' => [
-                    'itemKey' => ['admin' => 'sonata_admin_non_creatable'],
-                ],
-            ],
-            'group_with_creatable' => [
-                'items' => [
-                    'itemKey' => ['admin' => 'sonata_admin_creatable'],
-                ],
-            ],
-        ]);
-
         $this->assertSame([
             [
                 'items' => [
                     'itemKey' => $adminCreatable,
                 ],
             ],
-        ], $this->twigExtension->getDashboardGroupsWithCreatableAdmins());
+        ], $twigExtension->getDashboardGroupsWithCreatableAdmins());
     }
 }

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -130,9 +130,7 @@ class SonataAdminExtensionTest extends TestCase
 
         $container = new Container();
 
-        $this->pool = new Pool($container, '', '');
-        $this->pool->setAdminServiceIds(['sonata_admin_foo_service']);
-        $this->pool->setAdminClasses(['fooClass' => ['sonata_admin_foo_service']]);
+        $this->pool = new Pool($container, ['sonata_admin_foo_service'], [], ['fooClass' => ['sonata_admin_foo_service']]);
 
         $this->logger = $this->getMockForAbstractClass(LoggerInterface::class);
         $this->xEditableTypeMapping = [
@@ -2694,31 +2692,47 @@ EOT
     {
         $model = new \stdClass();
 
-        // set admin to pool
-        $this->pool->setAdminServiceIds(['sonata_admin_foo_service']);
-        $this->pool->setAdminClasses([\stdClass::class => ['sonata_admin_foo_service']]);
+        $pool = new Pool(
+            $this->container,
+            ['sonata_admin_foo_service'],
+            [],
+            [\stdClass::class => ['sonata_admin_foo_service']]
+        );
 
         $this->admin->expects($this->once())
             ->method('getUrlSafeIdentifier')
             ->with($this->equalTo($model))
             ->willReturn(1234567);
 
-        $this->assertSame(1234567, $this->twigExtension->getUrlSafeIdentifier($model));
+        $this->container->set('sonata_admin_foo_service', $this->admin);
+
+        $twigExtension = new SonataAdminExtension(
+            $pool,
+            $this->logger,
+            $this->translator,
+            $this->container,
+            PropertyAccess::createPropertyAccessor()
+        );
+
+        $this->assertSame(1234567, $twigExtension->getUrlSafeIdentifier($model));
     }
 
     public function testGetUrlsafeIdentifier_GivenAdmin_Foo(): void
     {
         $model = new \stdClass();
 
-        // set admin to pool
-        $this->pool->setAdminServiceIds([
-            'sonata_admin_foo_service',
-            'sonata_admin_bar_service',
-        ]);
-        $this->pool->setAdminClasses([\stdClass::class => [
-            'sonata_admin_foo_service',
-            'sonata_admin_bar_service',
-        ]]);
+        $pool = new Pool(
+            $this->container,
+            [
+                'sonata_admin_foo_service',
+                'sonata_admin_bar_service',
+            ],
+            [],
+            [\stdClass::class => [
+                'sonata_admin_foo_service',
+                'sonata_admin_bar_service',
+            ]]
+        );
 
         $this->admin->expects($this->once())
             ->method('getUrlSafeIdentifier')
@@ -2728,19 +2742,30 @@ EOT
         $this->adminBar->expects($this->never())
             ->method('getUrlSafeIdentifier');
 
-        $this->assertSame(1234567, $this->twigExtension->getUrlSafeIdentifier($model, $this->admin));
+        $twigExtension = new SonataAdminExtension(
+            $pool,
+            $this->logger,
+            $this->translator,
+            $this->container,
+            PropertyAccess::createPropertyAccessor()
+        );
+
+        $this->assertSame(1234567, $twigExtension->getUrlSafeIdentifier($model, $this->admin));
     }
 
     public function testGetUrlsafeIdentifier_GivenAdmin_Bar(): void
     {
         $model = new \stdClass();
 
-        // set admin to pool
-        $this->pool->setAdminServiceIds(['sonata_admin_foo_service', 'sonata_admin_bar_service']);
-        $this->pool->setAdminClasses([\stdClass::class => [
-            'sonata_admin_foo_service',
-            'sonata_admin_bar_service',
-        ]]);
+        $pool = new Pool(
+            $this->container,
+            ['sonata_admin_foo_service', 'sonata_admin_bar_service'],
+            [],
+            [\stdClass::class => [
+                'sonata_admin_foo_service',
+                'sonata_admin_bar_service',
+            ]]
+        );
 
         $this->admin->expects($this->never())
             ->method('getUrlSafeIdentifier');
@@ -2750,7 +2775,15 @@ EOT
             ->with($this->equalTo($model))
             ->willReturn(1234567);
 
-        $this->assertSame(1234567, $this->twigExtension->getUrlSafeIdentifier($model, $this->adminBar));
+        $twigExtension = new SonataAdminExtension(
+            $pool,
+            $this->logger,
+            $this->translator,
+            $this->container,
+            PropertyAccess::createPropertyAccessor()
+        );
+
+        $this->assertSame(1234567, $twigExtension->getUrlSafeIdentifier($model, $this->adminBar));
     }
 
     public function xEditableChoicesProvider()


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Ref: https://github.com/sonata-project/SonataAdminBundle/issues/6709

`Pool` works as an Admin registry and its state is not needed to be changed once is instantiated, this PR will make `Pool` immutable in `4.0`. 

Also `Pool` mocks used in tests have been replaced by instances of `Pool` (the remaining ones are supposed to be removed in `4.x`).

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6709.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `Pool::setAdminServiceIds` in favor of passing service ids as argument 2 to the constructor.
- Deprecated `Pool::setAdminGroups` in favor of passing service ids as argument 3 to the constructor.
- Deprecated `Pool::setAdminClasses` in favor of passing service ids as argument 4 to the constructor.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
