### PR TITLE
Fix FilterInterface::apply phpdoc

### DIFF
--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -43,7 +43,7 @@ interface FilterInterface
      * @param ProxyQueryInterface $query
      * @param mixed[]             $filterData
      *
-     * @phpstan array{type?: string, value?: mixed} $filterData
+     * @phpstan array{type?: string|int, value?: mixed} $filterData
      */
     public function apply($query, $filterData);
 


### PR DESCRIPTION
I think types right now are all `int`, should we change it? or just add `string|int`.

e.g:
https://github.com/sonata-project/SonataAdminBundle/blob/6a7c3067a977b8436572700c2a8ab284a268e4f2/src/Form/Type/Operator/DateOperatorType.php#L23-L27