### PR TITLE
Add accessor property instead of code

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -34,6 +34,10 @@ final class MyAdmin extends AbstractAdmin
 }
 ```
 
+### Deprecated the `Sonata\AdminBundle\AdminFieldDescription` `'code'` option.
+
+Use the `accessor` option instead.
+
 ### Deprecated `Sonata\AdminBundle\Admin\AbstractAdmin::formOptions` property.
 
 This property has been replaced by the new method `Sonata\AdminBundle\Admin\AbstractAdmin::configureFormOptions()`

--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -101,7 +101,7 @@ Here is an example::
 
             // you may also use a custom accessor
             ->add('description1', null, [
-                'accessor' => 'getDescription'
+                'accessor' => 'description'
             ])
             ->add('description2', null, [
                 'accessor' => function ($subject) {

--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -99,6 +99,16 @@ Here is an example::
             // specific properties of a relation to the entity
             ->add('image.name')
 
+            // you may also use a custom accessor
+            ->add('description1', null, [
+                'accessor' => 'getDescription'
+            ])
+            ->add('description2', null, [
+                'accessor' => function ($subject) {
+                    return $this->customService->formatDescription($subject);
+                }
+            ])
+
             // You may also specify the actions you want to be displayed in the list
             ->add('_action', null, [
                 'actions' => [

--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -36,7 +36,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
  *   - name (o) : the name used (label in the form, title in the list)
  *   - link_parameters (o) : add link parameter to the related Admin class when
  *                           the Admin.generateUrl is called
- *   - code : the method name to retrieve the related value
+ *   - accessor : the method or the method name to retrieve the related value
  *   - associated_tostring : (deprecated, use associated_property option)
  *                           the method to retrieve the "string" representation
  *                           of the collection element.
@@ -418,9 +418,23 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
             return $this->getFieldValue($child, substr($fieldName, $dotPos + 1));
         }
 
-        // prefer method name given in the code option
+        // NEXT_MAJOR: Remove this code.
         if ($this->getOption('code')) {
-            $getter = $this->getOption('code');
+            @trigger_error(
+                'The "code" option is deprecated since sonata-project/admin-bundle 3.x.'
+                .' Use the "accessor" code instead',
+                \E_USER_DEPRECATED
+            );
+        }
+
+        // prefer method name given in the code option
+        // NEXT_MAJOR: Remove this line and uncomment the following
+        $getter = $this->getOption('accessor', $this->getOption('code'));
+//        $getter = $this->getOption('accessor');
+        if ($getter) {
+            if (\is_callable($getter)) {
+                return $getter($object);
+            }
 
             if (!method_exists($object, $getter)) {
                 @trigger_error(

--- a/tests/Admin/BaseFieldDescriptionTest.php
+++ b/tests/Admin/BaseFieldDescriptionTest.php
@@ -188,7 +188,7 @@ class BaseFieldDescriptionTest extends TestCase
 
     public function testGetFieldValueWithAccessor(): void
     {
-        $description = new FieldDescription('name', ['accessor' => 'getFoo']);
+        $description = new FieldDescription('name', ['accessor' => 'foo']);
         $mock = $this->getMockBuilder(\stdClass::class)->addMethods(['getFoo'])->getMock();
         $mock->expects($this->once())->method('getFoo')->willReturn(42);
         $this->assertSame(42, $description->getFieldValue($mock, 'fake'));

--- a/tests/Admin/BaseFieldDescriptionTest.php
+++ b/tests/Admin/BaseFieldDescriptionTest.php
@@ -186,6 +186,31 @@ class BaseFieldDescriptionTest extends TestCase
         $this->assertNull($description->getFieldValue(null, 'fake'));
     }
 
+    public function testGetFieldValueWithAccessor(): void
+    {
+        $description = new FieldDescription('name', ['accessor' => 'getFoo']);
+        $mock = $this->getMockBuilder(\stdClass::class)->addMethods(['getFoo'])->getMock();
+        $mock->expects($this->once())->method('getFoo')->willReturn(42);
+        $this->assertSame(42, $description->getFieldValue($mock, 'fake'));
+    }
+
+    public function testGetFieldValueWithCallableAccessor(): void
+    {
+        $description = new FieldDescription('name', [
+            'accessor' => static function (object $object): int {
+                return $object->getFoo();
+            },
+        ]);
+        $mock = $this->getMockBuilder(\stdClass::class)->addMethods(['getFoo'])->getMock();
+        $mock->expects($this->once())->method('getFoo')->willReturn(42);
+        $this->assertSame(42, $description->getFieldValue($mock, 'fake'));
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetFieldValueWithCode(): void
     {
         $description = new FieldDescription('name', ['code' => 'getFoo']);


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

Closes #6831.
Closes #6741.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- `FieldDescription` `accessor` option

### Deprecated
- `FieldDescription` `code` option
```