### PR TITLE
Do not add '-' when there is nothing on the right side

### DIFF
--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -223,7 +223,9 @@ file that was distributed with this source code.
                                             </ul>
                                         </div>
 
-                                        &nbsp;-&nbsp;
+                                        {% if block('pager_results') is not empty %}
+                                            &nbsp;-&nbsp;
+                                        {% endif %}
                                     {% endif %}
 
                                     {% block pager_results %}


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

## Changelog

```markdown
### Fixed
- Do not add a '-' between the export button and the pager results if there is no pager results.
```