### PR TITLE
Declare getNewInstance as final in favor of alterNewInstance

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,10 @@ UPGRADE 3.x
 UPGRADE FROM 3.xx to 3.xx
 =========================
 
+### Deprecated overriding `AbstractAdmin::getNewInstance()`.
+
+Use `AbstractAdmin::alterNewInstance()` instead.
+
 ### Deprecated passing the field type and options to `DatagridMapper::add` as parameters 4 and 5.
 
 Before:

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1241,11 +1241,15 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $this->getTemplateRegistry()->getTemplate($name);
     }
 
+    /**
+     * @final since sonata-project/admin-bundle 3.x
+     */
     public function getNewInstance()
     {
         $object = $this->getModelManager()->getModelInstance($this->getClass());
 
         $this->appendParentObject($object);
+        $this->alterNewInstance($object);
 
         foreach ($this->getExtensions() as $extension) {
             $extension->alterNewInstance($this, $object);
@@ -2886,6 +2890,13 @@ EOT;
     final public function hasTemplateRegistry(): bool
     {
         return null !== $this->templateRegistry;
+    }
+
+    /**
+     * @phpstan-param T $object
+     */
+    protected function alterNewInstance(object $object): void
+    {
     }
 
     /**


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

There is an `alterNewInstance` for extensions, but not for the `AbstractAdmin`.
I think we should provide one instead of allowing to override `getNewInstance`.

## Changelog

```markdown
### Added
- Added `AbstractAdmin::alterNewInstance()`

### Deprecated
- Overriding `AbstractAdmin::getNewInstance()`
```