### PR TITLE
Handle case of Admin not found

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1318,6 +1318,11 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
             return;
         }
 
+        // NEXT_MAJOR: Remove this check
+        if (!$admin) {
+            return;
+        }
+
         if ($this->hasRequest()) {
             $admin->setRequest($this->getRequest());
         }

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -506,7 +506,7 @@ class Pool
      * @throws TooManyAdminClassException  if there is too many admin for the field description target model
      * @throws AdminCodeNotFoundException  if the admin_code option is invalid
      *
-     * @return AdminInterface
+     * @return AdminInterface|false|null NEXT_MAJOR: Restrict to AdminInterface
      */
     final public function getAdminByFieldDescription(FieldDescriptionInterface $fieldDescription)
     {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Bug fix.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Handle case when `attachAdminClass` does not find an admin to attach.
```