### PR TITLE
Allow null type for filter

### DIFF
--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -35,7 +35,7 @@ interface FilterInterface
      * @param string  $field
      * @param mixed[] $data
      *
-     * @phpstan array{type?: string, value?: mixed} $data
+     * @phpstan array{type?: string|int|null, value?: mixed} $data
      */
     public function filter(ProxyQueryInterface $query, $alias, $field, $data);
 
@@ -43,7 +43,7 @@ interface FilterInterface
      * @param ProxyQueryInterface $query
      * @param mixed[]             $filterData
      *
-     * @phpstan-param array{type?: string|int, value?: mixed} $filterData
+     * @phpstan-param array{type?: string|int|null, value?: mixed} $filterData
      */
     public function apply($query, $filterData);
 


### PR DESCRIPTION
Since we're doing isset or `??` checks, we can allow to pass a `null` type.
This way, both
```
['type' => null, 'value' => 'foo']
['value' => 'foo']
```
are valids.