### PR TITLE
fix phpdoc for ModelToIdPropertyTransformer::$property + add test

### DIFF
--- a/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
+++ b/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
@@ -44,7 +44,7 @@ class ModelToIdPropertyTransformer implements DataTransformerInterface
     protected $className;
 
     /**
-     * @var string
+     * @var string|string[]
      */
     protected $property;
 
@@ -59,13 +59,14 @@ class ModelToIdPropertyTransformer implements DataTransformerInterface
     protected $toStringCallback;
 
     /**
-     * @param string        $className
-     * @param string        $property
-     * @param bool          $multiple
-     * @param callable|null $toStringCallback
+     * @param string          $className
+     * @param string|string[] $property
+     * @param bool            $multiple
+     * @param callable|null   $toStringCallback
      *
+     * @phpstan-template P
      * @phpstan-param class-string<T> $className
-     * @phpstan-param null|callable(object, string): string $toStringCallback
+     * @phpstan-param null|callable(object, P): string $toStringCallback
      */
     public function __construct(
         ModelManagerInterface $modelManager,

--- a/tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
+++ b/tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
@@ -311,4 +311,33 @@ class ModelToIdPropertyTransformerTest extends TestCase
 
         $transformer->transform($collection);
     }
+
+    public function testTransformWithMultipleProperties(): void
+    {
+        $properties = ['bar', 'baz'];
+
+        $transformer = new ModelToIdPropertyTransformer(
+            $this->modelManager,
+            Foo::class,
+            $properties,
+            false,
+            function ($model, $property) use ($properties) {
+                $this->assertSame($properties, $property);
+
+                return 'nice_label';
+            }
+        );
+
+        $model = new Foo();
+        $this->modelManager->expects($this->once())
+            ->method('getIdentifierValues')
+            ->willReturn([123])
+        ;
+
+        $value = $transformer->transform($model);
+        $this->assertSame([
+            123,
+            '_labels' => ['nice_label'],
+        ], $value);
+    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to https://github.com/sonata-project/SonataAdminBundle/issues/6779 (fix needs to be merged into master first).

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- fixed phpdoc for `Sonata\AdminBundle\Form\DataTransformer\ModelToIdPropertyTransformer::$property` which can be `string[]` as well
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
