### PR TITLE
- add bc checks to the repo

### DIFF
--- a/.github/workflows/bc-check.yml
+++ b/.github/workflows/bc-check.yml
@@ -1,0 +1,12 @@
+on: [push]
+name: BC Check
+jobs:
+    roave_bc_check:
+        name: Roave BC Check
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: fetch tags
+              run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+            - name: Roave BC Check
+              uses: docker://nyholm/roave-bc-check-ga


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This is POC of integrating `Roave/BackwardCompatibilityCheck` into this repo.
Currently it fails on 
```
In IdentifierNotFound.php line 30:
                                                                               
  [Roave\BetterReflection\Reflector\Exception\IdentifierNotFound]              
  Roave\BetterReflection\Reflection\ReflectionClass "Sonata\AdminBundle\Objec  
  t\InternalMetadataInterface" could not be found in the located source        
                                                                               

Exception trace:
  at /composer/vendor/roave/better-reflection/src/Reflector/Exception/IdentifierNotFound.php:30
 Roave\BetterReflection\Reflector\Exception\IdentifierNotFound::fromIdentifier() at /composer/vendor/roave/better-reflection/src/Reflector/ClassReflector.php:40
 Roave\BetterReflection\Reflector\ClassReflector->reflect() at /composer/vendor/roave/backward-compatibility-check/src/CompareClasses.php:73
 Roave\BackwardCompatibility\CompareClasses->makeSymbolsIterator() at /composer/vendor/roave/backward-compatibility-check/src/Changes.php:91
 Roave\BackwardCompatibility\Changes->getIterator() at /composer/vendor/roave/backward-compatibility-check/src/Formatter/SymfonyConsoleTextFormatter.php:21
 Roave\BackwardCompatibility\Formatter\SymfonyConsoleTextFormatter->write() at /composer/vendor/roave/backward-compatibility-check/src/Command/AssertBackwardsCompatible.php:171
 Roave\BackwardCompatibility\Command\AssertBackwardsCompatible->execute() at /composer/vendor/symfony/console/Command/Command.php:255
 Symfony\Component\Console\Command\Command->run() at /composer/vendor/symfony/console/Application.php:971
 Symfony\Component\Console\Application->doRunCommand() at /composer/vendor/symfony/console/Application.php:290
 Symfony\Component\Console\Application->doRun() at /composer/vendor/symfony/console/Application.php:166
 Symfony\Component\Console\Application->run() at /composer/vendor/roave/backward-compatibility-check/bin/roave-backward-compatibility-check.php:313
 Roave\ApiCompareCli\{closure}() at /composer/vendor/roave/backward-compatibility-check/bin/roave-backward-compatibility-check.php:314
 require_once() at /composer/vendor/roave/backward-compatibility-check/bin/roave-backward-compatibility-check:6

```

I am targeting this branch, because want to automate BC checks in v3.

Closes https://github.com/sonata-project/SonataAdminBundle/issues/6164.

## Changelog

This is `pedantic` PR.

## To do

- [ ] investigate and fix error above;

