### PR TITLE
Deprecate CRUDController::configure() method

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -16,6 +16,10 @@ Deprecated `$nbResults` property, `getNbResults()` and `setNbResults()` methods.
 
 They have been moved to `Sonata\AdminBundle\Admin\FieldDescriptionInterface`.
 
+### Sonata\AdminBundle\Controller\CRUDController
+
+Deprecated `configure()` method for configuring the associated admin, you MUST call `configureAdmin()` method instead.
+
 UPGRADE FROM 3.83 to 3.84
 =========================
 

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1073,15 +1073,18 @@ class CRUDController implements ContainerAwareInterface
     /**
      * Contextualize the admin class depends on the current request.
      *
+     * NEXT_MAJOR: Change \RuntimeException by \InvalidArgumentException in the next line.
+     *
      * @throws \RuntimeException
      */
     final public function configureAdmin(Request $request): void
     {
         $adminCode = $request->get('_sonata_admin');
 
-        if (!$adminCode) {
+        if (null === $adminCode) {
+            // NEXT_MAJOR: Change \RuntimeException by \InvalidArgumentException in the next line.
             throw new \RuntimeException(sprintf(
-                'There is no `_sonata_admin` defined for the controller `%s` and the current route `%s`',
+                'There is no `_sonata_admin` defined for the controller `%s` and the current route `%s`.',
                 static::class,
                 $request->get('_route')
             ));
@@ -1089,9 +1092,9 @@ class CRUDController implements ContainerAwareInterface
 
         $this->admin = $this->container->get('sonata.admin.pool')->getAdminByAdminCode($adminCode);
 
-        if (!$this->admin) {
+        if (null === $this->admin) {
             throw new \RuntimeException(sprintf(
-                'Unable to find the admin class related to the current controller (%s)',
+                'Unable to find the admin class related to the current controller (%s).',
                 static::class
             ));
         }
@@ -1099,7 +1102,7 @@ class CRUDController implements ContainerAwareInterface
         $this->templateRegistry = $this->container->get(sprintf('%s.template_registry', $this->admin->getCode()));
         if (!$this->templateRegistry instanceof TemplateRegistryInterface) {
             throw new \RuntimeException(sprintf(
-                'Unable to find the template registry related to the current admin (%s)',
+                'Unable to find the template registry related to the current admin (%s).',
                 $this->admin->getCode()
             ));
         }
@@ -1204,7 +1207,8 @@ class CRUDController implements ContainerAwareInterface
     {
         if ('sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
             @trigger_error(sprintf(
-                'The "%s()" method is deprecated since version 3.x and will be removed in 4.0.',
+                'The "%s()" method is deprecated since sonata-project/admin-bundle version 3.x and will be'
+                .' removed in 4.0 version.',
                 __METHOD__
             ), E_USER_DEPRECATED);
         }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

In next major version, the controller will be configured with an external call from an event listener instead of using setContainer method.

For more context: https://github.com/sonata-project/SonataAdminBundle/pull/6615

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `CRUDController::configure()` method, to configure the associated admin, you should call `CRUDController::configureAdmin()` instead.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
