### PR TITLE
[POC] Add guessTypeForFieldDescription to TypeGuesserInterface

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,14 @@ UPGRADE 3.x
 UPGRADE FROM 3.xx to 3.xx
 =========================
 
+### Deprecated `Sonata\AdminBundle\Guesser\TypeGuesserInterface::guessType()` method.
+
+Deprecated `guessType()` method in favor of `guessTypeForFieldDescription()`.
+
+### Deprecated `Sonata\AdminBundle\Guesser\TypeGuesserChain::guessType()` method.
+
+Deprecated `guessType()` method in favor of `guessTypeForFieldDescription()`.
+
 ### Deprecated `Sonata\AdminBundle\Admin\AbstractAdmin::formOptions` property.
 
 This property has been replaced by the new method `Sonata\AdminBundle\Admin\AbstractAdmin::configureFormOptions()`

--- a/src/Guesser/TypeGuesserChain.php
+++ b/src/Guesser/TypeGuesserChain.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Guesser;
 
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Guess\TypeGuess;
@@ -47,12 +48,37 @@ class TypeGuesserChain implements TypeGuesserInterface
         }
     }
 
+    /**
+     * @deprecated since sonata-project/admin-bundle 3.x. Use guessTypeForFieldDescription instead.
+     */
     public function guessType($class, $property, ModelManagerInterface $modelManager)
     {
+        @trigger_error(sprintf(
+            'Method "%s()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.'
+            .' Use "%s::guessTypeForFieldDescription()" instead.',
+            __METHOD__,
+            self::class
+        ), \E_USER_DEPRECATED);
+
         $guesses = [];
 
         foreach ($this->guessers as $guesser) {
             $guess = $guesser->guessType($class, $property, $modelManager);
+
+            if (null !== $guess) {
+                $guesses[] = $guess;
+            }
+        }
+
+        return TypeGuess::getBestGuess($guesses);
+    }
+
+    public function guessTypeForFieldDescription(FieldDescriptionInterface $fieldDescription): ?TypeGuess
+    {
+        $guesses = [];
+
+        foreach ($this->guessers as $guesser) {
+            $guess = $guesser->guessTypeForFieldDescription($fieldDescription);
 
             if (null !== $guess) {
                 $guesses[] = $guess;

--- a/src/Guesser/TypeGuesserInterface.php
+++ b/src/Guesser/TypeGuesserInterface.php
@@ -13,15 +13,20 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Guesser;
 
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\Guess\TypeGuess;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @method TypeGuess|null guessTypeForFieldDescription(FieldDescriptionInterface $fieldDescription)
  */
 interface TypeGuesserInterface
 {
     /**
+     * @deprecated since sonata-project/admin-bundle 3.x. Use guessTypeForFieldDescription instead.
+     *
      * @param string $class
      * @param string $property
      *
@@ -30,4 +35,7 @@ interface TypeGuesserInterface
      * @phpstan-param class-string $class
      */
     public function guessType($class, $property, ModelManagerInterface $modelManager);
+
+    // NEXT_MAJOR: Uncomment next line.
+    // public function guessTypeForFieldDescription(FieldDescriptionInterface $fieldDescription): ?TypeGuess;
 }

--- a/tests/Guesser/TypeGuesserChainTest.php
+++ b/tests/Guesser/TypeGuesserChainTest.php
@@ -14,20 +14,22 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Guesser;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Guesser\TypeGuesserChain;
 use Sonata\AdminBundle\Guesser\TypeGuesserInterface;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Guess\Guess;
 use Symfony\Component\Form\Guess\TypeGuess;
 
 /**
- * TypeGuesserChain Test.
- *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class TypeGuesserChainTest extends TestCase
+final class TypeGuesserChainTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     public function testConstructorWithException(): void
     {
         $this->expectException(UnexpectedTypeException::class);
@@ -35,6 +37,11 @@ class TypeGuesserChainTest extends TestCase
         new TypeGuesserChain([new \stdClass()]);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGuessType(): void
     {
         $typeGuess1 = new TypeGuess('foo1', [], Guess::MEDIUM_CONFIDENCE);
@@ -61,6 +68,9 @@ class TypeGuesserChainTest extends TestCase
         $property = 'firstName';
 
         $typeGuesserChain = new TypeGuesserChain([$guesser1, $guesser2, $guesser3]);
+
+        $this->expectDeprecation('Method "Sonata\AdminBundle\Guesser\TypeGuesserChain::guessType()" is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0. Use "Sonata\AdminBundle\Guesser\TypeGuesserChain::guessTypeForFieldDescription()" instead.');
+
         $this->assertSame($typeGuess2, $typeGuesserChain->guessType($class, $property, $modelManager));
 
         $typeGuess4 = new TypeGuess('foo4', [], Guess::LOW_CONFIDENCE);
@@ -71,5 +81,52 @@ class TypeGuesserChainTest extends TestCase
 
         $typeGuesserChain = new TypeGuesserChain([$guesser4, $typeGuesserChain]);
         $this->assertSame($typeGuess2, $typeGuesserChain->guessType($class, $property, $modelManager));
+    }
+
+    public function testGuessTypeForFieldDescription(): void
+    {
+        $typeGuess1 = new TypeGuess('foo1', [], Guess::MEDIUM_CONFIDENCE);
+        // NEXT_MAJOR: Change this mock with a stub.
+        $guesser1 = $this->getMockBuilder(TypeGuesserInterface::class)
+            ->addMethods(['guessTypeForFieldDescription'])
+            ->getMockForAbstractClass();
+        $guesser1
+                ->method('guessTypeForFieldDescription')
+                ->willReturn($typeGuess1);
+
+        $typeGuess2 = new TypeGuess('foo2', [], Guess::HIGH_CONFIDENCE);
+        // NEXT_MAJOR: Change this mock with a stub.
+        $guesser2 = $this->getMockBuilder(TypeGuesserInterface::class)
+            ->addMethods(['guessTypeForFieldDescription'])
+            ->getMockForAbstractClass();
+        $guesser2
+                ->method('guessTypeForFieldDescription')
+                ->willReturn($typeGuess2);
+
+        $typeGuess3 = new TypeGuess('foo3', [], Guess::LOW_CONFIDENCE);
+        // NEXT_MAJOR: Change this mock with a stub.
+        $guesser3 = $this->getMockBuilder(TypeGuesserInterface::class)
+            ->addMethods(['guessTypeForFieldDescription'])
+            ->getMockForAbstractClass();
+        $guesser3
+                ->method('guessTypeForFieldDescription')
+                ->willReturn($typeGuess3);
+
+        $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
+
+        $typeGuesserChain = new TypeGuesserChain([$guesser1, $guesser2, $guesser3]);
+        $this->assertSame($typeGuess2, $typeGuesserChain->guessTypeForFieldDescription($fieldDescription));
+
+        $typeGuess4 = new TypeGuess('foo4', [], Guess::LOW_CONFIDENCE);
+        // NEXT_MAJOR: Change this mock with a stub.
+        $guesser4 = $this->getMockBuilder(TypeGuesserInterface::class)
+            ->addMethods(['guessTypeForFieldDescription'])
+            ->getMockForAbstractClass();
+        $guesser4
+                ->method('guessTypeForFieldDescription')
+                ->willReturn($typeGuess4);
+
+        $typeGuesserChain = new TypeGuesserChain([$guesser4, $typeGuesserChain]);
+        $this->assertSame($typeGuess2, $typeGuesserChain->guessTypeForFieldDescription($fieldDescription));
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

For a long description: https://github.com/sonata-project/SonataAdminBundle/issues/6701

Basically, in persistence bundles, to guess the type we have a call to a nonexistent `ModelManagerInterface::getParentMetadataForProperty()` which fetches the mapping for a property, the field description should have all the mapping information when is created, so it should be enough for guessing the right type.


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6701.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `TypeGuesserInterface::guessTypeForFieldDescription()` method.
- Added `TypeGuesserChain::guessTypeForFieldDescription()` method.
### Deprecated
- Deprecate `TypeGuesserInterface::guessType()` method in favor of `TypeGuesserInterface::guessTypeForFieldDescription()`.
- Deprecate `TypeGuesserChain::guessType()` method in favor of `TypeGuesserInterface::guessTypeForFieldDescription()`.

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
To be honest I don't like the name, but I think there is no way to reuse `guessType` without breaking BC, any other idea is welcome.