### PR TITLE
Restrict visibility of pre/post methods

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -431,30 +431,6 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         }
     }
 
-    public function preUpdate(object $object): void
-    {
-    }
-
-    public function postUpdate(object $object): void
-    {
-    }
-
-    public function prePersist(object $object): void
-    {
-    }
-
-    public function postPersist(object $object): void
-    {
-    }
-
-    public function preRemove(object $object): void
-    {
-    }
-
-    public function postRemove(object $object): void
-    {
-    }
-
     public function preBatchAction(string $actionName, ProxyQueryInterface $query, array &$idx, bool $allElements = false): void
     {
     }
@@ -1978,6 +1954,48 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
      * @phpstan-param T $object
      */
     protected function alterNewInstance(object $object): void
+    {
+    }
+
+    /**
+     * @phpstan-param T $object
+     */
+    protected function preUpdate(object $object): void
+    {
+    }
+
+    /**
+     * @phpstan-param T $object
+     */
+    protected function postUpdate(object $object): void
+    {
+    }
+
+    /**
+     * @phpstan-param T $object
+     */
+    protected function prePersist(object $object): void
+    {
+    }
+
+    /**
+     * @phpstan-param T $object
+     */
+    protected function postPersist(object $object): void
+    {
+    }
+
+    /**
+     * @phpstan-param T $object
+     */
+    protected function preRemove(object $object): void
+    {
+    }
+
+    /**
+     * @phpstan-param T $object
+     */
+    protected function postRemove(object $object): void
     {
     }
 

--- a/src/Admin/LifecycleHookProviderInterface.php
+++ b/src/Admin/LifecycleHookProviderInterface.php
@@ -45,34 +45,4 @@ interface LifecycleHookProviderInterface
      * @phpstan-param T $object
      */
     public function delete(object $object): void;
-
-    /**
-     * @phpstan-param T $object
-     */
-    public function preUpdate(object $object): void;
-
-    /**
-     * @phpstan-param T $object
-     */
-    public function postUpdate(object $object): void;
-
-    /**
-     * @phpstan-param T $object
-     */
-    public function prePersist(object $object): void;
-
-    /**
-     * @phpstan-param T $object
-     */
-    public function postPersist(object $object): void;
-
-    /**
-     * @phpstan-param T $object
-     */
-    public function preRemove(object $object): void;
-
-    /**
-     * @phpstan-param T $object
-     */
-    public function postRemove(object $object): void;
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I don't see why these methods are public.
Even the interface say that `update` should call `preUpdate` and `postUpdate`.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Visibility of `AbstractAdmin::preUpdate()` from public to protected
- Visibility of `AbstractAdmin::preCreate()` from public to protected
- Visibility of `AbstractAdmin::preDelete()` from public to protected
- Visibility of `AbstractAdmin::postUpdate()` from public to protected
- Visibility of `AbstractAdmin::postCreate()` from public to protected
- Visibility of `AbstractAdmin::postDelete()` from public to protected

### Removed
- `LifecycleHookProviderInterface::preUpdate()`
- `LifecycleHookProviderInterface::preCreate()`
- `LifecycleHookProviderInterface::preDelete()`
- `LifecycleHookProviderInterface::postUpdate()`
- `LifecycleHookProviderInterface::postCreate()`
- `LifecycleHookProviderInterface::postDelete()`
```
