### PR TITLE
Use propertyAccessor for BaseFieldDescription::getFieldValue

### DIFF
--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -16,6 +16,8 @@ namespace Sonata\AdminBundle\Admin;
 use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Sonata\AdminBundle\Exception\NoValueException;
+use Symfony\Component\PropertyAccess\Exception\ExceptionInterface;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
  * A FieldDescription hold the information about a field. A typical
@@ -416,17 +418,66 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
             return $this->getFieldValue($child, substr($fieldName, $dotPos + 1));
         }
 
-        $getters = [];
-        $parameters = [];
-
         // prefer method name given in the code option
         if ($this->getOption('code')) {
-            $getters[] = $this->getOption('code');
+            $getter = $this->getOption('code');
+
+            if (!method_exists($object, $getter)) {
+                @trigger_error(
+                    'Passing a non-existing method in the "code" option is deprecated'
+                    .' since sonata-project/admin-bundle 3.x and will throw an exception in 4.0.',
+                    \E_USER_DEPRECATED
+                );
+
+            // NEXT_MAJOR: Remove the deprecation and uncomment the next line.
+//                throw new \LogicException('The method "%s"() does not exist.', $getter);
+            } elseif (!\is_callable([$object, $getter])) {
+                @trigger_error(
+                    'Passing a non-callable method in the "code" option is deprecated'
+                    .' since sonata-project/admin-bundle 3.x and will throw an exception in 4.0.',
+                    \E_USER_DEPRECATED
+                );
+
+            // NEXT_MAJOR: Remove the deprecation and uncomment the next line.
+//                throw new \LogicException('The method "%s"() does not have public access.', $getter);
+            } else {
+                if ($this->getOption('parameters')) {
+                    @trigger_error(
+                        'The option "parameters" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                        \E_USER_DEPRECATED
+                    );
+
+                    return $object->{$getter}(...$this->getOption('parameters'));
+                }
+
+                return $object->{$getter}();
+            }
         }
-        // parameters for the method given in the code option
-        if ($this->getOption('parameters')) {
-            $parameters = $this->getOption('parameters');
+
+        // NEXT_MAJOR: Remove the condition code and the else part
+        if (!$this->getOption('parameters')) {
+            $propertyAccesor = PropertyAccess::createPropertyAccessorBuilder()
+                ->enableMagicCall()
+                ->getPropertyAccessor();
+
+            try {
+                return $propertyAccesor->getValue($object, $fieldName);
+            } catch (ExceptionInterface $exception) {
+                throw new NoValueException(
+                    sprintf('Cannot access property "%s" in class "%s".', $this->getName(), \get_class($object)),
+                    $exception->getCode(),
+                    $exception
+                );
+            }
         }
+
+        @trigger_error(
+            'The option "parameters" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+            \E_USER_DEPRECATED
+        );
+
+        $getters = [];
+        $parameters = $this->getOption('parameters');
 
         if (\is_string($fieldName) && '' !== $fieldName) {
             if ($this->hasCachedFieldGetter($object, $fieldName)) {
@@ -435,6 +486,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
 
             $camelizedFieldName = InflectorFactory::create()->build()->classify($fieldName);
 
+            $getters[] = lcfirst($camelizedFieldName);
             $getters[] = sprintf('get%s', $camelizedFieldName);
             $getters[] = sprintf('is%s', $camelizedFieldName);
             $getters[] = sprintf('has%s', $camelizedFieldName);

--- a/tests/Admin/BaseFieldDescriptionTest.php
+++ b/tests/Admin/BaseFieldDescriptionTest.php
@@ -18,7 +18,6 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\BaseFieldDescription;
 use Sonata\AdminBundle\Exception\NoValueException;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\FieldDescription;
-use Sonata\AdminBundle\Tests\Fixtures\Entity\Foo;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooCall;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 
@@ -195,6 +194,11 @@ class BaseFieldDescriptionTest extends TestCase
         $this->assertSame(42, $description->getFieldValue($mock, 'fake'));
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetFieldValueWithParametersForGetter(): void
     {
         $arg1 = 38;
@@ -206,6 +210,7 @@ class BaseFieldDescriptionTest extends TestCase
         $mock1 = $this->getMockBuilder(\stdClass::class)->addMethods(['getWithOneParameter'])->getMock();
         $mock1->expects($this->once())->method('getWithOneParameter')->with($arg1)->willReturn($arg1 + 2);
 
+        $this->expectDeprecation('The option "parameters" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.');
         $this->assertSame(40, $description1->getFieldValue($mock1, 'fake'));
 
         $arg2 = 4;
@@ -221,15 +226,13 @@ class BaseFieldDescriptionTest extends TestCase
 
     public function testGetFieldValueWithMagicCall(): void
     {
-        $parameters = ['foo', 'bar'];
         $foo = new FooCall();
 
         $description = new FieldDescription('name');
-        $description->setOption('parameters', $parameters);
-        $this->assertSame(['fake', $parameters], $description->getFieldValue($foo, 'fake'));
+        $this->assertSame(['getFake', []], $description->getFieldValue($foo, 'fake'));
 
         // repeating to cover retrieving cached getter
-        $this->assertSame(['fake', $parameters], $description->getFieldValue($foo, 'fake'));
+        $this->assertSame(['getFake', []], $description->getFieldValue($foo, 'fake'));
     }
 
     /**


### PR DESCRIPTION
It will solve https://github.com/sonata-project/SonataAdminBundle/issues/6795 and we will rely on propertyAccessor implementation instead of a custom one.

We're loosing the parameters option but I'm not sure it's used and it's solvable by using a custom template instead.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- FieldDescription `parameters` option.
```