### PR TITLE
Deprecate not registering filters

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,10 @@ UPGRADE 3.x
 UPGRADE FROM 3.xx to 3.xx
 =========================
 
+### `Sonata\AdminBundle\Filter\FilterFactory`
+
+Deprecated passing a value which is not registered as a service as argument 2 for `create()` method.
+
 ### Deprecated MenuBuilderInterface
 
 Deprecated `AbstractAdmin::getSideMenu()`

--- a/src/Filter/FilterFactory.php
+++ b/src/Filter/FilterFactory.php
@@ -55,12 +55,19 @@ class FilterFactory implements FilterFactoryInterface
             if ($filter && !class_exists($type)) {
                 @trigger_error(sprintf(
                     'Referencing a filter by name (%s) is deprecated since version 3.57 and will be removed in 4.0.'
-                    .' Use the fully-qualified type class name instead (%s)',
+                    .' Use the fully-qualified type class name instead (%s).',
                     $type,
                     \get_class($filter)
                 ), \E_USER_DEPRECATED);
             }
         } elseif (class_exists($type)) {
+            // NEXT_MAJOR: Remove this "elseif" block
+            @trigger_error(sprintf(
+                'Not declaring a filter as service is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will not work in 4.0.'
+                .' You MUST register a service with class name (%s) instead.',
+                $type,
+            ), \E_USER_DEPRECATED);
             $filter = new $type();
         } else {
             throw new \RuntimeException(sprintf('No attached service to type named `%s`', $type));

--- a/tests/DependencyInjection/Compiler/AddFilterTypeCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddFilterTypeCompilerPassTest.php
@@ -13,83 +13,112 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\DependencyInjection\Compiler;
 
-use PHPUnit\Framework\TestCase;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddFilterTypeCompilerPass;
+use Sonata\AdminBundle\Filter\FilterFactoryInterface;
+use Sonata\AdminBundle\Tests\Fixtures\Filter\BarFilter;
+use Sonata\AdminBundle\Tests\Fixtures\Filter\FooFilter;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
-class AddFilterTypeCompilerPassTest extends TestCase
+// NEXT_MAJOR: Uncomment next line.
+//use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
+
+final class AddFilterTypeCompilerPassTest extends AbstractCompilerPassTestCase
 {
-    private $filterFactory;
-
-    private $fooFilter;
-
-    private $barFilter;
-
-    private $bazFilter;
+    use ExpectDeprecationTrait;
 
     protected function setUp(): void
     {
-        $this->filterFactory = $this->createMock(Definition::class);
-        $this->fooFilter = $this->createMock(Definition::class);
-        $this->barFilter = $this->createMock(Definition::class);
-        $this->bazFilter = $this->createMock(Definition::class);
+        parent::setUp();
+
+        $filterFactoryDefinition = new Definition(FilterFactoryInterface::class, [
+            null,
+            [],
+        ]);
+
+        $this->container
+            ->setDefinition('sonata.admin.builder.filter.factory', $filterFactoryDefinition);
     }
 
     public function testProcess(): void
     {
-        $containerBuilderMock = $this->createMock(ContainerBuilder::class);
-
-        $containerBuilderMock
-            ->method('getDefinition')
-            ->with($this->anything())
-            ->willReturnMap([
-                ['sonata.admin.builder.filter.factory', $this->filterFactory],
-                ['acme.demo.foo_filter', $this->fooFilter],
-                ['acme.demo.bar_filter', $this->barFilter],
-                ['acme.demo.baz_filter', $this->bazFilter],
+        $fooFilter = new Definition(FooFilter::class);
+        $fooFilter
+            ->addTag('sonata.admin.filter.type', [
+                'alias' => 'foo_filter_alias',
             ]);
 
-        $containerBuilderMock->expects($this->once())
-            ->method('findTaggedServiceIds')
-            ->with($this->equalTo('sonata.admin.filter.type'))
-            ->willReturn([
-                'acme.demo.foo_filter' => [
-                    'tag1' => [
-                        'alias' => 'foo_filter_alias',
-                    ],
-                ],
-                'acme.demo.bar_filter' => [
-                    'tag1' => [
-                        'alias' => 'bar_filter_alias',
-                    ],
-                ],
-                'acme.demo.baz_filter' => [
-                    'tag1' => [
-                    ],
-                ],
-            ]);
+        $this->container
+            ->setDefinition('acme.demo.foo_filter', $fooFilter);
 
-        $this->fooFilter->method('getClass')
-            ->willReturn('Acme\Filter\FooFilter');
+        $barFilter = new Definition(BarFilter::class);
+        $barFilter
+            ->addTag('sonata.admin.filter.type');
 
-        $this->barFilter->method('getClass')
-            ->willReturn('Acme\Filter\BarFilter');
+        $this->container
+            ->setDefinition('acme.demo.bar_filter', $barFilter);
 
-        $this->bazFilter->method('getClass')
-            ->willReturn('Acme\Filter\BazFilter');
+        $this->compile();
 
-        $this->filterFactory->expects($this->once())
-            ->method('replaceArgument')
-            ->with(1, $this->equalTo([
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
+            'sonata.admin.builder.filter.factory',
+            1,
+            [
                 'foo_filter_alias' => 'acme.demo.foo_filter',
-                'Acme\Filter\FooFilter' => 'acme.demo.foo_filter',
-                'bar_filter_alias' => 'acme.demo.bar_filter',
-                'Acme\Filter\BarFilter' => 'acme.demo.bar_filter',
-                'Acme\Filter\BazFilter' => 'acme.demo.baz_filter',
-            ]));
+                FooFilter::class => 'acme.demo.foo_filter',
+                BarFilter::class => 'acme.demo.bar_filter',
+            ]
+        );
+    }
 
-        $extensionsPass = new AddFilterTypeCompilerPass();
-        $extensionsPass->process($containerBuilderMock);
+    /**
+     * NEXT_MAJOR: Remove legacy group.
+     *
+     * @group legacy
+     */
+    public function testServicesMustHaveAClassName(): void
+    {
+        $filter = new Definition('not_existing_class');
+        $filter
+            ->addTag('sonata.admin.filter.type');
+
+        $this->container
+            ->setDefinition('acme.demo.foo_filter', $filter);
+
+        // NEXT_MAJOR: Remove deprecation and uncomment exception.
+        $this->expectDeprecation('Not declaring a filter with an existing class name is deprecated since sonata-project/admin-bundle 3.x and will not work in 4.0. You MUST register a service with an existing class name for service "acme.demo.foo_filter".');
+//        $this->expectException(InvalidArgumentException::class);
+//        $this->expectExceptionMessage('Class "not_existing_class" used for service "acme.demo.foo_filter" cannot be found.');
+
+        $this->compile();
+    }
+
+    /**
+     * NEXT_MAJOR: Remove legacy group.
+     *
+     * @group legacy
+     */
+    public function testServicesMustImplementFilterInterface(): void
+    {
+        $filter = new Definition(\stdClass::class);
+        $filter
+            ->addTag('sonata.admin.filter.type');
+
+        $this->container
+            ->setDefinition('acme.demo.foo_filter', $filter);
+
+        // NEXT_MAJOR: Remove deprecation and uncomment exception.
+        $this->expectDeprecation('Registering service "acme.demo.foo_filter" without implementing interface "Sonata\AdminBundle\Filter\FilterInterface" is deprecated since sonata-project/admin-bundle 3.x and will be mandatory in 4.0.');
+//        $this->expectException(InvalidArgumentException::class);
+//        $this->expectExceptionMessage('Service "acme.demo.foo_filter" MUST implement interface "Sonata\AdminBundle\Filter\FilterInterface".');
+
+        $this->compile();
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new AddFilterTypeCompilerPass());
     }
 }

--- a/tests/Filter/FilterFactoryTest.php
+++ b/tests/Filter/FilterFactoryTest.php
@@ -17,16 +17,20 @@ use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Filter\FilterFactory;
 use Sonata\AdminBundle\Filter\FilterInterface;
 use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
+use Sonata\AdminBundle\Tests\Fixtures\Filter\FooFilter;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\Container;
 
 class FilterFactoryTest extends TestCase
 {
+    use ExpectDeprecationTrait;
+
     public function testEmptyType(): void
     {
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('The type must be defined');
 
-        $filter = new FilterFactory(new Container(), []);
+        $filter = new FilterFactory(new Container());
         $filter->create('test', null);
     }
 
@@ -35,7 +39,7 @@ class FilterFactoryTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('No attached service to type named `mytype`');
 
-        $filter = new FilterFactory(new Container(), []);
+        $filter = new FilterFactory(new Container());
         $filter->create('test', 'mytype');
     }
 
@@ -44,13 +48,18 @@ class FilterFactoryTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('No attached service to type named `Sonata\AdminBundle\Form\Type\Filter\FooType`');
 
-        $filter = new FilterFactory(new Container(), []);
+        $filter = new FilterFactory(new Container());
         $filter->create('test', 'Sonata\AdminBundle\Form\Type\Filter\FooType');
     }
 
     public function testClassType(): void
     {
-        $filter = new FilterFactory(new Container(), []);
+        $container = new Container();
+        $container
+            ->set(DefaultType::class, new DefaultType());
+        $filter = new FilterFactory($container, [
+            DefaultType::class => DefaultType::class,
+        ]);
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage(
@@ -58,6 +67,20 @@ class FilterFactoryTest extends TestCase
         );
 
         $filter->create('test', DefaultType::class);
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
+    public function testItTriggersDeprecationWithoutTheService(): void
+    {
+        $filter = new FilterFactory(new Container());
+
+        $this->expectDeprecation('Not declaring a filter as service is deprecated since sonata-project/admin-bundle 3.x and will not work in 4.0. You MUST register a service with class name (Sonata\AdminBundle\Tests\Fixtures\Filter\FooFilter) instead.');
+
+        $filter->create('test', FooFilter::class);
     }
 
     /**

--- a/tests/Fixtures/Filter/BarFilter.php
+++ b/tests/Fixtures/Filter/BarFilter.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Filter;
+
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Filter\Filter;
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
+
+final class BarFilter extends Filter
+{
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
+    public function filter(ProxyQueryInterface $query, $alias, $field, $value): void
+    {
+    }
+
+    // NEXT_MAJOR: Add type declarations
+    public function apply($query, $value): void
+    {
+    }
+
+    public function getDefaultOptions(): array
+    {
+        return ['bar' => 'bar'];
+    }
+
+    public function getRenderSettings(): array
+    {
+        return [DefaultType::class, [
+            'label' => 'label',
+        ]];
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

These changes force the user to register filters as services so in next major version a service locator could be used instead of the complete container.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated not registering filters as a service.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
