### PR TITLE
Fix access to TypeGuesserChain::guessers

### DIFF
--- a/src/Guesser/TypeGuesserChain.php
+++ b/src/Guesser/TypeGuesserChain.php
@@ -40,7 +40,7 @@ class TypeGuesserChain implements TypeGuesserInterface
             }
 
             if ($guesser instanceof self) {
-                $this->guessers = array_merge($this->guessers, $guesser->guessers);
+                $this->guessers = array_merge($this->guessers, $guesser->getGuessers());
             } else {
                 $this->guessers[] = $guesser;
             }
@@ -60,5 +60,13 @@ class TypeGuesserChain implements TypeGuesserInterface
         }
 
         return TypeGuess::getBestGuess($guesses);
+    }
+
+    /**
+     * @phpstan-return array<TypeGuesserInterface>
+     */
+    protected function getGuessers(): array
+    {
+        return $this->guessers;
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
It is fix for: https://github.com/sonata-project/SonataAdminBundle/pull/6839#issuecomment-775891710
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respec BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `Sonata\AdminBundle\Guesser\TypeGuesserInterface::getGuessers(): array`
