### PR TITLE
Optimize performance of checking is can access object

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -72,6 +72,32 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
             Doctrine\\\Orm|Doctrine\\\Phpcr|Doctrine\\\MongoDB|Doctrine\\\CouchDB
         )\\\(.*)@x';
 
+    private const ACTION_TREE = 1;
+    private const ACTION_SHOW = 2;
+    private const ACTION_EDIT = 4;
+    private const ACTION_DELETE = 8;
+    private const ACTION_ACL = 16;
+    private const ACTION_HISTORY = 32;
+    private const ACTION_LIST = 64;
+    private const ACTION_BATCH = 128;
+    private const INTERNAL_ACTIONS = [
+        'tree' => self::ACTION_TREE,
+        'show' => self::ACTION_SHOW,
+        'edit' => self::ACTION_EDIT,
+        'delete' => self::ACTION_DELETE,
+        'acl' => self::ACTION_ACL,
+        'history' => self::ACTION_HISTORY,
+        'list' => self::ACTION_LIST,
+        'batch' => self::ACTION_BATCH,
+    ];
+    private const MASK_OF_ACTION_CREATE = self::ACTION_TREE | self::ACTION_SHOW | self::ACTION_EDIT | self::ACTION_DELETE | self::ACTION_LIST | self::ACTION_BATCH;
+    private const MASK_OF_ACTION_SHOW = self::ACTION_EDIT | self::ACTION_HISTORY | self::ACTION_ACL;
+    private const MASK_OF_ACTION_EDIT = self::ACTION_SHOW | self::ACTION_DELETE | self::ACTION_ACL | self::ACTION_HISTORY;
+    private const MASK_OF_ACTION_HISTORY = self::ACTION_SHOW | self::ACTION_EDIT | self::ACTION_ACL;
+    private const MASK_OF_ACTION_ACL = self::ACTION_EDIT | self::ACTION_HISTORY;
+    private const MASK_OF_ACTION_LIST = self::ACTION_SHOW | self::ACTION_EDIT | self::ACTION_DELETE | self::ACTION_ACL | self::ACTION_BATCH;
+    private const MASK_OF_ACTIONS_USING_OBJECT = self::MASK_OF_ACTION_SHOW | self::MASK_OF_ACTION_EDIT | self::MASK_OF_ACTION_HISTORY | self::MASK_OF_ACTION_ACL;
+
     /**
      * The list FieldDescription constructed from the configureListField method.
      *
@@ -2712,9 +2738,16 @@ EOT;
      */
     public function configureActionButtons($action, $object = null)
     {
+        // nothing to do for non-internal actions
+        if (!isset(self::INTERNAL_ACTIONS[$action])) {
+            return [];
+        }
+
+        $actionBit = self::INTERNAL_ACTIONS[$action];
+
         $list = [];
 
-        if (\in_array($action, ['tree', 'show', 'edit', 'delete', 'list', 'batch'], true)
+        if (self::MASK_OF_ACTION_CREATE & $actionBit
             && $this->hasRoute('create')
             && $this->hasAccess('create')
         ) {
@@ -2725,10 +2758,11 @@ EOT;
             ];
         }
 
-        if (\in_array($action, ['show', 'delete', 'acl', 'history'], true)
+        $canAccessObject = self::MASK_OF_ACTIONS_USING_OBJECT & $actionBit && null !== $object && null !== $this->id($object);
+
+        if ($canAccessObject
+            && self::MASK_OF_ACTION_EDIT & $actionBit
             && $this->hasRoute('edit')
-            && null !== $object
-            && null !== $this->id($object)
             // NEXT_MAJOR: Replace by `$this->hasAccess`
             && $this->canAccessObject('edit', $object, 'sonata_deprecation_mute')
         ) {
@@ -2739,10 +2773,9 @@ EOT;
             ];
         }
 
-        if (\in_array($action, ['show', 'edit', 'acl'], true)
+        if ($canAccessObject
+            && self::MASK_OF_ACTION_HISTORY & $actionBit
             && $this->hasRoute('history')
-            && null !== $object
-            && null !== $this->id($object)
             // NEXT_MAJOR: Replace by `$this->hasAccess`
             && $this->canAccessObject('history', $object, 'sonata_deprecation_mute')
         ) {
@@ -2753,11 +2786,10 @@ EOT;
             ];
         }
 
-        if (\in_array($action, ['edit', 'history'], true)
+        if ($canAccessObject
+            && self::MASK_OF_ACTION_ACL & $actionBit
             && $this->isAclEnabled()
             && $this->hasRoute('acl')
-            && null !== $object
-            && null !== $this->id($object)
             // NEXT_MAJOR: Replace by `$this->hasAccess`
             && $this->canAccessObject('acl', $object, 'sonata_deprecation_mute')
         ) {
@@ -2768,10 +2800,9 @@ EOT;
             ];
         }
 
-        if (\in_array($action, ['edit', 'history', 'acl'], true)
+        if ($canAccessObject
+            && self::MASK_OF_ACTION_SHOW & $actionBit
             && $this->hasRoute('show')
-            && null !== $object
-            && null !== $this->id($object)
             // NEXT_MAJOR: Replace by `$this->hasAccess`
             && $this->canAccessObject('show', $object, 'sonata_deprecation_mute')
             && \count($this->getShow()) > 0
@@ -2783,7 +2814,7 @@ EOT;
             ];
         }
 
-        if (\in_array($action, ['show', 'edit', 'delete', 'acl', 'batch'], true)
+        if (self::MASK_OF_ACTION_LIST & $actionBit
             && $this->hasRoute('list')
             && $this->hasAccess('list')
         ) {

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -2172,7 +2172,7 @@ class AdminTest extends TestCase
         $admin->method('isAclEnabled')->willReturn(true);
         $admin->method('getExtensions')->willReturn([]);
 
-        $admin->expects($this->exactly(9))->method('hasRoute')->willReturn(false);
+        $admin->expects($this->exactly(4))->method('hasRoute')->willReturn(false);
         $admin->expects($this->never())->method('hasAccess');
         $admin->expects($this->never())->method('getShow');
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
Remove code duplication to improve performance.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed

- Optimize performance of checking is can access object in `AbstractAdmin::configureActionButtons()`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
