### PR TITLE
Add RouteCollection::getRouteName

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1170,7 +1170,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
             return false;
         }
 
-        return sprintf('%s_%s', $admin->getBaseRouteName(), $name) === $route;
+        return $admin->getRoutes()->getRouteName($name) === $route;
     }
 
     public function generateObjectUrl($name, $object, array $parameters = [], $referenceType = RoutingUrlGeneratorInterface::ABSOLUTE_PATH)

--- a/src/Route/RouteCollection.php
+++ b/src/Route/RouteCollection.php
@@ -66,6 +66,11 @@ class RouteCollection implements RouteCollectionInterface
         $this->baseControllerName = $baseControllerName;
     }
 
+    public function getRouteName(string $name): string
+    {
+        return sprintf('%s_%s', $this->baseRouteName, $name);
+    }
+
     /**
      * Add route.
      *
@@ -89,7 +94,6 @@ class RouteCollection implements RouteCollectionInterface
     ) {
         $pattern = sprintf('%s/%s', $this->baseRoutePattern, $pattern ?: $name);
         $code = $this->getCode($name);
-        $routeName = sprintf('%s_%s', $this->baseRouteName, $name);
 
         if (!isset($defaults['_controller'])) {
             $actionJoiner = false === strpos($this->baseControllerName, '\\') ? ':' : '::';
@@ -104,7 +108,7 @@ class RouteCollection implements RouteCollectionInterface
             $defaults['_sonata_admin'] = $this->baseCodeRoute;
         }
 
-        $defaults['_sonata_name'] = $routeName;
+        $defaults['_sonata_name'] = $this->getRouteName($name);
 
         $element = static function () use ($pattern, $defaults, $requirements, $options, $host, $schemes, $methods, $condition) {
             return new Route($pattern, $defaults, $requirements, $options, $host, $schemes, $methods, $condition);

--- a/src/Route/RouteCollectionInterface.php
+++ b/src/Route/RouteCollectionInterface.php
@@ -17,6 +17,8 @@ use Symfony\Component\Routing\Route;
 
 /**
  * @author Jordi Sala <jordism91@gmail.com>
+ *
+ * @method string getRouteName(string $name)
  */
 interface RouteCollectionInterface
 {
@@ -122,6 +124,9 @@ interface RouteCollectionInterface
      * @return string
      */
     public function getBaseRouteName();
+
+    // NEXT_MAJOR: Uncomment the following line and remove corresponding @method annotation.
+//    public function getRouteName(string $name): string;
 
     /**
      * @return string


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

Currently, I don't see any way to get the routeName of the postAdmin list.
It's computed as `sprintf('%s_%s', $this->baseRouteName, $name);` in `RouteCollection::add` and it's done the same way in the AbstractAdmin.
- I would like to avoid writing the same thing in my code, I think the developer should rely in a method instead
- In the Sonata code, it should be implemented only once

I'm not sure about the name of the method and where to put it.

Now you can do `$this->admin->getRoutes()->getRouteName('show')`.
I would have prefer to do `$this->admin->getRouteName('show')` but then it would be harder to call it in `RouteCollection`.

## Changelog

```markdown
### Added
- Added `RouteCollection::getRouteName`
- Added `RouteCollectionInterface::getRouteName`
```