### PR TITLE
Reset default filters in global search

### DIFF
--- a/src/Search/SearchHandler.php
+++ b/src/Search/SearchHandler.php
@@ -81,14 +81,21 @@ class SearchHandler
 
         $datagrid = $admin->getDatagrid();
 
+        $datagridValues = $datagrid->getValues();
+
         $found = false;
         foreach ($datagrid->getFilters() as $filter) {
-            /** @var $filter FilterInterface */
+            /** @var FilterInterface $filter */
+            $formName = $filter->getFormName();
+
             if ($filter->getOption('global_search', false)) {
                 $filter->setOption('case_sensitive', $this->caseSensitive);
                 $filter->setCondition(FilterInterface::CONDITION_OR);
-                $datagrid->setValue($filter->getFormName(), null, $term);
+                $datagrid->setValue($formName, null, $term);
                 $found = true;
+            } elseif (isset($datagridValues[$formName])) {
+                // Remove any previously set filter that is not configured for the global search.
+                $datagrid->removeFilter($formName);
             }
         }
 

--- a/tests/Search/SearchHandlerTest.php
+++ b/tests/Search/SearchHandlerTest.php
@@ -112,4 +112,33 @@ class SearchHandlerTest extends TestCase
         yield 'admin_search_disabled' => [false, 0, false, 'admin.bar'];
         yield 'admin_search_omitted' => [PagerInterface::class, 1, null, 'admin.baz'];
     }
+
+    public function testBuildPagerWithDefaultFilters(): void
+    {
+        $defaultFilter = $this->createMock(FilterInterface::class);
+        $defaultFilter->expects($this->once())->method('getOption')->with('global_search')->willReturn(false);
+        $defaultFilter->expects($this->once())->method('getFormName')->willReturn('filter1');
+
+        $filter = $this->createMock(FilterInterface::class);
+        $filter->expects($this->once())->method('getOption')->with('global_search')->willReturn(true);
+        $filter->expects($this->once())->method('getFormName')->willReturn('filter2');
+
+        $pager = $this->createMock(PagerInterface::class);
+        $pager->expects($this->once())->method('setPage');
+        $pager->expects($this->once())->method('setMaxPerPage');
+
+        $datagrid = $this->createMock(DatagridInterface::class);
+        $datagrid->expects($this->once())->method('getFilters')->willReturn([$defaultFilter, $filter]);
+        $datagrid->expects($this->once())->method('setValue')->with('filter2', null, 'myservice');
+        $datagrid->expects($this->once())->method('removeFilter')->with('filter1');
+        $datagrid->expects($this->once())->method('getValues')->willReturn(['filter1' => ['type' => null, 'value' => null]]);
+        $datagrid->expects($this->once())->method('getPager')->willReturn($pager);
+
+        $admin = $this->createMock(AdminInterface::class);
+        $admin->expects($this->once())->method('getDatagrid')->willReturn($datagrid);
+
+        $handler = new SearchHandler(true);
+        $pager = $handler->search($admin, 'myservice');
+        $this->assertInstanceOf(PagerInterface::class, $pager);
+    }
 }


### PR DESCRIPTION
## Subject

Global search uses OR conditions to combine multiple filters on the same admin. When an admin contains default filters the global search has no effect because either the default filter or the global search filter must match. As such, the default filters will be removed before global searching.

Example:

I have a default boolean filter on the field active with value 1. I have two global search enabled filters called name and code.
I search on `Test`.

In the current situation the query will become:

`WHERE active = 1 OR name LIKE '%Test%' OR code LIKE '%Test%'`

This returns all items with `active = 1`, effectively ignoring the global search parameter.

Ideally this would be:

`WHERE active = 1 AND (name LIKE '%Test%' OR code LIKE '%Test%')`

But this requires extensive changes to the code, because currently there is no support for grouping in the datagrid classes.

My quick solution is to just unset the default filters, giving:

`WHERE name LIKE '%Test%' OR code LIKE '%Test%'`

As the current situation is clearly broken, this it at least better than it used to be.

I am targeting this branch, because it is backwards compatible.

## Changelog

```markdown
### Fixed
- Global search on admins with default filter parameters.
```