### PR TITLE
Update recipe_sonata_admin_without_user_bundle.rst

### DIFF
--- a/docs/cookbook/recipe_sonata_admin_without_user_bundle.rst
+++ b/docs/cookbook/recipe_sonata_admin_without_user_bundle.rst
@@ -241,9 +241,9 @@ more about it `here <https://symfony.com/doc/4.4/security/guard_authentication.h
             return new RedirectResponse($this->router->generate('admin_login'));
         }
 
-        protected function getLoginUrl(): RedirectResponse
+        protected function getLoginUrl(): string
         {
-            return new RedirectResponse($this->router->generate('admin_login'));
+            return $this->router->generate('admin_login');
         }
 
         public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey): RedirectResponse


### PR DESCRIPTION
Return type method getLoginUrl() of base class AbstractFormLoginAuthenticator is string, so getLoginUrl must return string. Otherwise, opening route /admin/login/ (with slash on the end) will show error "Warning: Header may not contain more than a single header, new line detected".