### PR TITLE
Fix argument 3 of AdminMaker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
         "symfony/browser-kit": "^4.4 || ^5.1",
         "symfony/css-selector": "^4.4 || ^5.1",
         "symfony/filesystem": "^4.4 || ^5.1",
-        "symfony/maker-bundle": "^1.17",
+        "symfony/maker-bundle": "^1.25",
         "symfony/phpunit-bridge": "^5.1.8",
         "symfony/yaml": "^4.4 || ^5.1",
         "vimeo/psalm": "^4.3.2"

--- a/src/DependencyInjection/Compiler/AdminMakerCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AdminMakerCompilerPass.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class AdminMakerCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition('sonata.admin.maker')) {
+            return;
+        }
+
+        if (!$container->hasParameter('sonata.admin.configuration.default_controller')) {
+            return;
+        }
+
+        $defaultController = $container->getParameter('sonata.admin.configuration.default_controller');
+
+        if (!$container->hasDefinition($defaultController)) {
+            return;
+        }
+
+        $adminMaker = $container->getDefinition('sonata.admin.maker');
+        $controllerDefinition = $container->getDefinition($defaultController);
+
+        $adminMaker->replaceArgument(2, $controllerDefinition->getClass());
+    }
+}

--- a/src/Maker/AdminMaker.php
+++ b/src/Maker/AdminMaker.php
@@ -78,7 +78,7 @@ final class AdminMaker extends AbstractMaker
     private $defaultController;
 
     /**
-     * NEXT_MAJOR: Make $defaultController mandatory.
+     * NEXT_MAJOR: Make $modelManagers and $defaultController mandatory.
      *
      * @param string                               $projectDirectory
      * @param array<string, ModelManagerInterface> $modelManagers

--- a/src/SonataAdminBundle.php
+++ b/src/SonataAdminBundle.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle;
 use Mopa\Bundle\BootstrapBundle\Form\Type\TabType;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddFilterTypeCompilerPass;
+use Sonata\AdminBundle\DependencyInjection\Compiler\AdminMakerCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AdminSearchCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
@@ -57,6 +58,7 @@ class SonataAdminBundle extends Bundle
         $container->addCompilerPass(new ModelManagerCompilerPass());
         $container->addCompilerPass(new ObjectAclManipulatorCompilerPass());
         $container->addCompilerPass(new TwigStringExtensionCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, 1);
+        $container->addCompilerPass(new AdminMakerCompilerPass());
 
         $this->registerFormMapping();
     }

--- a/tests/DependencyInjection/Compiler/AdminMakerCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AdminMakerCompilerPassTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\AdminBundle\Controller\CRUDController;
+use Sonata\AdminBundle\DependencyInjection\Compiler\AdminMakerCompilerPass;
+use Sonata\AdminBundle\Maker\AdminMaker;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+final class AdminMakerCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    public function testDoesNothingWithoutAdminMaker(): void
+    {
+        $this->compile();
+
+        $this->assertContainerBuilderNotHasService('sonata.admin.maker');
+    }
+
+    public function testDoesNothingWithoutDefaultControllerParameter(): void
+    {
+        $definition = new Definition(AdminMaker::class);
+        $definition->setArguments([
+            'dir',
+            [],
+            CRUDController::class,
+        ]);
+        $this->container->setDefinition('sonata.admin.maker', $definition);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'sonata.admin.maker',
+            2,
+            CRUDController::class
+        );
+    }
+
+    public function testDoesNothingWithoutDefaultControllerNotBeingAService(): void
+    {
+        $definition = new Definition(AdminMaker::class);
+        $definition->setArguments([
+            'dir',
+            [],
+            CRUDController::class,
+        ]);
+        $this->container->setDefinition('sonata.admin.maker', $definition);
+
+        $this->container->setParameter('sonata.admin.configuration.default_controller', CRUDController::class);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'sonata.admin.maker',
+            2,
+            CRUDController::class
+        );
+    }
+
+    public function testReplacesTheServiceArgumentWithClassName(): void
+    {
+        $definition = new Definition(AdminMaker::class);
+        $definition->setArguments([
+            'dir',
+            [],
+            'sonata.admin.controller.crud',
+        ]);
+        $this->container->setDefinition('sonata.admin.maker', $definition);
+
+        $definition = new Definition(CRUDController::class);
+        $this->container->setDefinition('sonata.admin.controller.crud', $definition);
+
+        $this->container->setParameter('sonata.admin.configuration.default_controller', 'sonata.admin.controller.crud');
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'sonata.admin.maker',
+            2,
+            CRUDController::class
+        );
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new AdminMakerCompilerPass());
+    }
+}

--- a/tests/Maker/AdminMakerTest.php
+++ b/tests/Maker/AdminMakerTest.php
@@ -22,6 +22,7 @@ use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\Util\AutoloaderUtil;
 use Symfony\Bundle\MakerBundle\Util\MakerFileLinkFormatter;
+use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -131,7 +132,11 @@ class AdminMakerTest extends TestCase
         );
         $fileManager->setIO($this->io);
 
-        $this->generator = new Generator($fileManager, 'Sonata\AdminBundle\Tests');
+        $this->generator = new Generator(
+            $fileManager,
+            'Sonata\AdminBundle\Tests',
+            new PhpCompatUtil($fileManager)
+        );
         $maker->generate($this->input, $this->io, $this->generator);
     }
 }

--- a/tests/SonataAdminBundleTest.php
+++ b/tests/SonataAdminBundleTest.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Tests;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddFilterTypeCompilerPass;
+use Sonata\AdminBundle\DependencyInjection\Compiler\AdminMakerCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AdminSearchCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
@@ -36,7 +37,7 @@ class SonataAdminBundleTest extends TestCase
     {
         $containerBuilder = $this->createMock(ContainerBuilder::class);
 
-        $containerBuilder->expects($this->exactly(8))
+        $containerBuilder->expects($this->exactly(9))
             ->method('addCompilerPass')
             ->willReturnCallback(function (CompilerPassInterface $pass, $type = PassConfig::TYPE_BEFORE_OPTIMIZATION): void {
                 if ($pass instanceof AddDependencyCallsCompilerPass) {
@@ -71,8 +72,12 @@ class SonataAdminBundleTest extends TestCase
                     return;
                 }
 
+                if ($pass instanceof AdminMakerCompilerPass) {
+                    return;
+                }
+
                 $this->fail(sprintf(
-                    'CompilerPass is not one of the expected types. Expects "%s", "%s", "%s", "%s", "%s", "%s" or "%s", but got "%s".',
+                    'CompilerPass is not one of the expected types. Expects "%s", "%s", "%s", "%s", "%s", "%s", "%s" or "%s", but got "%s".',
                     AddDependencyCallsCompilerPass::class,
                     AddFilterTypeCompilerPass::class,
                     AdminSearchCompilerPass::class,
@@ -81,6 +86,7 @@ class SonataAdminBundleTest extends TestCase
                     ModelManagerCompilerPass::class,
                     ObjectAclManipulatorCompilerPass::class,
                     TwigStringExtensionCompilerPass::class,
+                    AdminMakerCompilerPass::class,
                     \get_class($pass)
                 ));
             });

--- a/tests/SonataAdminBundleTest.php
+++ b/tests/SonataAdminBundleTest.php
@@ -24,8 +24,6 @@ use Sonata\AdminBundle\DependencyInjection\Compiler\ModelManagerCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ObjectAclManipulatorCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\TwigStringExtensionCompilerPass;
 use Sonata\AdminBundle\SonataAdminBundle;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
-use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -39,57 +37,18 @@ class SonataAdminBundleTest extends TestCase
 
         $containerBuilder->expects($this->exactly(9))
             ->method('addCompilerPass')
-            ->willReturnCallback(function (CompilerPassInterface $pass, $type = PassConfig::TYPE_BEFORE_OPTIMIZATION): void {
-                if ($pass instanceof AddDependencyCallsCompilerPass) {
-                    return;
-                }
-
-                if ($pass instanceof AddFilterTypeCompilerPass) {
-                    return;
-                }
-
-                if ($pass instanceof AdminSearchCompilerPass) {
-                    return;
-                }
-
-                if ($pass instanceof ExtensionCompilerPass) {
-                    return;
-                }
-
-                if ($pass instanceof GlobalVariablesCompilerPass) {
-                    return;
-                }
-
-                if ($pass instanceof ModelManagerCompilerPass) {
-                    return;
-                }
-
-                if ($pass instanceof ObjectAclManipulatorCompilerPass) {
-                    return;
-                }
-
-                if ($pass instanceof TwigStringExtensionCompilerPass) {
-                    return;
-                }
-
-                if ($pass instanceof AdminMakerCompilerPass) {
-                    return;
-                }
-
-                $this->fail(sprintf(
-                    'CompilerPass is not one of the expected types. Expects "%s", "%s", "%s", "%s", "%s", "%s", "%s" or "%s", but got "%s".',
-                    AddDependencyCallsCompilerPass::class,
-                    AddFilterTypeCompilerPass::class,
-                    AdminSearchCompilerPass::class,
-                    ExtensionCompilerPass::class,
-                    GlobalVariablesCompilerPass::class,
-                    ModelManagerCompilerPass::class,
-                    ObjectAclManipulatorCompilerPass::class,
-                    TwigStringExtensionCompilerPass::class,
-                    AdminMakerCompilerPass::class,
-                    \get_class($pass)
-                ));
-            });
+            ->withConsecutive(
+                [new AddDependencyCallsCompilerPass()],
+                [new AddFilterTypeCompilerPass()],
+                [new AdminSearchCompilerPass()],
+                [new ExtensionCompilerPass()],
+                [new GlobalVariablesCompilerPass()],
+                [new ModelManagerCompilerPass()],
+                [new ObjectAclManipulatorCompilerPass()],
+                [new TwigStringExtensionCompilerPass()],
+                [new AdminMakerCompilerPass()],
+            )
+        ;
 
         $bundle = new SonataAdminBundle();
         $bundle->build($containerBuilder);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

The third argument of `AdminMaker` could be a service name:

https://github.com/sonata-project/SonataAdminBundle/blob/d3f9b58fa7cdf0c02128c09a89c0f4ae8415b1df/src/Resources/config/makers.php#L27

This PR adds a compiler pass which retrieves this parameters and check if it is a service, in that case, it replaces the argument 3 by the class name of the service definition.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed using admin maker command having a default controller service.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
