### PR TITLE
Remove Admin from Builder signature

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -173,3 +173,14 @@ They don't reset the existing templates anymore.
 
 ## BaseFieldDescription, FieldDescriptionCollection, FieldDescriptionInterface and FieldDescriptionRegistryInterface
 Moved from the `Sonata\AdminBundle\Admin` to the `Sonata\AdminBundle\FieldDescription` namespace.
+
+## BuilderInterface
+
+Remove `AdminInterface $admin` argument from
+- `BuilderInterface::fixFieldDescription()`
+- `DatagridBuilderInterface::addFilter()`
+- `ListBuilderInterface::buildField()`
+- `ListBuilderInterface::addField()`
+- `ShowBuilderInterface::addField()`
+
+Use `$fieldDescription->getAdmin()` to access to the admin value.

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2295,7 +2295,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
                     $filterParameters['_sort_by']
                 );
 
-                $this->getListBuilder()->buildField(null, $filterParameters['_sort_by'], $this);
+                $this->getListBuilder()->buildField(null, $filterParameters['_sort_by']);
             }
         }
 

--- a/src/Builder/BuilderInterface.php
+++ b/src/Builder/BuilderInterface.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Builder;
 
-use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 
 /**
@@ -24,8 +23,7 @@ interface BuilderInterface
     /**
      * Adds missing information to the given field description and the given admin.
      *
-     * @param AdminInterface<object>    $admin            will be used to gather information
      * @param FieldDescriptionInterface $fieldDescription will be modified
      */
-    public function fixFieldDescription(AdminInterface $admin, FieldDescriptionInterface $fieldDescription): void;
+    public function fixFieldDescription(FieldDescriptionInterface $fieldDescription): void;
 }

--- a/src/Builder/DatagridBuilderInterface.php
+++ b/src/Builder/DatagridBuilderInterface.php
@@ -22,14 +22,10 @@ use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
  */
 interface DatagridBuilderInterface extends BuilderInterface
 {
-    /**
-     * @param AdminInterface<object> $admin
-     */
     public function addFilter(
         DatagridInterface $datagrid,
         ?string $type,
-        FieldDescriptionInterface $fieldDescription,
-        AdminInterface $admin
+        FieldDescriptionInterface $fieldDescription
     ): void;
 
     /**

--- a/src/Builder/ListBuilderInterface.php
+++ b/src/Builder/ListBuilderInterface.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Builder;
 
-use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionCollection;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 
@@ -31,21 +30,17 @@ interface ListBuilderInterface extends BuilderInterface
 
     /**
      * Modify a field description to display it in the list view.
-     *
-     * @param AdminInterface<object> $admin
      */
-    public function buildField(?string $type, FieldDescriptionInterface $fieldDescription, AdminInterface $admin): void;
+    public function buildField(?string $type, FieldDescriptionInterface $fieldDescription): void;
 
     /**
      * Modify a field description and add it to the displayed columns.
      *
      * @param FieldDescriptionCollection<FieldDescriptionInterface> $list
-     * @param AdminInterface<object>                                $admin
      */
     public function addField(
         FieldDescriptionCollection $list,
         ?string $type,
-        FieldDescriptionInterface $fieldDescription,
-        AdminInterface $admin
+        FieldDescriptionInterface $fieldDescription
     ): void;
 }

--- a/src/Builder/ShowBuilderInterface.php
+++ b/src/Builder/ShowBuilderInterface.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Builder;
 
-use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionCollection;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 
@@ -31,12 +30,10 @@ interface ShowBuilderInterface extends BuilderInterface
 
     /**
      * @param FieldDescriptionCollection<FieldDescriptionInterface> $list
-     * @param AdminInterface<object>                                $admin
      */
     public function addField(
         FieldDescriptionCollection $list,
         ?string $type,
-        FieldDescriptionInterface $fieldDescription,
-        AdminInterface $admin
+        FieldDescriptionInterface $fieldDescription
     ): void;
 }

--- a/src/Datagrid/DatagridMapper.php
+++ b/src/Datagrid/DatagridMapper.php
@@ -86,7 +86,7 @@ final class DatagridMapper extends BaseMapper
 
         if (!isset($fieldDescriptionOptions['role']) || $this->admin->isGranted($fieldDescriptionOptions['role'])) {
             // add the field with the DatagridBuilder
-            $this->builder->addFilter($this->datagrid, $type, $fieldDescription, $this->admin);
+            $this->builder->addFilter($this->datagrid, $type, $fieldDescription);
         }
 
         return $this;

--- a/src/Datagrid/ListMapper.php
+++ b/src/Datagrid/ListMapper.php
@@ -138,7 +138,7 @@ final class ListMapper extends BaseMapper
 
         if (!isset($fieldDescriptionOptions['role']) || $this->admin->isGranted($fieldDescriptionOptions['role'])) {
             // add the field with the FormBuilder
-            $this->builder->addField($this->list, $type, $fieldDescription, $this->admin);
+            $this->builder->addField($this->list, $type, $fieldDescription);
 
             // Ensure batch and action pseudo-fields are tagged as virtual
             if (\in_array($fieldDescription->getType(), [self::TYPE_ACTIONS, self::TYPE_BATCH, self::TYPE_SELECT], true)) {

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -111,7 +111,7 @@ final class FormMapper extends BaseGroupedMapper
         );
 
         // Note that the builder var is actually the formContractor:
-        $this->builder->fixFieldDescription($this->admin, $fieldDescription);
+        $this->builder->fixFieldDescription($fieldDescription);
 
         if ($fieldName !== $name) {
             $fieldDescription->setName($fieldName);

--- a/src/Show/ShowMapper.php
+++ b/src/Show/ShowMapper.php
@@ -93,7 +93,7 @@ final class ShowMapper extends BaseGroupedMapper
 
         if (!isset($fieldDescriptionOptions['role']) || $this->admin->isGranted($fieldDescriptionOptions['role'])) {
             // add the field with the FormBuilder
-            $this->builder->addField($this->list, $type, $fieldDescription, $this->admin);
+            $this->builder->addField($this->list, $type, $fieldDescription);
         }
 
         return $this;

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1552,8 +1552,8 @@ class AdminTest extends TestCase
 
         $datagridBuilder->expects($this->exactly(3))
             ->method('addFilter')
-            ->willReturnCallback(static function ($datagrid, $type, $fieldDescription, AdminInterface $admin): void {
-                $admin->addFilterFieldDescription($fieldDescription->getName(), $fieldDescription);
+            ->willReturnCallback(static function ($datagrid, $type, $fieldDescription): void {
+                $fieldDescription->getAdmin()->addFilterFieldDescription($fieldDescription->getName(), $fieldDescription);
                 $fieldDescription->mergeOption('field_options', ['required' => false]);
             });
 

--- a/tests/App/Builder/DatagridBuilder.php
+++ b/tests/App/Builder/DatagridBuilder.php
@@ -49,11 +49,11 @@ final class DatagridBuilder implements DatagridBuilderInterface
         $this->proxyQuery = $proxyQuery;
     }
 
-    public function fixFieldDescription(AdminInterface $admin, FieldDescriptionInterface $fieldDescription): void
+    public function fixFieldDescription(FieldDescriptionInterface $fieldDescription): void
     {
     }
 
-    public function addFilter(DatagridInterface $datagrid, $type, FieldDescriptionInterface $fieldDescription, AdminInterface $admin): void
+    public function addFilter(DatagridInterface $datagrid, $type, FieldDescriptionInterface $fieldDescription): void
     {
     }
 

--- a/tests/App/Builder/FormContractor.php
+++ b/tests/App/Builder/FormContractor.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\App\Builder;
 
-use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Builder\FormContractorInterface;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
@@ -32,7 +31,7 @@ final class FormContractor implements FormContractorInterface
         $this->formFactory = $formFactory;
     }
 
-    public function fixFieldDescription(AdminInterface $admin, FieldDescriptionInterface $fieldDescription): void
+    public function fixFieldDescription(FieldDescriptionInterface $fieldDescription): void
     {
     }
 

--- a/tests/App/Builder/ListBuilder.php
+++ b/tests/App/Builder/ListBuilder.php
@@ -13,14 +13,13 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\App\Builder;
 
-use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Builder\ListBuilderInterface;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionCollection;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 
 final class ListBuilder implements ListBuilderInterface
 {
-    public function fixFieldDescription(AdminInterface $admin, FieldDescriptionInterface $fieldDescription): void
+    public function fixFieldDescription(FieldDescriptionInterface $fieldDescription): void
     {
     }
 
@@ -29,15 +28,14 @@ final class ListBuilder implements ListBuilderInterface
         return new FieldDescriptionCollection();
     }
 
-    public function buildField($type, FieldDescriptionInterface $fieldDescription, AdminInterface $admin): void
+    public function buildField($type, FieldDescriptionInterface $fieldDescription): void
     {
     }
 
-    public function addField(FieldDescriptionCollection $list, $type, FieldDescriptionInterface $fieldDescription, AdminInterface $admin): void
+    public function addField(FieldDescriptionCollection $list, $type, FieldDescriptionInterface $fieldDescription): void
     {
         $fieldDescription->setType($type);
-        $admin->addListFieldDescription($fieldDescription->getName(), $fieldDescription);
-        $fieldDescription->setAdmin($admin);
+        $fieldDescription->getAdmin()->addListFieldDescription($fieldDescription->getName(), $fieldDescription);
 
         $list->add($fieldDescription);
     }

--- a/tests/App/Builder/ShowBuilder.php
+++ b/tests/App/Builder/ShowBuilder.php
@@ -13,14 +13,13 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\App\Builder;
 
-use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Builder\ShowBuilderInterface;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionCollection;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 
 final class ShowBuilder implements ShowBuilderInterface
 {
-    public function fixFieldDescription(AdminInterface $admin, FieldDescriptionInterface $fieldDescription): void
+    public function fixFieldDescription(FieldDescriptionInterface $fieldDescription): void
     {
     }
 
@@ -29,10 +28,9 @@ final class ShowBuilder implements ShowBuilderInterface
         return new FieldDescriptionCollection();
     }
 
-    public function addField(FieldDescriptionCollection $list, $type, FieldDescriptionInterface $fieldDescription, AdminInterface $admin): void
+    public function addField(FieldDescriptionCollection $list, $type, FieldDescriptionInterface $fieldDescription): void
     {
         $fieldDescription->setType($type);
-        $fieldDescription->setAdmin($admin);
 
         $list->add($fieldDescription);
     }

--- a/tests/Datagrid/DatagridMapperTest.php
+++ b/tests/Datagrid/DatagridMapperTest.php
@@ -66,8 +66,7 @@ class DatagridMapperTest extends TestCase
             ->willReturnCallback(function (
                 Datagrid $datagrid,
                 ?string $type,
-                FieldDescriptionInterface $fieldDescription,
-                AdminInterface $admin
+                FieldDescriptionInterface $fieldDescription
             ): void {
                 $fieldDescription->setType($type);
 

--- a/tests/Show/ShowMapperTest.php
+++ b/tests/Show/ShowMapperTest.php
@@ -131,8 +131,7 @@ class ShowMapperTest extends TestCase
             ->willReturnCallback(static function (
                 FieldDescriptionCollection $list,
                 ?string $type,
-                FieldDescriptionInterface $fieldDescription,
-                AdminInterface $admin
+                FieldDescriptionInterface $fieldDescription
             ): void {
                 $list->add($fieldDescription);
             });
@@ -562,7 +561,7 @@ class ShowMapperTest extends TestCase
         $this->showBuilder = $this->getMockForAbstractClass(ShowBuilderInterface::class);
         $this->showBuilder
             ->method('addField')
-            ->willReturnCallback(static function (FieldDescriptionCollection $list, ?string $type, FieldDescriptionInterface $fieldDescription, AdminInterface $admin): void {
+            ->willReturnCallback(static function (FieldDescriptionCollection $list, ?string $type, FieldDescriptionInterface $fieldDescription): void {
                 $list->add($fieldDescription);
             });
         $this->fieldDescriptionCollection = new FieldDescriptionCollection();


### PR DESCRIPTION
Since the introduction of the fieldDescriptionFactory by @franmomu, the Admin is supposed to be set on the FieldDescription. So it does not make any sens to have both the field and the admin in the param of these methods.

Is there a BW way to do this ? @sonata-project/contributors ?