### PR TITLE
Add Final to multiple methods from the AbstractAdmin

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -736,7 +736,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $subClass;
     }
 
-    public function getBatchActions(): array
+    final public function getBatchActions(): array
     {
         $actions = [];
 
@@ -754,7 +754,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
             $actions = $extension->configureBatchActions($this, $actions);
         }
 
-        foreach ($actions  as $name => &$action) {
+        foreach ($actions as $name => &$action) {
             if (!\array_key_exists('label', $action)) {
                 $action['label'] = $this->getTranslationLabel($name, 'batch', 'label');
             }

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -841,12 +841,12 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         $this->templateRegistry = $templateRegistry;
     }
 
-    public function setTemplates(array $templates): void
+    final public function setTemplates(array $templates): void
     {
         $this->getTemplateRegistry()->setTemplates($templates);
     }
 
-    public function setTemplate(string $name, string $template): void
+    final public function setTemplate(string $name, string $template): void
     {
         $this->getTemplateRegistry()->setTemplate($name, $template);
     }

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -767,7 +767,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $actions;
     }
 
-    public function getRoutes(): RouteCollectionInterface
+    final public function getRoutes(): RouteCollectionInterface
     {
         $this->buildRoutes();
 
@@ -790,12 +790,12 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $parameter;
     }
 
-    public function hasRoute(string $name): bool
+    final public function hasRoute(string $name): bool
     {
         return $this->getRouteGenerator()->hasAdminRoute($this, $name);
     }
 
-    public function isCurrentRoute(string $name, ?string $adminCode = null): bool
+    final public function isCurrentRoute(string $name, ?string $adminCode = null): bool
     {
         if (!$this->hasRequest()) {
             return false;
@@ -819,19 +819,19 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $admin->getRoutes()->getRouteName($name) === $route;
     }
 
-    public function generateObjectUrl(string $name, object $object, array $parameters = [], int $referenceType = RoutingUrlGeneratorInterface::ABSOLUTE_PATH): string
+    final public function generateObjectUrl(string $name, object $object, array $parameters = [], int $referenceType = RoutingUrlGeneratorInterface::ABSOLUTE_PATH): string
     {
         $parameters['id'] = $this->getUrlSafeIdentifier($object);
 
         return $this->generateUrl($name, $parameters, $referenceType);
     }
 
-    public function generateUrl(string $name, array $parameters = [], int $referenceType = RoutingUrlGeneratorInterface::ABSOLUTE_PATH): string
+    final public function generateUrl(string $name, array $parameters = [], int $referenceType = RoutingUrlGeneratorInterface::ABSOLUTE_PATH): string
     {
         return $this->getRouteGenerator()->generateUrl($this, $name, $parameters, $referenceType);
     }
 
-    public function generateMenuUrl(string $name, array $parameters = [], int $referenceType = RoutingUrlGeneratorInterface::ABSOLUTE_PATH): array
+    final public function generateMenuUrl(string $name, array $parameters = [], int $referenceType = RoutingUrlGeneratorInterface::ABSOLUTE_PATH): array
     {
         return $this->getRouteGenerator()->generateMenuUrl($this, $name, $parameters, $referenceType);
     }

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -679,22 +679,22 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $this->class;
     }
 
-    public function getSubClasses(): array
+    final public function getSubClasses(): array
     {
         return $this->subClasses;
     }
 
-    public function setSubClasses(array $subClasses): void
+    final public function setSubClasses(array $subClasses): void
     {
         $this->subClasses = $subClasses;
     }
 
-    public function hasSubClass(string $name): bool
+    final public function hasSubClass(string $name): bool
     {
         return isset($this->subClasses[$name]);
     }
 
-    public function hasActiveSubClass(): bool
+    final public function hasActiveSubClass(): bool
     {
         if (\count($this->subClasses) > 0 && $this->hasRequest()) {
             return null !== $this->getRequest()->query->get('subclass');
@@ -703,7 +703,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return false;
     }
 
-    public function getActiveSubClass(): string
+    final public function getActiveSubClass(): string
     {
         if (!$this->hasActiveSubClass()) {
             throw new \LogicException(sprintf(
@@ -715,7 +715,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $this->getSubClass($this->getActiveSubclassCode());
     }
 
-    public function getActiveSubclassCode(): string
+    final public function getActiveSubclassCode(): string
     {
         if (!$this->hasActiveSubClass()) {
             throw new \LogicException(sprintf(

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -379,7 +379,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         $this->configure();
     }
 
-    public function update(object $object): object
+    final public function update(object $object): object
     {
         $this->preUpdate($object);
         foreach ($this->getExtensions() as $extension) {
@@ -396,7 +396,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $object;
     }
 
-    public function create(object $object): object
+    final public function create(object $object): object
     {
         $this->prePersist($object);
         foreach ($this->getExtensions() as $extension) {
@@ -415,7 +415,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $object;
     }
 
-    public function delete(object $object): void
+    final public function delete(object $object): void
     {
         $this->preRemove($object);
         foreach ($this->getExtensions() as $extension) {

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -526,7 +526,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
      *
      * @throws \InvalidArgumentException
      */
-    public function getParentAssociationMapping(): ?string
+    final public function getParentAssociationMapping(): ?string
     {
         if ($this->isChild()) {
             $parent = $this->getParent()->getCode();

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -550,7 +550,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         $this->parentAssociationMapping[$code] = $value;
     }
 
-    public function getBaseRoutePattern(): string
+    final public function getBaseRoutePattern(): string
     {
         if (null !== $this->cachedBaseRoutePattern) {
             return $this->cachedBaseRoutePattern;
@@ -604,7 +604,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
      *
      * @return string the baseRouteName used to generate the routing information
      */
-    public function getBaseRouteName(): string
+    final public function getBaseRouteName(): string
     {
         if (null !== $this->cachedBaseRouteName) {
             return $this->cachedBaseRouteName;

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -654,7 +654,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $this->cachedBaseRouteName;
     }
 
-    public function getClass(): string
+    final public function getClass(): string
     {
         if ($this->hasActiveSubClass()) {
             if ($this->hasParentFieldDescription()) {

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -467,7 +467,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         );
     }
 
-    public function getFilterParameters(): array
+    final public function getFilterParameters(): array
     {
         $parameters = $this->getDefaultFilterParameters();
 

--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -37,7 +37,7 @@ class AdminHelper
     /**
      * @var PropertyAccessorInterface
      */
-    protected $propertyAccessor;
+    private $propertyAccessor;
 
     public function __construct(PropertyAccessorInterface $propertyAccessor)
     {
@@ -197,7 +197,7 @@ class AdminHelper
      *
      * @param string[] $elements
      */
-    protected function getModelClassName(AdminInterface $admin, array $elements): string
+    private function getModelClassName(AdminInterface $admin, array $elements): string
     {
         $element = array_shift($elements);
         $associationAdmin = $admin->getFormFieldDescription($element)->getAssociationAdmin();

--- a/tests/Action/AppendFormFieldElementActionTest.php
+++ b/tests/Action/AppendFormFieldElementActionTest.php
@@ -16,7 +16,6 @@ namespace Sonata\AdminBundle\Tests\Action;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Action\AppendFormFieldElementAction;
 use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
-use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminHelper;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;

--- a/tests/Action/AppendFormFieldElementActionTest.php
+++ b/tests/Action/AppendFormFieldElementActionTest.php
@@ -18,6 +18,7 @@ use Sonata\AdminBundle\Action\AppendFormFieldElementAction;
 use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminHelper;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
@@ -47,7 +48,7 @@ final class AppendFormFieldElementActionTest extends TestCase
     private $action;
 
     /**
-     * @var AbstractAdmin
+     * @var AdminInterface
      */
     private $admin;
 
@@ -59,7 +60,7 @@ final class AppendFormFieldElementActionTest extends TestCase
     protected function setUp(): void
     {
         $this->twig = $this->createStub(Environment::class);
-        $this->admin = $this->createMock(AbstractAdmin::class);
+        $this->admin = $this->createMock(AdminInterface::class);
         $this->admin->expects($this->once())->method('setRequest');
         $container = new Container();
         $container->set('sonata.post.admin', $this->admin);

--- a/tests/Action/Baz.php
+++ b/tests/Action/Baz.php
@@ -22,7 +22,7 @@ class Baz
         $this->bar = $bar;
     }
 
-    public function getBar(): Bar
+    public function getBar(): ?Bar
     {
         return $this->bar;
     }

--- a/tests/Action/RetrieveFormFieldElementActionTest.php
+++ b/tests/Action/RetrieveFormFieldElementActionTest.php
@@ -18,6 +18,7 @@ use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
 use Sonata\AdminBundle\Action\RetrieveFormFieldElementAction;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminHelper;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\DependencyInjection\Container;
@@ -42,7 +43,7 @@ final class RetrieveFormFieldElementActionTest extends TestCase
     private $action;
 
     /**
-     * @var AbstractAdmin
+     * @var AdminInterface
      */
     private $admin;
 
@@ -59,7 +60,7 @@ final class RetrieveFormFieldElementActionTest extends TestCase
     protected function setUp(): void
     {
         $this->twig = $this->createStub(Environment::class);
-        $this->admin = $this->createMock(AbstractAdmin::class);
+        $this->admin = $this->createMock(AdminInterface::class);
         $this->admin->expects($this->once())->method('setRequest');
         $container = new Container();
         $container->set('sonata.post.admin', $this->admin);

--- a/tests/Action/RetrieveFormFieldElementActionTest.php
+++ b/tests/Action/RetrieveFormFieldElementActionTest.php
@@ -16,7 +16,6 @@ namespace Sonata\AdminBundle\Tests\Action;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
 use Sonata\AdminBundle\Action\RetrieveFormFieldElementAction;
-use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminHelper;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;

--- a/tests/Action/SetObjectFieldValueActionTest.php
+++ b/tests/Action/SetObjectFieldValueActionTest.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Tests\Action;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Action\SetObjectFieldValueAction;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Form\DataTransformerResolver;
@@ -52,7 +53,7 @@ final class SetObjectFieldValueActionTest extends TestCase
     private $action;
 
     /**
-     * @var AbstractAdmin
+     * @var AdminInterface
      */
     private $admin;
 
@@ -88,7 +89,7 @@ final class SetObjectFieldValueActionTest extends TestCase
             'field_template' => 'renderedTemplate',
         ]));
         $this->adminCode = 'sonata.post.admin';
-        $this->admin = $this->createMock(AbstractAdmin::class);
+        $this->admin = $this->createMock(AdminInterface::class);
         $container = new Container();
         $container->set($this->adminCode, $this->admin);
         $this->pool = new Pool($container, [$this->adminCode]);
@@ -104,7 +105,7 @@ final class SetObjectFieldValueActionTest extends TestCase
             $this->resolver,
             $this->propertyAccessor
         );
-        $this->admin->setModelManager($this->modelManager);
+        $this->admin->method('getModelManager')->willReturn($this->modelManager);
     }
 
     public function testSetObjectFieldValueAction(): void

--- a/tests/Action/SetObjectFieldValueActionTest.php
+++ b/tests/Action/SetObjectFieldValueActionTest.php
@@ -15,7 +15,6 @@ namespace Sonata\AdminBundle\Tests\Action;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Action\SetObjectFieldValueAction;
-use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Admin\Pool;

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1329,6 +1329,7 @@ class AdminTest extends TestCase
         $post = new Post();
 
         $postAdmin = $this->getMockBuilder(PostAdmin::class)->disableOriginalConstructor()->getMock();
+        $postAdmin->method('getCode')->willReturn('post');
         $postAdmin->method('getObject')->willReturn($post);
         $postAdmin->method('getIdParameter')->willReturn('parent_id');
 
@@ -1343,6 +1344,7 @@ class AdminTest extends TestCase
         $tagAdmin = new TagAdmin('admin.tag', Tag::class, 'MyBundle\MyController');
         $tagAdmin->setModelManager($modelManager);
         $tagAdmin->setParent($postAdmin);
+        $tagAdmin->addParentAssociationMapping('post', 'post');
 
         $request = $this->createStub(Request::class);
         $tagAdmin->setRequest($request);
@@ -1357,6 +1359,7 @@ class AdminTest extends TestCase
         $post = new Post();
 
         $postAdmin = $this->getMockBuilder(PostAdmin::class)->disableOriginalConstructor()->getMock();
+        $postAdmin->method('getCode')->willReturn('post');
         $postAdmin->method('getObject')->willReturn($post);
         $postAdmin->method('getIdParameter')->willReturn('parent_id');
 
@@ -1371,6 +1374,7 @@ class AdminTest extends TestCase
         $postCategoryAdmin = new PostCategoryAdmin('admin.post_category', PostCategoryAdmin::class, 'MyBundle\MyController');
         $postCategoryAdmin->setModelManager($modelManager);
         $postCategoryAdmin->setParent($postAdmin);
+        $postCategoryAdmin->addParentAssociationMapping('post', 'posts');
 
         $request = $this->createStub(Request::class);
         $postCategoryAdmin->setRequest($request);

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1764,7 +1764,10 @@ class AdminTest extends TestCase
         $admin->method('isAclEnabled')->willReturn(true);
         $admin->method('getExtensions')->willReturn([]);
 
-        $admin->expects($this->exactly(9))->method('hasRoute')->willReturn(false);
+        $routerGenerator = $this->createMock(RouteGeneratorInterface::class);
+        $routerGenerator->expects($this->exactly(9))->method('hasAdminRoute')->willReturn(false);
+        $admin->setRouteGenerator($routerGenerator);
+
         $admin->expects($this->never())->method('hasAccess');
         $admin->expects($this->never())->method('getShow');
 

--- a/tests/Admin/BreadcrumbsBuilderTest.php
+++ b/tests/Admin/BreadcrumbsBuilderTest.php
@@ -17,6 +17,7 @@ use Knp\Menu\ItemInterface;
 use Knp\Menu\MenuFactory;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\BreadcrumbsBuilder;
 use Sonata\AdminBundle\Route\RouteGeneratorInterface;
 use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
@@ -35,16 +36,16 @@ class BreadcrumbsBuilderTest extends TestCase
     {
         $action = 'my_action';
         $breadcrumbsBuilder = new BreadcrumbsBuilder(['child_admin_route' => 'show']);
-        $admin = $this->createStub(AbstractAdmin::class);
+        $admin = $this->createStub(AdminInterface::class);
         $admin->method('isChild')->willReturn(false);
 
-        $admin->setMenuFactory(new MenuFactory());
+        $admin->method('getMenuFactory')->willReturn(new MenuFactory());
         $labelTranslatorStrategy = $this->createStub(LabelTranslatorStrategyInterface::class);
 
         $routeGenerator = $this->createStub(RouteGeneratorInterface::class);
         $routeGenerator->method('generate')->with('sonata_admin_dashboard')->willReturn('/dashboard');
 
-        $admin->setRouteGenerator($routeGenerator);
+        $admin->method('getRouteGenerator')->willReturn($routeGenerator);
         $labelTranslatorStrategy->method('getLabel')->willReturnMap([
             ['my_class_name_list', 'breadcrumb', 'link', 'My class'],
             ['my_child_class_name_list', 'breadcrumb', 'link', 'My child class'],
@@ -53,11 +54,11 @@ class BreadcrumbsBuilderTest extends TestCase
         $subject = new \stdClass();
         $childSubject = new \stdClass();
 
-        $childAdmin = $this->createMock(AbstractAdmin::class);
+        $childAdmin = $this->createMock(AdminInterface::class);
         $childAdmin->method('isChild')->willReturn(true);
         $childAdmin->method('getParent')->willReturn($admin);
         $childAdmin->method('getTranslationDomain')->willReturn('ChildBundle');
-        $childAdmin->setLabelTranslatorStrategy($labelTranslatorStrategy);
+        $childAdmin->method('getLabelTranslatorStrategy')->willReturn($labelTranslatorStrategy);
         $childAdmin->method('getClassnameLabel')->willReturn('my_child_class_name');
         $childAdmin->method('hasRoute')->with('list')->willReturn(true);
         $childAdmin->method('hasAccess')->with('list')->willReturn(true);
@@ -93,7 +94,7 @@ class BreadcrumbsBuilderTest extends TestCase
         $admin->method('getSubject')->willReturn($subject);
         $admin->method('toString')->with($subject)->willReturn('My subject');
         $admin->method('getTranslationDomain')->willReturn('FooBundle');
-        $admin->setLabelTranslatorStrategy($labelTranslatorStrategy);
+        $admin->method('getLabelTranslatorStrategy')->willReturn($labelTranslatorStrategy);
         $admin->method('getClassnameLabel')->willReturn('my_class_name');
 
         $breadcrumbs = $breadcrumbsBuilder->getBreadcrumbs($childAdmin, $action);
@@ -155,13 +156,13 @@ class BreadcrumbsBuilderTest extends TestCase
         $menu = $this->createMock(ItemInterface::class);
         $menuFactory = $this->createStub(MenuFactory::class);
         $menuFactory->method('createItem')->with('root')->willReturn($menu);
-        $admin = $this->createStub(AbstractAdmin::class);
-        $admin->setMenuFactory($menuFactory);
+        $admin = $this->createStub(AdminInterface::class);
+        $admin->method('getMenuFactory')->willReturn($menuFactory);
         $labelTranslatorStrategy = $this->createStub(LabelTranslatorStrategyInterface::class);
 
         $routeGenerator = $this->createStub(RouteGeneratorInterface::class);
         $routeGenerator->method('generate')->with('sonata_admin_dashboard')->willReturn('/dashboard');
-        $admin->setRouteGenerator($routeGenerator);
+        $admin->method('getRouteGenerator')->willReturn($routeGenerator);
 
         $menu->method('addChild')->willReturnMap([
             ['link_breadcrumb_dashboard', [
@@ -200,9 +201,9 @@ class BreadcrumbsBuilderTest extends TestCase
             ['my_class_name_create', 'breadcrumb', 'link', 'create my object'],
         ]);
 
-        $childAdmin = $this->createStub(AbstractAdmin::class);
+        $childAdmin = $this->createStub(AdminInterface::class);
         $childAdmin->method('getTranslationDomain')->willReturn('ChildBundle');
-        $childAdmin->setLabelTranslatorStrategy($labelTranslatorStrategy);
+        $childAdmin->method('getLabelTranslatorStrategy')->willReturn($labelTranslatorStrategy);
         $childAdmin->method('getClassnameLabel')->willReturn('my_child_class_name');
         $childAdmin->method('hasRoute')->with('list')->willReturn(false);
         $childAdmin->method('getCurrentChildAdmin')->willReturn(null);
@@ -232,7 +233,7 @@ class BreadcrumbsBuilderTest extends TestCase
         $admin->method('getSubject')->willReturn($subject);
         $admin->method('toString')->with($subject)->willReturn('My subject');
         $admin->method('getTranslationDomain')->willReturn('FooBundle');
-        $admin->setLabelTranslatorStrategy($labelTranslatorStrategy);
+        $admin->method('getLabelTranslatorStrategy')->willReturn($labelTranslatorStrategy);
         $admin->method('getClassnameLabel')->willReturn('my_class_name');
 
         $breadcrumbsBuilder->buildBreadcrumbs($admin, $action);

--- a/tests/Admin/BreadcrumbsBuilderTest.php
+++ b/tests/Admin/BreadcrumbsBuilderTest.php
@@ -16,7 +16,6 @@ namespace Sonata\AdminBundle\Tests\Admin;
 use Knp\Menu\ItemInterface;
 use Knp\Menu\MenuFactory;
 use PHPUnit\Framework\TestCase;
-use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\BreadcrumbsBuilder;
 use Sonata\AdminBundle\Route\RouteGeneratorInterface;

--- a/tests/Datagrid/ListMapperTest.php
+++ b/tests/Datagrid/ListMapperTest.php
@@ -50,15 +50,15 @@ class ListMapperTest extends TestCase
     {
         $listBuilder = $this->createMock(ListBuilderInterface::class);
         $this->fieldDescriptionCollection = new FieldDescriptionCollection();
-        $this->admin = $this->createMock(AbstractAdmin::class);
+        $this->admin = $this->createMock(AdminInterface::class);
 
         $listBuilder
             ->method('addField')
             ->willReturnCallback(static function (
                 FieldDescriptionCollection $list,
                 ?string $type,
-                BaseFieldDescription $fieldDescription,
-                AbstractAdmin $admin
+                FieldDescriptionInterface $fieldDescription,
+                AdminInterface $admin
             ): void {
                 $fieldDescription->setType($type);
                 $list->add($fieldDescription);
@@ -75,11 +75,11 @@ class ListMapperTest extends TestCase
                 return $fieldDescription;
             });
 
-        $this->admin->setModelManager($modelManager);
+        $this->admin->method('getModelManager')->willReturn($modelManager);
 
         $labelTranslatorStrategy = new NoopLabelTranslatorStrategy();
 
-        $this->admin->setLabelTranslatorStrategy($labelTranslatorStrategy);
+        $this->admin->method('getLabelTranslatorStrategy')->willReturn($labelTranslatorStrategy);
 
         $this->admin
             ->method('isGranted')
@@ -138,32 +138,14 @@ class ListMapperTest extends TestCase
         $this->assertFalse($this->listMapper->get('bazName')->getOption('identifier'));
     }
 
-    /**
-     * @dataProvider getWrongIdentifierOptions
-     */
-    public function testAddOptionIdentifierWithWrongValue(bool $expected, $value): void
+    public function testAddOptionIdentifierWithWrongValue(): void
     {
         $this->assertFalse($this->listMapper->has('fooName'));
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessageMatches('/^Value for "identifier" option must be boolean, .+ given.$/');
 
-        $this->listMapper->add('fooName', null, ['identifier' => $value]);
-    }
-
-    public function getWrongIdentifierOptions(): iterable
-    {
-        return [
-            [true, 1],
-            [true, 'string'],
-            [true, new \stdClass()],
-            [true, [null]],
-            [false, 0],
-            [false, null],
-            [false, ''],
-            [false, '0'],
-            [false, []],
-        ];
+        $this->listMapper->add('fooName', null, ['identifier' => 1]);
     }
 
     public function testAdd(): void

--- a/tests/Datagrid/ListMapperTest.php
+++ b/tests/Datagrid/ListMapperTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Datagrid;
 
 use PHPUnit\Framework\TestCase;
-use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\BaseFieldDescription;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;

--- a/tests/Fixtures/Admin/PostCategoryAdmin.php
+++ b/tests/Fixtures/Admin/PostCategoryAdmin.php
@@ -17,12 +17,4 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 
 class PostCategoryAdmin extends AbstractAdmin
 {
-    public function getParentAssociationMapping(): ?string
-    {
-        if ($this->getParent() instanceof PostAdmin) {
-            return 'posts';
-        }
-
-        return null;
-    }
 }

--- a/tests/Fixtures/Admin/TagAdmin.php
+++ b/tests/Fixtures/Admin/TagAdmin.php
@@ -17,12 +17,4 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 
 class TagAdmin extends AbstractAdmin
 {
-    public function getParentAssociationMapping(): ?string
-    {
-        if ($this->getParent() instanceof PostAdmin) {
-            return 'post';
-        }
-
-        return null;
-    }
 }

--- a/tests/Form/Type/AdminTypeTest.php
+++ b/tests/Form/Type/AdminTypeTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Form\Type;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Form\Extension\Field\Type\FormTypeFieldExtension;

--- a/tests/Form/Type/AdminTypeTest.php
+++ b/tests/Form/Type/AdminTypeTest.php
@@ -69,7 +69,7 @@ class AdminTypeTest extends TypeTestCase
 
         $foo = new Foo();
 
-        $admin = $this->createMock(AbstractAdmin::class);
+        $admin = $this->createMock(AdminInterface::class);
         $admin->expects($this->exactly(2))->method('hasParentFieldDescription')->willReturn(true);
         $admin->expects($this->exactly(2))->method('getParentFieldDescription')->willReturn($parentField);
         $admin->expects($this->once())->method('hasAccess')->with('delete')->willReturn(false);
@@ -120,7 +120,7 @@ class AdminTypeTest extends TypeTestCase
 
         $modelManager = $this->createStub(ModelManagerInterface::class);
 
-        $admin = $this->createMock(AbstractAdmin::class);
+        $admin = $this->createMock(AdminInterface::class);
         $admin->expects($this->exactly(2))->method('hasParentFieldDescription')->willReturn(true);
         $admin->expects($this->exactly(2))->method('getParentFieldDescription')->willReturn($parentField);
         $admin->expects($this->once())->method('setSubject')->with($bar);
@@ -162,7 +162,7 @@ class AdminTypeTest extends TypeTestCase
 
         $modelManager = $this->createStub(ModelManagerInterface::class);
 
-        $admin = $this->createMock(AbstractAdmin::class);
+        $admin = $this->createMock(AdminInterface::class);
         $admin->expects($this->exactly(2))->method('hasParentFieldDescription')->willReturn(true);
         $admin->expects($this->exactly(2))->method('getParentFieldDescription')->willReturn($parentField);
         $admin->expects($this->once())->method('defineFormBuilder');
@@ -211,7 +211,7 @@ class AdminTypeTest extends TypeTestCase
             }
         };
 
-        $admin = $this->createMock(AbstractAdmin::class);
+        $admin = $this->createMock(AdminInterface::class);
         $admin->expects($this->exactly(2))->method('hasParentFieldDescription')->willReturn(true);
         $admin->expects($this->exactly(2))->method('getParentFieldDescription')->willReturn($parentField);
         $admin->expects($this->once())->method('defineFormBuilder');
@@ -262,7 +262,7 @@ class AdminTypeTest extends TypeTestCase
 
         $newInstance = new \stdClass();
 
-        $admin = $this->createMock(AbstractAdmin::class);
+        $admin = $this->createMock(AdminInterface::class);
         $admin->expects($this->exactly(2))->method('hasParentFieldDescription')->willReturn(true);
         $admin->expects($this->exactly(2))->method('getParentFieldDescription')->willReturn($parentField);
         $admin->expects($this->once())->method('defineFormBuilder');

--- a/tests/Menu/Matcher/Voter/AdminVoterTest.php
+++ b/tests/Menu/Matcher/Voter/AdminVoterTest.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Tests\Menu\Matcher\Voter;
 use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\Voter\VoterInterface;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Menu\Matcher\Voter\AdminVoter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -78,9 +79,9 @@ class AdminVoterTest extends AbstractVoterTest
     /**
      * {@inheritdoc}
      */
-    private function getAdmin(string $code, bool $list = false, bool $granted = false): AbstractAdmin
+    private function getAdmin(string $code, bool $list = false, bool $granted = false): AdminInterface
     {
-        $admin = $this->createMock(AbstractAdmin::class);
+        $admin = $this->createMock(AdminInterface::class);
         $admin
             ->method('hasRoute')
             ->with('list')
@@ -111,8 +112,8 @@ class AdminVoterTest extends AbstractVoterTest
         string $childCode,
         bool $list = false,
         bool $granted = false
-    ): AbstractAdmin {
-        $parentAdmin = $this->createMock(AbstractAdmin::class);
+    ): AdminInterface {
+        $parentAdmin = $this->createMock(AdminInterface::class);
         $parentAdmin
             ->method('hasRoute')
             ->with('list')
@@ -128,7 +129,7 @@ class AdminVoterTest extends AbstractVoterTest
             ->willReturn($parentCode)
         ;
 
-        $childAdmin = $this->createMock(AbstractAdmin::class);
+        $childAdmin = $this->createMock(AdminInterface::class);
         $childAdmin
             ->method('getBaseCodeRoute')
             ->willReturn(sprintf('%s|%s', $parentCode, $childCode))

--- a/tests/Menu/Matcher/Voter/AdminVoterTest.php
+++ b/tests/Menu/Matcher/Voter/AdminVoterTest.php
@@ -15,7 +15,6 @@ namespace Sonata\AdminBundle\Tests\Menu\Matcher\Voter;
 
 use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\Voter\VoterInterface;
-use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Menu\Matcher\Voter\AdminVoter;
 use Symfony\Component\HttpFoundation\Request;

--- a/tests/Menu/Provider/GroupMenuProviderTest.php
+++ b/tests/Menu/Provider/GroupMenuProviderTest.php
@@ -22,6 +22,7 @@ use Knp\Menu\Provider\MenuProviderInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Menu\Provider\GroupMenuProvider;
 use Symfony\Component\DependencyInjection\Container;
@@ -623,9 +624,9 @@ class GroupMenuProviderTest extends TestCase
         ];
     }
 
-    private function getAdminMock(bool $hasRoute = true, bool $isGranted = true): AbstractAdmin
+    private function getAdminMock(bool $hasRoute = true, bool $isGranted = true): AdminInterface
     {
-        $admin = $this->createMock(AbstractAdmin::class);
+        $admin = $this->createMock(AdminInterface::class);
         $admin->expects($this->once())
             ->method('hasRoute')
             ->with($this->equalTo('list'))
@@ -636,7 +637,7 @@ class GroupMenuProviderTest extends TestCase
             ->with($this->equalTo('list'))
             ->willReturn($isGranted);
 
-        $admin->setLabel('foo_admin_label');
+        $admin->method('getLabel')->willReturn('foo_admin_label');
 
         $admin
             ->method('generateMenuUrl')

--- a/tests/Menu/Provider/GroupMenuProviderTest.php
+++ b/tests/Menu/Provider/GroupMenuProviderTest.php
@@ -21,7 +21,6 @@ use Knp\Menu\MenuItem;
 use Knp\Menu\Provider\MenuProviderInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Menu\Provider\GroupMenuProvider;

--- a/tests/Twig/Extension/GroupExtensionTest.php
+++ b/tests/Twig/Extension/GroupExtensionTest.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Tests\Twig\Extension;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Twig\Extension\GroupExtension;
 use Symfony\Component\DependencyInjection\Container;
@@ -60,8 +61,8 @@ final class GroupExtensionTest extends TestCase
         ]);
         $twigExtension = new GroupExtension($pool);
 
-        $adminNonCreatable = $this->createMock(AbstractAdmin::class);
-        $adminCreatable = $this->createMock(AbstractAdmin::class);
+        $adminNonCreatable = $this->createMock(AdminInterface::class);
+        $adminCreatable = $this->createMock(AdminInterface::class);
 
         $container->set('sonata_admin_non_creatable', $adminNonCreatable);
         $container->set('sonata_admin_creatable', $adminCreatable);


### PR DESCRIPTION
Related to https://github.com/sonata-project/SonataAdminBundle/issues/5791

A lot of public method of the AbstractAdmin shouldn't be extended for different reason
- Some of them have a `protected configureFoo()` method provided for this
- Some of them are calling directly a service `return $this->service->method()`, so the service should be overridden instead.
- It does not make sens for some

Making these method final let me discovering we were often mocking AbstractAdmin instead of the Interface ; so I fixed the tests.

I didn't add final everywhere, this PR is big enough IMHO, I prefer to follow in another one.
Basically I'd like to add final to as much public method of AbstractAdmin as possible, if someone need to configure/override something, it should be done in a configure method or a specific service instead.