### PR TITLE
Add a configurePersistentParameters method

### DIFF
--- a/docs/reference/routing.rst
+++ b/docs/reference/routing.rst
@@ -363,14 +363,14 @@ Persistent parameters
 
 In some cases, the interface might be required to pass the same parameters
 across the different ``Admin``'s actions. Instead of setting them in the
-template or doing other weird hacks, you can define a ``getPersistentParameters``
+template or doing other weird hacks, you can define a ``configurePersistentParameters()``
 method. This method will be used when a link is being generated::
 
     // src/Admin/MediaAdmin.php
 
     final class MediaAdmin extends AbstractAdmin
     {
-        public function getPersistentParameters()
+        public function configurePersistentParameters(): array
         {
             if (!$this->getRequest()) {
                 return [];

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2128,22 +2128,29 @@ EOT;
         return $this->classnameLabel;
     }
 
+    /**
+     * @final since sonata-project/admin-bundle 3.x
+     */
     public function getPersistentParameters()
     {
-        $parameters = [];
-
+        $parameters = $this->configurePersistentParameters();
         foreach ($this->getExtensions() as $extension) {
-            $params = $extension->getPersistentParameters($this);
+            // NEXT_MAJOR: Remove the check and the else part.
+            if (method_exists($extension, 'configurePersistentParameters')) {
+                $parameters = $extension->configurePersistentParameters($this, $parameters);
+            } else {
+                $params = $extension->getPersistentParameters($this);
 
-            // NEXT_MAJOR: Remove this check, since return typehint is added
-            if (!\is_array($params)) {
-                throw new \RuntimeException(sprintf(
-                    'The %s::getPersistentParameters must return an array',
-                    \get_class($extension)
-                ));
+                // NEXT_MAJOR: Remove this check, since return typehint is added
+                if (!\is_array($params)) {
+                    throw new \RuntimeException(sprintf(
+                        'Method "%s::getPersistentParameters()" must return an array.',
+                        \get_class($extension)
+                    ));
+                }
+
+                $parameters = array_merge($parameters, $params);
             }
-
-            $parameters = array_merge($parameters, $params);
         }
 
         return $parameters;
@@ -2892,6 +2899,14 @@ EOT;
      */
     protected function alterObject(object $object): void
     {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function configurePersistentParameters(): array
+    {
+        return [];
     }
 
     /**

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -32,6 +32,7 @@ use Sonata\Form\Validator\ErrorElement;
  * @method void  configureDefaultFilterValues(AdminInterface $admin, array &$filterValues)
  * @method void  configureDefaultSortValues(AdminInterface $admin, array &$sortValues)
  * @method void  configureFormOptions(AdminInterface $admin, array &$formOptions)
+ * @method array configurePersistentParameters(AdminInterface $admin, array $parameters)
  *
  * @phpstan-template T of object
  */
@@ -150,6 +151,10 @@ interface AdminExtensionInterface
     public function alterObject(AdminInterface $admin, $object);
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x, use configurePersistentParameters() instead.
+     *
      * Get a chance to add persistent parameters.
      *
      * @return array<string, mixed>
@@ -157,6 +162,17 @@ interface AdminExtensionInterface
      * @phpstan-param AdminInterface<T> $admin
      */
     public function getPersistentParameters(AdminInterface $admin);
+
+    /**
+     * Get a chance to add persistent parameters.
+     *
+     * @param array<string, mixed> $parameters
+     *
+     * @return array<string, mixed>
+     *
+     * @phpstan-param AdminInterface<T> $admin
+     */
+//    public function configurePersistentParameters(AdminInterface $admin, array $parameters);
 
     /**
      * Return the controller access mapping.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This allow to declare `getPersistentParameters` as final.

This prevents the developer to override incorrectly the method and loosing the benefit of the extensions.
For instance, if you look at the doc I updated, the override was losing the code.
```
        foreach ($this->getExtensions() as $extension) {
                $params = $extension->getPersistentParameters($this);

                // NEXT_MAJOR: Remove this check, since return typehint is added
                if (!\is_array($params)) {
                    throw new \RuntimeException(sprintf(
                        'The %s::getPersistentParameters must return an array',
                        \get_class($extension)
                    ));
                }

                $parameters = array_merge($parameters, $params);
        }
```

Plus it add consistency: You want to override somethings ? Use the protected method `configure*`.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- `AbstractAdmin::configurePersistentParameters()`
- `AdminExtensionInterface::configurePersistentParameters()`

### Deprecated
- Overriding `AbstractAdmin::getPersistentParameters()`
- `AdminExtensionInterface::getPersistentParameters()`
```