### PR TITLE
Move TemplateRegistryInterface::TYPE_* constants

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -12,6 +12,10 @@ Deprecated `getNbResults()` method in favor of `countResults()`.
 
 Deprecated `$nbResults` property, `getNbResults()` and `setNbResults()` methods.
 
+### Deprecated `Sonata\AdminBundle\Templating\TemplateRegistryInterface::TYPE_*` constants.
+
+They have been moved to `Sonata\AdminBundle\Admin\FieldDescriptionInterface`.
+
 UPGRADE FROM 3.83 to 3.84
 =========================
 

--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -51,7 +51,7 @@ Here is an example::
 
             // you may specify the field type directly as the
             // second argument instead of in the options
-            ->add('isVariation', TemplateRegistry::TYPE_BOOLEAN)
+            ->add('isVariation', FieldDescriptionInterface::TYPE_BOOLEAN)
 
             // if null, the type will be guessed
             ->add('enabled', null, [
@@ -59,7 +59,7 @@ Here is an example::
             ])
 
             // editable association field
-            ->add('status', TemplateRegistry::TYPE_CHOICE, [
+            ->add('status', FieldDescriptionInterface::TYPE_CHOICE, [
                 'editable' => true,
                 'class' => 'Vendor\ExampleBundle\Entity\ExampleStatus',
                 'choices' => [
@@ -70,7 +70,7 @@ Here is an example::
             ])
 
             // editable multiple field
-            ->add('winner', TemplateRegistry::TYPE_CHOICE, [
+            ->add('winner', FieldDescriptionInterface::TYPE_CHOICE, [
                 'editable' => true,
                 'multiple' => true,
                 'choices' => [
@@ -81,7 +81,7 @@ Here is an example::
             ])
 
             // we can add options to the field depending on the type
-            ->add('price', TemplateRegistry::TYPE_CURRENCY, [
+            ->add('price', FieldDescriptionInterface::TYPE_CURRENCY, [
                 'currency' => $this->currencyDetector->getCurrency()->getLabel()
             ])
 
@@ -143,21 +143,21 @@ Options
 Available types and associated options
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-+--------------------------------------+---------------------+-----------------------------------------------------------------------+
-| Type                                 | Options             | Description                                                           |
-+======================================+=====================+=======================================================================+
-| ``ListMapper::TYPE_ACTIONS``         | actions             | List of available actions                                             |
-+                                      +                     +                                                                       +
-|                                      |   edit              | Name of the action (``show``, ``edit``, ``history``, ``delete``, etc) |
-+                                      +                     +                                                                       +
-|                                      |     link_parameters | Route parameters                                                      |
-+--------------------------------------+---------------------+-----------------------------------------------------------------------+
-| ``ListMapper::TYPE_BATCH``           |                     | Renders a checkbox                                                    |
-+--------------------------------------+---------------------+-----------------------------------------------------------------------+
-| ``ListMapper::TYPE_SELECT``          |                     | Renders a select box                                                  |
-+--------------------------------------+---------------------+-----------------------------------------------------------------------+
-| ``TemplateRegistry::TYPE_*``         |                     | See :doc:`Field Types <field_types>`                                  |
-+--------------------------------------+---------------------+-----------------------------------------------------------------------+
++---------------------------------------+---------------------+-----------------------------------------------------------------------+
+| Type                                  | Options             | Description                                                           |
++=======================================+=====================+=======================================================================+
+| ``ListMapper::TYPE_ACTIONS``          | actions             | List of available actions                                             |
++                                       +                     +                                                                       +
+|                                       |   edit              | Name of the action (``show``, ``edit``, ``history``, ``delete``, etc) |
++                                       +                     +                                                                       +
+|                                       |     link_parameters | Route parameters                                                      |
++---------------------------------------+---------------------+-----------------------------------------------------------------------+
+| ``ListMapper::TYPE_BATCH``            |                     | Renders a checkbox                                                    |
++---------------------------------------+---------------------+-----------------------------------------------------------------------+
+| ``ListMapper::TYPE_SELECT``           |                     | Renders a select box                                                  |
++---------------------------------------+---------------------+-----------------------------------------------------------------------+
+| ``FieldDescriptionInterface::TYPE_*`` |                     | See :doc:`Field Types <field_types>`                                  |
++---------------------------------------+---------------------+-----------------------------------------------------------------------+
 
 Symfony Data Transformers
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -614,10 +614,10 @@ Example::
                 'header_style' => 'width: 5%; text-align: center',
                 'row_align' => 'center'
             ])
-            ->add('name', TemplateRegistry::TYPE_STRING, [
+            ->add('name', FieldDescriptionInterface::TYPE_STRING, [
                 'header_style' => 'width: 35%'
             ])
-            ->add('description', TemplateRegistry::TYPE_STRING, [
+            ->add('description', FieldDescriptionInterface::TYPE_STRING, [
                 'header_style' => 'width: 35%',
                 'collapse' => true
             ])

--- a/docs/reference/action_show.rst
+++ b/docs/reference/action_show.rst
@@ -116,9 +116,9 @@ The following is a working example of a ShowAction::
                  // The boolean option is actually very cool
                  // true   shows a check mark and the 'yes' label
                  // false  shows a check mark and the 'no' label
-                ->add('dateCafe', TemplateRegistry::TYPE_BOOLEAN)
-                ->add('datePub', TemplateRegistry::TYPE_BOOLEAN)
-                ->add('dateClub', TemplateRegistry::TYPE_BOOLEAN)
+                ->add('dateCafe', FieldDescriptionInterface::TYPE_BOOLEAN)
+                ->add('datePub', FieldDescriptionInterface::TYPE_BOOLEAN)
+                ->add('dateClub', FieldDescriptionInterface::TYPE_BOOLEAN)
             ;
 
         }

--- a/docs/reference/field_types.rst
+++ b/docs/reference/field_types.rst
@@ -6,29 +6,29 @@ List and Show Actions
 
 There are many field types that can be used in the list and show action :
 
-=======================================    =============================================
-Fieldtype                                  Description
-=======================================    =============================================
-``TemplateRegistry::TYPE_ARRAY``           display value from an array
-``TemplateRegistry::TYPE_BOOLEAN``         display a green or red picture dependant on the boolean value
-``TemplateRegistry::TYPE_DATE``            display a formatted date. Accepts the option ``format``
-``TemplateRegistry::TYPE_TIME``            display a formatted time. Accepts the options ``format`` and ``timezone``
-``TemplateRegistry::TYPE_DATETIME``        display a formatted date and time. Accepts the options ``format`` and ``timezone``
-``TemplateRegistry::TYPE_STRING``          display a text
-``TemplateRegistry::TYPE_EMAIL``           display a mailto link. Accepts the options ``as_string``, ``subject`` and ``body``
-``TemplateRegistry::TYPE_TEXTAREA``        display a textarea
-``TemplateRegistry::TYPE_TRANS``           translate the value with a provided ``catalogue`` (translation domain) and ``format`` (sprintf format) option
-``TemplateRegistry::TYPE_FLOAT``           display a number
-``TemplateRegistry::TYPE_CURRENCY``        display a number with a provided ``currency`` option
-``TemplateRegistry::TYPE_PERCENT``         display a percentage
-``TemplateRegistry::TYPE_CHOICE``          uses the given value as index for the ``choices`` array and displays (and optionally translates) the matching value
-``TemplateRegistry::TYPE_URL``             display a link
-``TemplateRegistry::TYPE_HTML``            display (and optionally truncate or strip tags from) raw html
-``TemplateRegistry::TYPE_MANY_TO_MANY``    used for relational tables
-``TemplateRegistry::TYPE_MANY_TO_ONE``     used for relational tables
-``TemplateRegistry::TYPE_ONE_TO_MANY``     used for relational tables
-``TemplateRegistry::TYPE_ONE_TO_ONE``      used for relational tables
-=======================================    =============================================
+================================================    =============================================
+Fieldtype                                           Description
+================================================    =============================================
+``FieldDescriptionInterface::TYPE_ARRAY``           display value from an array
+``FieldDescriptionInterface::TYPE_BOOLEAN``         display a green or red picture dependant on the boolean value
+``FieldDescriptionInterface::TYPE_DATE``            display a formatted date. Accepts the option ``format``
+``FieldDescriptionInterface::TYPE_TIME``            display a formatted time. Accepts the options ``format`` and ``timezone``
+``FieldDescriptionInterface::TYPE_DATETIME``        display a formatted date and time. Accepts the options ``format`` and ``timezone``
+``FieldDescriptionInterface::TYPE_STRING``          display a text
+``FieldDescriptionInterface::TYPE_EMAIL``           display a mailto link. Accepts the options ``as_string``, ``subject`` and ``body``
+``FieldDescriptionInterface::TYPE_TEXTAREA``        display a textarea
+``FieldDescriptionInterface::TYPE_TRANS``           translate the value with a provided ``catalogue`` (translation domain) and ``format`` (sprintf format) option
+``FieldDescriptionInterface::TYPE_FLOAT``           display a number
+``FieldDescriptionInterface::TYPE_CURRENCY``        display a number with a provided ``currency`` option
+``FieldDescriptionInterface::TYPE_PERCENT``         display a percentage
+``FieldDescriptionInterface::TYPE_CHOICE``          uses the given value as index for the ``choices`` array and displays (and optionally translates) the matching value
+``FieldDescriptionInterface::TYPE_URL``             display a link
+``FieldDescriptionInterface::TYPE_HTML``            display (and optionally truncate or strip tags from) raw html
+``FieldDescriptionInterface::TYPE_MANY_TO_MANY``    used for relational tables
+``FieldDescriptionInterface::TYPE_MANY_TO_ONE``     used for relational tables
+``FieldDescriptionInterface::TYPE_ONE_TO_MANY``     used for relational tables
+``FieldDescriptionInterface::TYPE_ONE_TO_ONE``      used for relational tables
+================================================    =============================================
 
 Theses types accept an ``editable`` option to edit the value from within the list action.
 This is currently limited to scalar types (text, integer, url...) and choice types with association field.
@@ -41,10 +41,10 @@ This is currently limited to scalar types (text, integer, url...) and choice typ
     Option for currency type must be an official ISO code, example : EUR for "euros".
     List of ISO codes : `https://en.wikipedia.org/wiki/List_of_circulating_currencies <https://en.wikipedia.org/wiki/List_of_circulating_currencies>`_
 
-    In ``TemplateRegistry::TYPE_DATE``, ``TemplateRegistry::TYPE_TIME`` and ``TemplateRegistry::TYPE_DATETIME`` field types, ``format`` pattern must match twig's
+    In ``FieldDescriptionInterface::TYPE_DATE``, ``FieldDescriptionInterface::TYPE_TIME`` and ``FieldDescriptionInterface::TYPE_DATETIME`` field types, ``format`` pattern must match twig's
     ``date`` filter specification, available at: `https://twig.symfony.com/doc/2.x/filters/date.html <https://twig.symfony.com/doc/2.x/filters/date.html>`_
 
-    In ``TemplateRegistry::TYPE_TIME`` and ``TemplateRegistry::TYPE_DATETIME`` field types, ``timezone`` syntax must match twig's
+    In ``FieldDescriptionInterface::TYPE_TIME`` and ``FieldDescriptionInterface::TYPE_DATETIME`` field types, ``timezone`` syntax must match twig's
     ``date`` filter specification, available at: `https://twig.symfony.com/doc/2.x/filters/date.html <https://twig.symfony.com/doc/2.x/filters/date.html>`_
     and php timezone list: `https://www.php.net/manual/en/timezones.php <https://www.php.net/manual/en/timezones.php>`_
     You can use in lists what `view-timezone <https://symfony.com/doc/4.4/reference/forms/types/datetime.html#view-timezone>`_ allows on forms,
@@ -62,8 +62,8 @@ This is currently limited to scalar types (text, integer, url...) and choice typ
             ;
         }
 
-``TemplateRegistry::TYPE_ARRAY``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``FieldDescriptionInterface::TYPE_ARRAY``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can use the following options:
 
@@ -99,7 +99,7 @@ Option                                  Description
     protected function configureListFields(ListMapper $listMapper): void
     {
         $listMapper
-            ->add('options', TemplateRegistry::TYPE_ARRAY, [
+            ->add('options', FieldDescriptionInterface::TYPE_ARRAY, [
                 'inline' => true,
                 'display' => 'both',
                 'key_translation_domain' => true,
@@ -108,8 +108,8 @@ Option                                  Description
         ;
     }
 
-``TemplateRegistry::TYPE_BOOLEAN``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``FieldDescriptionInterface::TYPE_BOOLEAN``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can use the following options:
 
@@ -126,7 +126,7 @@ Option                                  Description
     protected function configureListFields(ListMapper $listMapper)
     {
         $listMapper
-            ->add('invalid', TemplateRegistry::TYPE_BOOLEAN, [
+            ->add('invalid', FieldDescriptionInterface::TYPE_BOOLEAN, [
                 'editable' => true,
                 'inverse'  => true,
             ])
@@ -138,8 +138,8 @@ Option                                  Description
     It is better to prefer non negative notions when possible for boolean values
     so use the ``inverse`` option if you really cannot find a good enough antonym for the name you have.
 
-``TemplateRegistry::TYPE_CHOICE``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``FieldDescriptionInterface::TYPE_CHOICE``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 You can use the following options:
 
@@ -162,7 +162,7 @@ Option                                  Description
     {
         // For the value `prog`, the displayed text is `In progress`. The `App` catalogue will be used to translate `In progress` message.
         $listMapper
-            ->add('status', TemplateRegistry::TYPE_CHOICE, [
+            ->add('status', FieldDescriptionInterface::TYPE_CHOICE, [
                 'choices' => [
                     'prep' => 'Prepared',
                     'prog' => 'In progress',
@@ -173,13 +173,13 @@ Option                                  Description
         ;
     }
 
-The ``TemplateRegistry::TYPE_CHOICE`` field type also supports multiple values that can be separated by a ``delimiter``::
+The ``FieldDescriptionInterface::TYPE_CHOICE`` field type also supports multiple values that can be separated by a ``delimiter``::
 
     protected function configureListFields(ListMapper $listMapper)
     {
         // For the value `['r', 'b']`, the displayed text ist `red | blue`.
         $listMapper
-            ->add('colors', TemplateRegistry::TYPE_CHOICE, [
+            ->add('colors', FieldDescriptionInterface::TYPE_CHOICE, [
                 'multiple' => true,
                 'delimiter' => ' | ',
                 'choices' => [
@@ -195,8 +195,8 @@ The ``TemplateRegistry::TYPE_CHOICE`` field type also supports multiple values t
 
     The default delimiter is a comma ``,``.
 
-``TemplateRegistry::TYPE_URL``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``FieldDescriptionInterface::TYPE_URL``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Display URL link to external website or controller action.
 
@@ -221,29 +221,29 @@ Option                                  Description
         $listMapper
             // Output for value `http://example.com`:
             // `<a href="http://example.com">http://example.com</a>`
-            ->add('targetUrl', TemplateRegistry::TYPE_URL)
+            ->add('targetUrl', FieldDescriptionInterface::TYPE_URL)
 
             // Output for value `http://example.com`:
             // `<a href="http://example.com" target="_blank">example.com</a>`
-            ->add('targetUrl', TemplateRegistry::TYPE_URL, [
+            ->add('targetUrl', FieldDescriptionInterface::TYPE_URL, [
                 'attributes' => ['target' => '_blank']
             ])
 
             // Output for value `http://example.com`:
             // `<a href="http://example.com">example.com</a>`
-            ->add('targetUrl', TemplateRegistry::TYPE_URL, [
+            ->add('targetUrl', FieldDescriptionInterface::TYPE_URL, [
                 'hide_protocol' => true
             ])
 
             // Output for value `Homepage of example.com` :
             // `<a href="http://example.com">Homepage of example.com</a>`
-            ->add('title', TemplateRegistry::TYPE_URL, [
+            ->add('title', FieldDescriptionInterface::TYPE_URL, [
                 'url' => 'http://example.com'
             ])
 
             // Output for value `Acme Blog Homepage`:
             // `<a href="http://blog.example.com">Acme Blog Homepage</a>`
-            ->add('title', TemplateRegistry::TYPE_URL, [
+            ->add('title', FieldDescriptionInterface::TYPE_URL, [
                 'route' => [
                     'name' => 'acme_blog_homepage',
                     'absolute' => true
@@ -252,7 +252,7 @@ Option                                  Description
 
             // Output for value `Sonata is great!` (related object has identifier `123`):
             // `<a href="http://blog.example.com/xml/123">Sonata is great!</a>`
-            ->add('title', TemplateRegistry::TYPE_URL, [
+            ->add('title', FieldDescriptionInterface::TYPE_URL, [
                 'route' => [
                     'name' => 'acme_blog_article',
                     'absolute' => true,
@@ -265,10 +265,10 @@ Option                                  Description
 
 .. note::
 
-    Do not use ``TemplateRegistry::TYPE_URL`` type with ``addIdentifier()`` method, because it will create invalid nested URLs.
+    Do not use ``FieldDescriptionInterface::TYPE_URL`` type with ``addIdentifier()`` method, because it will create invalid nested URLs.
 
-``TemplateRegistry::TYPE_HTML``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``FieldDescriptionInterface::TYPE_HTML``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Display (and optionally truncate or strip tags from) raw html.
 
@@ -292,23 +292,23 @@ Option                      Description
 
             // Output for value `<p><strong>Creating a Template for the Field</strong> and form</p>`:
             // `<p><strong>Creating a Template for the Field</strong> and form</p>` (no escaping is done)
-            ->add('content', TemplateRegistry::TYPE_HTML)
+            ->add('content', FieldDescriptionInterface::TYPE_HTML)
 
             // Output for value `<p><strong>Creating a Template for the Field</strong> and form</p>`:
             // `Creating a Template for the Fi...`
-            ->add('content', TemplateRegistry::TYPE_HTML, [
+            ->add('content', FieldDescriptionInterface::TYPE_HTML, [
                 'strip' => true
             ])
 
             // Output for value `<p><strong>Creating a Template for the Field</strong> and form</p>`:
             // `Creating a Template for...`
-            ->add('content', TemplateRegistry::TYPE_HTML, [
+            ->add('content', FieldDescriptionInterface::TYPE_HTML, [
                 'truncate' => true
             ])
 
             // Output for value `<p><strong>Creating a Template for the Field</strong> and form</p>`:
             // `Creating a...`
-            ->add('content', TemplateRegistry::TYPE_HTML, [
+            ->add('content', FieldDescriptionInterface::TYPE_HTML, [
                 'truncate' => [
                     'length' => 10
                 ]
@@ -316,7 +316,7 @@ Option                      Description
 
             // Output for value `<p><strong>Creating a Template for the Field</strong> and form</p>`:
             // `Creating a Template for the Field...`
-            ->add('content', TemplateRegistry::TYPE_HTML, [
+            ->add('content', FieldDescriptionInterface::TYPE_HTML, [
                 'truncate' => [
                     'cut' => false
                 ]
@@ -324,7 +324,7 @@ Option                      Description
 
             // Output for value `<p><strong>Creating a Template for the Field</strong> and form</p>`:
             // `Creating a Template for the Fi, etc.`
-            ->add('content', TemplateRegistry::TYPE_HTML, [
+            ->add('content', FieldDescriptionInterface::TYPE_HTML, [
                 'truncate' => [
                     'ellipsis' => ', etc.'
                 ]
@@ -332,7 +332,7 @@ Option                      Description
 
             // Output for value `<p><strong>Creating a Template for the Field</strong> and form</p>`:
             // `Creating a Template for***`
-            ->add('content', TemplateRegistry::TYPE_HTML, [
+            ->add('content', FieldDescriptionInterface::TYPE_HTML, [
                 'truncate' => [
                     'length' => 20,
                     'cut' => false,

--- a/src/Action/SetObjectFieldValueAction.php
+++ b/src/Action/SetObjectFieldValueAction.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Action;
 
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Form\DataTransformerResolver;
 use Sonata\AdminBundle\Form\DataTransformerResolverInterface;
-use Sonata\AdminBundle\Templating\TemplateRegistry;
 use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -179,7 +179,7 @@ final class SetObjectFieldValueAction
                 $value = $dataTransformer->reverseTransform($value);
             }
 
-            if (!$value && TemplateRegistry::TYPE_CHOICE === $fieldDescription->getType()) {
+            if (!$value && FieldDescriptionInterface::TYPE_CHOICE === $fieldDescription->getType()) {
                 return new JsonResponse(sprintf(
                     'Edit failed, object with id: %s not found in association: %s.',
                     $originalValue,

--- a/src/Admin/FieldDescriptionInterface.php
+++ b/src/Admin/FieldDescriptionInterface.php
@@ -25,6 +25,28 @@ use Sonata\AdminBundle\Exception\NoValueException;
  */
 interface FieldDescriptionInterface
 {
+    public const TYPE_ARRAY = 'array';
+    public const TYPE_BOOLEAN = 'boolean';
+    public const TYPE_DATE = 'date';
+    public const TYPE_TIME = 'time';
+    public const TYPE_DATETIME = 'datetime';
+    public const TYPE_TEXTAREA = 'textarea';
+    public const TYPE_EMAIL = 'email';
+    public const TYPE_TRANS = 'trans';
+    public const TYPE_STRING = 'string';
+    public const TYPE_INTEGER = 'integer';
+    public const TYPE_FLOAT = 'float';
+    public const TYPE_IDENTIFIER = 'identifier';
+    public const TYPE_CURRENCY = 'currency';
+    public const TYPE_PERCENT = 'percent';
+    public const TYPE_CHOICE = 'choice';
+    public const TYPE_URL = 'url';
+    public const TYPE_HTML = 'html';
+    public const TYPE_MANY_TO_MANY = 'many_to_many';
+    public const TYPE_MANY_TO_ONE = 'many_to_one';
+    public const TYPE_ONE_TO_MANY = 'one_to_many';
+    public const TYPE_ONE_TO_ONE = 'one_to_one';
+
     /**
      * NEXT_MAJOR: Remove this method.
      *

--- a/src/DependencyInjection/AbstractSonataAdminExtension.php
+++ b/src/DependencyInjection/AbstractSonataAdminExtension.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\DependencyInjection;
 
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Templating\TemplateRegistry;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -34,64 +35,64 @@ abstract class AbstractSonataAdminExtension extends Extension
             'templates' => [
                 'types' => [
                     'list' => [
-                        TemplateRegistry::TYPE_ARRAY => '@SonataAdmin/CRUD/list_array.html.twig',
-                        TemplateRegistry::TYPE_BOOLEAN => '@SonataAdmin/CRUD/list_boolean.html.twig',
-                        TemplateRegistry::TYPE_DATE => '@SonataAdmin/CRUD/list_date.html.twig',
-                        TemplateRegistry::TYPE_TIME => '@SonataAdmin/CRUD/list_time.html.twig',
-                        TemplateRegistry::TYPE_DATETIME => '@SonataAdmin/CRUD/list_datetime.html.twig',
+                        FieldDescriptionInterface::TYPE_ARRAY => '@SonataAdmin/CRUD/list_array.html.twig',
+                        FieldDescriptionInterface::TYPE_BOOLEAN => '@SonataAdmin/CRUD/list_boolean.html.twig',
+                        FieldDescriptionInterface::TYPE_DATE => '@SonataAdmin/CRUD/list_date.html.twig',
+                        FieldDescriptionInterface::TYPE_TIME => '@SonataAdmin/CRUD/list_time.html.twig',
+                        FieldDescriptionInterface::TYPE_DATETIME => '@SonataAdmin/CRUD/list_datetime.html.twig',
                         /* NEXT_MAJOR: Remove this line. */
                         TemplateRegistry::TYPE_TEXT => '@SonataAdmin/CRUD/list_string.html.twig',
-                        TemplateRegistry::TYPE_TEXTAREA => '@SonataAdmin/CRUD/list_string.html.twig',
-                        TemplateRegistry::TYPE_EMAIL => '@SonataAdmin/CRUD/list_email.html.twig',
-                        TemplateRegistry::TYPE_TRANS => '@SonataAdmin/CRUD/list_trans.html.twig',
-                        TemplateRegistry::TYPE_STRING => '@SonataAdmin/CRUD/list_string.html.twig',
+                        FieldDescriptionInterface::TYPE_TEXTAREA => '@SonataAdmin/CRUD/list_string.html.twig',
+                        FieldDescriptionInterface::TYPE_EMAIL => '@SonataAdmin/CRUD/list_email.html.twig',
+                        FieldDescriptionInterface::TYPE_TRANS => '@SonataAdmin/CRUD/list_trans.html.twig',
+                        FieldDescriptionInterface::TYPE_STRING => '@SonataAdmin/CRUD/list_string.html.twig',
                         /* NEXT_MAJOR: Remove this line. */
                         TemplateRegistry::TYPE_SMALLINT => '@SonataAdmin/CRUD/list_string.html.twig',
                         /* NEXT_MAJOR: Remove this line. */
                         TemplateRegistry::TYPE_BIGINT => '@SonataAdmin/CRUD/list_string.html.twig',
-                        TemplateRegistry::TYPE_INTEGER => '@SonataAdmin/CRUD/list_string.html.twig',
+                        FieldDescriptionInterface::TYPE_INTEGER => '@SonataAdmin/CRUD/list_string.html.twig',
                         /* NEXT_MAJOR: Remove this line. */
                         TemplateRegistry::TYPE_DECIMAL => '@SonataAdmin/CRUD/list_string.html.twig',
-                        TemplateRegistry::TYPE_FLOAT => '@SonataAdmin/CRUD/list_string.html.twig',
-                        TemplateRegistry::TYPE_IDENTIFIER => '@SonataAdmin/CRUD/list_string.html.twig',
-                        TemplateRegistry::TYPE_CURRENCY => '@SonataAdmin/CRUD/list_currency.html.twig',
-                        TemplateRegistry::TYPE_PERCENT => '@SonataAdmin/CRUD/list_percent.html.twig',
-                        TemplateRegistry::TYPE_CHOICE => '@SonataAdmin/CRUD/list_choice.html.twig',
-                        TemplateRegistry::TYPE_URL => '@SonataAdmin/CRUD/list_url.html.twig',
-                        TemplateRegistry::TYPE_HTML => '@SonataAdmin/CRUD/list_html.html.twig',
-                        TemplateRegistry::TYPE_MANY_TO_MANY => '@SonataAdmin/CRUD/Association/list_many_to_many.html.twig',
-                        TemplateRegistry::TYPE_MANY_TO_ONE => '@SonataAdmin/CRUD/Association/list_many_to_one.html.twig',
-                        TemplateRegistry::TYPE_ONE_TO_MANY => '@SonataAdmin/CRUD/Association/list_one_to_many.html.twig',
-                        TemplateRegistry::TYPE_ONE_TO_ONE => '@SonataAdmin/CRUD/Association/list_one_to_one.html.twig',
+                        FieldDescriptionInterface::TYPE_FLOAT => '@SonataAdmin/CRUD/list_string.html.twig',
+                        FieldDescriptionInterface::TYPE_IDENTIFIER => '@SonataAdmin/CRUD/list_string.html.twig',
+                        FieldDescriptionInterface::TYPE_CURRENCY => '@SonataAdmin/CRUD/list_currency.html.twig',
+                        FieldDescriptionInterface::TYPE_PERCENT => '@SonataAdmin/CRUD/list_percent.html.twig',
+                        FieldDescriptionInterface::TYPE_CHOICE => '@SonataAdmin/CRUD/list_choice.html.twig',
+                        FieldDescriptionInterface::TYPE_URL => '@SonataAdmin/CRUD/list_url.html.twig',
+                        FieldDescriptionInterface::TYPE_HTML => '@SonataAdmin/CRUD/list_html.html.twig',
+                        FieldDescriptionInterface::TYPE_MANY_TO_MANY => '@SonataAdmin/CRUD/Association/list_many_to_many.html.twig',
+                        FieldDescriptionInterface::TYPE_MANY_TO_ONE => '@SonataAdmin/CRUD/Association/list_many_to_one.html.twig',
+                        FieldDescriptionInterface::TYPE_ONE_TO_MANY => '@SonataAdmin/CRUD/Association/list_one_to_many.html.twig',
+                        FieldDescriptionInterface::TYPE_ONE_TO_ONE => '@SonataAdmin/CRUD/Association/list_one_to_one.html.twig',
                     ],
                     'show' => [
-                        TemplateRegistry::TYPE_ARRAY => '@SonataAdmin/CRUD/show_array.html.twig',
-                        TemplateRegistry::TYPE_BOOLEAN => '@SonataAdmin/CRUD/show_boolean.html.twig',
-                        TemplateRegistry::TYPE_DATE => '@SonataAdmin/CRUD/show_date.html.twig',
-                        TemplateRegistry::TYPE_TIME => '@SonataAdmin/CRUD/show_time.html.twig',
-                        TemplateRegistry::TYPE_DATETIME => '@SonataAdmin/CRUD/show_datetime.html.twig',
+                        FieldDescriptionInterface::TYPE_ARRAY => '@SonataAdmin/CRUD/show_array.html.twig',
+                        FieldDescriptionInterface::TYPE_BOOLEAN => '@SonataAdmin/CRUD/show_boolean.html.twig',
+                        FieldDescriptionInterface::TYPE_DATE => '@SonataAdmin/CRUD/show_date.html.twig',
+                        FieldDescriptionInterface::TYPE_TIME => '@SonataAdmin/CRUD/show_time.html.twig',
+                        FieldDescriptionInterface::TYPE_DATETIME => '@SonataAdmin/CRUD/show_datetime.html.twig',
                         /* NEXT_MAJOR: Remove this line. */
                         TemplateRegistry::TYPE_TEXT => '@SonataAdmin/CRUD/base_show_field.html.twig',
-                        TemplateRegistry::TYPE_EMAIL => '@SonataAdmin/CRUD/show_email.html.twig',
-                        TemplateRegistry::TYPE_TRANS => '@SonataAdmin/CRUD/show_trans.html.twig',
-                        TemplateRegistry::TYPE_STRING => '@SonataAdmin/CRUD/base_show_field.html.twig',
+                        FieldDescriptionInterface::TYPE_EMAIL => '@SonataAdmin/CRUD/show_email.html.twig',
+                        FieldDescriptionInterface::TYPE_TRANS => '@SonataAdmin/CRUD/show_trans.html.twig',
+                        FieldDescriptionInterface::TYPE_STRING => '@SonataAdmin/CRUD/base_show_field.html.twig',
                         /* NEXT_MAJOR: Remove this line. */
                         TemplateRegistry::TYPE_SMALLINT => '@SonataAdmin/CRUD/base_show_field.html.twig',
                         /* NEXT_MAJOR: Remove this line. */
                         TemplateRegistry::TYPE_BIGINT => '@SonataAdmin/CRUD/base_show_field.html.twig',
-                        TemplateRegistry::TYPE_INTEGER => '@SonataAdmin/CRUD/base_show_field.html.twig',
+                        FieldDescriptionInterface::TYPE_INTEGER => '@SonataAdmin/CRUD/base_show_field.html.twig',
                         /* NEXT_MAJOR: Remove this line. */
                         TemplateRegistry::TYPE_DECIMAL => '@SonataAdmin/CRUD/base_show_field.html.twig',
-                        TemplateRegistry::TYPE_FLOAT => '@SonataAdmin/CRUD/base_show_field.html.twig',
-                        TemplateRegistry::TYPE_CURRENCY => '@SonataAdmin/CRUD/show_currency.html.twig',
-                        TemplateRegistry::TYPE_PERCENT => '@SonataAdmin/CRUD/show_percent.html.twig',
-                        TemplateRegistry::TYPE_CHOICE => '@SonataAdmin/CRUD/show_choice.html.twig',
-                        TemplateRegistry::TYPE_URL => '@SonataAdmin/CRUD/show_url.html.twig',
-                        TemplateRegistry::TYPE_HTML => '@SonataAdmin/CRUD/show_html.html.twig',
-                        TemplateRegistry::TYPE_MANY_TO_MANY => '@SonataAdmin/CRUD/Association/show_many_to_many.html.twig',
-                        TemplateRegistry::TYPE_MANY_TO_ONE => '@SonataAdmin/CRUD/Association/show_many_to_one.html.twig',
-                        TemplateRegistry::TYPE_ONE_TO_MANY => '@SonataAdmin/CRUD/Association/show_one_to_many.html.twig',
-                        TemplateRegistry::TYPE_ONE_TO_ONE => '@SonataAdmin/CRUD/Association/show_one_to_one.html.twig',
+                        FieldDescriptionInterface::TYPE_FLOAT => '@SonataAdmin/CRUD/base_show_field.html.twig',
+                        FieldDescriptionInterface::TYPE_CURRENCY => '@SonataAdmin/CRUD/show_currency.html.twig',
+                        FieldDescriptionInterface::TYPE_PERCENT => '@SonataAdmin/CRUD/show_percent.html.twig',
+                        FieldDescriptionInterface::TYPE_CHOICE => '@SonataAdmin/CRUD/show_choice.html.twig',
+                        FieldDescriptionInterface::TYPE_URL => '@SonataAdmin/CRUD/show_url.html.twig',
+                        FieldDescriptionInterface::TYPE_HTML => '@SonataAdmin/CRUD/show_html.html.twig',
+                        FieldDescriptionInterface::TYPE_MANY_TO_MANY => '@SonataAdmin/CRUD/Association/show_many_to_many.html.twig',
+                        FieldDescriptionInterface::TYPE_MANY_TO_ONE => '@SonataAdmin/CRUD/Association/show_many_to_one.html.twig',
+                        FieldDescriptionInterface::TYPE_ONE_TO_MANY => '@SonataAdmin/CRUD/Association/show_one_to_many.html.twig',
+                        FieldDescriptionInterface::TYPE_ONE_TO_ONE => '@SonataAdmin/CRUD/Association/show_one_to_one.html.twig',
                     ],
                 ],
             ],
@@ -101,33 +102,33 @@ abstract class AbstractSonataAdminExtension extends Extension
         $bundles = $container->getParameter('kernel.bundles');
         if (isset($bundles['SonataIntlBundle'])) {
             $defaultConfig['templates']['types']['list'] = array_merge($defaultConfig['templates']['types']['list'], [
-                TemplateRegistry::TYPE_DATE => '@SonataIntl/CRUD/list_date.html.twig',
-                TemplateRegistry::TYPE_DATETIME => '@SonataIntl/CRUD/list_datetime.html.twig',
+                FieldDescriptionInterface::TYPE_DATE => '@SonataIntl/CRUD/list_date.html.twig',
+                FieldDescriptionInterface::TYPE_DATETIME => '@SonataIntl/CRUD/list_datetime.html.twig',
                 /* NEXT_MAJOR: Remove this line. */
                 TemplateRegistry::TYPE_SMALLINT => '@SonataIntl/CRUD/list_decimal.html.twig',
                 /* NEXT_MAJOR: Remove this line. */
                 TemplateRegistry::TYPE_BIGINT => '@SonataIntl/CRUD/list_decimal.html.twig',
-                TemplateRegistry::TYPE_INTEGER => '@SonataIntl/CRUD/list_decimal.html.twig',
+                FieldDescriptionInterface::TYPE_INTEGER => '@SonataIntl/CRUD/list_decimal.html.twig',
                 /* NEXT_MAJOR: Remove this line. */
                 TemplateRegistry::TYPE_DECIMAL => '@SonataIntl/CRUD/list_decimal.html.twig',
-                TemplateRegistry::TYPE_FLOAT => '@SonataIntl/CRUD/list_decimal.html.twig',
-                TemplateRegistry::TYPE_CURRENCY => '@SonataIntl/CRUD/list_currency.html.twig',
-                TemplateRegistry::TYPE_PERCENT => '@SonataIntl/CRUD/list_percent.html.twig',
+                FieldDescriptionInterface::TYPE_FLOAT => '@SonataIntl/CRUD/list_decimal.html.twig',
+                FieldDescriptionInterface::TYPE_CURRENCY => '@SonataIntl/CRUD/list_currency.html.twig',
+                FieldDescriptionInterface::TYPE_PERCENT => '@SonataIntl/CRUD/list_percent.html.twig',
             ]);
 
             $defaultConfig['templates']['types']['show'] = array_merge($defaultConfig['templates']['types']['show'], [
-                TemplateRegistry::TYPE_DATE => '@SonataIntl/CRUD/show_date.html.twig',
-                TemplateRegistry::TYPE_DATETIME => '@SonataIntl/CRUD/show_datetime.html.twig',
+                FieldDescriptionInterface::TYPE_DATE => '@SonataIntl/CRUD/show_date.html.twig',
+                FieldDescriptionInterface::TYPE_DATETIME => '@SonataIntl/CRUD/show_datetime.html.twig',
                 /* NEXT_MAJOR: Remove this line. */
                 TemplateRegistry::TYPE_SMALLINT => '@SonataIntl/CRUD/show_decimal.html.twig',
                 /* NEXT_MAJOR: Remove this line. */
                 TemplateRegistry::TYPE_BIGINT => '@SonataIntl/CRUD/show_decimal.html.twig',
-                TemplateRegistry::TYPE_INTEGER => '@SonataIntl/CRUD/show_decimal.html.twig',
+                FieldDescriptionInterface::TYPE_INTEGER => '@SonataIntl/CRUD/show_decimal.html.twig',
                 /* NEXT_MAJOR: Remove this line. */
                 TemplateRegistry::TYPE_DECIMAL => '@SonataIntl/CRUD/show_decimal.html.twig',
-                TemplateRegistry::TYPE_FLOAT => '@SonataIntl/CRUD/list_decimal.html.twig',
-                TemplateRegistry::TYPE_CURRENCY => '@SonataIntl/CRUD/show_currency.html.twig',
-                TemplateRegistry::TYPE_PERCENT => '@SonataIntl/CRUD/show_percent.html.twig',
+                FieldDescriptionInterface::TYPE_FLOAT => '@SonataIntl/CRUD/list_decimal.html.twig',
+                FieldDescriptionInterface::TYPE_CURRENCY => '@SonataIntl/CRUD/show_currency.html.twig',
+                FieldDescriptionInterface::TYPE_PERCENT => '@SonataIntl/CRUD/show_percent.html.twig',
             ]);
         }
 

--- a/src/Form/DataTransformerResolver.php
+++ b/src/Form/DataTransformerResolver.php
@@ -16,7 +16,6 @@ namespace Sonata\AdminBundle\Form;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
-use Sonata\AdminBundle\Templating\TemplateRegistry;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Extension\Core\DataTransformer\DateTimeToStringTransformer;
 
@@ -64,7 +63,7 @@ final class DataTransformerResolver implements DataTransformerResolverInterface
         }
 
         // Handle date type has setter expect a DateTime object
-        if (TemplateRegistry::TYPE_DATE === $fieldType) {
+        if (FieldDescriptionInterface::TYPE_DATE === $fieldType) {
             $this->globalCustomTransformers[$fieldType] = new DateTimeToStringTransformer(
                 null,
                 $this->getOutputTimezone($fieldDescription),
@@ -75,7 +74,7 @@ final class DataTransformerResolver implements DataTransformerResolverInterface
         }
 
         // Handle entity choice association type, transforming the value into entity
-        if (TemplateRegistry::TYPE_CHOICE === $fieldType) {
+        if (FieldDescriptionInterface::TYPE_CHOICE === $fieldType) {
             $className = $fieldDescription->getOption('class');
 
             if (null !== $className &&

--- a/src/Resources/views/CRUD/base_list_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_field.html.twig
@@ -54,10 +54,10 @@ file that was distributed with this source code.
                 })
             ) %}
 
-            {% if field_description.type == constant('Sonata\\AdminBundle\\Templating\\TemplateRegistry::TYPE_DATE') and value is not empty %}
+            {% if field_description.type == constant('Sonata\\AdminBundle\\Admin\\FieldDescriptionInterface::TYPE_DATE') and value is not empty %}
                 {# it is a x-editable format https://vitalets.github.io/x-editable/docs.html#date #}
                 {% set data_value = value|date('Y-m-d', options.timezone|default(null)) %}
-            {% elseif field_description.type == constant('Sonata\\AdminBundle\\Templating\\TemplateRegistry::TYPE_BOOLEAN') and value is empty %}
+            {% elseif field_description.type == constant('Sonata\\AdminBundle\\Admin\\FieldDescriptionInterface::TYPE_BOOLEAN') and value is empty %}
                 {% set data_value = 0 %}
             {% elseif value is iterable %}
                 {% set data_value = value|json_encode %}
@@ -71,7 +71,7 @@ file that was distributed with this source code.
                   {% if field_description.label is not same as(false) %}
                     data-title="{{ field_description.label|trans({}, field_description.translationDomain) }}"
                   {% endif %}
-                  {% if field_description.type == constant('Sonata\\AdminBundle\\Templating\\TemplateRegistry::TYPE_DATE') %}
+                  {% if field_description.type == constant('Sonata\\AdminBundle\\Admin\\FieldDescriptionInterface::TYPE_DATE') %}
                     data-format="yyyy-mm-dd"
                   {% endif %}
                   data-pk="{{ admin.id(object) }}"

--- a/src/Templating/TemplateRegistryInterface.php
+++ b/src/Templating/TemplateRegistryInterface.php
@@ -20,50 +20,204 @@ namespace Sonata\AdminBundle\Templating;
  */
 interface TemplateRegistryInterface
 {
-    public const TYPE_ARRAY = 'array';
-    public const TYPE_BOOLEAN = 'boolean';
-    public const TYPE_DATE = 'date';
-    public const TYPE_TIME = 'time';
-    public const TYPE_DATETIME = 'datetime';
     /**
      * NEXT_MAJOR: Remove this constant.
      *
-     * @deprecated since sonata-project/admin-bundle 3.68, to be removed in 4.0. Use Sonata\AdminBundle\Templating\TemplateRegistry::TYPE_STRING instead.
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_ARRAY instead.
+     */
+    public const TYPE_ARRAY = 'array';
+
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_BOOLEAN instead.
+     */
+    public const TYPE_BOOLEAN = 'boolean';
+
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_DATE instead.
+     */
+    public const TYPE_DATE = 'date';
+
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_TIME instead.
+     */
+    public const TYPE_TIME = 'time';
+
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_DATETIME instead.
+     */
+    public const TYPE_DATETIME = 'datetime';
+
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.68, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_STRING instead.
      */
     public const TYPE_TEXT = 'text';
-    public const TYPE_TEXTAREA = 'textarea';
-    public const TYPE_EMAIL = 'email';
-    public const TYPE_TRANS = 'trans';
-    public const TYPE_STRING = 'string';
+
     /**
      * NEXT_MAJOR: Remove this constant.
      *
-     * @deprecated since sonata-project/admin-bundle 3.68, to be removed in 4.0. Use Sonata\AdminBundle\Templating\TemplateRegistry::TYPE_INTEGER instead.
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_TEXTAREA instead.
+     */
+    public const TYPE_TEXTAREA = 'textarea';
+
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_EMAIL instead.
+     */
+    public const TYPE_EMAIL = 'email';
+
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_TRANS instead.
+     */
+    public const TYPE_TRANS = 'trans';
+
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_STRING instead.
+     */
+    public const TYPE_STRING = 'string';
+
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.68, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_INTEGER instead.
      */
     public const TYPE_SMALLINT = 'smallint';
+
     /**
      * NEXT_MAJOR: Remove this constant.
      *
-     * @deprecated since sonata-project/admin-bundle 3.68, to be removed in 4.0. Use Sonata\AdminBundle\Templating\TemplateRegistry::TYPE_INTEGER instead.
+     * @deprecated since sonata-project/admin-bundle 3.68, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_INTEGER instead.
      */
     public const TYPE_BIGINT = 'bigint';
-    public const TYPE_INTEGER = 'integer';
+
     /**
      * NEXT_MAJOR: Remove this constant.
      *
-     * @deprecated since sonata-project/admin-bundle 3.68, to be removed in 4.0. Use Sonata\AdminBundle\Templating\TemplateRegistry::TYPE_FLOAT instead.
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_INTEGER instead.
+     */
+    public const TYPE_INTEGER = 'integer';
+
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.68, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_FLOAT instead.
      */
     public const TYPE_DECIMAL = 'decimal';
+
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_FLOAT instead.
+     */
     public const TYPE_FLOAT = 'float';
+
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_IDENTIFIER instead.
+     */
     public const TYPE_IDENTIFIER = 'identifier';
+
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_CURRENCY instead.
+     */
     public const TYPE_CURRENCY = 'currency';
+
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_PERCENT instead.
+     */
     public const TYPE_PERCENT = 'percent';
+
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_CHOICE instead.
+     */
     public const TYPE_CHOICE = 'choice';
+
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_URL instead.
+     */
     public const TYPE_URL = 'url';
+
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_HTML instead.
+     */
     public const TYPE_HTML = 'html';
+
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_MANY_TO_MANY instead.
+     */
     public const TYPE_MANY_TO_MANY = 'many_to_many';
+
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_MANY_TO_ONE instead.
+     */
     public const TYPE_MANY_TO_ONE = 'many_to_one';
+
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_ONE_TO_MANY instead.
+     */
     public const TYPE_ONE_TO_MANY = 'one_to_many';
+
+    /**
+     * NEXT_MAJOR: Remove this constant.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+     * Use Sonata\AdminBundle\Admin\FieldDescriptionInterface::TYPE_ONE_TO_ONE instead.
+     */
     public const TYPE_ONE_TO_ONE = 'one_to_one';
 
     /**

--- a/tests/App/Admin/FooAdmin.php
+++ b/tests/App/Admin/FooAdmin.php
@@ -16,10 +16,10 @@ namespace Sonata\AdminBundle\Tests\App\Admin;
 use Knp\Menu\ItemInterface as MenuItemInterface;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
-use Sonata\AdminBundle\Templating\TemplateRegistry;
 use Sonata\AdminBundle\Tests\App\Model\Foo;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
@@ -32,7 +32,7 @@ final class FooAdmin extends AbstractAdmin
 
     protected function configureListFields(ListMapper $list): void
     {
-        $list->add('name', TemplateRegistry::TYPE_STRING, [
+        $list->add('name', FieldDescriptionInterface::TYPE_STRING, [
             'sortable' => true,
         ]);
     }
@@ -44,7 +44,7 @@ final class FooAdmin extends AbstractAdmin
 
     protected function configureShowFields(ShowMapper $show): void
     {
-        $show->add('name', TemplateRegistry::TYPE_STRING);
+        $show->add('name', FieldDescriptionInterface::TYPE_STRING);
     }
 
     protected function configureTabMenu(MenuItemInterface $menu, $action, ?AdminInterface $childAdmin = null)

--- a/tests/App/Admin/TranslatedAdmin.php
+++ b/tests/App/Admin/TranslatedAdmin.php
@@ -14,17 +14,17 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\App\Admin;
 
 use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
-use Sonata\AdminBundle\Templating\TemplateRegistry;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 final class TranslatedAdmin extends AbstractAdmin
 {
     protected function configureListFields(ListMapper $list): void
     {
-        $list->add('name_list', TemplateRegistry::TYPE_STRING);
+        $list->add('name_list', FieldDescriptionInterface::TYPE_STRING);
     }
 
     protected function configureFormFields(FormMapper $form): void
@@ -38,6 +38,6 @@ final class TranslatedAdmin extends AbstractAdmin
 
     protected function configureShowFields(ShowMapper $show): void
     {
-        $show->add('name_show', TemplateRegistry::TYPE_STRING);
+        $show->add('name_show', FieldDescriptionInterface::TYPE_STRING);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

They have been moved to `FieldDescriptionInterface` since they are the values of `FieldDescriptionInterface::getType()`.

In the future, maybe we can create classes for each type and have some configuration and logic in there instead of having it in the associated template.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6749.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `TemplateRegistryInterface::TYPE_*` constants, they have been moved to `FieldDescriptionInterface`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
