### PR TITLE
Deprecate Pool::setTemplateRegistry

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,13 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.xx to 3.xx
+=========================
+
+### Deprecated `Sonata\AdminBundle\Admin\Pool::setTemplateRegistry()` method.
+
+This method has been deprecated without replacement.
+
 UPGRADE FROM 3.86 to 3.87
 =========================
 

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -117,7 +117,9 @@ class Pool
     protected $propertyAccessor;
 
     /**
-     * NEXT_MAJOR: change to TemplateRegistryInterface.
+     * NEXT_MAJOR: Remove this property.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.
      *
      * @var MutableTemplateRegistryInterface
      */
@@ -649,10 +651,19 @@ class Pool
     }
 
     /**
-     * NEXT_MAJOR: change to TemplateRegistryInterface.
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.
      */
     final public function setTemplateRegistry(MutableTemplateRegistryInterface $templateRegistry): void
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
+            @trigger_error(sprintf(
+                'The "%s()" method is deprecated since version 3.x and will be removed in 4.0.',
+                __METHOD__,
+            ), \E_USER_DEPRECATED);
+        }
+
         $this->templateRegistry = $templateRegistry;
     }
 

--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -56,8 +56,10 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 [], // admin service groups
                 [], // admin service classes
             ])
+            // NEXT_MAJOR: Remove this call.
             ->call('setTemplateRegistry', [
                 new ReferenceConfigurator('sonata.admin.global_template_registry'),
+                'sonata_deprecation_mute',
             ])
 
         ->alias(Pool::class, 'sonata.admin.pool')

--- a/tests/Action/DashboardActionTest.php
+++ b/tests/Action/DashboardActionTest.php
@@ -42,7 +42,6 @@ class DashboardActionTest extends TestCase
         $this->templateRegistry = $this->createStub(MutableTemplateRegistryInterface::class);
 
         $pool = new Pool($container);
-        $pool->setTemplateRegistry($this->templateRegistry);
 
         $twig = $this->createMock(Environment::class);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Based on the comments: https://github.com/sonata-project/SonataAdminBundle/pull/6792#issuecomment-764102492

This deprecates `Pool::setTemplateRegistry` in `3.x`.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `Pool::setTemplateRegistry()` method.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
