### PR TITLE
Remove param from ProxyQueryInterface::execute

### DIFF
--- a/src/Datagrid/ProxyQueryInterface.php
+++ b/src/Datagrid/ProxyQueryInterface.php
@@ -29,11 +29,9 @@ interface ProxyQueryInterface
     public function __call($name, $args);
 
     /**
-     * @param int|null $hydrationMode
-     *
      * @return mixed
      */
-    public function execute(array $params = [], $hydrationMode = null);
+    public function execute();
 
     /**
      * @param array $parentAssociationMappings

--- a/src/Datagrid/SimplePager.php
+++ b/src/Datagrid/SimplePager.php
@@ -128,6 +128,7 @@ class SimplePager extends Pager
             return $this->results;
         }
 
+        // @phpstan-ignore-next-line
         $this->results = $this->getQuery()->execute([], $hydrationMode);
         $this->thresholdCount = \count($this->results);
         if (\count($this->results) > $this->getMaxPerPage()) {

--- a/tests/App/Datagrid/ProxyQuery.php
+++ b/tests/App/Datagrid/ProxyQuery.php
@@ -21,7 +21,7 @@ final class ProxyQuery implements ProxyQueryInterface
     {
     }
 
-    public function execute(array $params = [], $hydrationMode = null)
+    public function execute()
     {
         throw new \BadMethodCallException('Not implemented.');
     }

--- a/tests/Datagrid/SimplePagerTest.php
+++ b/tests/Datagrid/SimplePagerTest.php
@@ -39,7 +39,6 @@ class SimplePagerTest extends TestCase
         $pager = new SimplePager(10, 2);
         $this->proxyQuery->expects($this->once())
                 ->method('execute')
-                ->with([], null)
                 ->willReturn(new ArrayCollection(range(0, 12)));
 
         $this->proxyQuery->expects($this->once())
@@ -60,7 +59,6 @@ class SimplePagerTest extends TestCase
     {
         $this->proxyQuery->expects($this->once())
             ->method('execute')
-            ->with([], null)
             ->willReturn(new ArrayCollection(range(0, 12)));
 
         $this->proxyQuery->expects($this->once())
@@ -102,7 +100,6 @@ class SimplePagerTest extends TestCase
     {
         $this->proxyQuery->expects($this->once())
             ->method('execute')
-            ->with([], null)
             ->willReturn([]);
 
         $this->proxyQuery->expects($this->once())
@@ -131,7 +128,6 @@ class SimplePagerTest extends TestCase
     {
         $this->proxyQuery->expects($this->once())
             ->method('execute')
-            ->with([], null)
             ->willReturn(['foo', 'bar']);
 
         $this->pager->setQuery($this->proxyQuery);
@@ -155,7 +151,6 @@ class SimplePagerTest extends TestCase
     {
         $this->proxyQuery->expects($this->once())
             ->method('execute')
-            ->with([], null)
             ->willReturn($queryReturnValues);
 
         $this->pager->setQuery($this->proxyQuery);


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

Closes #6260.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- `ProxyQueryInterface::execute(array $params = [], ?int $hydrationMode = null)` signature to `ProxyQueryInterface::execute()`
```