### PR TITLE
Clean up the way `required` => false is set

### DIFF
--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -92,7 +92,7 @@ abstract class Filter implements FilterInterface
 
     public function getFieldOptions(): array
     {
-        return $this->getOption('field_options', ['required' => false]);
+        return $this->getOption('field_options', []);
     }
 
     public function getFieldOption(string $name, $default = null)

--- a/src/Form/Type/Filter/ChoiceType.php
+++ b/src/Form/Type/Filter/ChoiceType.php
@@ -35,8 +35,8 @@ final class ChoiceType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('type', $options['operator_type'], array_merge(['required' => false], $options['operator_options']))
-            ->add('value', $options['field_type'], array_merge(['required' => false], $options['field_options']))
+            ->add('type', $options['operator_type'], $options['operator_options'] + ['required' => false])
+            ->add('value', $options['field_type'], $options['field_options'] + ['required' => false])
         ;
     }
 

--- a/src/Form/Type/Filter/DateRangeType.php
+++ b/src/Form/Type/Filter/DateRangeType.php
@@ -36,7 +36,7 @@ final class DateRangeType extends AbstractType
     {
         $builder
             ->add('type', DateRangeOperatorType::class, ['required' => false])
-            ->add('value', $options['field_type'], array_merge(['required' => false], $options['field_options']))
+            ->add('value', $options['field_type'], $options['field_options'] + ['required' => false])
         ;
     }
 

--- a/src/Form/Type/Filter/DateRangeType.php
+++ b/src/Form/Type/Filter/DateRangeType.php
@@ -36,7 +36,7 @@ final class DateRangeType extends AbstractType
     {
         $builder
             ->add('type', DateRangeOperatorType::class, ['required' => false])
-            ->add('value', $options['field_type'], $options['field_options'])
+            ->add('value', $options['field_type'], array_merge(['required' => false], $options['field_options']))
         ;
     }
 

--- a/src/Form/Type/Filter/DateTimeRangeType.php
+++ b/src/Form/Type/Filter/DateTimeRangeType.php
@@ -36,7 +36,7 @@ final class DateTimeRangeType extends AbstractType
     {
         $builder
             ->add('type', DateRangeOperatorType::class, ['required' => false])
-            ->add('value', $options['field_type'], array_merge(['required' => false], $options['field_options']))
+            ->add('value', $options['field_type'], $options['field_options'] + ['required' => false])
         ;
     }
 

--- a/src/Form/Type/Filter/DateTimeRangeType.php
+++ b/src/Form/Type/Filter/DateTimeRangeType.php
@@ -36,7 +36,7 @@ final class DateTimeRangeType extends AbstractType
     {
         $builder
             ->add('type', DateRangeOperatorType::class, ['required' => false])
-            ->add('value', $options['field_type'], $options['field_options'])
+            ->add('value', $options['field_type'], array_merge(['required' => false], $options['field_options']))
         ;
     }
 

--- a/src/Form/Type/Filter/DateTimeType.php
+++ b/src/Form/Type/Filter/DateTimeType.php
@@ -36,7 +36,7 @@ final class DateTimeType extends AbstractType
     {
         $builder
             ->add('type', DateOperatorType::class, ['required' => false])
-            ->add('value', $options['field_type'], array_merge(['required' => false], $options['field_options']))
+            ->add('value', $options['field_type'], $options['field_options'] + ['required' => false])
         ;
     }
 

--- a/src/Form/Type/Filter/DateType.php
+++ b/src/Form/Type/Filter/DateType.php
@@ -36,7 +36,7 @@ final class DateType extends AbstractType
     {
         $builder
             ->add('type', DateOperatorType::class, ['required' => false])
-            ->add('value', $options['field_type'], array_merge(['required' => false], $options['field_options']))
+            ->add('value', $options['field_type'], $options['field_options'] + ['required' => false])
         ;
     }
 

--- a/src/Form/Type/Filter/DefaultType.php
+++ b/src/Form/Type/Filter/DefaultType.php
@@ -35,8 +35,8 @@ final class DefaultType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('type', $options['operator_type'], array_merge(['required' => false], $options['operator_options']))
-            ->add('value', $options['field_type'], array_merge(['required' => false], $options['field_options']))
+            ->add('type', $options['operator_type'], $options['operator_options'] + ['required' => false])
+            ->add('value', $options['field_type'], $options['field_options'] + ['required' => false])
         ;
     }
 

--- a/src/Form/Type/Filter/NumberType.php
+++ b/src/Form/Type/Filter/NumberType.php
@@ -36,7 +36,7 @@ final class NumberType extends AbstractType
     {
         $builder
             ->add('type', NumberOperatorType::class, ['required' => false])
-            ->add('value', $options['field_type'], array_merge(['required' => false], $options['field_options']))
+            ->add('value', $options['field_type'], $options['field_options'] + ['required' => false])
         ;
     }
 

--- a/tests/Datagrid/DatagridMapperTest.php
+++ b/tests/Datagrid/DatagridMapperTest.php
@@ -140,7 +140,7 @@ class DatagridMapperTest extends TestCase
         $this->assertSame('foo__name', $filter->getFormName());
         $this->assertSame(TextType::class, $filter->getFieldType());
         $this->assertSame('fooLabel', $filter->getLabel());
-        $this->assertSame(['required' => false], $filter->getFieldOptions());
+        $this->assertSame([], $filter->getFieldOptions());
         $this->assertSame([
             'show_filter' => null,
             'advanced_filter' => true,

--- a/tests/Filter/FilterTest.php
+++ b/tests/Filter/FilterTest.php
@@ -25,7 +25,7 @@ class FilterTest extends TestCase
         $filter = new FooFilter();
 
         $this->assertSame(TextType::class, $filter->getFieldType());
-        $this->assertSame(['required' => false], $filter->getFieldOptions());
+        $this->assertSame([], $filter->getFieldOptions());
         $this->assertNull($filter->getLabel());
 
         $options = [
@@ -70,7 +70,7 @@ class FilterTest extends TestCase
     public function testSetFieldOption(): void
     {
         $filter = new FooFilter();
-        $this->assertSame(['required' => false], $filter->getFieldOptions());
+        $this->assertSame([], $filter->getFieldOptions());
 
         $filter->setFieldOption('foo', 'bar');
         $filter->setFieldOption('baz', 12345);


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC-break.

`DatagridMapper::add` used a nullable `$fieldOptions` param in order to default to `['required' => false]` thanks to 
```
    public function getFieldOptions()
    {
        return $this->getOption('field_options', ['required' => false]);
    }
```
But this is not needed for two reasons:
- The Filter are already adding this option: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/src/Form/Type/Filter/ChoiceType.php#L81
- The persistence bundle is already adding this option: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/3.x/src/Builder/DatagridBuilder.php#L179
=> Since it's already set in the filter, I recommend to remove this line in the persistence bundle in order to only rely on the filter.

I also added this option to the filter which didn't have like `DateRangeType`, even if it's not needed https://github.com/sonata-project/form-extensions/blob/1.x/src/Type/DateRangeType.php#L44 but just in case the default behavior change (for example we could use `array_merge(['required' => $options['required'], $options['field_options'], $options['field_options_start'])` one day).

Closes #6272

## Changelog

```markdown
### Changed
- Restrict `DatagridMapper::add` fifth type param to array
```