### PR TITLE
Add generic for PagerInterface

### DIFF
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -18,6 +18,9 @@ namespace Sonata\AdminBundle\Datagrid;
  *
  * @author Fabien Potencier <fabien.potencier@symfony-project.com>
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @phpstan-template T of ProxyQueryInterface
+ * @phpstan-implements PagerInterface<T>
  */
 abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInterface
 {
@@ -113,6 +116,8 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
 
     /**
      * @var ProxyQueryInterface|null
+     *
+     * @phpstan-var T|null
      */
     protected $query;
 
@@ -856,6 +861,8 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
 
     /**
      * @return ProxyQueryInterface|null
+     *
+     * @phpstan-return T|null $query
      */
     public function getQuery()
     {

--- a/src/Datagrid/PagerInterface.php
+++ b/src/Datagrid/PagerInterface.php
@@ -30,6 +30,8 @@ namespace Sonata\AdminBundle\Datagrid;
  * @method array                    getLinks(?int $nbLinks = null)
  * @method bool                     haveToPaginate()
  * @method ProxyQueryInterface|null getQuery()
+ *
+ * @phpstan-template T of ProxyQueryInterface
  */
 interface PagerInterface
 {
@@ -79,10 +81,17 @@ interface PagerInterface
 //    public function isLastPage(): bool;
 
 //    NEXT_MAJOR: uncomment this method in 4.0
+//    /**
+//     * @return ProxyQueryInterface|null
+//     *
+//     * @phpstan-return T|null
+//     */
 //    public function getQuery(): ?ProxyQueryInterface;
 
     /**
      * @param ProxyQueryInterface $query
+     *
+     * @phpstan-param T $query
      */
     public function setQuery($query);
 


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

DoctrineORMBundle need the Query to implement the DoctrineORMBundle\Datagrid\ProxyQueryInterface.
This will allow the Pager to restrict the type of the $query.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Add generics to `PagerInterface`.
```