### PR TITLE
Display errors from XHR requests at `edit_many_script.html.twig`

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -280,6 +280,12 @@ This code manages the many-to-[one|many] association field popup
 
         Admin.log('[{{ id }}|field_dialog_form_action] execute ajax call');
 
+        var oldErrorMessages = jQuery(field_dialog_content_{{ id }}).find('div.alert-danger');
+        // Remove old error messages.
+        if (oldErrorMessages.length > 0) {
+          oldErrorMessages.remove();
+        }
+
         // the ajax post
         jQuery(form).ajaxSubmit({
             url: url,
@@ -343,6 +349,37 @@ This code manages the many-to-[one|many] association field popup
 
                 // reattach the event
                 jQuery('form', field_dialog_{{ id }}).submit(field_dialog_form_action_{{ id }});
+            },
+            error: function(xhr) {
+                var content = '';
+
+                if ('application/json' === xhr.getResponseHeader('Content-Type')) {
+                    var jsonContent = JSON.parse(xhr.responseText);
+
+                    if (jsonContent.message) {
+                        content += '<div class="alert alert-danger alert-dismissable">'
+                            + '<button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>'
+                            + jsonContent.message
+                            + '</div>';
+                    }
+
+                    if (jsonContent.errors) {
+                        for (error of jsonContent.errors) {
+                            content += '<div class="alert alert-danger alert-dismissable">'
+                                + '<button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>'
+                                + error
+                                + '</div>';
+                        }
+                    }
+                } else {
+                    content += xhr.responseText;
+                }
+
+                // Display the error.
+                field_dialog_content_{{ id }}.prepend(content);
+
+                // Reset the submit buttons.
+                $(form).find('button[type="submit"]').removeAttr('disabled');
             }
         });
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Display errors from XHR requests at `edit_many_script.html.twig`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Show XHR errors on "one to many" and "many to many" forms.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
## To do

- [x] Render the error in a proper DOM node instead of replacing the whole modal contents;
- [x] Reset the original state in the submit buttons.

This is an example of how the error messages are shown:
![image](https://user-images.githubusercontent.com/1231441/109077135-76063b00-76da-11eb-9758-d7eef9e56a75.png)
