### PR TITLE
replace formOptions property by configureFormOptions method

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,35 @@ UPGRADE 3.x
 UPGRADE FROM 3.xx to 3.xx
 =========================
 
+### Deprecated `Sonata\AdminBundle\Admin\AbstractAdmin::formOptions` property.
+
+This property has been replaced by the new method `Sonata\AdminBundle\Admin\AbstractAdmin::configureFormOptions()`
+
+Before:
+```php
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+
+final class MyAdmin extends AbstractAdmin
+{
+    protected $formOptions = [
+        'validation_groups' => ['Default', 'MyAdmin'],
+    ];
+}
+```
+
+After:
+```php
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+
+final class MyAdmin extends AbstractAdmin
+{
+    protected function configureFormOptions(array &$formOptions): void
+    {
+        $formOptions['validation_groups'] = ['Default', 'MyAdmin'];
+    }
+}
+```
+
 ### Deprecated `Sonata\AdminBundle\Admin\Pool::setTemplateRegistry()` method.
 
 This method has been deprecated without replacement.

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -145,6 +145,8 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
     /**
      * Options to set to the form (ie, validation_groups).
      *
+     * @deprecated since sonata-project/admin-bundle 3.x, use configureFormOptions() instead.
+     *
      * @var array<string, mixed>
      */
     protected $formOptions = [];
@@ -1258,7 +1260,8 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
 
         $formBuilder = $this->getFormContractor()->getFormBuilder(
             $this->getUniqid(),
-            $this->formOptions
+            // NEXT_MAJOR : remove the merge with $this->formOptions
+            array_merge($this->getFormOptions(), $this->formOptions)
         );
 
         $this->defineFormBuilder($formBuilder);
@@ -2945,6 +2948,27 @@ EOT;
         return $defaultFilterValues;
     }
 
+    /**
+     * Returns a list of form options.
+     *
+     * @return array<string, mixed>
+     */
+    final protected function getFormOptions()
+    {
+        $formOptions = [];
+
+        $this->configureFormOptions($formOptions);
+
+        foreach ($this->getExtensions() as $extension) {
+            // NEXT_MAJOR: remove method check
+            if (method_exists($extension, 'configureFormOptions')) {
+                $extension->configureFormOptions($this, $formOptions);
+            }
+        }
+
+        return $formOptions;
+    }
+
     protected function configureFormFields(FormMapper $form)
     {
     }
@@ -3223,6 +3247,15 @@ EOT;
      * @param array<string, mixed> $filterValues
      */
     protected function configureDefaultFilterValues(array &$filterValues)
+    {
+    }
+
+    /**
+     * Configures a list of form options.
+     *
+     * @param array<string, mixed> $formOptions
+     */
+    protected function configureFormOptions(array &$formOptions)
     {
     }
 

--- a/src/Admin/AbstractAdminExtension.php
+++ b/src/Admin/AbstractAdminExtension.php
@@ -168,6 +168,13 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
     public function configureDefaultSortValues(AdminInterface $admin, array &$sortValues): void
     {
     }
+
+    /**
+     * @phpstan-param AdminInterface<T> $admin
+     */
+    public function configureFormOptions(AdminInterface $admin, array &$formOptions): void
+    {
+    }
 }
 
 class_exists(\Sonata\Form\Validator\ErrorElement::class);

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -31,6 +31,7 @@ use Sonata\Form\Validator\ErrorElement;
  * @method array configureActionButtons(AdminInterface $admin, array $list, string $action, object $object)
  * @method void  configureDefaultFilterValues(AdminInterface $admin, array &$filterValues)
  * @method void  configureDefaultSortValues(AdminInterface $admin, array &$sortValues)
+ * @method void  configureFormOptions(AdminInterface $admin, array &$formOptions)
  *
  * @phpstan-template T of object
  */
@@ -271,6 +272,15 @@ interface AdminExtensionInterface
      * @phpstan-param AdminInterface<T> $admin
      */
     // public function configureDefaultSortValues(AdminInterface $admin, array &$sortValues): void;
+
+    /*
+     * NEXT_MAJOR: Uncomment this method and remove the corresponding @method annotation.
+     *
+     * Returns a list of form options
+     *
+     * @phpstan-param AdminInterface<T> $admin
+     */
+    // public function configureFormOptions(AdminInterface $admin, array &$formOptions): void;
 }
 
 class_exists(\Sonata\Form\Validator\ErrorElement::class);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because BC.
The form options could allow some logic, for instance it could depends on the roles. It's not possible with a property, it will be with a method.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added some `Sonata\AdminBundle\Admin\AbstractAdmin::configureFormOptions()` to do great stuff.

### Deprecated
- Deprecated `Sonata\AdminBundle\Admin\AbstractAdmin::formOptions` property. 
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
