### PR TITLE
Fix submit filters

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -709,7 +709,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
                 }
             }
 
-            $parameters = array_merge($parameters, $filters);
+            $parameters = array_replace_recursive($parameters, $filters);
 
             // always force the parent value
             if ($this->isChild() && $this->getParentAssociationMapping()) {

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -3338,7 +3338,6 @@ EOT;
 
     /**
      *  Merge parameters but replace them when it's a subarray
-     *  Merge parameters but replace them when it's a subarray
      */
     private function mergeParameters(array $parameters, array $filters): array
     {

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -709,7 +709,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
                 }
             }
 
-            $parameters = array_replace_recursive($parameters, $filters);
+            $parameters = $this->mergeParameters($parameters, $filters);
 
             // always force the parent value
             if ($this->isChild() && $this->getParentAssociationMapping()) {
@@ -3334,6 +3334,23 @@ EOT;
         foreach ($this->getExtensions() as $extension) {
             $extension->configureRoutes($this, $this->routes);
         }
+    }
+
+    /**
+     *  Merge parameters but replace them when it's a subarray
+     *  Merge parameters but replace them when it's a subarray
+     */
+    private function mergeParameters(array $parameters, array $filters): array
+    {
+        foreach (array_intersect_key($parameters, $filters) as $key => $parameter) {
+            if (is_array($parameter)) {
+                $parameters[$key] = array_replace($parameter, $filters[$key]);
+            } else {
+                $parameters[$key] = $filters[$key];
+            }
+        }
+
+        return array_merge($parameters, array_diff_key($filters, $parameters));
     }
 }
 

--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -334,22 +334,16 @@ var Admin = {
                 return;
             }
 
-            var defaultValues = $.param({'filter': JSON.parse(this.dataset.defaultValues)}).split('&'),
-                submittedValues = $form.serialize().split('&');
+            var defaults = Admin.convert_query_string_to_object(
+                $.param({'filter': JSON.parse(this.dataset.defaultValues)})
+            );
 
-            // Compare default and submitted filter values in `keyValue` representation. (`keyValue` ex: "filter[publish][value][end]=2020-12-12")
-            // Only allow to submit non default and non empty values, because empty values means they are not present.
-            var changedValues = submittedValues.filter(function (keyValue) {
-                return defaultValues.indexOf(keyValue) === -1 && keyValue.split('=')[1] !== '';
+            // Keep only changed values
+            $form.find('[name*=filter]').each(function (i, field) {
+                if ((defaults[field.name] || '') === field.value) {
+                    field.removeAttribute('name');
+                }
             });
-
-            // Disable all inputs and enable only the required ones
-            $form.find('[name*=filter]').attr('disabled', 'disabled');
-            changedValues
-                .map(function (keyValue) { return decodeURIComponent(keyValue.split('=')[0]); })
-                .forEach(function (key) {
-                    $form.find('[name="' + key + '"]').removeAttr('disabled');
-                });
         });
 
         /* Advanced filters */
@@ -781,6 +775,13 @@ var Admin = {
                 form.find('input[name="_tab"]').val(tabSelected.attr('aria-controls'));
             }
         });
+    },
+    convert_query_string_to_object: function (str) {
+        return str.split('&').reduce(function (accumulator, keyValue) {
+            accumulator[decodeURIComponent(keyValue.split('=')[0])] = keyValue.split('=')[1];
+
+            return accumulator;
+        }, {});
     },
     /**
      * Remember open tab after refreshing page.

--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -668,6 +668,7 @@ var Admin = {
             Admin.handleScroll(footer, navbar, wrapper);
         }
     },
+
     handleScroll: function(footer, navbar, wrapper) {
         if (footer.length && jQuery(window).scrollTop() + jQuery(window).height() != jQuery(document).height()) {
             jQuery(footer).addClass('stuck');
@@ -697,6 +698,7 @@ var Admin = {
             }, 250)
         );
     },
+
     handleResize: function(footer, navbar, wrapper) {
         if (navbar.length && jQuery(navbar).hasClass('stuck')) {
             jQuery(navbar).width(jQuery(wrapper).outerWidth());
@@ -706,6 +708,7 @@ var Admin = {
             jQuery(footer).width(jQuery(wrapper).outerWidth());
         }
     },
+
     refreshNavbarStuckClass: function(topNavbar) {
         var stuck = jQuery('#navbar-stuck');
 
@@ -718,6 +721,7 @@ var Admin = {
 
         stuck.html('body.fixed .content-header .navbar.stuck { top: ' + jQuery(topNavbar).outerHeight() + 'px; }');
     },
+
     // http://davidwalsh.name/javascript-debounce-function
     debounce: function (func, wait, immediate) {
         var timeout;
@@ -744,6 +748,7 @@ var Admin = {
             }
         };
     },
+
     setup_readmore_elements: function(subject) {
         Admin.log('[core|setup_readmore_elements] setup readmore elements on', subject);
 
@@ -755,9 +760,11 @@ var Admin = {
             });
         });
     },
+
     handle_top_navbar_height: function() {
         jQuery('body.fixed .content-wrapper').css('padding-top', jQuery('.navbar-static-top').outerHeight());
     },
+
     setup_form_submit: function(subject) {
         Admin.log('[core|setup_form_submit] setup form submit on', subject);
 
@@ -776,6 +783,7 @@ var Admin = {
             }
         });
     },
+
     convert_query_string_to_object: function (str) {
         return str.split('&').reduce(function (accumulator, keyValue) {
             accumulator[decodeURIComponent(keyValue.split('=')[0])] = keyValue.split('=')[1];
@@ -783,6 +791,7 @@ var Admin = {
             return accumulator;
         }, {});
     },
+
     /**
      * Remember open tab after refreshing page.
      */

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -2832,4 +2832,135 @@ class AdminTest extends TestCase
             [1, 1, 1],
         ];
     }
+
+    public function provideMergeParameters()
+    {
+        return [
+            [
+                [
+                    '_sort_order' => 'DESC',
+                    '_sort_by' => 'id',
+                    'status' => [
+                        'type' => '1',
+                        'value' => 'foo',
+                    ],
+                ],
+                [
+                    'status' => [
+                        'type' => '2',
+                        'value' => 'foo',
+                    ],
+                ],
+                [
+                    '_sort_order' => 'DESC',
+                    '_sort_by' => 'id',
+                    'status' => [
+                        'type' => '2',
+                        'value' => 'foo',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'status' => [
+                        'type' => '1',
+                    ],
+                ],
+                [
+                    'status' => [
+                        'value' => 'foo',
+                    ],
+                ],
+                [
+                    'status' => [
+                        'type' => '1',
+                        'value' => 'foo',
+                    ],
+                ],
+            ],
+            [
+                [
+                    'status' => [
+                        'type' => '1',
+                        'value' => 'foo',
+                    ],
+                ],
+                [
+                    'status' => [
+                        'type' => '2',
+                    ],
+                    '_page' => 2,
+                    '_per_page' => 25,
+                ],
+                [
+                    'status' => [
+                        'type' => '2',
+                        'value' => 'foo',
+                    ],
+                    '_page' => 2,
+                    '_per_page' => 25,
+                ],
+            ],
+            [
+                [
+                    'status' => [
+                        'type' => '1',
+                        'value' => [
+                            'foo',
+                            'bar',
+                        ],
+                    ],
+                ],
+                [
+                    'status' => [
+                        'value' => [
+                            'foo',
+                        ],
+                    ],
+                ],
+                [
+                    'status' => [
+                        'type' => '1',
+                        'value' => [
+                            'foo',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                [
+                    'status' => [
+                        'value' => [
+                            'foo',
+                            'bar',
+                        ],
+                    ],
+                ],
+                [
+                    'status' => [
+                        'value' => [
+                            'baz',
+                        ],
+                    ],
+                ],
+                [
+                    'status' => [
+                        'value' => [
+                            'baz',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideMergeParameters
+     */
+    public function testMergeParameters(array $parameters, array $filters, array $result): void
+    {
+        $admin = new FilteredAdmin('sonata.post.admin.model', 'Application\Sonata\FooBundle\Entity\Model', 'Sonata\FooBundle\Controller\ModelAdminController');
+
+        $this->assertSame($result, $admin->mergeParameters($parameters, $filters));
+    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->

Closes #6865

## Changelog

### Fixed by @kirya-dev
- Fix lost filter value when only type submitted
- Allow submit empty value when default filter non empty
- Invisible disabling filters (using remove name)

### Fixed
- Fix merge problem for filters with array value

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `AbstractAdmin::mergeParameters` to merge parameters but replace them when it's a subarray.
- Added tests for `mergeParameters`