### PR TITLE
Update actions from `CRUDController` in order to assert that referenced objects exist

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -135,6 +135,8 @@ class CRUDController implements ContainerAwareInterface
     {
         $request = $this->getRequest();
 
+        $this->assertObjectExists($request);
+
         $this->admin->checkAccess('list');
 
         $preResponse = $this->preList($request);
@@ -213,9 +215,7 @@ class CRUDController implements ContainerAwareInterface
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
-        if (!$object) {
-            throw $this->createNotFoundException(sprintf('unable to find the object with id: %s', $id));
-        }
+        $this->assertObjectExists($request);
 
         $this->checkParentChildAssociation($request, $object);
 
@@ -306,9 +306,7 @@ class CRUDController implements ContainerAwareInterface
         $id = $request->get($this->admin->getIdParameter());
         $existingObject = $this->admin->getObject($id);
 
-        if (!$existingObject) {
-            throw $this->createNotFoundException(sprintf('unable to find the object with id: %s', $id));
-        }
+        $this->assertObjectExists($request);
 
         $this->checkParentChildAssociation($request, $existingObject);
 
@@ -564,10 +562,13 @@ class CRUDController implements ContainerAwareInterface
     public function createAction()
     {
         $request = $this->getRequest();
-        // the key used to lookup the template
-        $templateKey = 'edit';
+
+        $this->assertObjectExists($request);
 
         $this->admin->checkAccess('create');
+
+        // the key used to lookup the template
+        $templateKey = 'edit';
 
         $class = new \ReflectionClass($this->admin->hasActiveSubClass() ? $this->admin->getActiveSubClass() : $this->admin->getClass());
 
@@ -694,9 +695,7 @@ class CRUDController implements ContainerAwareInterface
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
-        if (!$object) {
-            throw $this->createNotFoundException(sprintf('unable to find the object with id: %s', $id));
-        }
+        $this->assertObjectExists($request);
 
         $this->checkParentChildAssociation($request, $object);
 
@@ -748,9 +747,7 @@ class CRUDController implements ContainerAwareInterface
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
-        if (!$object) {
-            throw $this->createNotFoundException(sprintf('unable to find the object with id: %s', $id));
-        }
+        $this->assertObjectExists($request);
 
         $this->admin->checkAccess('history', $object);
 
@@ -796,9 +793,7 @@ class CRUDController implements ContainerAwareInterface
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
-        if (!$object) {
-            throw $this->createNotFoundException(sprintf('unable to find the object with id: %s', $id));
-        }
+        $this->assertObjectExists($request);
 
         $this->admin->checkAccess('historyViewRevision', $object);
 
@@ -858,9 +853,7 @@ class CRUDController implements ContainerAwareInterface
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
-        if (!$object) {
-            throw $this->createNotFoundException(sprintf('unable to find the object with id: %s', $id));
-        }
+        $this->assertObjectExists($request);
 
         $manager = $this->get('sonata.admin.audit.manager');
 
@@ -1001,9 +994,7 @@ class CRUDController implements ContainerAwareInterface
         $id = $request->get($this->admin->getIdParameter());
         $object = $this->admin->getObject($id);
 
-        if (!$object) {
-            throw $this->createNotFoundException(sprintf('unable to find the object with id: %s', $id));
-        }
+        $this->assertObjectExists($request);
 
         $this->admin->checkAccess('acl', $object);
 
@@ -1641,6 +1632,27 @@ class CRUDController implements ContainerAwareInterface
             'objectId' => $this->admin->getNormalizedIdentifier($object),
             'objectName' => $this->escapeHtml($this->admin->toString($object)),
         ], Response::HTTP_OK);
+    }
+
+    final protected function assertObjectExists(Request $request): void
+    {
+        $admin = $this->admin;
+
+        do {
+            $objectId = $request->get($admin->getIdParameter());
+
+            if (null !== $objectId) {
+                $adminObject = $admin->getObject($objectId);
+
+                if (null === $adminObject) {
+                    throw $this->createNotFoundException(sprintf(
+                        'Unable to find %s object with id: %s.',
+                        $admin->getClassnameLabel(),
+                        $objectId
+                    ));
+                }
+            }
+        } while ($admin->isChild() && $admin = $admin->getParent());
     }
 
     private function getSelectedTab(Request $request): array


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Update actions from `CRUDController` in order to assert that referenced objects exist.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
Given a route like "/country/21/state/create" (where `StateAdmin` is a child of `CountryAdmin`) these changes allows the child admin route to ensure that the object referenced by the parent admin exists.
This way, the code at the child admin can rely on the existence of a proper object in its ancestor hierarchy:
```php
// StateAdmin.php

if ($this->isChild()) {
    $parentAdmin = $this->getParent();
    $parentObject = $parentAdmin->getObject($this->request->get($parentAdmin->getIdParameter()));

    // This call can be made safely, since the check about the resource existence is done in the controller.
    $parentObject->doSomething();
}
```

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Possibility to access nonexistent parent objects from child admins.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

## To do

- [x] Update the tests.
