### PR TITLE
fix phpstan error

### DIFF
--- a/src/SonataConfiguration.php
+++ b/src/SonataConfiguration.php
@@ -61,7 +61,6 @@ final class SonataConfiguration
     private $options;
 
     /**
-     * @var array
      * @psalm-param SonataConfigurationOptions $options
      * @phpstan-param array<string, mixed> $options
      */


### PR DESCRIPTION
fixes

``` 
 ------ ------------------------------------------------------------------------------------------ 
  Line   SonataConfiguration.php                                                                   
 ------ ------------------------------------------------------------------------------------------ 
  67     PHPDoc tag @var does not specify variable name.                                           
  67     PHPDoc tag @var has no value type specified in iterable type array.                       
         💡 See: https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type  
 ------ ------------------------------------------------------------------------------------------ 
```