### PR TITLE
Deprecate name option

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -360,7 +360,9 @@ file that was distributed with this source code.
     {% set row_id = 'sonata-ba-field-container-'~id %}
     {% set row_class = (row_attr.class|default('') ~ ' form-group' ~ (errors|length > 0 ? ' has-error'))|trim %}
     <div{% with {attr: row_attr|merge({id: row_id, class: row_class})} %}{{ block('attributes') }}{% endwith %}>
-        {% if sonata_admin.field_description.options is defined %}
+        {# NEXT_MAJOR: Remove this block #}
+        {% if sonata_admin.field_description.options.name is defined %}
+            {% deprecated 'The "name" option is deprecated in field description since sonata-project/admin-bundle 3.x, to be removed in 4.0.' %}
             {% set label = sonata_admin.field_description.options.name|default(label) %}
         {% endif %}
 


### PR DESCRIPTION
## Subject

In the template we are sometimes using a `name` option to replace the label.
This seems useless. You should just use the `label` property instead.

## Changelog

```markdown
### Deprecated
- Passing a fieldDescription option `name`
```