### PR TITLE
Use constant for batch, select and actions fields

### DIFF
--- a/docs/cookbook/recipe_custom_action.rst
+++ b/docs/cookbook/recipe_custom_action.rst
@@ -171,7 +171,7 @@ Next we have to add the action in ``configureListFields`` specifying the templat
     protected function configureListFields(ListMapper $listMapper)
     {
         $listMapper
-            ->add('_action', null, [
+            ->add(ListMapper::NAME_ACTIONS, null, [
                 'actions' => [
 
                     // ...
@@ -208,7 +208,7 @@ The full ``CarAdmin.php`` example looks like this::
                 ->add('engine')
                 ->add('rescueEngine')
                 ->add('createdAt')
-                ->add('_action', null, [
+                ->add(ListMapper::NAME_ACTIONS, null, [
                     'actions' => [
                         'show' => [],
                         'edit' => [],

--- a/docs/cookbook/recipe_sortable_listing.rst
+++ b/docs/cookbook/recipe_sortable_listing.rst
@@ -73,7 +73,7 @@ In our ``ClientAdmin`` we are going to add a custom action in the ``configureLis
 and use the default twig template provided in the ``pixSortableBehaviorBundle``::
 
     $listMapper
-        ->add('_action', null, [
+        ->add(ListMapper::NAME_ACTIONS, null, [
             'actions' => [
                 'move' => [
                     'template' => '@PixSortableBehavior/Default/_sort.html.twig'
@@ -139,7 +139,7 @@ Now we need to define the sort by field to be ``$position``::
             $listMapper
                 ->addIdentifier('name')
                 ->add('enabled')
-                ->add('_action', null, [
+                ->add(ListMapper::NAME_ACTIONS, null, [
                     'actions' => [
                         'move' => [
                             'template' => '@App/Admin/_sort.html.twig'

--- a/docs/cookbook/recipe_virtual_field.rst
+++ b/docs/cookbook/recipe_virtual_field.rst
@@ -2,7 +2,7 @@ Virtual Field Descriptions
 ==========================
 
 Some fields including in the various Mappers don't rely on any actual field in
-the Model (e.g., ``_action`` or ``batch``).
+the Model (e.g., ``ListMapper::NAME_ACTIONS`` or ``ListMapper::NAME_BATCH``).
 
 In order to prevent any side-effects when trying to retrieve the value of this
 field (which doesn't exist), the option ``virtual_field`` is specified for these

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -3232,9 +3232,10 @@ EOT;
 
         if (\count($this->getBatchActions()) > 0 && $this->hasRequest() && !$this->getRequest()->isXmlHttpRequest()) {
             $fieldDescription = $this->createFieldDescription(
-                'batch',
+                ListMapper::NAME_BATCH,
                 [
                     'label' => 'batch',
+                    // NEXT_MAJOR: Remove this code.
                     'code' => '_batch',
                     'sortable' => false,
                     'virtual_field' => true,
@@ -3256,9 +3257,10 @@ EOT;
 
         if ($this->hasRequest() && $this->getRequest()->isXmlHttpRequest()) {
             $fieldDescription = $this->createFieldDescription(
-                'select',
+                ListMapper::NAME_SELECT,
                 [
                     'label' => false,
+                    // NEXT_MAJOR: Remove this code.
                     'code' => '_select',
                     'sortable' => false,
                     'virtual_field' => false,

--- a/src/Admin/FieldDescriptionCollection.php
+++ b/src/Admin/FieldDescriptionCollection.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Admin;
 
+use Sonata\AdminBundle\Datagrid\ListMapper;
+
 /**
  * @final since sonata-project/admin-bundle 3.52
  *
@@ -120,8 +122,8 @@ class FieldDescriptionCollection implements \ArrayAccess, \Countable
 
     public function reorder(array $keys)
     {
-        if ($this->has('batch')) {
-            array_unshift($keys, 'batch');
+        if ($this->has(ListMapper::NAME_BATCH)) {
+            array_unshift($keys, ListMapper::NAME_BATCH);
         }
 
         $this->elements = array_merge(array_flip($keys), $this->elements);

--- a/src/Datagrid/ListMapper.php
+++ b/src/Datagrid/ListMapper.php
@@ -28,6 +28,13 @@ use Sonata\AdminBundle\Mapper\BaseMapper;
  */
 class ListMapper extends BaseMapper
 {
+    // NEXT_MAJOR: Change for '_actions' and add an UPGRADE NOTE.
+    public const NAME_ACTIONS = '_action';
+    // NEXT_MAJOR: Change for '_batch' and add an UPGRADE NOTE.
+    public const NAME_BATCH = 'batch';
+    // NEXT_MAJOR: Change for '_select' and add an UPGRADE NOTE.
+    public const NAME_SELECT = 'select';
+
     public const TYPE_ACTIONS = 'actions';
     public const TYPE_BATCH = 'batch';
     public const TYPE_SELECT = 'select';
@@ -101,12 +108,12 @@ class ListMapper extends BaseMapper
         }
 
         // Type-guess the action field here because it is not a model property.
-        if ('_action' === $name && null === $type) {
+        if (self::NAME_ACTIONS === $name && null === $type) {
             $type = self::TYPE_ACTIONS;
         }
 
         // Change deprecated inline action "view" to "show"
-        if ('_action' === $name && self::TYPE_ACTIONS === $type) {
+        if (self::NAME_ACTIONS === $name && self::TYPE_ACTIONS === $type) {
             if (isset($fieldDescriptionOptions['actions']['view'])) {
                 @trigger_error(
                     'Inline action "view" is deprecated since version 2.2.4 and will be removed in 4.0. Use inline action "show" instead.',

--- a/src/Resources/skeleton/Admin.tpl.php
+++ b/src/Resources/skeleton/Admin.tpl.php
@@ -22,7 +22,7 @@ final class <?= $class_name ?> extends AbstractAdmin
     protected function configureListFields(ListMapper $listMapper): void
     {
         $listMapper
-<?= $fields ?>->add('_action', null, [
+<?= $fields ?>->add(ListMapper::NAME_ACTIONS, null, [
                 'actions' => [
                     'show' => [],
                     'edit' => [],

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -52,13 +52,13 @@ file that was distributed with this source code.
                             <thead>
                                 <tr class="sonata-ba-list-field-header">
                                     {% for field_description in admin.list.elements %}
-                                        {% if admin.hasRoute('batch') and field_description.getOption('code') == '_batch' and batchactions|length > 0 %}
+                                        {% if admin.hasRoute('batch') and field_description.name == constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_BATCH') and batchactions|length > 0 %}
                                             <th class="sonata-ba-list-field-header sonata-ba-list-field-header-batch">
                                               <input type="checkbox" id="list_batch_checkbox">
                                             </th>
-                                        {% elseif field_description.getOption('code') == '_select' %}
+                                        {% elseif field_description.name == constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_SELECT') %}
                                             <th class="sonata-ba-list-field-header sonata-ba-list-field-header-select"></th>
-                                        {% elseif field_description.name == '_action' and app.request.isXmlHttpRequest %}
+                                        {% elseif field_description.name == constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_ACTIONS') and app.request.isXmlHttpRequest %}
                                             {# Action buttons disabled in ajax view! #}
                                         {% elseif field_description.getOption('ajax_hidden') == true and app.request.isXmlHttpRequest %}
                                             {# Disable fields with 'ajax_hidden' option set to true #}

--- a/src/Resources/views/CRUD/base_list_flat_inner_row.html.twig
+++ b/src/Resources/views/CRUD/base_list_flat_inner_row.html.twig
@@ -9,18 +9,20 @@ file that was distributed with this source code.
 
 #}
 
-{% if admin.list.has('batch') and not app.request.isXmlHttpRequest %}
+{% if admin.list.has(constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_BATCH')) and not app.request.isXmlHttpRequest %}
     <td class="sonata-ba-list-field sonata-ba-list-field-batch">
-        {{ object|render_list_element(admin.list['batch']) }}
+        {{ object|render_list_element(admin.list[constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_BATCH')]) }}
     </td>
 {% endif %}
 
-<td class="sonata-ba-list-field sonata-ba-list-field-inline-fields" colspan="{{ admin.list.elements|length - (admin.list.has('_action') + admin.list.has('batch')) }}" objectId="{{ admin.id(object) }}">
+<td class="sonata-ba-list-field sonata-ba-list-field-inline-fields"
+    colspan="{{ admin.list.elements|length - (admin.list.has(constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_ACTIONS')) + admin.list.has(constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_BATCH'))) }}"
+    objectId="{{ admin.id(object) }}">
     {% block row %}{% endblock %}
 </td>
 
-{% if admin.list.has('_action') and not app.request.isXmlHttpRequest %}
+{% if admin.list.has(constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_ACTIONS')) and not app.request.isXmlHttpRequest %}
     <td class="sonata-ba-list-field sonata-ba-list-field-_action" objectId="{{ admin.id(object) }}">
-        {{ object|render_list_element(admin.list['_action']) }}
+        {{ object|render_list_element(admin.list[constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_ACTIONS')]) }}
     </td>
 {% endif %}

--- a/src/Resources/views/CRUD/base_list_inner_row.html.twig
+++ b/src/Resources/views/CRUD/base_list_inner_row.html.twig
@@ -10,7 +10,7 @@ file that was distributed with this source code.
 #}
 
 {% for field_description in admin.list.elements %}
-    {% if field_description.name == '_action' and app.request.isXmlHttpRequest %}
+    {% if field_description.name == constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_ACTIONS') and app.request.isXmlHttpRequest %}
         {# Action buttons disabled in ajax view! #}
     {% elseif field_description.getOption('ajax_hidden') == true and app.request.isXmlHttpRequest %}
         {# Disable fields with 'ajax_hidden' option set to true #}

--- a/src/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
+++ b/src/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
@@ -17,7 +17,7 @@ This template can be customized to match your needs. You should only extends the
 -->
 
 <tr>
-    <td colspan="{{ admin.list.elements|length - (app.request.isXmlHttpRequest ? (admin.list.has('_action') + admin.list.has('batch')) : 0) }}">
+    <td colspan="{{ admin.list.elements|length - (app.request.isXmlHttpRequest ? (admin.list.has(constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_ACTIONS')) + admin.list.has(constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_BATCH'))) : 0) }}">
         <div class="row">
             {% for object in admin.datagrid.results %}
                 {% set meta = admin.getObjectMetadata(object) %}

--- a/tests/Admin/FieldDescriptionCollectionTest.php
+++ b/tests/Admin/FieldDescriptionCollectionTest.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Tests\Admin;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
 use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Sonata\AdminBundle\Datagrid\ListMapper;
 
 class FieldDescriptionCollectionTest extends TestCase
 {
@@ -102,12 +103,12 @@ class FieldDescriptionCollectionTest extends TestCase
         $collection->add($fieldDescription);
 
         $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
-        $fieldDescription->expects($this->once())->method('getName')->willReturn('batch');
+        $fieldDescription->expects($this->once())->method('getName')->willReturn(ListMapper::NAME_BATCH);
         $collection->add($fieldDescription);
 
         $newOrder = ['position', 'title'];
         $collection->reorder($newOrder);
-        array_unshift($newOrder, 'batch');
+        array_unshift($newOrder, ListMapper::NAME_BATCH);
 
         $actualElements = array_keys($collection->getElements());
         $this->assertSame($newOrder, $actualElements, 'the order is wrong');

--- a/tests/Datagrid/ListMapperTest.php
+++ b/tests/Datagrid/ListMapperTest.php
@@ -207,30 +207,30 @@ class ListMapperTest extends TestCase
      */
     public function testLegacyAddViewInlineAction(): void
     {
-        $this->assertFalse($this->listMapper->has('_action'));
-        $this->listMapper->add('_action', 'actions', ['actions' => ['view' => []]]);
+        $this->assertFalse($this->listMapper->has(ListMapper::NAME_ACTIONS));
+        $this->listMapper->add(ListMapper::NAME_ACTIONS, ListMapper::TYPE_ACTIONS, ['actions' => ['view' => []]]);
 
-        $this->assertTrue($this->listMapper->has('_action'));
+        $this->assertTrue($this->listMapper->has(ListMapper::NAME_ACTIONS));
 
-        $fieldDescription = $this->listMapper->get('_action');
+        $fieldDescription = $this->listMapper->get(ListMapper::NAME_ACTIONS);
 
         $this->assertInstanceOf(FieldDescriptionInterface::class, $fieldDescription);
-        $this->assertSame('_action', $fieldDescription->getName());
+        $this->assertSame(ListMapper::NAME_ACTIONS, $fieldDescription->getName());
         $this->assertCount(1, $fieldDescription->getOption('actions'));
         $this->assertSame(['show' => []], $fieldDescription->getOption('actions'));
     }
 
     public function testAddViewInlineAction(): void
     {
-        $this->assertFalse($this->listMapper->has('_action'));
-        $this->listMapper->add('_action', 'actions', ['actions' => ['show' => []]]);
+        $this->assertFalse($this->listMapper->has(ListMapper::NAME_ACTIONS));
+        $this->listMapper->add(ListMapper::NAME_ACTIONS, ListMapper::TYPE_ACTIONS, ['actions' => ['show' => []]]);
 
-        $this->assertTrue($this->listMapper->has('_action'));
+        $this->assertTrue($this->listMapper->has(ListMapper::NAME_ACTIONS));
 
-        $fieldDescription = $this->listMapper->get('_action');
+        $fieldDescription = $this->listMapper->get(ListMapper::NAME_ACTIONS);
 
         $this->assertInstanceOf(FieldDescriptionInterface::class, $fieldDescription);
-        $this->assertSame('_action', $fieldDescription->getName());
+        $this->assertSame(ListMapper::NAME_ACTIONS, $fieldDescription->getName());
         $this->assertCount(1, $fieldDescription->getOption('actions'));
         $this->assertSame(['show' => []], $fieldDescription->getOption('actions'));
     }
@@ -422,9 +422,9 @@ class ListMapperTest extends TestCase
 
     public function testTypeGuessActionField(): void
     {
-        $this->listMapper->add('_action', null);
+        $this->listMapper->add(ListMapper::NAME_ACTIONS);
 
-        $field = $this->fieldDescriptionCollection->get('_action');
+        $field = $this->fieldDescriptionCollection->get(ListMapper::NAME_ACTIONS);
 
         $this->assertTrue(
             $field->isVirtual(),

--- a/tests/Fixtures/Admin/ModelAdmin.php
+++ b/tests/Fixtures/Admin/ModelAdmin.php
@@ -36,7 +36,7 @@ final class ModelAdmin extends AbstractAdmin
             ->add('foo')
             ->add('bar')
             ->add('baz')
-            ->add('_action', null, [
+            ->add(ListMapper::NAME_ACTIONS, null, [
                 'actions' => [
                     'show' => [],
                     'edit' => [],


### PR DESCRIPTION
## Subject

BC

As you can see, we're using `_actions` for the name of actions, but `batch` and `select` for the others.
It could create a conflict if someone want to display an entity which has a `select` field.
So I recommend to prefix by `_` in Next major.

## Changelog

```markdown
### Added
- Added constant `ListMapper::NAME_ACTIONS`
- Added constant `ListMapper::NAME_SELECT`
- Added constant `ListMapper::NAME_BATCH`

### Deprecated
- Relying on the code `_select` or `_batch` to determine if a field description is a `select` or a `batch` one. You should rely on the name `ListMapper::NAME_SELECT` or `ListMapper::NAME_BATCH` instead.
```