### PR TITLE
Avoid error when a wrong code is provided

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -237,11 +237,6 @@ parameters:
 
 # Symfony related errors
         -
-            message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\:\\:arrayNode\\(\\)\\.$#"
-            count: 1
-            path: src/DependencyInjection/Configuration.php
-
-        -
             # Symfony BC break policy
             message: "#^Method Symfony\\\\Contracts\\\\EventDispatcher\\\\EventDispatcherInterface\\:\\:dispatch\\(\\) invoked with 2 parameters, 1 required\\.$#"
             count: 1

--- a/tests/Admin/BaseFieldDescriptionTest.php
+++ b/tests/Admin/BaseFieldDescriptionTest.php
@@ -224,6 +224,19 @@ class BaseFieldDescriptionTest extends TestCase
      *
      * @group legacy
      */
+    public function testGetFieldValueWithWrongCode(): void
+    {
+        $description = new FieldDescription('name', ['code' => 'getFoo']);
+        $mock = $this->getMockBuilder(\stdClass::class)->addMethods(['getFake'])->getMock();
+        $mock->expects($this->once())->method('getFake')->willReturn(42);
+        $this->assertSame(42, $description->getFieldValue($mock, 'fake'));
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testGetFieldValueWithParametersForGetter(): void
     {
         $arg1 = 38;


### PR DESCRIPTION
Fix BC.

No changelog needed since the version is not released.