### PR TITLE
Introduce field description factory

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,14 @@ UPGRADE 3.x
 UPGRADE FROM 3.89 to 3.90
 =========================
 
+### Deprecated `Sonata\AdminBundle\Guesser\TypeGuesserInterface` interface.
+
+Use `Sonata\AdminBundle\FieldDescription\TypeGuesserInterface` interface instead.
+
+### Deprecated `Sonata\AdminBundle\Guesser\TypeGuesserChain` class.
+
+Use `Sonata\AdminBundle\FieldDescription\TypeGuesserChain` class instead.
+
 ### Deprecated `Sonata\AdminBundle\Model\ModelManagerInterface::getModelInstance()` method.
 
 Use `Sonata\AdminBundle\Admin\AbstractAdmin::createNewInstance()` method instead.

--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -11,6 +11,10 @@ Use `Sonata\AdminBundle\Admin\AbstractAdmin::createNewInstance()` method instead
 UPGRADE FROM 3.88 to 3.89
 =========================
 
+### Deprecated `Sonata\AdminBundle\Model\ModelManager::getNewFieldDescriptionInstance()` method.
+
+This method has been deprecated in favor of `FieldFactoryInterface::create()`.
+
 ### Deprecated overriding `AbstractAdmin::getNewInstance()`.
 
 Use `AbstractAdmin::alterNewInstance()` instead.

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2890,6 +2890,26 @@ EOT;
         return null !== $this->templateRegistry;
     }
 
+    final public function createFieldDescription(string $propertyName, array $options = []): FieldDescriptionInterface
+    {
+        $fieldDescriptionFactory = $this->getFieldDescriptionFactory();
+
+        // NEXT_MAJOR: Remove the "if" block and leave the "else" one.
+        if (null === $fieldDescriptionFactory) {
+            $fieldDescription = $this->getModelManager()->getNewFieldDescriptionInstance(
+                $this->getClass(),
+                $propertyName,
+                $options
+            );
+        } else {
+            $fieldDescription = $fieldDescriptionFactory->create($this->getClass(), $propertyName, $options);
+        }
+
+        $fieldDescription->setAdmin($this);
+
+        return $fieldDescription;
+    }
+
     /**
      * @phpstan-return T
      */
@@ -3363,26 +3383,6 @@ EOT;
         foreach ($this->getExtensions() as $extension) {
             $extension->configureRoutes($this, $this->routes);
         }
-    }
-
-    private function createFieldDescription(string $name, array $options = []): FieldDescriptionInterface
-    {
-        $fieldDescriptionFactory = $this->getFieldDescriptionFactory();
-
-        // NEXT_MAJOR: Remove the "if" block and leave the "else" one.
-        if (null === $fieldDescriptionFactory) {
-            $fieldDescription = $this->getModelManager()->getNewFieldDescriptionInstance(
-                $this->getClass(),
-                $name,
-                $options
-            );
-        } else {
-            $fieldDescription = $fieldDescriptionFactory->create($this->getClass(), $name, $options);
-        }
-
-        $fieldDescription->setAdmin($this);
-
-        return $fieldDescription;
     }
 }
 

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -51,6 +51,7 @@ use Symfony\Component\HttpFoundation\Request;
  * @method string|null                     getParentAssociationMapping()
  * @method void                            reorderFormGroup(string $group, array $keys)
  * @method void                            defineFormBuilder(FormBuilderInterface $formBuilder)
+ * @method FieldDescriptionInterface       createFieldDescription(string $propertyName, array $options = [])
  *
  * @phpstan-template T of object
  * @phpstan-extends AccessRegistryInterface<T>
@@ -789,6 +790,9 @@ interface AdminInterface extends TaggedAdminInterface, AccessRegistryInterface, 
 //     * the getFormBuilder is only call by the main admin class.
 //     */
 //    public function defineFormBuilder(FormBuilderInterface $formBuilder): void;
+
+//    NEXT_MAJOR: uncomment this method in 4.0
+//    public function createFieldDescription(string $propertyName, array $options = []): FieldDescriptionInterface;
 }
 
 class_exists(\Sonata\Form\Validator\ErrorElement::class);

--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -63,6 +63,8 @@ use Symfony\Component\PropertyAccess\PropertyPathInterface;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
+ * @psalm-import-type FieldDescriptionOptions from FieldDescriptionInterface
+ *
  * @method void setFieldMapping(array $fieldMapping)
  * @method void setAssociationMapping(array $associationMapping)
  * @method void setParentAssociationMappings(array $parentAssociationMappings)
@@ -141,6 +143,9 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
 
     /**
      * NEXT_MAJOR: Remove the null default value for $name and restrict param type to `string`.
+     *
+     * @psalm-param FieldDescriptionOptions $options
+     * @phpstan-param array<string, mixed> $options
      */
     public function __construct(
         ?string $name = null,

--- a/src/Admin/FieldDescriptionInterface.php
+++ b/src/Admin/FieldDescriptionInterface.php
@@ -14,9 +14,45 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Admin;
 
 use Sonata\AdminBundle\Exception\NoValueException;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\PropertyAccess\PropertyPathInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @psalm-type FieldDescriptionOptions = array{
+ *  accessor?: string|callable|PropertyPathInterface,
+ *  actions?: array,
+ *  admin_code?: string,
+ *  associated_property?: string,
+ *  block_name?: string,
+ *  catalogue?: string,
+ *  data_transformer?: DataTransformerInterface,
+ *  edit?: string,
+ *  editable?: bool,
+ *  field_name?: string,
+ *  field_options?: array,
+ *  field_type?: string,
+ *  header_class?: string,
+ *  identifier?: bool,
+ *  inline?: string,
+ *  label?: bool|string|null,
+ *  link_parameters?: array,
+ *  multiple?: bool,
+ *  placeholder?: string,
+ *  required?: bool,
+ *  role?: string|string[],
+ *  route?: array,
+ *  safe?: bool,
+ *  sort_field_mapping?: array,
+ *  sort_parent_association_mappings?: array,
+ *  sortable?: bool,
+ *  template?: string,
+ *  timezone?: string|\DateTimeZone,
+ *  translation_domain?: string,
+ *  type?: string,
+ *  virtual_field?: bool
+ * }
  *
  * @method string|null getTargetModel()
  * @method bool        hasAdmin()
@@ -105,6 +141,9 @@ interface FieldDescriptionInterface
      *   - template.
      *
      * Then the value are copied across to the related property value
+     *
+     * @psalm-param FieldDescriptionOptions $options
+     * @phpstan-param array<string, mixed> $options
      */
     public function setOptions(array $options);
 
@@ -112,6 +151,9 @@ interface FieldDescriptionInterface
      * Returns options.
      *
      * @return array<string, mixed> options
+     *
+     * @psalm-return FieldDescriptionOptions
+     * @phpstan-return array<string, mixed>
      */
     public function getOptions();
 

--- a/src/Datagrid/DatagridMapper.php
+++ b/src/Datagrid/DatagridMapper.php
@@ -114,11 +114,19 @@ class DatagridMapper extends BaseMapper
                 $filterOptions['field_name'] = substr(strrchr('.'.$name, '.'), 1);
             }
 
-            $fieldDescription = $this->admin->getModelManager()->getNewFieldDescriptionInstance(
-                $this->admin->getClass(),
-                $name,
-                array_merge($filterOptions, $fieldDescriptionOptions)
-            );
+            // NEXT_MAJOR: Remove the check and use `createFieldDescription`.
+            if (method_exists($this->admin, 'createFieldDescription')) {
+                $fieldDescription = $this->admin->createFieldDescription(
+                    $name,
+                    array_merge($filterOptions, $fieldDescriptionOptions)
+                );
+            } else {
+                $fieldDescription = $this->admin->getModelManager()->getNewFieldDescriptionInstance(
+                    $this->admin->getClass(),
+                    $name,
+                    array_merge($filterOptions, $fieldDescriptionOptions)
+                );
+            }
         } else {
             throw new \TypeError(
                 'Unknown field name in datagrid mapper.'

--- a/src/Datagrid/ListMapper.php
+++ b/src/Datagrid/ListMapper.php
@@ -144,11 +144,19 @@ class ListMapper extends BaseMapper
                 ));
             }
 
-            $fieldDescription = $this->admin->getModelManager()->getNewFieldDescriptionInstance(
-                $this->admin->getClass(),
-                $name,
-                $fieldDescriptionOptions
-            );
+            // NEXT_MAJOR: Remove the check and use `createFieldDescription`.
+            if (method_exists($this->admin, 'createFieldDescription')) {
+                $fieldDescription = $this->admin->createFieldDescription(
+                    $name,
+                    $fieldDescriptionOptions
+                );
+            } else {
+                $fieldDescription = $this->admin->getModelManager()->getNewFieldDescriptionInstance(
+                    $this->admin->getClass(),
+                    $name,
+                    $fieldDescriptionOptions
+                );
+            }
         } else {
             throw new \TypeError(
                 'Unknown field name in list mapper.'

--- a/src/DependencyInjection/Admin/AbstractTaggedAdmin.php
+++ b/src/DependencyInjection/Admin/AbstractTaggedAdmin.php
@@ -22,6 +22,7 @@ use Sonata\AdminBundle\Builder\RouteBuilderInterface;
 use Sonata\AdminBundle\Builder\ShowBuilderInterface;
 use Sonata\AdminBundle\Datagrid\Pager;
 use Sonata\AdminBundle\Exporter\DataSourceInterface;
+use Sonata\AdminBundle\FieldDescription\FieldDescriptionFactoryInterface;
 use Sonata\AdminBundle\Filter\Persister\FilterPersisterInterface;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Route\RouteGeneratorInterface;
@@ -201,6 +202,11 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
      * @var LabelTranslatorStrategyInterface|null
      */
     protected $labelTranslatorStrategy;
+
+    /**
+     * @var FieldDescriptionFactoryInterface|null
+     */
+    private $fieldDescriptionFactory;
 
     /**
      * NEXT_MAJOR: Change signature to __construct(string $code, string $class, string $baseControllerName).
@@ -421,6 +427,32 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
         }
 
         return $this->dataSource;
+    }
+
+    final public function setFieldDescriptionFactory(FieldDescriptionFactoryInterface $fieldDescriptionFactory): void
+    {
+        $this->fieldDescriptionFactory = $fieldDescriptionFactory;
+    }
+
+    /**
+     * NEXT_MAJOR: Change typehint for FieldDescriptionFactoryInterface.
+     */
+    public function getFieldDescriptionFactory(): ?FieldDescriptionFactoryInterface
+    {
+        if (null === $this->fieldDescriptionFactory) {
+            // NEXT_MAJOR: Remove this deprecation and uncomment the following exception
+            @trigger_error(sprintf(
+                'Calling %s() when no field description factory is set is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will throw a LogicException in 4.0',
+                __METHOD__,
+            ), \E_USER_DEPRECATED);
+//            throw new \LogicException(sprintf(
+//                'Admin "%s" has no field description factory.',
+//                static::class
+//            ));
+        }
+
+        return $this->fieldDescriptionFactory;
     }
 
     /**

--- a/src/DependencyInjection/Admin/TaggedAdminInterface.php
+++ b/src/DependencyInjection/Admin/TaggedAdminInterface.php
@@ -21,6 +21,7 @@ use Sonata\AdminBundle\Builder\ListBuilderInterface;
 use Sonata\AdminBundle\Builder\RouteBuilderInterface;
 use Sonata\AdminBundle\Builder\ShowBuilderInterface;
 use Sonata\AdminBundle\Exporter\DataSourceInterface;
+use Sonata\AdminBundle\FieldDescription\FieldDescriptionFactoryInterface;
 use Sonata\AdminBundle\Filter\Persister\FilterPersisterInterface;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Route\RouteGeneratorInterface;
@@ -41,25 +42,27 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  *     - The first and third argument are automatically injected by the AddDependencyCallsCompilerPass.
  *     - The second one is used as a reference of the Admin in the Pool, with the `setAdminClasses` call.
  *
- * @method void                          initialize()
- * @method void                          setLabel(?string $label)
- * @method void                          showMosaicButton(bool $isShown)
- * @method void                          setPagerType(string $pagerType)
- * @method string                        getPagerType()
- * @method void                          setManagerType(string $managerType)
- * @method void                          setSecurityInformation(array $information)
- * @method void                          setFilterPersister(?FilterPersisterInterface $filterPersister = null)
- * @method FilterPersisterInterface|null getFilterPersister()
- * @method bool                          hasFilterPersister()
- * @method void                          setModelManager(ModelManagerInterface $modelManager)
- * @method void                          setDataSource(DataSourceInterface $dataSource)
- * @method DataSourceInterface           getDataSource()
- * @method FormContractorInterface       getFormContractor()
- * @method void                          setShowBuilder(ShowBuilderInterface $showBuilder)
- * @method ShowBuilderInterface          getShowBuilder()
- * @method Pool                          getConfigurationPool()
- * @method void                          setRouteGenerator(RouteGeneratorInterface $routeGenerator)
- * @method RouteGeneratorInterface       getRouteGenerator()
+ * @method void                             initialize()
+ * @method void                             setLabel(?string $label)
+ * @method void                             showMosaicButton(bool $isShown)
+ * @method void                             setPagerType(string $pagerType)
+ * @method string                           getPagerType()
+ * @method void                             setManagerType(string $managerType)
+ * @method void                             setSecurityInformation(array $information)
+ * @method void                             setFilterPersister(?FilterPersisterInterface $filterPersister = null)
+ * @method FilterPersisterInterface|null    getFilterPersister()
+ * @method bool                             hasFilterPersister()
+ * @method void                             setModelManager(ModelManagerInterface $modelManager)
+ * @method void                             setDataSource(DataSourceInterface $dataSource)
+ * @method DataSourceInterface              getDataSource()
+ * @method void                             setFieldDescriptionFactory(FieldDescriptionFactoryInterface $fieldDescriptionFactory)
+ * @method FieldDescriptionFactoryInterface getFieldDescriptionFactory()
+ * @method FormContractorInterface          getFormContractor()
+ * @method void                             setShowBuilder(ShowBuilderInterface $showBuilder)
+ * @method ShowBuilderInterface             getShowBuilder()
+ * @method Pool                             getConfigurationPool()
+ * @method void                             setRouteGenerator(RouteGeneratorInterface $routeGenerator)
+ * @method RouteGeneratorInterface          getRouteGenerator()
  */
 interface TaggedAdminInterface
 {
@@ -167,6 +170,16 @@ interface TaggedAdminInterface
      * NEXT_MAJOR: Uncomment this method.
      */
 //    public function getDataSource(): DataSourceInterface;
+
+    /**
+     * NEXT_MAJOR: Uncomment this method.
+     */
+//    public function setFieldDescriptionFactory(FieldDescriptionFactoryInterface $fieldDescriptionFactory): void;
+
+    /**
+     * NEXT_MAJOR: Uncomment this method.
+     */
+//    public function getFieldDescriptionFactory(): FieldDescriptionFactoryInterface;
 
     /**
      * @return void

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -253,6 +253,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
         $keys = [
             'model_manager',
             'data_source',
+            'field_description_factory',
             'form_contractor',
             'show_builder',
             'list_builder',
@@ -301,6 +302,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
         $defaultAddServices = [
             'model_manager' => sprintf('sonata.admin.manager.%s', $managerType),
             'data_source' => sprintf('sonata.admin.data_source.%s', $managerType),
+            'field_description_factory' => sprintf('sonata.admin.field_description_factory.%s', $managerType),
             'form_contractor' => sprintf('sonata.admin.builder.%s_form', $managerType),
             'show_builder' => sprintf('sonata.admin.builder.%s_show', $managerType),
             'list_builder' => sprintf('sonata.admin.builder.%s_list', $managerType),
@@ -321,6 +323,11 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
         foreach ($defaultAddServices as $attr => $addServiceId) {
             // NEXT_MAJOR: Remove this check
             if ('data_source' === $attr && !$container->has($addServiceId)) {
+                continue;
+            }
+
+            // NEXT_MAJOR: Remove this check
+            if ('field_description_factory' === $attr && !$container->has($addServiceId)) {
                 continue;
             }
 

--- a/src/FieldDescription/FieldDescriptionFactoryInterface.php
+++ b/src/FieldDescription/FieldDescriptionFactoryInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\FieldDescription;
+
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+
+interface FieldDescriptionFactoryInterface
+{
+    /**
+     * @phpstan-param class-string $class
+     */
+    public function create(string $class, string $name, array $options = []): FieldDescriptionInterface;
+}

--- a/src/FieldDescription/FieldDescriptionFactoryInterface.php
+++ b/src/FieldDescription/FieldDescriptionFactoryInterface.php
@@ -15,10 +15,15 @@ namespace Sonata\AdminBundle\FieldDescription;
 
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 
+/**
+ * @psalm-import-type FieldDescriptionOptions from FieldDescriptionInterface
+ */
 interface FieldDescriptionFactoryInterface
 {
     /**
      * @phpstan-param class-string $class
+     * @psalm-param FieldDescriptionOptions $options
+     * @phpstan-param array<string, mixed> $options
      */
     public function create(string $class, string $name, array $options = []): FieldDescriptionInterface;
 }

--- a/src/FieldDescription/TypeGuesserChain.php
+++ b/src/FieldDescription/TypeGuesserChain.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\FieldDescription;
+
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Symfony\Component\Form\Guess\TypeGuess;
+
+/**
+ * The code is based on Symfony2 Form Components.
+ */
+final class TypeGuesserChain implements TypeGuesserInterface
+{
+    /**
+     * @var TypeGuesserInterface[]
+     */
+    private $guessers = [];
+
+    /**
+     * @param TypeGuesserInterface[] $guessers
+     */
+    public function __construct(array $guessers)
+    {
+        $allGuessers = [];
+
+        foreach ($guessers as $guesser) {
+            if (!$guesser instanceof TypeGuesserInterface) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Expected argument of type "%s", "%s" given',
+                    TypeGuesserInterface::class,
+                    \is_object($guesser) ? \get_class($guesser) : \gettype($guesser)
+                ));
+            }
+
+            if ($guesser instanceof self) {
+                $allGuessers[] = $guesser->guessers;
+            } else {
+                $allGuessers[] = [$guesser];
+            }
+        }
+
+        $this->guessers = array_merge(...$allGuessers);
+    }
+
+    public function guess(FieldDescriptionInterface $fieldDescription): TypeGuess
+    {
+        $guesses = [];
+
+        foreach ($this->guessers as $guesser) {
+            $guesses[] = $guesser->guess($fieldDescription);
+        }
+
+        return TypeGuess::getBestGuess($guesses);
+    }
+}

--- a/src/FieldDescription/TypeGuesserInterface.php
+++ b/src/FieldDescription/TypeGuesserInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\FieldDescription;
+
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Symfony\Component\Form\Guess\TypeGuess;
+
+interface TypeGuesserInterface
+{
+    public function guess(FieldDescriptionInterface $fieldDescription): TypeGuess;
+}

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -108,11 +108,19 @@ class FormMapper extends BaseGroupedMapper
             $fieldDescriptionOptions['translation_domain'] = $group['translation_domain'];
         }
 
-        $fieldDescription = $this->admin->getModelManager()->getNewFieldDescriptionInstance(
-            $this->admin->getClass(),
-            $name instanceof FormBuilderInterface ? $name->getName() : $name,
-            $fieldDescriptionOptions
-        );
+        // NEXT_MAJOR: Remove the check and use `createFieldDescription`.
+        if (method_exists($this->admin, 'createFieldDescription')) {
+            $fieldDescription = $this->admin->createFieldDescription(
+                $name instanceof FormBuilderInterface ? $name->getName() : $name,
+                $fieldDescriptionOptions
+            );
+        } else {
+            $fieldDescription = $this->admin->getModelManager()->getNewFieldDescriptionInstance(
+                $this->admin->getClass(),
+                $name instanceof FormBuilderInterface ? $name->getName() : $name,
+                $fieldDescriptionOptions
+            );
+        }
 
         // Note that the builder var is actually the formContractor:
         $this->builder->fixFieldDescription($this->admin, $fieldDescription);

--- a/src/Guesser/TypeGuesserChain.php
+++ b/src/Guesser/TypeGuesserChain.php
@@ -20,6 +20,11 @@ use Symfony\Component\Form\Guess\TypeGuess;
 /**
  * The code is based on Symfony2 Form Components.
  *
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+ * Use Sonata\AdminBundle\FieldDescription\TypeGuesserChain instead.
+ *
  * @final since sonata-project/admin-bundle 3.52
  *
  * @author Bernhard Schussek <bernhard.schussek@symfony.com>

--- a/src/Guesser/TypeGuesserInterface.php
+++ b/src/Guesser/TypeGuesserInterface.php
@@ -17,6 +17,11 @@ use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\Guess\TypeGuess;
 
 /**
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @deprecated since sonata-project/admin-bundle 3.x, to be removed in 4.0.
+ * Use Sonata\AdminBundle\FieldDescription\TypeGuesserInterface instead.
+ *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 interface TypeGuesserInterface

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -29,6 +29,8 @@ use Sonata\Exporter\Source\SourceIteratorInterface;
 interface ModelManagerInterface extends DatagridManagerInterface
 {
     /**
+     * @deprecated since sonata-project/admin-bundle 3.x.
+     *
      * @param string $class
      * @param string $name
      *

--- a/src/Show/ShowMapper.php
+++ b/src/Show/ShowMapper.php
@@ -71,11 +71,20 @@ class ShowMapper extends BaseGroupedMapper
             $fieldDescription->mergeOptions($fieldDescriptionOptions);
         } elseif (\is_string($name)) {
             if (!$this->admin->hasShowFieldDescription($name)) {
-                $fieldDescription = $this->admin->getModelManager()->getNewFieldDescriptionInstance(
-                    $this->admin->getClass(),
-                    $name,
-                    $fieldDescriptionOptions
-                );
+
+                // NEXT_MAJOR: Remove the check and use `createFieldDescription`.
+                if (method_exists($this->admin, 'createFieldDescription')) {
+                    $fieldDescription = $this->admin->createFieldDescription(
+                        $name,
+                        $fieldDescriptionOptions
+                    );
+                } else {
+                    $fieldDescription = $this->admin->getModelManager()->getNewFieldDescriptionInstance(
+                        $this->admin->getClass(),
+                        $name,
+                        $fieldDescriptionOptions
+                    );
+                }
             } else {
                 throw new \LogicException(sprintf(
                     'Duplicate field name "%s" in show mapper. Names should be unique.',

--- a/tests/App/FieldDescription/FieldDescriptionFactory.php
+++ b/tests/App/FieldDescription/FieldDescriptionFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\App\FieldDescription;
+
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Sonata\AdminBundle\FieldDescription\FieldDescriptionFactoryInterface;
+use Sonata\AdminBundle\Tests\App\Admin\FieldDescription;
+
+final class FieldDescriptionFactory implements FieldDescriptionFactoryInterface
+{
+    public function create(string $class, string $name, array $options = []): FieldDescriptionInterface
+    {
+        if (!isset($options['route']['name'])) {
+            $options['route']['name'] = 'edit';
+        }
+
+        if (!isset($options['route']['parameters'])) {
+            $options['route']['parameters'] = [];
+        }
+
+        return new FieldDescription($name, $options);
+    }
+}

--- a/tests/App/Model/ModelManager.php
+++ b/tests/App/Model/ModelManager.php
@@ -31,6 +31,7 @@ final class ModelManager implements ModelManagerInterface
         $this->repository = $repository;
     }
 
+    // NEXT_MAJOR: Remove this method.
     public function getNewFieldDescriptionInstance($class, $name, array $options = [])
     {
         if (!isset($options['route']['name'])) {

--- a/tests/App/config/services.yml
+++ b/tests/App/config/services.yml
@@ -37,6 +37,9 @@ services:
     sonata.admin.data_source.test:
         class: Sonata\AdminBundle\Tests\App\Exporter\DataSource
 
+    sonata.admin.field_description_factory.test:
+        class: Sonata\AdminBundle\Tests\App\FieldDescription\FieldDescriptionFactory
+
     Sonata\AdminBundle\Tests\App\Admin\FooAdmin:
         arguments: [~, Sonata\AdminBundle\Tests\App\Model\Foo, Sonata\AdminBundle\Controller\CRUDController]
         tags:

--- a/tests/Datagrid/DatagridMapperTest.php
+++ b/tests/Datagrid/DatagridMapperTest.php
@@ -25,7 +25,6 @@ use Sonata\AdminBundle\Datagrid\PagerInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Filter\Filter;
 use Sonata\AdminBundle\Filter\FilterInterface;
-use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilder;
@@ -60,7 +59,10 @@ class DatagridMapperTest extends TestCase
 
         $this->datagrid = new Datagrid($proxyQuery, $fieldDescriptionCollection, $pager, $formBuilder, []);
 
-        $admin = $this->createMock(AdminInterface::class);
+        // NEXT_MAJOR: Change to $this->createStub(AdminInterface::class).
+        $admin = $this->getMockBuilder(AdminInterface::class)
+            ->addMethods(['createFieldDescription'])
+            ->getMockForAbstractClass();
 
         $datagridBuilder
             ->method('addFilter')
@@ -82,20 +84,14 @@ class DatagridMapperTest extends TestCase
                 $datagrid->addFilter($filter);
             });
 
-        $modelManager = $this->createMock(ModelManagerInterface::class);
-
-        $modelManager
-            ->method('getNewFieldDescriptionInstance')
-            ->willReturnCallback(function (?string $class, string $name, array $options = []): BaseFieldDescription {
+        $admin
+            ->method('createFieldDescription')
+            ->willReturnCallback(function (string $name, array $options = []): FieldDescriptionInterface {
                 $fieldDescription = $this->getFieldDescriptionMock($name);
                 $fieldDescription->setOptions($options);
 
                 return $fieldDescription;
             });
-
-        $admin
-            ->method('getModelManager')
-            ->willReturn($modelManager);
 
         $admin
             ->method('isGranted')

--- a/tests/FieldDescription/TypeGuesserChainTest.php
+++ b/tests/FieldDescription/TypeGuesserChainTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\FieldDescription;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Sonata\AdminBundle\FieldDescription\TypeGuesserChain;
+use Sonata\AdminBundle\FieldDescription\TypeGuesserInterface;
+use Symfony\Component\Form\Guess\Guess;
+use Symfony\Component\Form\Guess\TypeGuess;
+
+final class TypeGuesserChainTest extends TestCase
+{
+    public function testConstructorWithException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        new TypeGuesserChain([new \stdClass()]);
+    }
+
+    public function testGuessType(): void
+    {
+        $typeGuess1 = new TypeGuess('foo1', [], Guess::MEDIUM_CONFIDENCE);
+        $guesser1 = $this->createStub(TypeGuesserInterface::class);
+        $guesser1
+                ->method('guess')
+                ->willReturn($typeGuess1);
+
+        $typeGuess2 = new TypeGuess('foo2', [], Guess::HIGH_CONFIDENCE);
+        $guesser2 = $this->createStub(TypeGuesserInterface::class);
+        $guesser2
+                ->method('guess')
+                ->willReturn($typeGuess2);
+
+        $typeGuess3 = new TypeGuess('foo3', [], Guess::LOW_CONFIDENCE);
+        $guesser3 = $this->createStub(TypeGuesserInterface::class);
+        $guesser3
+                ->method('guess')
+                ->willReturn($typeGuess3);
+
+        $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
+
+        $typeGuesserChain = new TypeGuesserChain([$guesser1, $guesser2, $guesser3]);
+        $this->assertSame($typeGuess2, $typeGuesserChain->guess($fieldDescription));
+
+        $typeGuess4 = new TypeGuess('foo4', [], Guess::LOW_CONFIDENCE);
+        $guesser4 = $this->createStub(TypeGuesserInterface::class);
+        $guesser4
+                ->method('guess')
+                ->willReturn($typeGuess4);
+
+        $typeGuesserChain = new TypeGuesserChain([$guesser4, $typeGuesserChain]);
+        $this->assertSame($typeGuess2, $typeGuesserChain->guess($fieldDescription));
+    }
+}

--- a/tests/Form/FormMapperTest.php
+++ b/tests/Form/FormMapperTest.php
@@ -16,7 +16,9 @@ namespace Sonata\AdminBundle\Tests\Form;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\BaseFieldDescription;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\FormContractorInterface;
+use Sonata\AdminBundle\FieldDescription\FieldDescriptionFactoryInterface;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
@@ -91,18 +93,17 @@ class FormMapperTest extends TestCase
         $this->admin->setSecurityHandler($securityHandler);
         $this->admin->setFormContractor($this->contractor);
 
-        $this->modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
-
-        $this->modelManager
-            ->method('getNewFieldDescriptionInstance')
-            ->willReturnCallback(function (string $class, string $name, array $options = []): BaseFieldDescription {
+        $fieldDescriptionFactory = $this->createStub(FieldDescriptionFactoryInterface::class);
+        $fieldDescriptionFactory
+            ->method('create')
+            ->willReturnCallback(function (string $class, string $name, array $options = []): FieldDescriptionInterface {
                 $fieldDescription = $this->getFieldDescriptionMock($name);
                 $fieldDescription->setOptions($options);
 
                 return $fieldDescription;
             });
 
-        $this->admin->setModelManager($this->modelManager);
+        $this->admin->setFieldDescriptionFactory($fieldDescriptionFactory);
 
         $labelTranslatorStrategy = $this->getMockForAbstractClass(LabelTranslatorStrategyInterface::class);
         $this->admin->setLabelTranslatorStrategy($labelTranslatorStrategy);

--- a/tests/Show/ShowMapperTest.php
+++ b/tests/Show/ShowMapperTest.php
@@ -19,7 +19,7 @@ use Sonata\AdminBundle\Admin\BaseFieldDescription;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
 use Sonata\AdminBundle\Builder\ShowBuilderInterface;
-use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\AdminBundle\FieldDescription\FieldDescriptionFactoryInterface;
 use Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\AdminBundle\Tests\App\Builder\ShowBuilder;
@@ -69,7 +69,9 @@ class ShowMapperTest extends TestCase
     {
         $this->showBuilder = $this->getMockForAbstractClass(ShowBuilderInterface::class);
         $this->fieldDescriptionCollection = new FieldDescriptionCollection();
-        $this->admin = $this->getMockForAbstractClass(AdminInterface::class);
+        $this->admin = $this->getMockBuilder(AdminInterface::class)
+            ->addMethods(['createFieldDescription'])
+            ->getMockForAbstractClass();
 
         $this->admin
             ->method('getLabel')
@@ -100,20 +102,14 @@ class ShowMapperTest extends TestCase
                 $this->groups[$group]['fields'] = array_merge(array_flip($keys), $this->groups[$group]['fields']);
             });
 
-        $modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
-
-        $modelManager
-            ->method('getNewFieldDescriptionInstance')
-            ->willReturnCallback(function (?string $class, string $name, array $options = []) {
+        $this->admin
+            ->method('createFieldDescription')
+            ->willReturnCallback(function (string $name, array $options = []): FieldDescriptionInterface {
                 $fieldDescription = $this->getFieldDescriptionMock($name);
                 $fieldDescription->setOptions($options);
 
                 return $fieldDescription;
             });
-
-        $this->admin
-            ->method('getModelManager')
-            ->willReturn($modelManager);
 
         $labelTranslatorStrategy = new NoopLabelTranslatorStrategy();
 
@@ -580,10 +576,9 @@ class ShowMapperTest extends TestCase
 
         $this->showMapper = new ShowMapper($this->showBuilder, $this->fieldDescriptionCollection, $this->admin);
 
-        $modelManager = $this->getMockForAbstractClass(ModelManagerInterface::class);
-
-        $modelManager
-            ->method('getNewFieldDescriptionInstance')
+        $fieldDescriptionFactory = $this->createStub(FieldDescriptionFactoryInterface::class);
+        $fieldDescriptionFactory
+            ->method('create')
             ->willReturnCallback(function (string $class, string $name, array $options = []): FieldDescriptionInterface {
                 $fieldDescription = $this->getFieldDescriptionMock($name);
                 $fieldDescription->setOptions($options);
@@ -591,7 +586,7 @@ class ShowMapperTest extends TestCase
                 return $fieldDescription;
             });
 
-        $this->admin->setModelManager($modelManager);
+        $this->admin->setFieldDescriptionFactory($fieldDescriptionFactory);
         $this->admin->setLabelTranslatorStrategy(new NoopLabelTranslatorStrategy());
 
         $this->admin->setShowBuilder(new ShowBuilder());


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

For background: #6761 and #6701.

First of all, I had this half done, so I've "finished", I'm fine postponing this for `5.0` if we think this shouldn't be done now (and if this is fine ofc).

The idea of this is basically to move responsibility of creating a `FieldDescription` from `ModelManagerInterface` to `FielDescriptionFactoryInterface`.

And also there is a new `Sonata\AdminBundle\FieldDescription\TypeGuesserInterface` that will guess the FieldDescription type base on a `FieldDescriptionInterface` properties instead of rely on `ModelManagerInterface`.

I've created https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/531 (unfinished) as example of implementation.
 
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6761 and #6701.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `FieldDescriptionFactoryInterface` to create FieldDescription instances.
- Added `TypeGuesserInterface` to guess the proper FieldDescription type based on its properties.
### Deprecated
- Deprecated `ModelManagerInterface::getNewFieldDescriptionInstance`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
