### PR TITLE
Deprecate some AbstractAdmin methods

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,10 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+### Deprecated `Sonata\AdminBundle\Model\AdminInterface::canAccessObject()` method.
+
+Use `Sonata\AdminBundle\Admin\AdminInterface::hasAccess()` instead.
+
 ### `Sonata\AdminBundle\Controller\CRUDController::historyCompareRevisionsAction()`
 
 - Deprecated route parameter "base_revision" in favor of "baseRevision";

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2911,7 +2911,7 @@ EOT;
         if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
             @trigger_error(sprintf(
                 'The method %s() is deprecated since sonata-project/admin-bundle 3.x'
-                .' and will be removed an in 4.0. Use `hasAccess` instead',
+                .' and will be removed an in 4.0. Use `hasAccess()` instead',
                 __METHOD__,
             ), \E_USER_DEPRECATED);
         }
@@ -3179,6 +3179,8 @@ EOT;
 
     /**
      * NEXT_MAJOR: Change visibility to private.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x will be private in 4.0
      */
     protected function buildList()
     {
@@ -3244,6 +3246,8 @@ EOT;
 
     /**
      * NEXT_MAJOR: Change visibility to private.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x will be private in 4.0
      */
     protected function buildForm()
     {

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2725,7 +2725,9 @@ EOT;
 
         if (\in_array($action, ['show', 'delete', 'acl', 'history'], true)
             && $this->hasRoute('edit')
-            && $this->canAccessObject('edit', $object)
+            && null !== $object
+            // NEXT_MAJOR: Replace by `$this->hasAccess`
+            && $this->canAccessObject('edit', $object, 'sonata_deprecation_mute')
         ) {
             $list['edit'] = [
                 // NEXT_MAJOR: Remove this line and use commented line below it instead
@@ -2736,7 +2738,9 @@ EOT;
 
         if (\in_array($action, ['show', 'edit', 'acl'], true)
             && $this->hasRoute('history')
-            && $this->canAccessObject('history', $object)
+            && null !== $object
+            // NEXT_MAJOR: Replace by `$this->hasAccess`
+            && $this->canAccessObject('history', $object, 'sonata_deprecation_mute')
         ) {
             $list['history'] = [
                 // NEXT_MAJOR: Remove this line and use commented line below it instead
@@ -2748,7 +2752,9 @@ EOT;
         if (\in_array($action, ['edit', 'history'], true)
             && $this->isAclEnabled()
             && $this->hasRoute('acl')
-            && $this->canAccessObject('acl', $object)
+            && null !== $object
+            // NEXT_MAJOR: Replace by `$this->hasAccess`
+            && $this->canAccessObject('acl', $object, 'sonata_deprecation_mute')
         ) {
             $list['acl'] = [
                 // NEXT_MAJOR: Remove this line and use commented line below it instead
@@ -2759,7 +2765,9 @@ EOT;
 
         if (\in_array($action, ['edit', 'history', 'acl'], true)
             && $this->hasRoute('show')
-            && $this->canAccessObject('show', $object)
+            && null !== $object
+            // NEXT_MAJOR: Replace by `$this->hasAccess`
+            && $this->canAccessObject('show', $object, 'sonata_deprecation_mute')
             && \count($this->getShow()) > 0
         ) {
             $list['show'] = [
@@ -2881,6 +2889,8 @@ EOT;
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * Check object existence and access, without throw Exception.
      *
      * @param string $action
@@ -2892,6 +2902,14 @@ EOT;
      */
     public function canAccessObject($action, $object)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
+            @trigger_error(sprintf(
+                'The method %s() is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will be removed an in 4.0. Use `hasAccess` instead',
+                __METHOD__,
+            ), \E_USER_DEPRECATED);
+        }
+
         if (!\is_object($object)) {
             return false;
         }

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2728,6 +2728,7 @@ EOT;
         if (\in_array($action, ['show', 'delete', 'acl', 'history'], true)
             && $this->hasRoute('edit')
             && null !== $object
+            && null !== $this->id($object)
             // NEXT_MAJOR: Replace by `$this->hasAccess`
             && $this->canAccessObject('edit', $object, 'sonata_deprecation_mute')
         ) {
@@ -2741,6 +2742,7 @@ EOT;
         if (\in_array($action, ['show', 'edit', 'acl'], true)
             && $this->hasRoute('history')
             && null !== $object
+            && null !== $this->id($object)
             // NEXT_MAJOR: Replace by `$this->hasAccess`
             && $this->canAccessObject('history', $object, 'sonata_deprecation_mute')
         ) {
@@ -2755,6 +2757,7 @@ EOT;
             && $this->isAclEnabled()
             && $this->hasRoute('acl')
             && null !== $object
+            && null !== $this->id($object)
             // NEXT_MAJOR: Replace by `$this->hasAccess`
             && $this->canAccessObject('acl', $object, 'sonata_deprecation_mute')
         ) {
@@ -2768,6 +2771,7 @@ EOT;
         if (\in_array($action, ['edit', 'history', 'acl'], true)
             && $this->hasRoute('show')
             && null !== $object
+            && null !== $this->id($object)
             // NEXT_MAJOR: Replace by `$this->hasAccess`
             && $this->canAccessObject('show', $object, 'sonata_deprecation_mute')
             && \count($this->getShow()) > 0

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2458,6 +2458,8 @@ EOT;
     }
 
     /**
+     * NEXT_MAJOR: Change visibility to protected.
+     *
      * Return the list of permissions the user should have in order to display the admin.
      *
      * @param string $context

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -741,10 +741,18 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
     }
 
     /**
-     * NEXT_MAJOR: Change the visibility to protected (similar to buildShow, buildForm, ...).
+     * NEXT_MAJOR: Change the visibility to private.
      */
     public function buildDatagrid()
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s() method is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will become private in version 4.0.',
+                __METHOD__
+            ), \E_USER_DEPRECATED);
+        }
+
         if ($this->loaded['datagrid']) {
             return;
         }
@@ -1367,14 +1375,16 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
 
     public function getForm()
     {
-        $this->buildForm();
+        // NEXT_MAJOR: Remove the `'sonata_deprecation_mute'` param
+        $this->buildForm('sonata_deprecation_mute');
 
         return $this->form;
     }
 
     public function getList()
     {
-        $this->buildList();
+        // NEXT_MAJOR: Remove the `'sonata_deprecation_mute'` param
+        $this->buildList('sonata_deprecation_mute');
 
         return $this->list;
     }
@@ -1403,7 +1413,8 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
 
     public function getDatagrid()
     {
-        $this->buildDatagrid();
+        // NEXT_MAJOR: Remove the `'sonata_deprecation_mute'` param
+        $this->buildDatagrid('sonata_deprecation_mute');
 
         return $this->datagrid;
     }
@@ -1741,14 +1752,16 @@ EOT;
 
     public function getFormFieldDescriptions()
     {
-        $this->buildForm();
+        // NEXT_MAJOR: Remove the `'sonata_deprecation_mute'` param
+        $this->buildForm('sonata_deprecation_mute');
 
         return $this->formFieldDescriptions;
     }
 
     public function getFormFieldDescription($name)
     {
-        $this->buildForm();
+        // NEXT_MAJOR: Remove the `'sonata_deprecation_mute'` param
+        $this->buildForm('sonata_deprecation_mute');
 
         if (!$this->hasFormFieldDescription($name)) {
             @trigger_error(sprintf(
@@ -1780,7 +1793,8 @@ EOT;
      */
     public function hasFormFieldDescription($name)
     {
-        $this->buildForm();
+        // NEXT_MAJOR: Remove the `'sonata_deprecation_mute'` param
+        $this->buildForm('sonata_deprecation_mute');
 
         return \array_key_exists($name, $this->formFieldDescriptions);
     }
@@ -1807,7 +1821,8 @@ EOT;
      */
     public function getShowFieldDescriptions()
     {
-        $this->buildShow();
+        // NEXT_MAJOR: Remove the `'sonata_deprecation_mute'` param
+        $this->buildShow('sonata_deprecation_mute');
 
         return $this->showFieldDescriptions;
     }
@@ -1821,7 +1836,8 @@ EOT;
      */
     public function getShowFieldDescription($name)
     {
-        $this->buildShow();
+        // NEXT_MAJOR: Remove the `'sonata_deprecation_mute'` param
+        $this->buildShow('sonata_deprecation_mute');
 
         if (!$this->hasShowFieldDescription($name)) {
             @trigger_error(sprintf(
@@ -1846,7 +1862,8 @@ EOT;
 
     public function hasShowFieldDescription($name)
     {
-        $this->buildShow();
+        // NEXT_MAJOR: Remove the `'sonata_deprecation_mute'` param
+        $this->buildShow('sonata_deprecation_mute');
 
         return \array_key_exists($name, $this->showFieldDescriptions);
     }
@@ -1863,14 +1880,16 @@ EOT;
 
     public function getListFieldDescriptions()
     {
-        $this->buildList();
+        // NEXT_MAJOR: Remove the `'sonata_deprecation_mute'` param
+        $this->buildList('sonata_deprecation_mute');
 
         return $this->listFieldDescriptions;
     }
 
     public function getListFieldDescription($name)
     {
-        $this->buildList();
+        // NEXT_MAJOR: Remove the `'sonata_deprecation_mute'` param
+        $this->buildList('sonata_deprecation_mute');
 
         if (!$this->hasListFieldDescription($name)) {
             @trigger_error(sprintf(
@@ -1896,7 +1915,8 @@ EOT;
 
     public function hasListFieldDescription($name)
     {
-        $this->buildList();
+        // NEXT_MAJOR: Remove the `'sonata_deprecation_mute'` param
+        $this->buildList('sonata_deprecation_mute');
 
         return \array_key_exists($name, $this->listFieldDescriptions);
     }
@@ -1913,7 +1933,8 @@ EOT;
 
     public function getFilterFieldDescription($name)
     {
-        $this->buildDatagrid();
+        // NEXT_MAJOR: Remove the `'sonata_deprecation_mute'` param
+        $this->buildDatagrid('sonata_deprecation_mute');
 
         if (!$this->hasFilterFieldDescription($name)) {
             @trigger_error(sprintf(
@@ -1938,7 +1959,8 @@ EOT;
 
     public function hasFilterFieldDescription($name)
     {
-        $this->buildDatagrid();
+        // NEXT_MAJOR: Remove the `'sonata_deprecation_mute'` param
+        $this->buildDatagrid('sonata_deprecation_mute');
 
         return \array_key_exists($name, $this->filterFieldDescriptions);
     }
@@ -1955,7 +1977,8 @@ EOT;
 
     public function getFilterFieldDescriptions()
     {
-        $this->buildDatagrid();
+        // NEXT_MAJOR: Remove the `'sonata_deprecation_mute'` param
+        $this->buildDatagrid('sonata_deprecation_mute');
 
         return $this->filterFieldDescriptions;
     }
@@ -2485,7 +2508,8 @@ EOT;
 
     public function getShow()
     {
-        $this->buildShow();
+        // NEXT_MAJOR: Remove the `'sonata_deprecation_mute'` param
+        $this->buildShow('sonata_deprecation_mute');
 
         return $this->show;
     }
@@ -3101,10 +3125,18 @@ EOT;
     }
 
     /**
-     * build the view FieldDescription array.
+     * NEXT_MAJOR: Change the visibility to private.
      */
     protected function buildShow()
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s() method is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will become private in version 4.0.',
+                __METHOD__
+            ), \E_USER_DEPRECATED);
+        }
+
         if ($this->loaded['show']) {
             return;
         }
@@ -3122,10 +3154,18 @@ EOT;
     }
 
     /**
-     * build the list FieldDescription array.
+     * NEXT_MAJOR: Change visibility to private.
      */
     protected function buildList()
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s() method is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will become private in version 4.0.',
+                __METHOD__
+            ), \E_USER_DEPRECATED);
+        }
+
         if ($this->loaded['list']) {
             return;
         }
@@ -3179,10 +3219,18 @@ EOT;
     }
 
     /**
-     * Build the form FieldDescription collection.
+     * NEXT_MAJOR: Change visibility to private.
      */
     protected function buildForm()
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[0] ?? null)) {
+            @trigger_error(sprintf(
+                'The %s() method is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will become private in version 4.0.',
+                __METHOD__
+            ), \E_USER_DEPRECATED);
+        }
+
         if ($this->loaded['form']) {
             return;
         }

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -34,7 +34,6 @@ use Symfony\Component\HttpFoundation\Request;
  * @method string                          getSearchResultLink(object $object)
  * @method array                           getDefaultFilterParameters()
  * @method bool                            isCurrentRoute(string $name, ?string $adminCode)
- * @method bool                            canAccessObject(string $action, object $object)
  * @method mixed                           getPersistentParameter(string $name)
  * @method string[]                        getExportFields()
  * @method array                           getSubClasses()

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -30,7 +30,6 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * NEXT_MAJOR: Add all these methods to the interface by uncommenting them.
  *
- * @method array                           configureActionButtons(string $action, ?object $object = null)
  * @method string                          getSearchResultLink(object $object)
  * @method array                           getDefaultFilterParameters()
  * @method bool                            isCurrentRoute(string $name, ?string $adminCode)
@@ -730,11 +729,6 @@ interface AdminInterface extends TaggedAdminInterface, AccessRegistryInterface, 
      * @return string
      */
     public function getListMode();
-
-    /*
-     * Configure buttons for an action
-     */
-    // public function configureActionButtons(string $action, ?object $object = null): array;
 
     // NEXT_MAJOR: uncomment this method for 4.0
     /*

--- a/src/Resources/views/Button/acl_button.html.twig
+++ b/src/Resources/views/Button/acl_button.html.twig
@@ -8,7 +8,13 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% if admin.isAclEnabled() and admin.canAccessObject('acl', object) and admin.hasRoute('acl') %}
+
+{# NEXT_MAJOR: Replace canAccessObject by hasAccess #}
+{% if admin.isAclEnabled()
+    and object is not null
+    and admin.canAccessObject('acl', object, 'sonata_deprecation_mute')
+    and admin.hasRoute('acl')
+%}
     <li>
         <a class="sonata-action-element" href="{{ admin.generateObjectUrl('acl', object) }}">
             <i class="fa fa-users" aria-hidden="true"></i>

--- a/src/Resources/views/Button/acl_button.html.twig
+++ b/src/Resources/views/Button/acl_button.html.twig
@@ -12,6 +12,7 @@ file that was distributed with this source code.
 {# NEXT_MAJOR: Replace canAccessObject by hasAccess #}
 {% if admin.isAclEnabled()
     and object is not null
+    and admin.id(object) is not null
     and admin.canAccessObject('acl', object, 'sonata_deprecation_mute')
     and admin.hasRoute('acl')
 %}

--- a/src/Resources/views/Button/edit_button.html.twig
+++ b/src/Resources/views/Button/edit_button.html.twig
@@ -10,7 +10,11 @@ file that was distributed with this source code.
 #}
 
 {# NEXT_MAJOR: Replace canAccessObject by hasAccess #}
-{% if object is not null and admin.canAccessObject('edit', object, 'sonata_deprecation_mute') and admin.hasRoute('edit') %}
+{% if object is not null
+    and admin.id(object) is not null
+    and admin.canAccessObject('edit', object, 'sonata_deprecation_mute')
+    and admin.hasRoute('edit')
+%}
     <li>
         <a class="sonata-action-element" href="{{ admin.generateObjectUrl('edit', object) }}">
             <i class="fa fa-edit" aria-hidden="true"></i>

--- a/src/Resources/views/Button/edit_button.html.twig
+++ b/src/Resources/views/Button/edit_button.html.twig
@@ -9,7 +9,8 @@ file that was distributed with this source code.
 
 #}
 
-{% if admin.canAccessObject('edit', object) and admin.hasRoute('edit') %}
+{# NEXT_MAJOR: Replace canAccessObject by hasAccess #}
+{% if object is not null and admin.canAccessObject('edit', object, 'sonata_deprecation_mute') and admin.hasRoute('edit') %}
     <li>
         <a class="sonata-action-element" href="{{ admin.generateObjectUrl('edit', object) }}">
             <i class="fa fa-edit" aria-hidden="true"></i>

--- a/src/Resources/views/Button/history_button.html.twig
+++ b/src/Resources/views/Button/history_button.html.twig
@@ -10,7 +10,11 @@ file that was distributed with this source code.
 #}
 
 {# NEXT_MAJOR: Replace canAccessObject by hasAccess #}
-{% if object is not null and admin.canAccessObject('history', object, 'sonata_deprecation_mute') and admin.hasRoute('history') %}
+{% if object is not null
+    and admin.id(object) is not null
+    and admin.canAccessObject('history', object, 'sonata_deprecation_mute')
+    and admin.hasRoute('history')
+%}
     <li>
         <a class="sonata-action-element" href="{{ admin.generateObjectUrl('history', object) }}">
             <i class="fa fa-archive" aria-hidden="true"></i>

--- a/src/Resources/views/Button/history_button.html.twig
+++ b/src/Resources/views/Button/history_button.html.twig
@@ -9,7 +9,8 @@ file that was distributed with this source code.
 
 #}
 
-{% if admin.canAccessObject('history', object) and admin.hasRoute('history') %}
+{# NEXT_MAJOR: Replace canAccessObject by hasAccess #}
+{% if object is not null and admin.canAccessObject('history', object, 'sonata_deprecation_mute') and admin.hasRoute('history') %}
     <li>
         <a class="sonata-action-element" href="{{ admin.generateObjectUrl('history', object) }}">
             <i class="fa fa-archive" aria-hidden="true"></i>

--- a/src/Resources/views/Button/show_button.html.twig
+++ b/src/Resources/views/Button/show_button.html.twig
@@ -8,7 +8,13 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% if admin.canAccessObject('show', object) and admin.show|length > 0 and admin.hasRoute('show') %}
+
+{# NEXT_MAJOR: Replace canAccessObject by hasAccess #}
+{% if object is not null
+    and admin.canAccessObject('show', object, 'sonata_deprecation_mute')
+    and admin.show|length > 0
+    and admin.hasRoute('show')
+%}
     <li>
         <a class="sonata-action-element" href="{{ admin.generateObjectUrl('show', object) }}">
             <i class="fa fa-eye" aria-hidden="true"></i>

--- a/src/Resources/views/Button/show_button.html.twig
+++ b/src/Resources/views/Button/show_button.html.twig
@@ -11,6 +11,7 @@ file that was distributed with this source code.
 
 {# NEXT_MAJOR: Replace canAccessObject by hasAccess #}
 {% if object is not null
+    and admin.id(object) is not null
     and admin.canAccessObject('show', object, 'sonata_deprecation_mute')
     and admin.show|length > 0
     and admin.hasRoute('show')

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -2180,6 +2180,11 @@ class AdminTest extends TestCase
         $this->assertSame([], $admin->getActionButtons('edit'));
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testCantAccessObjectIfNullPassed(): void
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
@@ -2187,6 +2192,11 @@ class AdminTest extends TestCase
         $this->assertFalse($admin->canAccessObject('list', null));
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testCantAccessObjectIfRandomObjectPassed(): void
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
@@ -2196,6 +2206,11 @@ class AdminTest extends TestCase
         $this->assertFalse($admin->canAccessObject('list', new \stdClass()));
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testCanAccessObject(): void
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because BC

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `AbstractAdmin::buildForm()`
- `AbstractAdmin::buildDatagrid()`
- `AbstractAdmin::buildShow()`
- `AbstractAdmin::buildList()`
- `AbstractAdmin::canAccessObject()` in favor of `AbstractAdmin::hasAccess()`
- `AdminInterface::canAccessObject()`
- `AdminInterface::configureActionButtons()` and `AbstractAdmin::configureActionButtons()` will become protected
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
