### PR TITLE
Add extension point for dashboardButtons

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,13 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.xx to 3.xx
+=========================
+
+### Deprecated overriding `Sonata\AdminBundle\Admin\AbstractAdmin::getActionButtons()` method.
+
+Override `Sonata\AdminBundle\Admin\AbstractAdmin::configureActionButtons()` instead.
+
 UPGRADE FROM 3.91 to 3.92
 =========================
 

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2820,6 +2820,8 @@ EOT;
     }
 
     /**
+     * @final since sonata-project/admin-bundle 3.x.
+     *
      * Get the list of actions that can be accessed directly from the dashboard.
      *
      * @return array<string, array<string, mixed>>
@@ -2847,6 +2849,15 @@ EOT;
                 'url' => $this->generateUrl('list'),
                 'icon' => 'list',
             ];
+        }
+
+        $actions = $this->configureDashboardButtons($actions);
+
+        foreach ($this->getExtensions() as $extension) {
+            // NEXT_MAJOR: remove method check
+            if (method_exists($extension, 'configureDashboardButtons')) {
+                $actions = $extension->configureDashboardButtons($this, $actions);
+            }
         }
 
         return $actions;
@@ -3119,6 +3130,16 @@ EOT;
      * @return array<string, mixed>
      */
     protected function configureBatchActions($actions)
+    {
+        return $actions;
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $actions
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    protected function configureDashboardButtons(array $actions): array
     {
         return $actions;
     }

--- a/src/Admin/AbstractAdminExtension.php
+++ b/src/Admin/AbstractAdminExtension.php
@@ -165,6 +165,18 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
     }
 
     /**
+     * @param array<string, array<string, mixed>> $actions
+     *
+     * @return array<string, array<string, mixed>>
+     *
+     * @phpstan-param AdminInterface<T> $admin
+     */
+    public function configureDashboardButtons(AdminInterface $admin, array $actions): array
+    {
+        return $actions;
+    }
+
+    /**
      * @phpstan-param AdminInterface<T> $admin
      */
     public function configureDefaultFilterValues(AdminInterface $admin, array &$filterValues)

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -29,6 +29,7 @@ use Sonata\Form\Validator\ErrorElement;
  * @method array configureBatchActions(AdminInterface $admin, array $actions)
  * @method array configureExportFields(AdminInterface $admin, array $fields)
  * @method array configureActionButtons(AdminInterface $admin, array $list, string $action, object $object)
+ * @method array configureDashboardButtons(AdminInterface $admin, array $actions)
  * @method void  configureDefaultFilterValues(AdminInterface $admin, array &$filterValues)
  * @method void  configureDefaultSortValues(AdminInterface $admin, array &$sortValues)
  * @method void  configureFormOptions(AdminInterface $admin, array &$formOptions)
@@ -271,6 +272,12 @@ interface AdminExtensionInterface
      */
     // NEXT_MAJOR: Uncomment this method
     // public function configureActionButtons(AdminInterface $admin, array $list, string $action, object $object): array;
+
+    /*
+     * @phpstan-param AdminInterface<T> $admin
+     */
+    // NEXT_MAJOR: Uncomment this method
+    // public function configureDashboardButtons(AdminInterface $admin, array $actions): array;
 
     /*
      * NEXT_MAJOR: Uncomment this method


### PR DESCRIPTION
## Subject

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- `AbstractAdmin::configureActionButtons()`
- `AdminExtensionInterface::configureActionButtons()`
- `AbstractAdminExtension::configureActionButtons()`

### Deprecated
- Overriding `AbstractAdmin::getActionButtons()`
```