### PR TITLE
Deprecate old datagridMapper signature

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,36 @@ UPGRADE 3.x
 UPGRADE FROM 3.xx to 3.xx
 =========================
 
+### Deprecated passing the field type and options to `DatagridMapper::add` as parameters 4 and 5.
+
+Before:
+```php
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+
+final class MyAdmin extends AbstractAdmin
+{
+    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+    {
+        $datagridMapper->add('foo', null, [], MyFormType::class, ['foo' => 'bar']);
+    }
+}
+```
+After
+```php
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+
+final class MyAdmin extends AbstractAdmin
+{
+    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+    {
+        datagridMapper->add('foo', null, [
+            'field_type' => MyFormType::class,
+            'field_options' => ['foo' => 'bar'],
+        ]);
+    }
+}
+```
+
 ### Deprecated `Sonata\AdminBundle\Admin\AbstractAdmin::formOptions` property.
 
 This property has been replaced by the new method `Sonata\AdminBundle\Admin\AbstractAdmin::configureFormOptions()`

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -26,7 +26,7 @@ final class MyAdmin extends AbstractAdmin
 {
     protected function configureDatagridFilters(DatagridMapper $datagridMapper)
     {
-        datagridMapper->add('foo', null, [
+        $datagridMapper->add('foo', null, [
             'field_type' => MyFormType::class,
             'field_options' => ['foo' => 'bar'],
         ]);

--- a/docs/getting_started/the_list_view.rst
+++ b/docs/getting_started/the_list_view.rst
@@ -172,9 +172,12 @@ the search field to use the ``name`` property of the Category::
         {
             $datagridMapper
                 ->add('title')
-                ->add('category', null, [], EntityType::class, [
-                    'class' => Category::class,
-                    'choice_label' => 'name',
+                ->add('category', null, [
+                    'field_type' => EntityType::class,
+                    'field_options' => [
+                        'class' => Category::class,
+                        'choice_label' => 'name',
+                    ],
                 ])
             ;
         }

--- a/docs/reference/architecture.rst
+++ b/docs/reference/architecture.rst
@@ -222,7 +222,7 @@ which stores instances of ``FieldDescriptionInterface``. Picking up on our previ
             $datagridMapper
                 ->add('title')
                 ->add('author')
-                ->add('privateNotes', null, [], null, null, [
+                ->add('privateNotes', null, [], [
                     'role' => 'ROLE_ADMIN_MODERATOR'
                 ])
             ;

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -772,7 +772,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
                     'model_manager' => $this->getModelManager(),
                 ],
                 'operator_type' => HiddenType::class,
-            ], null, null, [
+            ], [
                 'admin_code' => $this->getParent()->getCode(),
             ]);
         }

--- a/src/Datagrid/DatagridMapper.php
+++ b/src/Datagrid/DatagridMapper.php
@@ -47,10 +47,13 @@ class DatagridMapper extends BaseMapper
     }
 
     /**
+     * NEXT_MAJOR: Change signature for ($name, ?string $type = null, array $filterOptions = [], array $fieldDescriptionOptions = []).
+     *
      * @param FieldDescriptionInterface|string $name
      * @param string|null                      $type
-     * @param string|null                      $fieldType
-     * @param array|null                       $fieldOptions
+     * @param array|string|null                $fieldDescriptionOptionsOrDeprecatedFieldType
+     * @param array|null                       $deprecatedFieldOptions
+     * @param array|null                       $deprecatedFieldDescriptionOptions
      *
      * @throws \LogicException
      *
@@ -60,16 +63,40 @@ class DatagridMapper extends BaseMapper
         $name,
         $type = null,
         array $filterOptions = [],
-        $fieldType = null,
-        $fieldOptions = null,
-        array $fieldDescriptionOptions = []
+        $fieldDescriptionOptionsOrDeprecatedFieldType = [],
+        $deprecatedFieldOptions = null,
+        $deprecatedFieldDescriptionOptions = []
     ) {
-        if (\is_array($fieldOptions)) {
-            $filterOptions['field_options'] = $fieldOptions;
-        }
+        // NEXT_MAJOR remove the check and the else part.
+        if (\is_array($fieldDescriptionOptionsOrDeprecatedFieldType)) {
+            $fieldDescriptionOptions = $fieldDescriptionOptionsOrDeprecatedFieldType;
+        } else {
+            @trigger_error(
+                'Not passing an array as argument 4 is deprecated since sonata-project/admin-bundle 3.x.',
+                \E_USER_DEPRECATED
+            );
 
-        if ($fieldType) {
-            $filterOptions['field_type'] = $fieldType;
+            if (\is_array($deprecatedFieldOptions)) {
+                @trigger_error(
+                    'Passing the field_options as argument 5 is deprecated since sonata-project/admin-bundle 3.x.'.
+                    'Use the `field_options` option of the third argument instead.',
+                    \E_USER_DEPRECATED
+                );
+
+                $filterOptions['field_options'] = $deprecatedFieldOptions;
+            }
+
+            if ($fieldDescriptionOptionsOrDeprecatedFieldType) {
+                @trigger_error(
+                    'Passing the field_type as argument 4 is deprecated since sonata-project/admin-bundle 3.x.'.
+                    'Use the `field_type` option of the third argument instead.',
+                    \E_USER_DEPRECATED
+                );
+
+                $filterOptions['field_type'] = $fieldDescriptionOptionsOrDeprecatedFieldType;
+            }
+
+            $fieldDescriptionOptions = $deprecatedFieldDescriptionOptions;
         }
 
         if ($name instanceof FieldDescriptionInterface) {

--- a/tests/Datagrid/DatagridMapperTest.php
+++ b/tests/Datagrid/DatagridMapperTest.php
@@ -158,7 +158,13 @@ class DatagridMapperTest extends TestCase
 
         $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
 
-        $this->datagridMapper->add($fieldDescription, 'foo_type', ['field_name' => 'fooFilterName', 'foo_filter_option' => 'foo_filter_option_value', 'foo_default_option' => 'bar_custom'], 'foo_field_type', ['foo_field_option' => 'baz']);
+        $this->datagridMapper->add($fieldDescription, 'foo_type', [
+            'field_name' => 'fooFilterName',
+            'field_type' => 'foo_field_type',
+            'field_options' => ['foo_field_option' => 'baz'],
+            'foo_filter_option' => 'foo_filter_option_value',
+            'foo_default_option' => 'bar_custom',
+        ]);
 
         $filter = $this->datagridMapper->get('fooName');
         $this->assertInstanceOf(FilterInterface::class, $filter);
@@ -175,9 +181,9 @@ class DatagridMapperTest extends TestCase
             'link_parameters' => [],
             'label' => 'fooLabel',
             'field_name' => 'fooFilterName',
-            'foo_filter_option' => 'foo_filter_option_value',
-            'field_options' => ['foo_field_option' => 'baz'],
             'field_type' => 'foo_field_type',
+            'field_options' => ['foo_field_option' => 'baz'],
+            'foo_filter_option' => 'foo_filter_option_value',
         ], $filter->getOptions());
     }
 
@@ -299,14 +305,14 @@ class DatagridMapperTest extends TestCase
 
         $this->assertTrue($this->datagridMapper->has('bar'));
 
-        $this->datagridMapper->add('quux', 'bar', [], null, null, ['role' => 'ROLE_QUX']);
+        $this->datagridMapper->add('quux', 'bar', [], ['role' => 'ROLE_QUX']);
 
         $this->assertTrue($this->datagridMapper->has('bar'));
         $this->assertFalse($this->datagridMapper->has('quux'));
 
         $this->datagridMapper
-            ->add('foobar', 'bar', [], null, null, ['role' => self::DEFAULT_GRANTED_ROLE])
-            ->add('foo', 'bar', [], null, null, ['role' => 'ROLE_QUX'])
+            ->add('foobar', 'bar', [], ['role' => self::DEFAULT_GRANTED_ROLE])
+            ->add('foo', 'bar', [], ['role' => 'ROLE_QUX'])
             ->add('baz', 'bar');
 
         $this->assertTrue($this->datagridMapper->has('foobar'));


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

I am targeting this branch, because BC.

Related to https://github.com/sonata-project/SonataAdminBundle/pull/6828

Currently there is two way to pass `field_type` and `field_options`
- Directly in the filterOption param
- By the filterType and filterOptions param

It creates issues when both are used. One way to do things is better.
So I propose to migrate the `DatagridMapper::add` method from 6 to 4 parameters.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- From `DatagridMapper::add($name, $type, $filterOptions = [], $fieldType = null, $fieldOptions = null, $fieldDescriptionOptions = [])` to `DatagridMapper::add($name, $type, $filterOptions = [], $fieldDescriptionOptions = [])`
```