### PR TITLE
Some Pool definition fixes

### DIFF
--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -214,9 +214,9 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
         $pool->addMethodCall('setAdminGroups', [$groups, 'sonata_deprecation_mute']);
         $pool->addMethodCall('setAdminClasses', [$classes, 'sonata_deprecation_mute']);
 
-        $pool->replaceArgument(1, [$admins]);
-        $pool->replaceArgument(2, [$groups]);
-        $pool->replaceArgument(3, [$classes]);
+        $pool->replaceArgument(1, $admins);
+        $pool->replaceArgument(2, $groups);
+        $pool->replaceArgument(3, $classes);
 
         $routeLoader = $container->getDefinition('sonata.admin.route_loader');
         $routeLoader->replaceArgument(1, $admins);

--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -52,9 +52,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->public()
             ->args([
                 new ReferenceConfigurator('service_container'),
-                '',
-                '',
-                [],
+                [], // admin service ids
+                [], // admin service groups
+                [], // admin service classes
             ])
             ->call('setTemplateRegistry', [
                 new ReferenceConfigurator('sonata.admin.global_template_registry'),

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -170,6 +170,12 @@ class AddDependencyCallsCompilerPassTest extends TestCase
         $this->assertContains('sonata_article_admin', $adminServiceIds);
         $this->assertContains('sonata_news_admin', $adminServiceIds);
 
+        $poolDefinition = $container->getDefinition('sonata.admin.pool');
+
+        $this->assertContains('sonata_post_admin', $poolDefinition->getArgument(1));
+        $this->assertArrayHasKey('sonata_group_one', $poolDefinition->getArgument(2));
+        $this->assertArrayHasKey(News::class, $poolDefinition->getArgument(3));
+
         $this->assertArrayHasKey('sonata_group_one', $adminGroups);
         $this->assertArrayHasKey('label', $adminGroups['sonata_group_one']);
         $this->assertArrayHasKey('label_catalogue', $adminGroups['sonata_group_one']);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

The arguments are wrong because they are already arrays.

Projects should not fail because these arguments are overriden by the method calls:

```php
$pool->addMethodCall('setAdminServiceIds', [$admins, 'sonata_deprecation_mute']);
$pool->addMethodCall('setAdminGroups', [$groups, 'sonata_deprecation_mute']);
$pool->addMethodCall('setAdminClasses', [$classes, 'sonata_deprecation_mute']);
```
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed `Pool` definition arguments.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
