### PR TITLE
Deprecate getResults in favor of getCurrentPageResults

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -27,6 +27,10 @@ UPGRADE FROM 3.xx to 3.xx
 - Deprecated `SonataAdminExtension::getTemplate()` method.
 - Deprecated `SonataAdminExtension::getTemplateRegistry()` method.
 
+### Sonata\AdminBundle\Datagrid\PagerInterface
+
+Deprecated `getResults()` method in favor of `getCurrentPageResults()`.
+
 UPGRADE FROM 3.85 to 3.86
 =========================
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -238,12 +238,6 @@ parameters:
 
         -
             # will be fixed in v4
-            message: "#^Property Sonata\\\\AdminBundle\\\\Datagrid\\\\Pager:\\:$results \\(array<object>|null\\) does not accept Doctrine\\\\Common\\\\Collections\\\\ArrayCollection<mixed, mixed>\\.$#"
-            count: 2
-            path: src/Datagrid/SimplePager.php
-
-        -
-            # will be fixed in v4
             message: "#^Method Sonata\\\\AdminBundle\\\\Datagrid\\\\Pager::next\\(\\) with return type void returns mixed but should not return anything\\.$#"
             count: 1
             path: src/Datagrid/Pager.php

--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Action;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Datagrid\PagerInterface;
 use Sonata\AdminBundle\Filter\FilterInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -148,7 +149,17 @@ final class RetrieveAutocompleteItemsAction
         $pager = $datagrid->getPager();
 
         $items = [];
-        $results = $pager->getResults();
+        // NEXT_MAJOR: remove the existence check and just use $pager->getCurrentPageResults()
+        if (method_exists($pager, 'getCurrentPageResults')) {
+            $results = $pager->getCurrentPageResults();
+        } else {
+            @trigger_error(sprintf(
+                'Not implementing "%s::getCurrentPageResults()" is deprecated since sonata-project/admin-bundle 3.x and will fail in 4.0.',
+                PagerInterface::class
+            ), E_USER_DEPRECATED);
+
+            $results = $pager->getResults();
+        }
 
         foreach ($results as $model) {
             if (null !== $toStringCallback) {

--- a/src/Action/SearchAction.php
+++ b/src/Action/SearchAction.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Action;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Datagrid\PagerInterface;
 use Sonata\AdminBundle\Search\SearchHandler;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
@@ -106,7 +107,19 @@ final class SearchAction
             $request->get('page'),
             $request->get('offset')
         )) {
-            foreach ($pager->getResults() as $result) {
+            // NEXT_MAJOR: remove the existence check and just use $pager->getCurrentPageResults()
+            if (method_exists($pager, 'getCurrentPageResults')) {
+                $pageResults = $pager->getCurrentPageResults();
+            } else {
+                @trigger_error(sprintf(
+                    'Not implementing "%s::getCurrentPageResults()" is deprecated since sonata-project/admin-bundle 3.x and will fail in 4.0.',
+                    PagerInterface::class
+                ), E_USER_DEPRECATED);
+
+                $pageResults = $pager->getResults();
+            }
+
+            foreach ($pageResults as $result) {
                 $results[] = [
                     'label' => $admin->toString($result),
                     'link' => $admin->getSearchResultLink($result),

--- a/src/Datagrid/DatagridInterface.php
+++ b/src/Datagrid/DatagridInterface.php
@@ -37,7 +37,7 @@ interface DatagridInterface
     public function getQuery();
 
     /**
-     * @return object[]
+     * @return iterable<object>
      */
     public function getResults();
 

--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -940,7 +940,23 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
             ), E_USER_DEPRECATED);
         }
 
-        $this->results = $this->getResults();
+        if (method_exists($this, 'getCurrentPageResults')) {
+            $results = $this->getCurrentPageResults();
+        } else {
+            @trigger_error(sprintf(
+                'Not implementing "%s::getCurrentPageResults()" is deprecated since sonata-project/admin-bundle 3.x and will fail in 4.0.',
+                PagerInterface::class
+            ), E_USER_DEPRECATED);
+
+            $results = $this->getResults();
+        }
+
+        if (\is_array($results)) {
+            $this->results = $results;
+        } else {
+            $this->results = iterator_to_array($results);
+        }
+
         $this->resultsCounter = \count($this->results);
     }
 

--- a/src/Datagrid/PagerInterface.php
+++ b/src/Datagrid/PagerInterface.php
@@ -30,6 +30,7 @@ namespace Sonata\AdminBundle\Datagrid;
  * @method array                    getLinks(?int $nbLinks = null)
  * @method bool                     haveToPaginate()
  * @method ProxyQueryInterface|null getQuery()
+ * @method iterable                 getCurrentPageResults()
  *
  * @phpstan-template T of ProxyQueryInterface
  */
@@ -102,11 +103,23 @@ interface PagerInterface
 //    public function haveToPaginate(): bool;
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x. To be removed in 4.0. Use getCurrentPageResults() instead.
+     *
      * Returns an array of results on the given page.
      *
-     * @return object[]
+     * @return iterable<object>
      */
     public function getResults();
+
+//    NEXT_MAJOR: uncomment this method in 4.0
+//    /**
+//     * Returns an array of results on the given page.
+//     *
+//     * @return iterable<object>
+//     */
+//    public function getCurrentPageResults(): iterable;
 
 //    NEXT_MAJOR: uncomment this method in 4.0
 //    public function countResults(): int;

--- a/src/Datagrid/PagerInterface.php
+++ b/src/Datagrid/PagerInterface.php
@@ -107,7 +107,7 @@ interface PagerInterface
      *
      * @deprecated since sonata-project/admin-bundle 3.x. To be removed in 4.0. Use getCurrentPageResults() instead.
      *
-     * Returns an array of results on the given page.
+     * Returns a collection of results on the given page.
      *
      * @return iterable<object>
      */
@@ -115,7 +115,7 @@ interface PagerInterface
 
 //    NEXT_MAJOR: uncomment this method in 4.0
 //    /**
-//     * Returns an array of results on the given page.
+//     * Returns a collection of results on the given page.
 //     *
 //     * @return iterable<object>
 //     */

--- a/src/Datagrid/SimplePager.php
+++ b/src/Datagrid/SimplePager.php
@@ -88,7 +88,7 @@ class SimplePager extends Pager
 
     public function getCurrentPageResults(): iterable
     {
-        if ($this->results) {
+        if (null !== $this->results) {
             return $this->results;
         }
 
@@ -121,7 +121,7 @@ class SimplePager extends Pager
             __METHOD__
         ), E_USER_DEPRECATED);
 
-        if ($this->results) {
+        if (null !== $this->results) {
             return $this->results;
         }
 
@@ -177,7 +177,7 @@ class SimplePager extends Pager
 
             // NEXT_MAJOR: Remove this line and uncomment the following one instead.
             $this->initializeIterator('sonata_deprecation_mute');
-//            $this->results = $this->getResults();
+//            $this->results = $this->getCurrentPageResults();
 
             $t = (int) ceil($this->thresholdCount / $this->getMaxPerPage()) + $this->getPage() - 1;
             $this->setLastPage(max(1, $t));

--- a/src/Datagrid/SimplePager.php
+++ b/src/Datagrid/SimplePager.php
@@ -121,7 +121,25 @@ class SimplePager extends Pager
             __METHOD__
         ), E_USER_DEPRECATED);
 
-        return $this->getCurrentPageResults();
+        if ($this->results) {
+            return $this->results;
+        }
+
+        $this->results = $this->getQuery()->execute([], $hydrationMode);
+        $this->thresholdCount = \count($this->results);
+        if (\count($this->results) > $this->getMaxPerPage()) {
+            $this->haveToPaginate = true;
+
+            if ($this->results instanceof ArrayCollection) {
+                $this->results = new ArrayCollection($this->results->slice(0, $this->getMaxPerPage()));
+            } else {
+                $this->results = new ArrayCollection(\array_slice($this->results, 0, $this->getMaxPerPage()));
+            }
+        } else {
+            $this->haveToPaginate = false;
+        }
+
+        return $this->results;
     }
 
     public function haveToPaginate()

--- a/src/Datagrid/SimplePager.php
+++ b/src/Datagrid/SimplePager.php
@@ -24,7 +24,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 class SimplePager extends Pager
 {
     /**
-     * @var object[]|null
+     * @var iterable<object>|null
      */
     protected $results;
 
@@ -86,13 +86,13 @@ class SimplePager extends Pager
         return $n;
     }
 
-    public function getResults($hydrationMode = null)
+    public function getCurrentPageResults(): iterable
     {
         if ($this->results) {
             return $this->results;
         }
 
-        $this->results = $this->getQuery()->execute([], $hydrationMode);
+        $this->results = $this->getQuery()->execute();
         $this->thresholdCount = \count($this->results);
         if (\count($this->results) > $this->getMaxPerPage()) {
             $this->haveToPaginate = true;
@@ -107,6 +107,21 @@ class SimplePager extends Pager
         }
 
         return $this->results;
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x. To be removed in 4.0. Use getCurrentPageResults() instead.
+     */
+    public function getResults($hydrationMode = null)
+    {
+        @trigger_error(sprintf(
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0. Use getCurrentPageResults() instead.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
+        return $this->getCurrentPageResults();
     }
 
     public function haveToPaginate()

--- a/src/Resources/views/Block/block_search_result.html.twig
+++ b/src/Resources/views/Block/block_search_result.html.twig
@@ -15,7 +15,8 @@ file that was distributed with this source code.
     {# NEXT_MAJOR: Remove the following line #}
     {% set show_empty_boxes = show_empty_boxes|default(sonata_admin.adminPool.container.getParameter('sonata.admin.configuration.global_search.empty_boxes')) %}
     {% set visibility_class = 'sonata-search-result-' ~ show_empty_boxes %}
-    {% if pager and pager.getResults()|length %}
+    {# NEXT_MAJOR: remove the attribute check and just use .currentPageResults #}
+    {% if pager and (attribute(pager, 'getCurrentPageResults') is defined ? pager.currentPageResults : pager.results)|length %}
         {% set visibility_class = 'sonata-search-result-show' %}
     {% endif %}
 
@@ -47,10 +48,12 @@ file that was distributed with this source code.
                     {% endif %}
                 </div>
             </div>
-            {% if pager and pager.getResults()|length %}
+            {# NEXT_MAJOR: remove the attribute check and just use .currentPageResults #}
+            {% if pager and (attribute(pager, 'getCurrentPageResults') is defined ? pager.currentPageResults : pager.results)|length %}
                 <div class="box-body no-padding">
                     <ul class="nav nav-stacked sonata-search-result-list">
-                        {% for result in pager.getResults() %}
+                        {# NEXT_MAJOR: remove the attribute check and just use .currentPageResults #}
+                        {% for result in (attribute(pager, 'getCurrentPageResults') is defined ? pager.currentPageResults : pager.results) %}
                             {% set link = admin.getSearchResultLink(result) %}
                             {% if link %}
                                 <li><a href="{{ link }}">{{ admin.toString(result) }}</a></li>

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -113,7 +113,7 @@ file that was distributed with this source code.
                                 </div>
                                 <div class="progress-description">
                                     <ul class="list-inline">
-                                        {%- if admin.datagrid.pager.results|length > 0 -%}
+                                        {%- if admin.datagrid.results|length > 0 -%}
                                             <li>
                                                 <a href="{{ admin.generateUrl('list') }}">
                                                     {{- 'go_to_the_first_page'|trans({}, 'SonataAdminBundle') -}}

--- a/tests/Action/RetrieveAutocompleteItemsActionTest.php
+++ b/tests/Action/RetrieveAutocompleteItemsActionTest.php
@@ -21,7 +21,7 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
-use Sonata\AdminBundle\Datagrid\Pager;
+use Sonata\AdminBundle\Datagrid\PagerInterface;
 use Sonata\AdminBundle\Object\MetadataInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Filter\FooFilter;
 use Symfony\Component\DependencyInjection\Container;
@@ -242,7 +242,10 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         $targetAdmin = $this->createMock(AbstractAdmin::class);
         $datagrid = $this->createStub(DatagridInterface::class);
         $metadata = $this->createStub(MetadataInterface::class);
-        $pager = $this->createStub(Pager::class);
+        // NEXT_MAJOR: Use createMock instead.
+        $pager = $this->getMockBuilder(PagerInterface::class)
+            ->addMethods(['getCurrentPageResults', 'isLastPage'])
+            ->getMockForAbstractClass();
         // NEXT_MAJOR: Use `createStub` instead of using mock builder
         $fieldDescription = $this->getMockBuilder(FieldDescriptionInterface::class)
             ->addMethods(['getTargetModel'])
@@ -262,7 +265,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
 
         $datagrid->method('buildPager')->willReturn(null);
         $datagrid->method('getPager')->willReturn($pager);
-        $pager->method('getResults')->willReturn([$model]);
+        $pager->method('getCurrentPageResults')->willReturn([$model]);
         $pager->method('isLastPage')->willReturn(true);
         $fieldDescription->method('getTargetModel')->willReturn(Foo::class);
         $fieldDescription->method('getName')->willReturn('barField');

--- a/tests/App/Datagrid/Pager.php
+++ b/tests/App/Datagrid/Pager.php
@@ -73,7 +73,7 @@ final class Pager implements PagerInterface
 
     public function getLastPage(): int
     {
-        return 2;
+        return 1;
     }
 
     public function isLastPage(): bool
@@ -95,7 +95,15 @@ final class Pager implements PagerInterface
         return false;
     }
 
-    public function getResults(): array
+    /**
+     * NEXT_MAJOR: remove this method.
+     */
+    public function getResults(): iterable
+    {
+        return $this->getCurrentPageResults();
+    }
+
+    public function getCurrentPageResults(): iterable
     {
         return $this->repository->all();
     }
@@ -110,7 +118,7 @@ final class Pager implements PagerInterface
 
     public function countResults(): int
     {
-        return \count($this->getResults());
+        return 1;
     }
 
     public function getLinks(?int $nbLinks = null): array

--- a/tests/Datagrid/DatagridTest.php
+++ b/tests/Datagrid/DatagridTest.php
@@ -70,7 +70,10 @@ class DatagridTest extends TestCase
     {
         $this->query = $this->createMock(ProxyQueryInterface::class);
         $this->columns = new FieldDescriptionCollection();
-        $this->pager = $this->createMock(PagerInterface::class);
+        // NEXT_MAJOR: Use createMock instead.
+        $this->pager = $this->getMockBuilder(PagerInterface::class)
+            ->addMethods(['getCurrentPageResults'])
+            ->getMockForAbstractClass();
 
         $this->formData = [];
         $this->formTypes = [];
@@ -331,7 +334,7 @@ class DatagridTest extends TestCase
         $this->assertNull($this->datagrid->getResults());
 
         $this->pager->expects($this->once())
-            ->method('getResults')
+            ->method('getCurrentPageResults')
             ->willReturn(['foo', 'bar']);
 
         $this->assertSame(['foo', 'bar'], $this->datagrid->getResults());
@@ -340,7 +343,7 @@ class DatagridTest extends TestCase
     public function testEmptyResults(): void
     {
         $this->pager->expects($this->once())
-            ->method('getResults')
+            ->method('getCurrentPageResults')
             ->willReturn([]);
 
         $this->assertSame([], $this->datagrid->getResults());

--- a/tests/Datagrid/SimplePagerTest.php
+++ b/tests/Datagrid/SimplePagerTest.php
@@ -127,7 +127,7 @@ class SimplePagerTest extends TestCase
     /**
      * NEXT_MAJOR: Remove this test along with fixes to SimplePager.
      */
-    public function testGetResultsReturnTypeArrayCollection(): void
+    public function testGetCurrentPageResultsReturnTypeArrayCollection(): void
     {
         $this->proxyQuery->expects($this->once())
             ->method('execute')
@@ -137,10 +137,10 @@ class SimplePagerTest extends TestCase
         $this->pager->setQuery($this->proxyQuery);
         $this->pager->setMaxPerPage(1);
 
-        $this->assertInstanceOf(ArrayCollection::class, $this->pager->getResults());
+        $this->assertInstanceOf(ArrayCollection::class, $this->pager->getCurrentPageResults());
     }
 
-    public function getResultsReturnType(): array
+    public function getCurrentPageResultsReturnType(): array
     {
         return [
             [['foo', 'bar'], 2],
@@ -149,9 +149,9 @@ class SimplePagerTest extends TestCase
     }
 
     /**
-     * @dataProvider getResultsReturnType
+     * @dataProvider getCurrentPageResultsReturnType
      */
-    public function testGetResultsReturnTypeArray(array $queryReturnValues, ?int $maxPerPage): void
+    public function testGetCurrentPageResultsReturnTypeArray(array $queryReturnValues, ?int $maxPerPage): void
     {
         $this->proxyQuery->expects($this->once())
             ->method('execute')
@@ -161,6 +161,6 @@ class SimplePagerTest extends TestCase
         $this->pager->setQuery($this->proxyQuery);
         $this->pager->setMaxPerPage($maxPerPage);
 
-        $this->assertIsArray($this->pager->getResults());
+        $this->assertIsArray($this->pager->getCurrentPageResults());
     }
 }


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

I just discover that
```
count($pager->getResults()) !== $pager->countResults()
```
And I think it's misleading.

`getResults` is returning the results of the current page, so I think it's better to rename this function.

I also close #6620

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `PagerInterface::getCurrentPageResults()`

### Deprecated
- Added `PagerInterface::getResults()`
```