### PR TITLE
Fix display of select filter list with no choice

### DIFF
--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -248,7 +248,8 @@ file that was distributed with this source code.
 {% endblock %}
 
 {% block list_filters_actions %}
-    {%- if admin.datagrid.filters|length %}
+    {% set displayableFilters = admin.datagrid.filters|filter(filter => filter.options['show_filter'] is not same as (false)) %}
+    {%- if displayableFilters|length %}
         <ul class="nav navbar-nav navbar-right">
 
             <li class="dropdown sonata-actions">
@@ -260,7 +261,7 @@ file that was distributed with this source code.
                 </a>
 
                 <ul class="dropdown-menu dropdown-menu-scrollable" role="menu">
-                    {% for filter in admin.datagrid.filters|filter(filter => filter.options['show_filter'] is not same as (false)) %}
+                    {% for filter in displayableFilters %}
                         {% set filterDisplayed = filter.isActive() or filter.options['show_filter'] is same as (true) %}
                         <li>
                             <a href="#" class="sonata-toggle-filter sonata-ba-action" filter-target="filter-{{ admin.uniqid }}-{{ filter.name }}" filter-container="filter-container-{{ admin.uniqid() }}">


### PR DESCRIPTION
## Subject

I am targeting this branch, because bugfix.

## Changelog

```markdown
### Fixed
- Stop displaying the filter dropdown with no usable filters
```