### PR TITLE
Added callback with possibility to modify each individual item in res…

### DIFF
--- a/docs/reference/form_types.rst
+++ b/docs/reference/form_types.rst
@@ -315,6 +315,18 @@ The available options are:
         ])
     ;
 
+``response_item_callback``
+  defaults to ``null``. Callable function that can be used to customize each item individually returned in JSON::
+
+    $formMapper
+        ->add('category', ModelAutocompleteType::class, [
+            'property' => 'title',
+            'response_item_callback' => function ($admin, $entity, &$item) {
+                $item['type'] = $entity->getType();
+            },
+        ])
+    ;
+
 ``multiple``
   defaults to ``false``. Set to ``true``, if your field is in a many-to-many relation.
 
@@ -407,6 +419,12 @@ The available options are:
 
     {# change the default selection format #}
     {% block sonata_type_model_autocomplete_selection_format %}'<b>'+item.label+'</b>'{% endblock %}
+
+    {# customize select2 options #}
+    {% block sonata_type_model_autocomplete_select2_options_js %}
+    options.multiple = false;
+    options.dropdownAutoWidth = false;
+    {% endblock %}
 
 ``target_admin_access_action``
   defaults to ``list``.

--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -69,6 +69,7 @@ final class RetrieveAutocompleteItemsAction
             $reqParamPageNumber = $filterAutocomplete->getFieldOption('req_param_name_page_number', '_page');
             $toStringCallback = $filterAutocomplete->getFieldOption('to_string_callback');
             $targetAdminAccessAction = $filterAutocomplete->getFieldOption('target_admin_access_action', 'list');
+            $responseItemCallback = $filterAutocomplete->getFieldOption('response_item_callback');
         } else {
             // create/edit form
             $fieldDescription = $this->retrieveFormFieldDescription($admin, $request->get('field'));
@@ -88,6 +89,7 @@ final class RetrieveAutocompleteItemsAction
             $reqParamPageNumber = $formAutocompleteConfig->getAttribute('req_param_name_page_number');
             $toStringCallback = $formAutocompleteConfig->getAttribute('to_string_callback');
             $targetAdminAccessAction = $formAutocompleteConfig->getAttribute('target_admin_access_action');
+            $responseItemCallback = $formAutocompleteConfig->getAttribute('response_item_callback');
         }
 
         $searchText = $request->get('q', '');
@@ -173,10 +175,16 @@ final class RetrieveAutocompleteItemsAction
                 $label = $resultMetadata->getTitle();
             }
 
-            $items[] = [
+            $item = [
                 'id' => $admin->id($model),
                 'label' => $label,
             ];
+
+            if (\is_callable($responseItemCallback)) {
+                \call_user_func($responseItemCallback, $admin, $model, $item);
+            }
+
+            $items[] = $item;
         }
 
         return new JsonResponse([

--- a/src/Form/Type/ModelAutocompleteType.php
+++ b/src/Form/Type/ModelAutocompleteType.php
@@ -108,6 +108,7 @@ class ModelAutocompleteType extends AbstractType
         $resolver->setDefaults([
             'attr' => [],
             'compound' => $compound,
+            'error_bubbling' => false,
             'model_manager' => null,
             'class' => null,
             'admin_code' => null,
@@ -123,6 +124,7 @@ class ModelAutocompleteType extends AbstractType
             'cache' => false,
 
             'to_string_callback' => null,
+            'response_item_callback' => null,
 
             // add button
             // NEXT_MAJOR: Set this value to 'link_add' to display button by default

--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -579,9 +579,9 @@ var Admin = {
 
         var options = Object.assign({
             width: function(){
-              // Select2 v3 and v4 BC. If window.Select2 is defined, then the v3 is installed.
-              // NEXT_MAJOR: Remove Select2 v3 support.
-              return Admin.get_select2_width(window.Select2 ? this.element : subject);
+                // Select2 v3 and v4 BC. If window.Select2 is defined, then the v3 is installed.
+                // NEXT_MAJOR: Remove Select2 v3 support.
+                return Admin.get_select2_width(window.Select2 ? this.element : subject);
             },
             dropdownAutoWidth: true,
             data: transformedData,

--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -571,22 +571,24 @@ var Admin = {
         return '100%';
     },
 
-    setup_sortable_select2: function(subject, data) {
+    setup_sortable_select2: function(subject, data, customOptions) {
         var transformedData = [];
         for (var i = 0 ; i < data.length ; i++) {
             transformedData[i] = {id: data[i].data, text: data[i].label};
         }
 
-        subject.select2({
+        var options = Object.assign({
             width: function(){
-                // Select2 v3 and v4 BC. If window.Select2 is defined, then the v3 is installed.
-                // NEXT_MAJOR: Remove Select2 v3 support.
-                return Admin.get_select2_width(window.Select2 ? this.element : subject);
+              // Select2 v3 and v4 BC. If window.Select2 is defined, then the v3 is installed.
+              // NEXT_MAJOR: Remove Select2 v3 support.
+              return Admin.get_select2_width(window.Select2 ? this.element : subject);
             },
             dropdownAutoWidth: true,
             data: transformedData,
             multiple: true
-        });
+        }, customOptions);
+
+        subject.select2(options);
 
         subject.select2("container").find("ul.select2-choices").sortable({
             containment: 'parent',

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -577,7 +577,11 @@ file that was distributed with this source code.
 
     <script>
         jQuery(document).ready(function() {
-            Admin.setup_sortable_select2(jQuery('#{{ id }}'), {{ form.vars.choices|json_encode|raw }});
+            var options = {};
+
+            {% block sonata_type_model_autocomplete_select2_options_js %}{% endblock %}
+
+            Admin.setup_sortable_select2(jQuery('#{{ id }}'), {{ form.vars.choices|json_encode|raw }}, options);
         });
     </script>
 {% endblock %}

--- a/tests/Action/RetrieveAutocompleteItemsActionTest.php
+++ b/tests/Action/RetrieveAutocompleteItemsActionTest.php
@@ -292,6 +292,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
             ['req_param_name_page_number', null, '_page'],
             ['to_string_callback', null, null],
             ['target_admin_access_action', null, 'list'],
+            ['response_item_callback', null, null],
         ]);
     }
 
@@ -312,6 +313,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
             ['items_per_page', null, 10],
             ['req_param_name_page_number', null, '_page'],
             ['target_admin_access_action', null, 'list'],
+            ['response_item_callback', null, null],
         ]);
     }
 
@@ -332,6 +334,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
             ['items_per_page', null, 10],
             ['req_param_name_page_number', null, '_page'],
             ['target_admin_access_action', null, 'list'],
+            ['response_item_callback', null, null],
         ]);
     }
 }

--- a/tests/Form/Type/ModelAutocompleteTypeTest.php
+++ b/tests/Form/Type/ModelAutocompleteTypeTest.php
@@ -65,6 +65,7 @@ class ModelAutocompleteTypeTest extends TypeTestCase
         $this->assertSame('_per_page', $options['req_param_name_items_per_page']);
 
         $this->assertSame('list', $options['target_admin_access_action']);
+        $this->assertNull($options['response_item_callback']);
 
         $this->assertSame('', $options['container_css_class']);
         $this->assertSame('', $options['dropdown_css_class']);


### PR DESCRIPTION
## Autocomplete customizations

I am targeting this branch, because this PR adds extra functionality to sonata_type_model_autocomplete, fixes few glitches & extends customization options.

## Changelog
```markdown
### Added
- A callback with a possibility to modify each individual item in the response.
- A way to customize any autocomplete select2 properties in js via adding sonata_type_model_autocomplete_select2_options_js block before initializing select2 element because select2 doesn't allow modification of several options after it has been initialized, you can only destroy it and initialize again from scratch.
- Set error bubbling to false - prevent passing error to parent form elements, which occurs by default for compound form types.

### Changed
- The autocomplete item list is now independent of filters set in the corresponding list via removing its filters. Before these changes, it returned only items that matched the selected filter.