### PR TITLE
Improve default templates setters

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -841,14 +841,14 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         $this->templateRegistry = $templateRegistry;
     }
 
-    public function setTemplates(array $templates): void
+    final public function setTemplates(array $templates, bool $override = true): void
     {
-        $this->getTemplateRegistry()->setTemplates($templates);
+        $this->getTemplateRegistry()->setTemplates($templates, $override);
     }
 
-    public function setTemplate(string $name, string $template): void
+    final public function setTemplate(string $name, string $template, bool $override = true): void
     {
-        $this->getTemplateRegistry()->setTemplate($name, $template);
+        $this->getTemplateRegistry()->setTemplate($name, $template, $override);
     }
 
     public function getNewInstance(): object

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -58,18 +58,6 @@ interface AdminInterface extends TaggedAdminInterface, AccessRegistryInterface, 
      */
     public function getBaseControllerName(): string;
 
-    /**
-     * Sets a list of templates.
-     *
-     * @param array<string, string> $templates
-     */
-    public function setTemplates(array $templates): void;
-
-    /**
-     * Sets a specific template.
-     */
-    public function setTemplate(string $name, string $template): void;
-
     public function createQuery(): ProxyQueryInterface;
 
     public function getFormBuilder(): FormBuilderInterface;

--- a/src/Templating/MutableTemplateRegistry.php
+++ b/src/Templating/MutableTemplateRegistry.php
@@ -18,13 +18,23 @@ namespace Sonata\AdminBundle\Templating;
  */
 final class MutableTemplateRegistry extends AbstractTemplateRegistry implements MutableTemplateRegistryInterface
 {
-    public function setTemplates(array $templates): void
+    public function setTemplates(array $templates, bool $override = true): void
     {
-        $this->templates = $templates + $this->templates;
+        if ($override) {
+            $this->templates = $templates + $this->templates;
+
+            return;
+        }
+
+        $this->templates = $this->templates + $templates;
     }
 
-    public function setTemplate(string $name, string $template): void
+    public function setTemplate(string $name, string $template, bool $override = true): void
     {
+        if (!$override && $this->hasTemplate($name)) {
+            return;
+        }
+
         $this->templates[$name] = $template;
     }
 }

--- a/src/Templating/MutableTemplateRegistryAwareInterface.php
+++ b/src/Templating/MutableTemplateRegistryAwareInterface.php
@@ -24,10 +24,10 @@ interface MutableTemplateRegistryAwareInterface
 
     public function hasTemplateRegistry(): bool;
 
-    public function setTemplate(string $name, string $template): void;
+    public function setTemplate(string $name, string $template, bool $override = true): void;
 
     /**
      * @param array<string, string> $templates
      */
-    public function setTemplates(array $templates): void;
+    public function setTemplates(array $templates, bool $override = true): void;
 }

--- a/src/Templating/MutableTemplateRegistryInterface.php
+++ b/src/Templating/MutableTemplateRegistryInterface.php
@@ -21,7 +21,7 @@ interface MutableTemplateRegistryInterface extends TemplateRegistryInterface
     /**
      * @param array<string, string> $templates 'name' => 'file_path.html.twig'
      */
-    public function setTemplates(array $templates): void;
+    public function setTemplates(array $templates, bool $override = true): void;
 
-    public function setTemplate(string $name, string $template): void;
+    public function setTemplate(string $name, string $template, bool $override = true): void;
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
For now `AddDependencyCallsCompilerPass` is creating `MutableTemplateRegistry` for each `Admin` and register it as `admin_code.template_registry` service. It is also make some problems like:
- when you can call `setTemplate()` or `setTemplates()` method on `Admin` (to avoid override it by compiler pass)
- how to set own template registry
- in which order setters for template(s) and templates registry should be call

To avoid this problem and improve Admin templates system I want create `MutableTemplateRegistry` directly in `AbstractAdmin::__constructor()` and add optional `override` argumets to setters. Also generate extra template registry service will be remove. 

#### advantages:
- if you want set templates you have to do it by `Admin` or get template registry from it
- admin template(s) can not be change  by call setter on custom template registry 
- template can be set diretly in Admin class (for example in `__constructor()` or `configure()`)
- `AddDependencyCallsCompilerPass` will be simpler

#### disadvantages:
- ?

 
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change provide BC-break.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added some `Class::newMethod()` to do great stuff.

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
- [ ] Improve `AbstractAdmin`
- [ ] Changing `AddDependencyCallsCompilerPass`

