### PR TITLE
Use camel case for arguments and variables at `CRUDController::historyCompareRevisionsAction()`

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,30 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=======================
+
+### `Sonata\AdminBundle\Controller\CRUDController::historyCompareRevisionsAction()`
+
+- Deprecated route parameter "base_revision" in favor of "baseRevision";
+- Deprecated route parameter "compare_revision" in favor of "compareRevision".
+
+Before:
+```php
+$admin->generateObjectUrl('history_compare_revisions', $subject, [
+    'base_revision' => $currentRev,
+    'compare_revision' => $rev,
+]);
+```
+
+After:
+```php
+$admin->generateObjectUrl('history_compare_revisions', $subject, [
+    'baseRevision' => $currentRev,
+    'compareRevision' => $rev,
+]);
+```
+
 UPGRADE FROM 3.89 to 3.90
 =========================
 

--- a/src/Resources/views/CRUD/base_history.html.twig
+++ b/src/Resources/views/CRUD/base_history.html.twig
@@ -42,7 +42,7 @@ file that was distributed with this source code.
                                     {% if (currentRevision == false or revision.rev == currentRevision.rev) %}
                                         /
                                     {% else %}
-                                        <a href="{{ admin.generateObjectUrl('history_compare_revisions', object, {'base_revision': currentRevision.rev, 'compare_revision': revision.rev }) }}" class="revision-compare-link" rel="{{ revision.rev }}">{{ 'label_compare_revision'|trans({}, 'SonataAdminBundle') }}</a>
+                                        <a href="{{ admin.generateObjectUrl('history_compare_revisions', object, {'baseRevision': currentRevision.rev, 'compareRevision': revision.rev }) }}" class="revision-compare-link" rel="{{ revision.rev }}">{{ 'label_compare_revision'|trans({}, 'SonataAdminBundle') }}</a>
                                     {% endif %}
                                 </td>
                             </tr>

--- a/src/Route/PathInfoBuilder.php
+++ b/src/Route/PathInfoBuilder.php
@@ -47,7 +47,7 @@ class PathInfoBuilder implements RouteBuilderInterface
         if ($this->manager->hasReader($admin->getClass())) {
             $collection->add('history', sprintf('%s/history', $admin->getRouterIdParameter()));
             $collection->add('history_view_revision', sprintf('%s/history/{revision}/view', $admin->getRouterIdParameter()));
-            $collection->add('history_compare_revisions', sprintf('%s/history/{base_revision}/{compare_revision}/compare', $admin->getRouterIdParameter()));
+            $collection->add('history_compare_revisions', sprintf('%s/history/{baseRevision}/{compareRevision}/compare', $admin->getRouterIdParameter()));
         }
 
         if ($admin->isAclEnabled()) {

--- a/tests/Form/Type/Operator/StringOperatorTypeTest.php
+++ b/tests/Form/Type/Operator/StringOperatorTypeTest.php
@@ -23,7 +23,7 @@ class StringOperatorTypeTest extends TypeTestCase
     {
         $formType = new StringOperatorType();
         $optionsResolver = new OptionsResolver();
-        $expected_choices = [
+        $expectedChoices = [
             'label_type_contains' => StringOperatorType::TYPE_CONTAINS,
             'label_type_not_contains' => StringOperatorType::TYPE_NOT_CONTAINS,
             'label_type_equals' => StringOperatorType::TYPE_EQUAL,
@@ -33,7 +33,7 @@ class StringOperatorTypeTest extends TypeTestCase
         ];
         $formType->configureOptions($optionsResolver);
         $options = $optionsResolver->resolve([]);
-        $this->assertSame($expected_choices, $options['choices']);
+        $this->assertSame($expectedChoices, $options['choices']);
         $this->assertSame('SonataAdminBundle', $options['choice_translation_domain']);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Use camel case for arguments and variables at `CRUDController::historyCompareRevisionsAction()`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Route parameters "baseRevision" and "compareRevision" for `CRUDController::historyCompareRevisionsAction()`.

### Deprecated
- Route parameters "base_revision" and "compare_revision" for `CRUDController::historyCompareRevisionsAction()`.
```
