### PR TITLE
fix nested admin (one-to-one-to-many relation) that opens inline (fixes #6777)

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -205,37 +205,6 @@ parameters:
             count: 1
             path: src/Form/FormMapper.php
 
-# next 6 errors are due to not installed Doctrine ORM\ODM
-        -
-            message: "#^Class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection not found\\.$#"
-            count: 1
-            path: src/Admin/AdminHelper.php
-
-        -
-            message: "#^Class Doctrine\\\\ORM\\\\PersistentCollection not found\\.$#"
-            count: 1
-            path: src/Admin/AdminHelper.php
-
-        -
-            message: "#^Call to method getTypeClass\\(\\) on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\.$#"
-            count: 1
-            path: src/Admin/AdminHelper.php
-
-        -
-            message: "#^Call to method getTypeClass\\(\\) on an unknown class Doctrine\\\\ORM\\\\PersistentCollection\\.$#"
-            count: 1
-            path: src/Admin/AdminHelper.php
-
-        -
-            message: "#^Call to method add\\(\\) on an unknown class Doctrine\\\\ODM\\\\MongoDB\\\\PersistentCollection\\.$#"
-            count: 1
-            path: src/Admin/AdminHelper.php
-
-        -
-            message: "#^Call to method add\\(\\) on an unknown class Doctrine\\\\ORM\\\\PersistentCollection\\.$#"
-            count: 1
-            path: src/Admin/AdminHelper.php
-
         -
             # will be fixed in v4
             message: "#^Method Sonata\\\\AdminBundle\\\\Datagrid\\\\Pager::next\\(\\) with return type void returns mixed but should not return anything\\.$#"


### PR DESCRIPTION
## Subject
Fix form rendering of nested Admin properties.

I am targeting this branch, because everything is backwards compatible.

Closes #6777.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
How `AdminHelper::appendFormFieldElement` renders nested forms.
```
