### PR TITLE
Remove default field_name value

### DIFF
--- a/src/Datagrid/DatagridMapper.php
+++ b/src/Datagrid/DatagridMapper.php
@@ -80,10 +80,6 @@ final class DatagridMapper extends BaseMapper
                 ));
             }
 
-            if (!isset($filterOptions['field_name'])) {
-                $filterOptions['field_name'] = substr(strrchr('.'.$name, '.'), 1);
-            }
-
             $fieldDescription = $this->admin->getModelManager()->getNewFieldDescriptionInstance(
                 $this->admin->getClass(),
                 $name,

--- a/tests/Datagrid/DatagridMapperTest.php
+++ b/tests/Datagrid/DatagridMapperTest.php
@@ -204,7 +204,7 @@ class DatagridMapperTest extends TestCase
 
         $this->assertInstanceOf(FilterInterface::class, $filter);
         $this->assertSame('foo.bar', $filter->getName());
-        $this->assertSame('bar', $filter->getOption('field_name'));
+        $this->assertNull($filter->getOption('field_name'));
     }
 
     public function testAddRemove(): void


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC-break.

Related to https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1297
The field_name option shouldn't be set by default, in order to let the persistence bundle to set it correctly this way:
```
$fieldDescription->setOption('field_name', $fieldDescription->getOption('field_name', $fieldDescription->getFieldName()));
```
I tried in DoctrineORMAdmin to comment the code I removed here, and the functional tests are working.