### PR TITLE
Deprecate pre and post method of LifecycleHookProviderInterface

### DIFF
--- a/src/Admin/LifecycleHookProviderInterface.php
+++ b/src/Admin/LifecycleHookProviderInterface.php
@@ -57,6 +57,10 @@ interface LifecycleHookProviderInterface
     public function delete($object);
 
     /**
+     * NEXT_MAJOR: Remove this.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * @param object $object
      *
      * @phpstan-param T $object
@@ -64,6 +68,10 @@ interface LifecycleHookProviderInterface
     public function preUpdate($object);
 
     /**
+     * NEXT_MAJOR: Remove this.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * @param object $object
      *
      * @phpstan-param T $object
@@ -71,6 +79,10 @@ interface LifecycleHookProviderInterface
     public function postUpdate($object);
 
     /**
+     * NEXT_MAJOR: Remove this.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * @param object $object
      *
      * @phpstan-param T $object
@@ -78,6 +90,10 @@ interface LifecycleHookProviderInterface
     public function prePersist($object);
 
     /**
+     * NEXT_MAJOR: Remove this.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * @param object $object
      *
      * @phpstan-param T $object
@@ -85,6 +101,10 @@ interface LifecycleHookProviderInterface
     public function postPersist($object);
 
     /**
+     * NEXT_MAJOR: Remove this.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * @param object $object
      *
      * @phpstan-param T $object
@@ -92,6 +112,10 @@ interface LifecycleHookProviderInterface
     public function preRemove($object);
 
     /**
+     * NEXT_MAJOR: Remove this.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     *
      * @param object $object
      *
      * @phpstan-param T $object


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Related to https://github.com/sonata-project/SonataAdminBundle/pull/6863

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `LifecycleHookProviderInterface::preUpdate()`
- `LifecycleHookProviderInterface::preCreate()`
- `LifecycleHookProviderInterface::preDelete()`
- `LifecycleHookProviderInterface::postUpdate()`
- `LifecycleHookProviderInterface::postCreate()`
- `LifecycleHookProviderInterface::postDelete()`
```
