### PR TITLE
Add AbstractFormContractor and field description methods

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -15,5 +15,11 @@
                 <file name="src/Admin/FieldDescriptionRegistryInterface.php"/>
             </errorLevel>
         </UnrecognizedStatement>
+        <UndefinedClass>
+            <errorLevel type="suppress">
+                <!-- NEXT_MAJOR: Remove next line -->
+                <referencedClass name="Sonata\CoreBundle\Form\Type\CollectionType"/>
+            </errorLevel>
+        </UndefinedClass>
     </issueHandlers>
 </psalm>

--- a/src/Admin/BaseFieldDescription.php
+++ b/src/Admin/BaseFieldDescription.php
@@ -38,4 +38,10 @@ if (false) {
     abstract class BaseFieldDescription extends \Sonata\AdminBundle\FieldDescription\BaseFieldDescription
     {
     }
+
+    // NEXT_MAJOR: Uncomment this code:
+//    final public function describesAssociation(): bool
+//    {
+//        return $this->describesSingleValuedAssociation() || $this->describesCollectionValuedAssociation();
+//    }
 }

--- a/src/Builder/AbstractFormContractor.php
+++ b/src/Builder/AbstractFormContractor.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Builder;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
+use Sonata\AdminBundle\Form\Type\AdminType;
+use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
+use Sonata\AdminBundle\Form\Type\ModelHiddenType;
+use Sonata\AdminBundle\Form\Type\ModelListType;
+use Sonata\AdminBundle\Form\Type\ModelReferenceType;
+use Sonata\AdminBundle\Form\Type\ModelType;
+use Sonata\AdminBundle\Form\Type\ModelTypeList;
+use Sonata\Form\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormFactoryInterface;
+
+abstract class AbstractFormContractor implements FormContractorInterface
+{
+    /**
+     * @var FormFactoryInterface
+     */
+    protected $formFactory;
+
+    public function __construct(FormFactoryInterface $formFactory)
+    {
+        $this->formFactory = $formFactory;
+    }
+
+    public function fixFieldDescription(AdminInterface $admin, FieldDescriptionInterface $fieldDescription)
+    {
+        $fieldDescription->setOption('edit', $fieldDescription->getOption('edit', 'standard'));
+
+        // NEXT_MAJOR: Change "$this->hasAssociation($fieldDescription)" with: "$fieldDescription->describesAssociation()".
+        if ($this->hasAssociation($fieldDescription) || $fieldDescription->getOption('admin_code')) {
+            $admin->attachAdminClass($fieldDescription);
+        }
+    }
+
+    /**
+     * @return FormFactoryInterface
+     */
+    public function getFormFactory()
+    {
+        return $this->formFactory;
+    }
+
+    public function getFormBuilder($name, array $formOptions = [])
+    {
+        return $this->getFormFactory()->createNamedBuilder($name, FormType::class, null, $formOptions);
+    }
+
+    public function getDefaultOptions($type, FieldDescriptionInterface $fieldDescription)
+    {
+        // NEXT_MAJOR: Remove this line and update the function signature.
+        $formOptions = \func_get_args()[2] ?? [];
+
+        $options = [];
+        $options['sonata_field_description'] = $fieldDescription;
+
+        if ($this->isAnyInstanceOf($type, [
+            ModelType::class,
+            ModelTypeList::class,
+            ModelListType::class,
+            ModelHiddenType::class,
+            ModelAutocompleteType::class,
+            ModelReferenceType::class,
+        ])) {
+            // NEXT_MAJOR: Remove this check.
+            if ('list' === $fieldDescription->getOption('edit')) {
+                throw new \LogicException(sprintf(
+                    'The `%s` type does not accept an `edit` option anymore,'
+                    .' please review the `UPGRADE-2.1.md` file at "sonata-project/admin-bundle".',
+                    ModelType::class
+                ));
+            }
+
+            $options['class'] = $fieldDescription->getTargetModel();
+            $options['model_manager'] = $fieldDescription->getAdmin()->getModelManager();
+
+            if ($this->isAnyInstanceOf($type, [ModelAutocompleteType::class])) {
+                if (!$fieldDescription->getAssociationAdmin()) {
+                    // NEXT_MAJOR: Use \InvalidArgumentException instead.
+                    throw new \RuntimeException(sprintf(
+                        'The current field `%s` is not linked to an admin.'
+                        .' Please create one for the target model: `%s`.',
+                        $fieldDescription->getName(),
+                        $fieldDescription->getTargetModel()
+                    ));
+                }
+            }
+        } elseif ($this->isAnyInstanceOf($type, [AdminType::class])) {
+            if (!$fieldDescription->getAssociationAdmin()) {
+                // NEXT_MAJOR: Use \InvalidArgumentException instead.
+                throw new \RuntimeException(sprintf(
+                    'The current field `%s` is not linked to an admin.'
+                    .' Please create one for the target model: `%s`.',
+                    $fieldDescription->getName(),
+                    $fieldDescription->getTargetModel()
+                ));
+            }
+
+            // NEXT_MAJOR: Change this check with: "if (!$fieldDescription->hasSingleValueAssociation())".
+            if (!$this->hasSingleValueAssociation($fieldDescription)) {
+                // NEXT_MAJOR: Use \InvalidArgumentException instead.
+                throw new \RuntimeException(sprintf(
+                    'You are trying to add `%s` field `%s` which is not a One-To-One or Many-To-One association.'
+                    .' You SHOULD use `%s` instead.',
+                    AdminType::class,
+                    $fieldDescription->getName(),
+                    CollectionType::class
+                ));
+            }
+
+            // set sensitive default value to have a component working fine out of the box
+            $options['btn_add'] = false;
+            $options['delete'] = false;
+
+            $options['data_class'] = $fieldDescription->getAssociationAdmin()->getClass();
+            // Add "object" return type
+            $options['empty_data'] = static function () use ($fieldDescription) {
+                return $fieldDescription->getAssociationAdmin()->getNewInstance();
+            };
+            $fieldDescription->setOption('edit', $fieldDescription->getOption('edit', 'admin'));
+        // @phpstan-ignore-next-line
+        } elseif ($this->isAnyInstanceOf($type, [
+            CollectionType::class,
+            // NEXT_MAJOR: remove 'Sonata\CoreBundle\Form\Type\CollectionType'
+            'Sonata\CoreBundle\Form\Type\CollectionType',
+        ])) {
+            if (!$fieldDescription->getAssociationAdmin()) {
+                // NEXT_MAJOR: Use \InvalidArgumentException instead.
+                throw new \RuntimeException(sprintf(
+                    'The current field `%s` is not linked to an admin.'
+                    .' Please create one for the target model: `%s`.',
+                    $fieldDescription->getName(),
+                    $fieldDescription->getTargetModel()
+                ));
+            }
+
+            $options['type'] = AdminType::class;
+            $options['modifiable'] = true;
+            $options['type_options'] = $this->getDefaultAdminTypeOptions($fieldDescription, $formOptions);
+        }
+
+        return $options;
+    }
+
+    // NEXT_MAJOR: Remove this method.
+    abstract protected function hasAssociation(FieldDescriptionInterface $fieldDescription): bool;
+
+    // NEXT_MAJOR: Remove this method.
+    abstract protected function hasSingleValueAssociation(FieldDescriptionInterface $fieldDescription): bool;
+
+    /**
+     * @param string[] $classes
+     *
+     * @phpstan-param class-string[] $classes
+     */
+    private function isAnyInstanceOf(?string $type, array $classes): bool
+    {
+        if (null === $type) {
+            return false;
+        }
+
+        foreach ($classes as $class) {
+            if (is_a($type, $class, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function getDefaultAdminTypeOptions(FieldDescriptionInterface $fieldDescription, array $formOptions): array
+    {
+        $typeOptions = [
+            'sonata_field_description' => $fieldDescription,
+            'data_class' => $fieldDescription->getAssociationAdmin()->getClass(),
+            // Add "object" return type
+            'empty_data' => static function () use ($fieldDescription) {
+                return $fieldDescription->getAssociationAdmin()->getNewInstance();
+            },
+        ];
+
+        if (isset($formOptions['by_reference'])) {
+            $typeOptions['collection_by_reference'] = $formOptions['by_reference'];
+        }
+
+        return $typeOptions;
+    }
+}

--- a/src/FieldDescription/FieldDescriptionInterface.php
+++ b/src/FieldDescription/FieldDescriptionInterface.php
@@ -59,6 +59,9 @@ use Symfony\Component\PropertyAccess\PropertyPathInterface;
  * @method bool        hasAdmin()
  * @method bool        hasParent()
  * @method bool        hasAssociationAdmin()
+ * @method bool        describesAssociation()
+ * @method bool        describesSingleValuedAssociation()
+ * @method bool        describesCollectionValuedAssociation()
  */
 interface FieldDescriptionInterface
 {
@@ -282,6 +285,24 @@ interface FieldDescriptionInterface
 
     // NEXT_MAJOR: Uncomment the following line
     // public function hasAssociationAdmin(): bool;
+
+    // NEXT_MAJOR: Uncomment the following line
+    // /**
+    //  * Returns whether this object describes an association between two related models.
+    //  */
+    // public function describesAssociation(): bool;
+
+    // NEXT_MAJOR: Uncomment the following line
+    // /**
+    //  * Returns whether this object describes a single-valued (N..1) association.
+    //  */
+    // public function describesSingleValuedAssociation(): bool;
+
+    // NEXT_MAJOR: Uncomment the following line
+    // /**
+    //  * Returns whether this object describes a collection-valued (N..*) association.
+    //  */
+    // public function describesCollectionValuedAssociation(): bool;
 
     /**
      * Returns true if the FieldDescription is linked to an identifier field.

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -587,3 +587,100 @@ file that was distributed with this source code.
         });
     </script>
 {% endblock %}
+
+{% block sonata_type_model_list_widget %}
+    <div id="field_container_{{ id }}" class="field-container">
+        <span id="field_widget_{{ id }}" class="field-short-description">
+            {% if sonata_admin.value and sonata_admin.field_description.associationadmin.id(sonata_admin.value) is not null %}
+                {{ render(path('sonata_admin_short_object_information', {
+                    'code': sonata_admin.field_description.associationadmin.code,
+                    'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
+                    'uniqid': sonata_admin.field_description.associationadmin.uniqid,
+                    'linkParameters': sonata_admin.field_description.options.link_parameters
+                })) }}
+            {% elseif sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
+                <span class="inner-field-short-description">
+                    {{ sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') }}
+                </span>
+            {% endif %}
+        </span>
+        <span id="field_actions_{{ id }}" class="field-actions">
+            <span class="btn-group">
+                {% if sonata_admin.field_description.associationadmin.hasroute('list') and sonata_admin.field_description.associationadmin.hasAccess('list') and btn_list %}
+                    <a href="{{ sonata_admin.field_description.associationadmin.generateUrl('list') }}"
+                       onclick="return start_field_dialog_form_list_{{ id }}(this);"
+                       class="btn btn-info btn-sm sonata-ba-action"
+                       title="{{ btn_list|trans({}, btn_catalogue) }}"
+                    >
+                        <i class="fa fa-list"></i>
+                        {{ btn_list|trans({}, btn_catalogue) }}
+                    </a>
+                {% endif %}
+
+                {% if sonata_admin.field_description.associationadmin.hasroute('create')
+                    and sonata_admin.field_description.associationadmin.hasAccess('create')
+                    and btn_add
+                %}
+                    <a href="{{ sonata_admin.field_description.associationadmin.generateUrl('create') }}"
+                       onclick="return start_field_dialog_form_add_{{ id }}(this);"
+                       class="btn btn-success btn-sm sonata-ba-action"
+                       title="{{ btn_add|trans({}, btn_catalogue) }}"
+                    >
+                        <i class="fa fa-plus-circle"></i>
+                        {{ btn_add|trans({}, btn_catalogue) }}
+                    </a>
+                {% endif %}
+                {% if sonata_admin.field_description.associationadmin.hasroute('edit')
+                    and sonata_admin.field_description.associationadmin.hasAccess('edit')
+                    and btn_edit
+                %}
+                    <a href="{{ sonata_admin.value == null ? '' : sonata_admin.field_description.associationadmin.generateUrl('edit', {
+                        'id' : sonata_admin.field_description.associationadmin.normalizedIdentifier(sonata_admin.value)})
+                    }}"
+                       onclick="return start_field_dialog_form_edit_{{ id }}(this);"
+                       class="btn btn-warning btn-sm sonata-ba-action {% if sonata_admin.value == null %}hidden{% endif %}"
+                       title="{{ btn_edit|trans({}, btn_catalogue) }}"
+                    >
+                        <i class="fa fa-pencil"></i>
+                        {{ btn_edit|trans({}, btn_catalogue) }}
+                    </a>
+                {% endif %}
+            </span>
+
+            <span class="btn-group">
+                {% if btn_delete %}
+                    <button
+                        onclick="return remove_selected_element_{{ id }}(this);"
+                        class="btn btn-danger btn-sm sonata-ba-action"
+                        title="{{ btn_delete|trans({}, btn_catalogue) }}"
+                    >
+                        <i class="fa fa-minus-circle"></i>
+                        {{ btn_delete|trans({}, btn_catalogue) }}
+                    </button>
+                {% endif %}
+            </span>
+        </span>
+
+        <span style="display: none" >
+            {# Hidden text input cannot be required, because browser will throw error "An invalid form control with name='' is not focusable"  #}
+            {{ form_widget(form, {'required':false}) }}
+        </span>
+
+        {{ block('sonata_help') }}
+
+        <div class="modal fade" id="field_dialog_{{ id }}" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+            <div class="modal-dialog modal-lg">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                        <h4 class="modal-title"></h4>
+                    </div>
+                    <div class="modal-body">
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {% include '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
+{% endblock %}

--- a/tests/App/Admin/FieldDescription.php
+++ b/tests/App/Admin/FieldDescription.php
@@ -48,4 +48,19 @@ final class FieldDescription extends BaseFieldDescription
     {
         return $this->getFieldValue($object, $this->fieldName);
     }
+
+    public function describesAssociation(): bool
+    {
+        return $this->describesSingleValuedAssociation() || $this->describesCollectionValuedAssociation();
+    }
+
+    public function describesSingleValuedAssociation(): bool
+    {
+        return false;
+    }
+
+    public function describesCollectionValuedAssociation(): bool
+    {
+        return false;
+    }
 }

--- a/tests/App/Builder/FormContractor.php
+++ b/tests/App/Builder/FormContractor.php
@@ -13,36 +13,18 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\App\Builder;
 
-use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Builder\FormContractorInterface;
+use Sonata\AdminBundle\Builder\AbstractFormContractor;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
-use Symfony\Component\Form\Extension\Core\Type\FormType;
-use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\FormFactoryInterface;
 
-final class FormContractor implements FormContractorInterface
+final class FormContractor extends AbstractFormContractor
 {
-    /**
-     * @var FormFactoryInterface
-     */
-    private $formFactory;
-
-    public function __construct(FormFactoryInterface $formFactory)
+    protected function hasAssociation(FieldDescriptionInterface $fieldDescription): bool
     {
-        $this->formFactory = $formFactory;
+        return false;
     }
 
-    public function fixFieldDescription(AdminInterface $admin, FieldDescriptionInterface $fieldDescription): void
+    protected function hasSingleValueAssociation(FieldDescriptionInterface $fieldDescription): bool
     {
-    }
-
-    public function getFormBuilder($name, array $options = []): FormBuilderInterface
-    {
-        return $this->formFactory->createNamedBuilder($name, FormType::class, null, $options);
-    }
-
-    public function getDefaultOptions($type, FieldDescriptionInterface $fieldDescription): array
-    {
-        return [];
+        return false;
     }
 }

--- a/tests/Builder/AbstractFormContractorTest.php
+++ b/tests/Builder/AbstractFormContractorTest.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Builder;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Builder\AbstractFormContractor;
+use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
+use Sonata\AdminBundle\Form\Type\AdminType;
+use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
+use Sonata\AdminBundle\Form\Type\ModelHiddenType;
+use Sonata\AdminBundle\Form\Type\ModelListType;
+use Sonata\AdminBundle\Form\Type\ModelType;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
+use Sonata\Form\Type\CollectionType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormFactoryInterface;
+
+final class AbstractFormContractorTest extends TestCase
+{
+    /**
+     * @var FormFactoryInterface&MockObject
+     */
+    private $formFactory;
+
+    /**
+     * @var \Sonata\DoctrineMongoDBAdminBundle\Builder\FormContractor
+     */
+    private $formContractor;
+
+    /**
+     * @var MockObject&FieldDescriptionInterface
+     */
+    private $fieldDescription;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // NEXT_MAJOR: Mock `FieldDescriptionInterface` instead and replace `getTargetEntity()` with `getTargetModel().
+        $this->fieldDescription = $this->getMockBuilder(FieldDescriptionInterface::class)
+            ->addMethods(['getTargetModel', 'describesAssociation', 'describesSingleValuedAssociation'])
+            ->getMockForAbstractClass();
+
+        $this->formFactory = $this->createMock(FormFactoryInterface::class);
+
+        $this->formContractor = new class($this->formFactory) extends AbstractFormContractor {
+            protected function hasAssociation(FieldDescriptionInterface $fieldDescription): bool
+            {
+                return $fieldDescription->describesAssociation();
+            }
+
+            protected function hasSingleValueAssociation(FieldDescriptionInterface $fieldDescription): bool
+            {
+                return $fieldDescription->describesSingleValuedAssociation();
+            }
+        };
+    }
+
+    public function testGetFormBuilder(): void
+    {
+        $this->formFactory->expects($this->once())->method('createNamedBuilder')
+            ->willReturn($this->createMock(FormBuilderInterface::class));
+
+        $this->assertInstanceOf(
+            FormBuilderInterface::class,
+            $this->formContractor->getFormBuilder('test', ['foo' => 'bar'])
+        );
+    }
+
+    public function testDefaultOptionsForSonataFormTypes(): void
+    {
+        $admin = $this->createMock(AdminInterface::class);
+        $modelClass = 'FooModel';
+
+        $modelManager = $this->createStub(ModelManagerInterface::class);
+        $admin->method('getModelManager')->willReturn($modelManager);
+        $admin->method('getClass')->willReturn($modelClass);
+
+        $this->fieldDescription->method('getAdmin')->willReturn($admin);
+        $this->fieldDescription->method('getTargetModel')->willReturn($modelClass);
+        $this->fieldDescription->method('getAssociationAdmin')->willReturn($admin);
+
+        $modelTypes = [
+            ModelType::class,
+            ModelListType::class,
+            ModelHiddenType::class,
+            ModelAutocompleteType::class,
+        ];
+        $adminTypes = [
+            AdminType::class,
+        ];
+        $collectionTypes = [
+            CollectionType::class,
+        ];
+
+        // model types
+        foreach ($modelTypes as $formType) {
+            $options = $this->formContractor->getDefaultOptions($formType, $this->fieldDescription);
+            $this->assertSame($this->fieldDescription, $options['sonata_field_description']);
+            $this->assertSame($modelClass, $options['class']);
+            $this->assertSame($modelManager, $options['model_manager']);
+        }
+
+        // admin type
+        $this->fieldDescription
+            ->method('describesSingleValuedAssociation')
+            ->willReturn(true);
+        foreach ($adminTypes as $formType) {
+            $options = $this->formContractor->getDefaultOptions($formType, $this->fieldDescription);
+            $this->assertSame($this->fieldDescription, $options['sonata_field_description']);
+            $this->assertSame($modelClass, $options['data_class']);
+            $this->assertFalse($options['btn_add']);
+            $this->assertFalse($options['delete']);
+        }
+
+        // collection type
+        foreach ($collectionTypes as $index => $formType) {
+            $options = $this->formContractor->getDefaultOptions($formType, $this->fieldDescription, [
+                'by_reference' => false,
+            ]);
+            $this->assertSame($this->fieldDescription, $options['sonata_field_description']);
+            $this->assertSame(AdminType::class, $options['type']);
+            $this->assertTrue($options['modifiable']);
+            $this->assertSame($this->fieldDescription, $options['type_options']['sonata_field_description']);
+            $this->assertSame($modelClass, $options['type_options']['data_class']);
+            $this->assertFalse($options['type_options']['collection_by_reference']);
+        }
+    }
+
+    public function testAdminClassAttachForFieldDescriptionWithAssociation(): void
+    {
+        $admin = $this->createMock(AdminInterface::class);
+
+        $this->fieldDescription
+            ->method('describesAssociation')
+            ->willReturn(true);
+
+        // Then
+        $admin
+            ->expects($this->once())
+            ->method('attachAdminClass')
+            ->with($this->fieldDescription)
+        ;
+
+        // When
+        $this->formContractor->fixFieldDescription($admin, $this->fieldDescription);
+    }
+
+    public function testAdminClassAttachForNotMappedField(): void
+    {
+        $admin = $this->createMock(AdminInterface::class);
+
+        $this->fieldDescription
+            ->method('describesAssociation')
+            ->willReturn(false);
+        $this->fieldDescription->method('getOption')->with($this->logicalOr(
+            $this->equalTo('edit'),
+            $this->equalTo('admin_code')
+        ))->willReturn('sonata.admin.code');
+
+        // Then
+        $admin
+            ->expects($this->once())
+            ->method('attachAdminClass')
+            ->with($this->fieldDescription)
+        ;
+
+        // When
+        $this->formContractor->fixFieldDescription($admin, $this->fieldDescription);
+    }
+
+    /**
+     * @dataProvider getFieldDescriptionValidationProvider
+     */
+    public function testThrowsExceptionWithInvalidFieldDescriptionInGetDefaultOptions(string $formType): void
+    {
+        $admin = $this->createStub(AdminInterface::class);
+        $admin->method('getClass')->willReturn('Foo');
+
+        $this->fieldDescription->method('getAdmin')->willReturn($admin);
+        $this->fieldDescription->method('getAssociationAdmin')->willReturn(null);
+        $this->fieldDescription->method('describesSingleValuedAssociation')->willReturn(false);
+
+        $this->expectException(\RuntimeException::class);
+        $this->formContractor->getDefaultOptions($formType, $this->fieldDescription);
+    }
+
+    /**
+     * @return iterable<array{0: class-string}>
+     */
+    public function getFieldDescriptionValidationProvider(): iterable
+    {
+        yield 'ModelAutocompleteType, no target model' => [
+            ModelAutocompleteType::class,
+        ];
+
+        yield 'AdminType, no association admin' => [
+            AdminType::class,
+        ];
+
+        yield 'AdminType, no single valued association' => [
+            AdminType::class,
+        ];
+
+        yield 'CollectionType, no association admin' => [
+            CollectionType::class,
+        ];
+    }
+}

--- a/tests/Fixtures/Admin/FieldDescription.php
+++ b/tests/Fixtures/Admin/FieldDescription.php
@@ -54,4 +54,19 @@ class FieldDescription extends BaseFieldDescription
     {
         throw new \BadMethodCallException(sprintf('Implement %s() method.', __METHOD__));
     }
+
+    public function describesAssociation(): bool
+    {
+        return $this->describesSingleValuedAssociation() || $this->describesCollectionValuedAssociation();
+    }
+
+    public function describesSingleValuedAssociation(): bool
+    {
+        return false;
+    }
+
+    public function describesCollectionValuedAssociation(): bool
+    {
+        return false;
+    }
 }

--- a/tests/Form/AbstractLayoutTestCase.php
+++ b/tests/Form/AbstractLayoutTestCase.php
@@ -16,12 +16,15 @@ namespace Sonata\AdminBundle\Tests\Form;
 use Sonata\AdminBundle\Form\Extension\Field\Type\FormTypeFieldExtension;
 use Sonata\Form\Fixtures\StubTranslator;
 use Symfony\Bridge\Twig\Extension\FormExtension;
+use Symfony\Bridge\Twig\Extension\HttpKernelExtension;
+use Symfony\Bridge\Twig\Extension\RoutingExtension;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Bridge\Twig\Form\TwigRendererEngine;
 use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormRendererInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\Test\FormIntegrationTestCase;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
@@ -49,6 +52,8 @@ abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
         $environment = new Environment($loader, ['strict_variables' => true]);
         $environment->addExtension(new TranslationExtension(new StubTranslator()));
         $environment->addExtension(new FormExtension());
+        $environment->addExtension(new RoutingExtension($this->createStub(UrlGeneratorInterface::class)));
+        $environment->addExtension(new HttpKernelExtension());
 
         $rendererEngine = new TwigRendererEngine([
             'form_admin_fields.html.twig',

--- a/tests/Form/Widget/BaseWidgetTest.php
+++ b/tests/Form/Widget/BaseWidgetTest.php
@@ -14,9 +14,12 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Form\Widget;
 
 use Sonata\Form\Test\AbstractWidgetTestCase;
+use Symfony\Bridge\Twig\Extension\HttpKernelExtension;
+use Symfony\Bridge\Twig\Extension\RoutingExtension;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Bridge\Twig\Form\TwigRendererEngine;
 use Symfony\Bundle\FrameworkBundle\Tests\Templating\Helper\Fixtures\StubTranslator;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Environment;
 
 /**
@@ -57,6 +60,8 @@ abstract class BaseWidgetTest extends AbstractWidgetTestCase
     {
         $environment = parent::getEnvironment();
         $environment->addGlobal('sonata_admin', $this->getSonataAdmin());
+        $environment->addExtension(new RoutingExtension($this->createStub(UrlGeneratorInterface::class)));
+        $environment->addExtension(new HttpKernelExtension());
         if (!$environment->hasExtension(TranslationExtension::class)) {
             $environment->addExtension(new TranslationExtension(new StubTranslator()));
         }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This is something I had in mind for a while, because there are some code duplication in the persistence bundles.

It's a follow-up of https://github.com/sonata-project/SonataAdminBundle/pull/3971, the `AbstractFormContractor` and `FieldDescription` part.

After this I think we can move some more duplicated code from builders here, that would also make easier to create a persistence bundle.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `FieldDescriptionInterface::describesAssociation`, `FieldDescriptionInterface::describesSingleValuedAssociation`, `FieldDescriptionInterface::describesCollectionValuedAssociation` to abstract the association mapping types.
- Added `AbstractFormContractor` base class to centralize association form option validation & defaults.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->

The implementation would look like: https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/555