### PR TITLE
- partially move PHPStan to level6

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -217,6 +217,24 @@ parameters:
             count: 1
             path: src/Datagrid/Pager.php
 
+        -
+            # will be fixed in v4. This class will be removed
+            message: "#^Class Sonata\\\\AdminBundle\\\\Admin\\\\Admin extends generic class Sonata\\\\AdminBundle\\\\Admin\\\\AbstractAdmin but does not specify its types\\: T$#"
+            count: 1
+            path: src/Admin/Admin.php
+
+        -
+            # will be fixed in v4. This class will be removed
+            message: "#^Class Sonata\\\\AdminBundle\\\\Admin\\\\AdminExtension extends generic class Sonata\\\\AdminBundle\\\\Admin\\\\AbstractAdminExtension but does not specify its types\\: T$#"
+            count: 1
+            path: src/Admin/AdminExtension.php
+
+        -
+            # will be fixed in v4. Iterator interface will be removed
+            message: "#^Class Sonata\\\\AdminBundle\\\\Datagrid\\\\Pager implements generic interface Iterator but does not specify its types\\: TKey, TValue$#"
+            count: 1
+            path: src/Datagrid/Pager.php
+
 # Symfony related errors
         -
             message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\:\\:arrayNode\\(\\)\\.$#"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -13,3 +13,7 @@ parameters:
         - .phpstan/stubs/MetadataInterface.file
         - .phpstan/stubs/Exporter.file
         - .phpstan/stubs/TextExtension.file
+    checkGenericClassInNonGenericObjectType: true
+    checkMissingIterableValueType: true
+    checkMissingVarTagTypehint: true
+    checkMissingTypehints: true

--- a/src/Admin/FieldDescriptionCollection.php
+++ b/src/Admin/FieldDescriptionCollection.php
@@ -17,14 +17,22 @@ namespace Sonata\AdminBundle\Admin;
  * @final since sonata-project/admin-bundle 3.52
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @phpstan-template TValue of FieldDescriptionInterface
+ * @phpstan-implements \ArrayAccess<string,TValue>
  */
 class FieldDescriptionCollection implements \ArrayAccess, \Countable
 {
     /**
      * @var array<string, FieldDescriptionInterface>
+     *
+     * @phpstan-var array<string, TValue>
      */
     protected $elements = [];
 
+    /**
+     * @phpstan-param TValue $fieldDescription
+     */
     public function add(FieldDescriptionInterface $fieldDescription)
     {
         $this->elements[$fieldDescription->getName()] = $fieldDescription;
@@ -32,6 +40,8 @@ class FieldDescriptionCollection implements \ArrayAccess, \Countable
 
     /**
      * @return array<string, FieldDescriptionInterface>
+     *
+     * @phpstan-return array<string, TValue>
      */
     public function getElements()
     {
@@ -54,6 +64,8 @@ class FieldDescriptionCollection implements \ArrayAccess, \Countable
      * @throws \InvalidArgumentException
      *
      * @return FieldDescriptionInterface
+     *
+     * @phpstan-return TValue
      */
     public function get($name)
     {
@@ -79,6 +91,13 @@ class FieldDescriptionCollection implements \ArrayAccess, \Countable
         return $this->has($offset);
     }
 
+    /**
+     * @param string $offset
+     *
+     * @return FieldDescriptionInterface
+     *
+     * @phpstan-return TValue
+     */
     public function offsetGet($offset)
     {
         return $this->get($offset);

--- a/src/Datagrid/SimplePager.php
+++ b/src/Datagrid/SimplePager.php
@@ -20,6 +20,9 @@ use Doctrine\Common\Collections\ArrayCollection;
  *
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  * @author Sjoerd Peters <sjoerd.peters@gmail.com>
+ *
+ * @phpstan-template T of ProxyQueryInterface
+ * @phpstan-extends Pager<T>
  */
 class SimplePager extends Pager
 {

--- a/src/Twig/Extension/SonataAdminExtension.php
+++ b/src/Twig/Extension/SonataAdminExtension.php
@@ -568,6 +568,7 @@ EOT;
     public function getUrlSafeIdentifier($model, ?AdminInterface $admin = null)
     {
         if (null === $admin) {
+            /** @phpstan-var class-string $class */
             $class = ClassUtils::getClass($model);
             if (!$this->pool->hasAdminByClass($class)) {
                 throw new \InvalidArgumentException('You must pass an admin.');


### PR DESCRIPTION
## Subject
During last update (to level 5) https://github.com/sonata-project/SonataAdminBundle/pull/6277#issue-466353939 I thought that it will be last one, because level 6 gives 983 errors in 136 files. But now I've discovered that, you can enable rules partially and found config folder (https://github.com/phpstan/phpstan-src/tree/master/conf) of PHPStan, where it describes each level. I'll do smallest possible rule adding, since it can take long time to merge big PRs.


I am targeting this branch, because it's not BC break.

## Changelog
Half way to phpstan level 6


`Pedantic` PR.


------------------

This is how config looks with error count

```neon
includes:
    - phpstan-baseline.neon

parameters:
    parallel:
        processTimeout: 300.0
    level: 5
    paths:
        - src
    excludes_analyse:
        # temporarily ignore template files
        - src/Resources/**.tpl.php
    scanFiles:
        # NEXT_MAJOR: Remove those files
        - .phpstan/stubs/MetadataInterface.file
        - .phpstan/stubs/Exporter.file
        - .phpstan/stubs/TextExtension.file
    checkGenericClassInNonGenericObjectType: true
    checkMissingIterableValueType: true
    checkMissingVarTagTypehint: true
    checkMissingTypehints: true
    # level 7
    #checkUnionTypes: true - 109 errors
    #reportMaybes: true - 7 errors
    # level 8
    #checkNullables: true - 14 erros

rules:
    - PHPStan\Rules\Functions\MissingFunctionParameterTypehintRule
    - PHPStan\Rules\Functions\MissingFunctionReturnTypehintRule
    # level 6
    #- PHPStan\Rules\Methods\MissingMethodParameterTypehintRule - 291 errors
    #- PHPStan\Rules\Methods\MissingMethodReturnTypehintRule - 383 errors
    #- PHPStan\Rules\Properties\MissingPropertyTypehintRule - 52 errors

```