### PR TITLE
Rename configureDashboardButtons

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2853,12 +2853,38 @@ EOT;
             ];
         }
 
-        $actions = $this->configureDashboardButtons($actions);
+        $actions = $this->configureDashboardActions($actions);
+
+        // NEXT_MAJOR: Remove this code.
+        $newActions = $this->configureDashboardButtons($actions);
+        if ($newActions !== $actions) {
+            @trigger_error(sprintf(
+                'The "%s::configureDashboardButtons()" method is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will not be used in version 4.0. Use "configureDashboardActions()" instead.',
+                __CLASS__
+            ), \E_USER_DEPRECATED);
+
+            $actions = $newActions;
+        }
 
         foreach ($this->getExtensions() as $extension) {
             // NEXT_MAJOR: remove method check
+            if (method_exists($extension, 'configureDashboardActions')) {
+                $actions = $extension->configureDashboardActions($this, $actions);
+            }
+            // NEXT_MAJOR: remove this code.
             if (method_exists($extension, 'configureDashboardButtons')) {
-                $actions = $extension->configureDashboardButtons($this, $actions);
+                $newActions = $extension->configureDashboardButtons($this, $actions);
+
+                if ($newActions !== $actions) {
+                    @trigger_error(
+                        'configureDashboardButtons() is deprecated since sonata-project/admin-bundle 3.x'
+                        .' and will not be used in version 4.0. Use configureDashboardActions() instead.',
+                        \E_USER_DEPRECATED
+                    );
+
+                    $actions = $newActions;
+                }
             }
         }
 
@@ -3143,6 +3169,18 @@ EOT;
     }
 
     /**
+     * @param array<string, array<string, mixed>> $actions
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    protected function configureDashboardActions(array $actions): array
+    {
+        return $actions;
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @param array<string, array<string, mixed>> $actions
      *
      * @return array<string, array<string, mixed>>

--- a/src/Admin/AbstractAdminExtension.php
+++ b/src/Admin/AbstractAdminExtension.php
@@ -171,6 +171,20 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
      *
      * @phpstan-param AdminInterface<T> $admin
      */
+    public function configureDashboardActions(AdminInterface $admin, array $actions): array
+    {
+        return $actions;
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @param array<string, array<string, mixed>> $actions
+     *
+     * @return array<string, array<string, mixed>>
+     *
+     * @phpstan-param AdminInterface<T> $admin
+     */
     public function configureDashboardButtons(AdminInterface $admin, array $actions): array
     {
         return $actions;

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -29,7 +29,7 @@ use Sonata\Form\Validator\ErrorElement;
  * @method array configureBatchActions(AdminInterface $admin, array $actions)
  * @method array configureExportFields(AdminInterface $admin, array $fields)
  * @method array configureActionButtons(AdminInterface $admin, array $list, string $action, object $object)
- * @method array configureDashboardButtons(AdminInterface $admin, array $actions)
+ * @method array configureDashboardActions(AdminInterface $admin, array $actions)
  * @method void  configureDefaultFilterValues(AdminInterface $admin, array &$filterValues)
  * @method void  configureDefaultSortValues(AdminInterface $admin, array &$sortValues)
  * @method void  configureFormOptions(AdminInterface $admin, array &$formOptions)
@@ -277,7 +277,7 @@ interface AdminExtensionInterface
      * @phpstan-param AdminInterface<T> $admin
      */
     // NEXT_MAJOR: Uncomment this method
-    // public function configureDashboardButtons(AdminInterface $admin, array $actions): array;
+    // public function configureDashboardActions(AdminInterface $admin, array $actions): array;
 
     /*
      * NEXT_MAJOR: Uncomment this method


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

BC, to keep consistency with the name `getDashboardActions`.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- `AbstractAdmin::configureDashboardActions()`
- `AdminExtension::configureDashboardActions()`
- `AdminExtensionInterface::configureDashboardActions()`

### Deprecated
- `AbstractAdmin::configureDashboardButtons()`
- `AdminExtension::configureDashboardButtons()`
- `AdminExtensionInterface::configureDashboardButtons()`
```