### PR TITLE
Add generic information for child admins

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1432,6 +1432,8 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
      * @param string $action
      *
      * @return ItemInterface
+     *
+     * @phpstan-param AdminInterface<object>|null $childAdmin
      */
     public function getSideMenu($action, ?AdminInterface $childAdmin = null)
     {
@@ -3023,6 +3025,8 @@ EOT;
      * NEXT_MAJOR: remove this method.
      *
      * @deprecated Use configureTabMenu instead
+     *
+     * @phpstan-param AdminInterface<object>|null $childAdmin
      */
     protected function configureSideMenu(ItemInterface $menu, string $action, ?AdminInterface $childAdmin = null)
     {
@@ -3032,6 +3036,8 @@ EOT;
      * Configures the tab menu in your admin.
      *
      * @param string $action
+     *
+     * @phpstan-param AdminInterface<object>|null $childAdmin
      */
     protected function configureTabMenu(ItemInterface $menu, $action, ?AdminInterface $childAdmin = null)
     {

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -75,7 +75,7 @@ interface AdminExtensionInterface
      * @return void
      *
      * @phpstan-param AdminInterface<T> $admin
-     * @phpstan-param AdminInterface<T>|null $childAdmin
+     * @phpstan-param AdminInterface<object>|null $childAdmin
      *
      * @deprecated
      */
@@ -94,7 +94,7 @@ interface AdminExtensionInterface
      * @return void
      *
      * @phpstan-param AdminInterface<T> $admin
-     * @phpstan-param AdminInterface<T>|null $childAdmin
+     * @phpstan-param AdminInterface<object>|null $childAdmin
      */
     public function configureTabMenu(
         AdminInterface $admin,

--- a/src/Admin/MenuBuilderInterface.php
+++ b/src/Admin/MenuBuilderInterface.php
@@ -30,6 +30,8 @@ interface MenuBuilderInterface
      * @return ItemInterface|bool
      *
      * @deprecated Use buildTabMenu instead
+     *
+     * @phpstan-param AdminInterface<object>|null $childAdmin
      */
     public function buildSideMenu($action, ?AdminInterface $childAdmin = null);
 
@@ -39,6 +41,8 @@ interface MenuBuilderInterface
      * @param string $action
      *
      * @return ItemInterface|bool
+     *
+     * @phpstan-param AdminInterface<object>|null $childAdmin
      */
     public function buildTabMenu($action, ?AdminInterface $childAdmin = null);
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

There are some method signatures that does not specify the generic type of the `AdminInterface`. Some types are wrong. 

From the API perspective, you can not determine the type of the child admin. It could be of any type.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Add generic information for child admins
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
