### PR TITLE
Add an option to define a default admin

### DIFF
--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Admin;
 
+use Sonata\AdminBundle\Exception\AdminClassNotFoundException;
+use Sonata\AdminBundle\Exception\AdminCodeNotFoundException;
+use Sonata\AdminBundle\Exception\TooManyAdminClassException;
 use Sonata\AdminBundle\SonataConfiguration;
 use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -341,6 +344,9 @@ class Pool
      *
      * @param string $class
      *
+     * @throws AdminClassNotFoundException if there is no admin class for the class provided
+     * @throws TooManyAdminClassException  if there is multiple admin class for the class provided
+     *
      * @return AdminInterface|null
      *
      * @phpstan-template T of object
@@ -361,7 +367,7 @@ class Pool
             // NEXT_MAJOR : remove the previous `trigger_error()` call, the `return null` statement,
             // uncomment the following exception and declare AdminInterface as return type
             //
-            // throw new \LogicException(sprintf('Pool has no admin for the class %s.', $class));
+            // throw new AdminClassNotFoundException(sprintf('Pool has no admin for the class %s.', $class));
 
             return null;
         }
@@ -374,7 +380,7 @@ class Pool
             ));
         }
 
-        return $this->getInstance($this->adminClasses[$class][0]);
+        return $this->getInstance(reset($this->adminClasses[$class]));
     }
 
     /**
@@ -407,7 +413,7 @@ class Pool
      *
      * @param string $adminCode
      *
-     * @throws \InvalidArgumentException if the root admin code is an empty string
+     * @throws AdminCodeNotFoundException
      *
      * @return AdminInterface|false
      */
@@ -428,13 +434,6 @@ class Pool
 
         $codes = explode('|', $adminCode);
         $code = trim(array_shift($codes));
-
-        if ('' === $code) {
-            throw new \InvalidArgumentException(
-                'Root admin code must contain a valid admin reference, empty string given.'
-            );
-        }
-
         $admin = $this->getInstance($code);
 
         foreach ($codes as $code) {
@@ -445,7 +444,7 @@ class Pool
                     __METHOD__
                 ), \E_USER_DEPRECATED);
 
-                // NEXT_MAJOR : throw `\InvalidArgumentException` instead
+                // NEXT_MAJOR : throw `AdminCodeNotFoundException` instead
             }
 
             if (!$admin->hasChild($code)) {
@@ -456,7 +455,7 @@ class Pool
                 ), \E_USER_DEPRECATED);
 
                 // NEXT_MAJOR : remove the previous `trigger_error()` call, uncomment the following exception and declare AdminInterface as return type
-                // throw new \InvalidArgumentException(sprintf(
+                // throw new AdminCodeNotFoundException(sprintf(
                 //    'Argument 1 passed to %s() must contain a valid admin hierarchy,'
                 //    .' "%s" is not a valid child for "%s"',
                 //    __METHOD__,
@@ -491,21 +490,54 @@ class Pool
     }
 
     /**
+     * @throws AdminClassNotFoundException if there is no admin for the field description target model
+     * @throws TooManyAdminClassException  if there is too many admin for the field description target model
+     * @throws AdminCodeNotFoundException  if the admin_code option is invalid
+     *
+     * @return AdminInterface
+     */
+    final public function getAdminByFieldDescription(FieldDescriptionInterface $fieldDescription)
+    {
+        $adminCode = $fieldDescription->getOption('admin_code');
+
+        if (null !== $adminCode) {
+            return $this->getAdminByAdminCode($adminCode);
+        }
+
+        // NEXT_MAJOR: Remove the check and use `getTargetModel`.
+        if (method_exists($fieldDescription, 'getTargetModel')) {
+            /** @var class-string $targetModel */
+            $targetModel = $fieldDescription->getTargetModel();
+        } else {
+            $targetModel = $fieldDescription->getTargetEntity();
+        }
+
+        return $this->getAdminByClass($targetModel);
+    }
+
+    /**
      * Returns a new admin instance depends on the given code.
      *
      * @param string $id
      *
-     * @throws \InvalidArgumentException
+     * @throws AdminCodeNotFoundException if the code is not found in admin pool
      *
      * @return AdminInterface
      */
     public function getInstance($id)
     {
+        if ('' === $id) {
+            throw new \InvalidArgumentException(
+                'Admin code must contain a valid admin reference, empty string given.'
+            );
+        }
+
         if (!\in_array($id, $this->adminServiceIds, true)) {
             $msg = sprintf('Admin service "%s" not found in admin pool.', $id);
             $shortest = -1;
             $closest = null;
             $alternatives = [];
+
             foreach ($this->adminServiceIds as $adminServiceId) {
                 $lev = levenshtein($id, $adminServiceId);
                 if ($lev <= $shortest || $shortest < 0) {
@@ -516,6 +548,7 @@ class Pool
                     $alternatives[$adminServiceId] = $lev;
                 }
             }
+
             if (null !== $closest) {
                 asort($alternatives);
                 unset($alternatives[$closest]);
@@ -526,7 +559,8 @@ class Pool
                     implode(', ', array_keys($alternatives))
                 );
             }
-            throw new \InvalidArgumentException($msg);
+
+            throw new AdminCodeNotFoundException($msg);
         }
 
         $admin = $this->container->get($id);

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -47,6 +47,8 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
  */
 class Pool
 {
+    public const DEFAULT_ADMIN_KEY = 'default';
+
     /**
      * @var ContainerInterface
      */
@@ -372,9 +374,14 @@ class Pool
             return null;
         }
 
-        if (!$this->hasSingleAdminByClass($class)) {
-            throw new \RuntimeException(sprintf(
-                'Unable to find a valid admin for the class: %s, there are too many registered: %s',
+        if (isset($this->adminClasses[$class][self::DEFAULT_ADMIN_KEY])) {
+            return $this->getInstance($this->adminClasses[$class][self::DEFAULT_ADMIN_KEY]);
+        }
+
+        if (1 !== \count($this->adminClasses[$class])) {
+            throw new TooManyAdminClassException(sprintf(
+                'Unable to find a valid admin for the class: %s, there are too many registered: %s.'
+                .' Please define a default one with the tag attribute `default: true` in your admin configuration.',
                 $class,
                 implode(', ', $this->adminClasses[$class])
             ));
@@ -392,14 +399,21 @@ class Pool
      */
     public function hasAdminByClass($class)
     {
-        return isset($this->adminClasses[$class]);
+        return isset($this->adminClasses[$class]) && \count($this->adminClasses[$class]) > 0;
     }
 
     /**
      * @phpstan-param class-string $class
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
      */
     public function hasSingleAdminByClass(string $class): bool
     {
+        @trigger_error(sprintf(
+            'Method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.',
+            __METHOD__
+        ), \E_USER_DEPRECATED);
+
         if (!$this->hasAdminByClass($class)) {
             return false;
         }

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -379,7 +379,8 @@ class Pool
         }
 
         if (1 !== \count($this->adminClasses[$class])) {
-            throw new TooManyAdminClassException(sprintf(
+            // NEXT_MAJOR: Throw TooManyAdminClassException instead.
+            throw new \RuntimeException(sprintf(
                 'Unable to find a valid admin for the class: %s, there are too many registered: %s.'
                 .' Please define a default one with the tag attribute `default: true` in your admin configuration.',
                 $class,

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\DependencyInjection\Compiler;
 
 use Doctrine\Inflector\InflectorFactory;
+use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Datagrid\Pager;
 use Sonata\AdminBundle\DependencyInjection\Admin\TaggedAdminInterface;
 use Sonata\AdminBundle\Templating\TemplateRegistry;
@@ -86,7 +87,21 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
                     $classes[$arguments[1]] = [];
                 }
 
-                $classes[$arguments[1]][] = $id;
+                $default = (bool) (isset($attributes['default']) ? $parameterBag->resolveValue($attributes['default']) : false);
+                if ($default) {
+                    if (isset($classes[$arguments[1]][Pool::DEFAULT_ADMIN_KEY])) {
+                        throw new \RuntimeException(sprintf(
+                            'The class %s has two default admins %s and %s.',
+                            $arguments[1],
+                            $classes[$arguments[1]][Pool::DEFAULT_ADMIN_KEY],
+                            $id
+                        ));
+                    }
+
+                    $classes[$arguments[1]][Pool::DEFAULT_ADMIN_KEY] = $id;
+                } else {
+                    $classes[$arguments[1]][] = $id;
+                }
 
                 $showInDashboard = (bool) (isset($attributes['show_in_dashboard']) ? $parameterBag->resolveValue($attributes['show_in_dashboard']) : true);
                 if (!$showInDashboard) {

--- a/src/Exception/AdminClassNotFoundException.php
+++ b/src/Exception/AdminClassNotFoundException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Exception;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+final class AdminClassNotFoundException extends \InvalidArgumentException
+{
+}

--- a/src/Exception/AdminCodeNotFoundException.php
+++ b/src/Exception/AdminCodeNotFoundException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Exception;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+final class AdminCodeNotFoundException extends \InvalidArgumentException
+{
+}

--- a/src/Exception/TooManyAdminClassException.php
+++ b/src/Exception/TooManyAdminClassException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Exception;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+final class TooManyAdminClassException extends \InvalidArgumentException
+{
+}

--- a/tests/Admin/PoolTest.php
+++ b/tests/Admin/PoolTest.php
@@ -17,7 +17,6 @@ use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Exception\AdminCodeNotFoundException;
-use Sonata\AdminBundle\Exception\TooManyAdminClassException;
 use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\Container;
@@ -194,7 +193,9 @@ class PoolTest extends TestCase
 
         $this->assertTrue($pool->hasAdminByClass('someclass'));
 
-        $this->expectException(TooManyAdminClassException::class);
+        // NEXT_MAJOR: Remove this line and uncomment the following one.
+        $this->expectException(\RuntimeException::class);
+        // $this->expectException(TooManyAdminClassException::class);
 
         $pool->getAdminByClass('someclass');
     }

--- a/tests/Admin/PoolTest.php
+++ b/tests/Admin/PoolTest.php
@@ -188,16 +188,27 @@ class PoolTest extends TestCase
 
     public function testGetAdminForClassWithTooManyRegisteredAdmin(): void
     {
-        $pool = new Pool($this->container, [], [], [
+        $pool = new Pool($this->container, ['sonata.user.admin.group1'], [], [
             'someclass' => ['sonata.user.admin.group1', 'sonata.user.admin.group2'],
         ]);
 
         $this->assertTrue($pool->hasAdminByClass('someclass'));
-        $this->assertFalse($pool->hasSingleAdminByClass('someclass'));
 
         $this->expectException(TooManyAdminClassException::class);
 
         $pool->getAdminByClass('someclass');
+    }
+
+    public function testGetAdminForClassWithTooManyRegisteredAdminButOneDefaultAdmin(): void
+    {
+        $this->container->set('sonata.user.admin.group1', $this->createMock(AdminInterface::class));
+
+        $pool = new Pool($this->container, ['sonata.user.admin.group1'], [], [
+            'someclass' => [Pool::DEFAULT_ADMIN_KEY => 'sonata.user.admin.group1', 'sonata.user.admin.group2'],
+        ]);
+
+        $this->assertTrue($pool->hasAdminByClass('someclass'));
+        $this->assertInstanceOf(AdminInterface::class, $pool->getAdminByClass('someclass'));
     }
 
     public function testGetAdminForClassWhenAdminClassIsSet(): void

--- a/tests/Admin/PoolTest.php
+++ b/tests/Admin/PoolTest.php
@@ -16,6 +16,8 @@ namespace Sonata\AdminBundle\Tests\Admin;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Exception\AdminCodeNotFoundException;
+use Sonata\AdminBundle\Exception\TooManyAdminClassException;
 use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
 use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\Container;
@@ -193,7 +195,7 @@ class PoolTest extends TestCase
         $this->assertTrue($pool->hasAdminByClass('someclass'));
         $this->assertFalse($pool->hasSingleAdminByClass('someclass'));
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(TooManyAdminClassException::class);
 
         $pool->getAdminByClass('someclass');
     }
@@ -205,13 +207,12 @@ class PoolTest extends TestCase
         $pool = new Pool($this->container, ['sonata.user.admin.group1'], [], ['someclass' => ['sonata.user.admin.group1']]);
 
         $this->assertTrue($pool->hasAdminByClass('someclass'));
-        $this->assertTrue($pool->hasSingleAdminByClass('someclass'));
         $this->assertInstanceOf(AdminInterface::class, $pool->getAdminByClass('someclass'));
     }
 
     public function testGetInstanceWithUndefinedServiceId(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(AdminCodeNotFoundException::class);
         $this->expectExceptionMessage('Admin service "sonata.news.admin.post" not found in admin pool.');
 
         $this->pool->getInstance('sonata.news.admin.post');
@@ -276,7 +277,7 @@ class PoolTest extends TestCase
         $this->pool->setAdminServiceIds(['sonata.news.admin.post']);
 
         // NEXT_MAJOR: remove the assertion around getAdminByAdminCode(), remove the "@group" and "@expectedDeprecation" annotations, and uncomment the following line
-        // $this->expectException(\InvalidArgumentException::class);
+        // $this->expectException(AdminCodeNotFoundException::class);
         $this->assertFalse($this->pool->getAdminByAdminCode('sonata.news.admin.post|sonata.news.admin.invalid'));
     }
 
@@ -322,7 +323,7 @@ class PoolTest extends TestCase
         $this->assertFalse($this->pool->getAdminByAdminCode('sonata.news.admin.post|sonata.news.admin.invalid'));
 
         // NEXT_MAJOR: remove the "@group" and "@expectedDeprecation" annotations, the previous assertion and uncomment the following lines
-        // $this->expectException(\InvalidArgumentException::class);
+        // $this->expectException(AdminCodeNotFoundException::class);
         // $this->expectExceptionMessage('Argument 1 passed to Sonata\AdminBundle\Admin\Pool::getAdminByAdminCode() must contain a valid admin hierarchy, "sonata.news.admin.valid" is not a valid child for "sonata.news.admin.post"');
         //
         // $this->pool->getAdminByAdminCode('sonata.news.admin.post|sonata.news.admin.valid');
@@ -340,7 +341,7 @@ class PoolTest extends TestCase
         $pool = new Pool($this->container, [$adminId]);
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Root admin code must contain a valid admin reference, empty string given.');
+        $this->expectExceptionMessage('Admin code must contain a valid admin reference, empty string given.');
         $pool->getAdminByAdminCode($adminId);
     }
 
@@ -373,7 +374,7 @@ class PoolTest extends TestCase
         $pool = new Pool($this->container, ['admin1']);
 
         // NEXT_MAJOR: remove the assertion around getAdminByAdminCode(), remove the "@group" and "@expectedDeprecation" annotations, and uncomment the following line
-        // $this->expectException(\InvalidArgumentException::class);
+        // $this->expectException(AdminCodeNotFoundException::class);
         $this->assertFalse($pool->getAdminByAdminCode($adminId));
     }
 

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -590,6 +590,28 @@ class AddDependencyCallsCompilerPassTest extends TestCase
         $this->assertSame(FooAdminController::class, $definition->getArgument(2));
     }
 
+    public function testMultipleDefaultAdmin(): void
+    {
+        $container = $this->getContainer();
+        $container
+            ->register('sonata_post_admin_2')
+            ->setClass(MockAdmin::class)
+            ->setPublic(true)
+            ->setArguments(['', Post::class, CRUDController::class])
+            ->addTag('sonata.admin', ['default' => true, 'group' => 'sonata_group_one', 'manager_type' => 'orm']);
+
+        $config = $this->config;
+
+        $this->extension->load([$config], $container);
+
+        $compilerPass = new AddDependencyCallsCompilerPass();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('The class Sonata\AdminBundle\Tests\DependencyInjection\Compiler\Post has two default admins sonata_post_admin and sonata_post_admin_2.');
+        $compilerPass->process($container);
+        $container->compile();
+    }
+
     /**
      * @return array
      */
@@ -763,7 +785,7 @@ class AddDependencyCallsCompilerPassTest extends TestCase
             ->setClass(MockAdmin::class)
             ->setPublic(true)
             ->setArguments(['', Post::class, CRUDController::class])
-            ->addTag('sonata.admin', ['group' => 'sonata_group_one', 'manager_type' => 'orm']);
+            ->addTag('sonata.admin', ['default' => true, 'group' => 'sonata_group_one', 'manager_type' => 'orm']);
         $container
             ->register('sonata_article_admin')
             ->setPublic(true)


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

BC

Closes #6266

## Changelog

```markdown
### Added
- `Pool::getAdminByFieldDescription()`
- `AdminClassNotFoundException`
- `AdminCodeNotFoundException`
- `TooManyAdminClassException`
- A tag attribute `default: true` for the tag `sonata.admin` to define a default admin for a specific class

### Deprecated
- `Pool::hasSingleAdminByClass()`
```