### PR TITLE
`AbstractAdmin::getObject()` does not return boolean values

### DIFF
--- a/tests/Action/GetShortObjectDescriptionActionTest.php
+++ b/tests/Action/GetShortObjectDescriptionActionTest.php
@@ -102,7 +102,7 @@ final class GetShortObjectDescriptionActionTest extends TestCase
 
         $this->admin->expects($this->once())->method('setRequest')->with($request);
         $this->admin->expects($this->once())->method('setUniqid')->with('asdasd123');
-        $this->admin->method('getObject')->with(42)->willReturn(false);
+        $this->admin->method('getObject')->with(42)->willReturn(null);
 
         ($this->action)($request);
     }

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -1470,7 +1470,7 @@ class CRUDControllerTest extends TestCase
 
         $this->admin->expects($this->once())
             ->method('getObject')
-            ->willReturn(false);
+            ->willReturn(null);
 
         $this->controller->editAction(null);
     }
@@ -2694,7 +2694,7 @@ class CRUDControllerTest extends TestCase
 
         $this->admin->expects($this->once())
             ->method('getObject')
-            ->willReturn(false);
+            ->willReturn(null);
 
         $this->controller->historyAction(null);
     }

--- a/tests/Controller/HelperControllerTest.php
+++ b/tests/Controller/HelperControllerTest.php
@@ -138,7 +138,7 @@ class HelperControllerTest extends TestCase
 
         $this->admin->expects($this->once())->method('setRequest')->with($this->isInstanceOf(Request::class));
         $this->admin->expects($this->once())->method('setUniqid')->with('asdasd123');
-        $this->admin->method('getObject')->with(42)->willReturn(false);
+        $this->admin->method('getObject')->with(42)->willReturn(null);
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Invalid format');
@@ -156,7 +156,7 @@ class HelperControllerTest extends TestCase
 
         $this->admin->expects($this->once())->method('setRequest')->with($this->isInstanceOf(Request::class));
         $this->admin->expects($this->once())->method('setUniqid')->with('asdasd123');
-        $this->admin->method('getObject')->with(null)->willReturn(false);
+        $this->admin->method('getObject')->with(null)->willReturn(null);
 
         $response = $this->controller->getShortObjectDescriptionAction($request);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
`AbstractAdmin::getObject()` does not return boolean values.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these chages are pedantic.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->