### PR TITLE
Make Pool final

### DIFF
--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -35,34 +35,32 @@ use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
  *  roles: list<string>
  * }
  *
- * @final since sonata-project/admin-bundle 3.52
- *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-class Pool
+final class Pool
 {
     /**
      * @var ContainerInterface
      */
-    protected $container;
+    private $container;
 
     /**
      * @var string[]
      */
-    protected $adminServiceIds = [];
+    private $adminServiceIds = [];
 
     /**
      * @var array
      * @phpstan-var array<string, array<string, mixed>>
      * @psalm-var array<string, Group>
      */
-    protected $adminGroups = [];
+    private $adminGroups = [];
 
     /**
      * @var array<string, string[]>
      * @phpstan-var array<class-string, string[]>
      */
-    protected $adminClasses = [];
+    private $adminClasses = [];
 
     /**
      * NEXT_MAJOR: change to TemplateRegistryInterface.
@@ -224,7 +222,7 @@ class Pool
     /**
      * Checks if an admin with a certain admin code exists.
      */
-    final public function hasAdminByAdminCode(string $adminCode): bool
+    public function hasAdminByAdminCode(string $adminCode): bool
     {
         try {
             $this->getAdminByAdminCode($adminCode);
@@ -370,7 +368,7 @@ class Pool
     /**
      * NEXT_MAJOR: change to TemplateRegistryInterface.
      */
-    final public function setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry): void
+    public function setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry): void
     {
         $this->templateRegistry = $templateRegistry;
     }

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Admin;
 
 use Psr\Container\ContainerInterface;
-use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
 
 /**
  * @psalm-type Group = array{
@@ -62,31 +61,16 @@ final class Pool
      */
     private $adminClasses = [];
 
-    /**
-     * NEXT_MAJOR: change to TemplateRegistryInterface.
-     *
-     * @var MutableTemplateRegistryInterface
-     */
-    private $templateRegistry;
-
-    /**
-     * NEXT_MAJOR: Rename $titleOrAdminServiceIds to $adminServices, $logoTitleOrAdminGroups to $adminGroups and
-     * $optionsOrAdminClasses to $adminClasses and add "array" type declaration.
-     *
-     * @param string|array $titleOrAdminServiceIds
-     * @param string|array $logoTitleOrAdminGroups
-     * @param array        $optionsOrAdminClasses
-     */
     public function __construct(
         ContainerInterface $container,
-        $titleOrAdminServiceIds = [],
-        $logoTitleOrAdminGroups = [],
-        $optionsOrAdminClasses = []
+        array $adminServices = [],
+        array $adminGroups = [],
+        array $adminClasses = []
     ) {
         $this->container = $container;
-        $this->adminServiceIds = $titleOrAdminServiceIds;
-        $this->adminGroups = $logoTitleOrAdminGroups;
-        $this->adminClasses = $optionsOrAdminClasses;
+        $this->adminServiceIds = $adminServices;
+        $this->adminGroups = $adminGroups;
+        $this->adminClasses = $adminClasses;
     }
 
     /**
@@ -278,51 +262,11 @@ final class Pool
     }
 
     /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @deprecated since sonata-project/admin-bundle 3.86, will be dropped in 4.0. Pass $adminGroups as argument 3
-     * to the __construct method instead.
-     *
-     * @phpstan-param array<string, array<string, mixed>> $adminGroups
-     * @psalm-param array<string, Group> $adminGroups
-     */
-    public function setAdminGroups(array $adminGroups): void
-    {
-        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
-            @trigger_error(sprintf(
-                'Method "%s()" is deprecated since sonata-project/admin-bundle 3.86 and will be removed in version 4.0.',
-                __METHOD__
-            ), \E_USER_DEPRECATED);
-        }
-
-        $this->adminGroups = $adminGroups;
-    }
-
-    /**
      * @return array<string, array<string, mixed>>
      */
     public function getAdminGroups(): array
     {
         return $this->adminGroups;
-    }
-
-    /**
-     * @param string[] $adminServiceIds
-     *                                  NEXT_MAJOR: Remove this method
-     *
-     * @deprecated since sonata-project/admin-bundle 3.86, will be dropped in 4.0. Pass $adminGroups as argument 2
-     * to the __construct method instead.
-     */
-    public function setAdminServiceIds(array $adminServiceIds): void
-    {
-        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
-            @trigger_error(sprintf(
-                'Method "%s()" is deprecated since sonata-project/admin-bundle 3.86 and will be removed in version 4.0.',
-                __METHOD__
-            ), \E_USER_DEPRECATED);
-        }
-
-        $this->adminServiceIds = $adminServiceIds;
     }
 
     /**
@@ -334,28 +278,6 @@ final class Pool
     }
 
     /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @deprecated since sonata-project/admin-bundle 3.86, will be dropped in 4.0. Pass $adminGroups as argument 4
-     * to the __construct method instead.
-     *
-     * @param array<string, string[]> $adminClasses
-     *
-     * @phpstan-param array<class-string, string[]> $adminClasses
-     */
-    public function setAdminClasses(array $adminClasses): void
-    {
-        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
-            @trigger_error(sprintf(
-                'Method "%s()" is deprecated since sonata-project/admin-bundle 3.86 and will be removed in version 4.0.',
-                __METHOD__
-            ), \E_USER_DEPRECATED);
-        }
-
-        $this->adminClasses = $adminClasses;
-    }
-
-    /**
      * @return array<string, string[]>
      *
      * @phpstan-return array<class-string, string[]>
@@ -363,45 +285,5 @@ final class Pool
     public function getAdminClasses(): array
     {
         return $this->adminClasses;
-    }
-
-    /**
-     * NEXT_MAJOR: change to TemplateRegistryInterface.
-     */
-    public function setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry): void
-    {
-        $this->templateRegistry = $templateRegistry;
-    }
-
-    /**
-     * @deprecated since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry "sonata.admin.global_template_registry" instead
-     *
-     * @return void
-     */
-    public function setTemplates(array $templates)
-    {
-        $this->templateRegistry->setTemplates($templates);
-    }
-
-    /**
-     * @deprecated since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry "sonata.admin.global_template_registry" instead
-     *
-     * @return array<string, string>
-     */
-    public function getTemplates()
-    {
-        return $this->templateRegistry->getTemplates();
-    }
-
-    /**
-     * @deprecated since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry "sonata.admin.global_template_registry" instead
-     *
-     * @param string $name
-     *
-     * @return string|null
-     */
-    public function getTemplate($name)
-    {
-        return $this->templateRegistry->getTemplate($name);
     }
 }

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -207,11 +207,6 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
         }
 
         $pool->replaceArgument(0, ServiceLocatorTagPass::register($container, $adminServices));
-        // NEXT_MAJOR: Remove the following 3 lines
-        $pool->addMethodCall('setAdminServiceIds', [$admins, 'sonata_deprecation_mute']);
-        $pool->addMethodCall('setAdminGroups', [$groups, 'sonata_deprecation_mute']);
-        $pool->addMethodCall('setAdminClasses', [$classes, 'sonata_deprecation_mute']);
-
         $pool->replaceArgument(1, $admins);
         $pool->replaceArgument(2, $groups);
         $pool->replaceArgument(3, $classes);

--- a/tests/Block/AdminListBlockServiceTest.php
+++ b/tests/Block/AdminListBlockServiceTest.php
@@ -17,6 +17,7 @@ use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Block\AdminListBlockService;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Sonata\BlockBundle\Test\BlockServiceTestCase;
+use Symfony\Component\DependencyInjection\Container;
 
 /**
  * @author Sullivan Senechal <soullivaneuh@gmail.com>
@@ -37,7 +38,7 @@ class AdminListBlockServiceTest extends BlockServiceTestCase
     {
         parent::setUp();
 
-        $this->pool = $this->createMock(Pool::class);
+        $this->pool = new Pool(new Container());
         $this->templateRegistry = $this->createMock(TemplateRegistryInterface::class);
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this breaks BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Add final modifier to `Pool` class.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->

PS: @wbloszyk I'm not updated with the template changes, can we remove all template related methods from `Pool`? All of them are deprecated, but this one:

https://github.com/sonata-project/SonataAdminBundle/blob/28f49a881015e0df91602214fe94dd754ddcdf38/src/Admin/Pool.php#L370-L376

So I guess we can remove it, but just in case.