### PR TITLE
Set "SEARCH_LEAD" as condition for the first admin filter at `SearchHandler::search()`

### DIFF
--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -24,6 +24,8 @@ interface FilterInterface
 
     public const CONDITION_AND = 'AND';
 
+    public const CONDITION_SEARCH_LEAD = 'SEARCH_LEAD';
+
     /**
      * NEXT_MAJOR: Remove this method.
      *

--- a/src/Search/SearchHandler.php
+++ b/src/Search/SearchHandler.php
@@ -84,13 +84,20 @@ class SearchHandler
         $datagridValues = $datagrid->getValues();
 
         $found = false;
+        $isLeadingSearchFilter = true;
         foreach ($datagrid->getFilters() as $filter) {
             /** @var FilterInterface $filter */
             $formName = $filter->getFormName();
 
             if ($filter->getOption('global_search', false)) {
+                if (false !== $isLeadingSearchFilter) {
+                    $filter->setCondition(FilterInterface::CONDITION_SEARCH_LEAD);
+                    $isLeadingSearchFilter = false;
+                } else {
+                    $filter->setCondition(FilterInterface::CONDITION_OR);
+                }
+
                 $filter->setOption('case_sensitive', $this->caseSensitive);
-                $filter->setCondition(FilterInterface::CONDITION_OR);
                 $datagrid->setValue($formName, null, $term);
                 $found = true;
             } elseif (isset($datagridValues[$formName])) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Set "SEARCH_LEAD" as condition for the first admin filter at `SearchHandler::search()`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #5569.
Closes #3368.

This is a rework of #5589.
Requires sonata-project/SonataDoctrineORMAdminBundle#1358.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- `FilterInterface::CONDITION_SEARCH_LEAD` constant.

### Changed
- Filter condition set at `SearchHandler::search()`, using `FilterInterface::CONDITION_SEARCH_LEAD`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Check if we must declare a conflict with the model bundles.
-->
