### PR TITLE
Deprecate constructing AdminPoolLoader with more than one argument

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,11 @@ UPGRADE 3.x
 UPGRADE FROM 3.xx to 3.xx
 =========================
 
+### `Sonata\AdminBundle\Route\AdminPoolLoader`
+
+- Deprecated constructing it passing more than one argument.
+- Deprecated `Sonata\AdminBundle\Route\AdminPoolLoader` service alias.
+
 ## Deprecated not setting "sonata.admin.audit_reader" tag in audit reader services
 
 If you are using [autoconfiguration](https://symfony.com/doc/4.4/service_container.html#the-autoconfigure-option),

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "symfony/event-dispatcher-contracts": "^1.1 || ^2.0",
         "symfony/expression-language": "^4.4 || ^5.1",
         "symfony/form": "^4.4.12",
-        "symfony/framework-bundle": "^4.4",
+        "symfony/framework-bundle": "^4.4.6",
         "symfony/http-foundation": "^4.4 || ^5.1",
         "symfony/http-kernel": "^4.4",
         "symfony/options-resolver": "^4.4 || ^5.1",

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -238,9 +238,6 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
         $pool->replaceArgument(1, $admins);
         $pool->replaceArgument(2, $groups);
         $pool->replaceArgument(3, $classes);
-
-        $routeLoader = $container->getDefinition('sonata.admin.route_loader');
-        $routeLoader->replaceArgument(1, $admins);
     }
 
     /**

--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -78,11 +78,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->tag('routing.loader')
             ->args([
                 new ReferenceConfigurator('sonata.admin.pool'),
-                [],
-                new ReferenceConfigurator('service_container'),
             ])
 
         ->alias(AdminPoolLoader::class, 'sonata.admin.route_loader')
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ))
 
         ->set('sonata.admin.helper', AdminHelper::class)
             ->public()

--- a/src/Route/AdminPoolLoader.php
+++ b/src/Route/AdminPoolLoader.php
@@ -34,18 +34,33 @@ class AdminPoolLoader extends Loader
     protected $pool;
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
      * @var array
      */
     protected $adminServiceIds = [];
 
     /**
-     * @var ContainerInterface
+     * NEXT_MAJOR: Remove this property.
+     *
+     * @var ContainerInterface|null
      */
     protected $container;
 
-    public function __construct(Pool $pool, array $adminServiceIds, ContainerInterface $container)
+    // NEXT_MAJOR: Remove $adminServiceIds and $container parameters.
+    public function __construct(Pool $pool, array $adminServiceIds = [], ?ContainerInterface $container = null)
     {
         $this->pool = $pool;
+        // NEXT_MAJOR: Remove next line.
+        if (\func_num_args() > 1) {
+            @trigger_error(sprintf(
+                'Passing more than one argument to "%s()" is deprecated since'
+                .' sonata-project/admin-bundle 3.x.',
+                __METHOD__
+            ), \E_USER_DEPRECATED);
+        }
+
+        // NEXT_MAJOR: Remove the following two lines.
         $this->adminServiceIds = $adminServiceIds;
         $this->container = $container;
     }
@@ -58,7 +73,8 @@ class AdminPoolLoader extends Loader
     public function load($resource, $type = null)
     {
         $collection = new SymfonyRouteCollection();
-        foreach ($this->adminServiceIds as $id) {
+        // NEXT_MAJOR: Replace $this->getAdminServiceIds() with $this->pool->getAdminServiceIds()
+        foreach ($this->getAdminServiceIds() as $id) {
             $admin = $this->pool->getInstance($id);
 
             foreach ($admin->getRoutes()->getElements() as $code => $route) {
@@ -71,11 +87,26 @@ class AdminPoolLoader extends Loader
             }
         }
 
-        $reflection = new \ReflectionObject($this->container);
-        if (file_exists($reflection->getFileName())) {
-            $collection->addResource(new FileResource($reflection->getFileName()));
+        // NEXT_MAJOR: Remove this block.
+        if (null !== $this->container) {
+            $reflection = new \ReflectionObject($this->container);
+            if (file_exists($reflection->getFileName())) {
+                $collection->addResource(new FileResource($reflection->getFileName()));
+            }
         }
 
         return $collection;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getAdminServiceIds(): array
+    {
+        if ([] !== $this->adminServiceIds) {
+            return $this->adminServiceIds;
+        }
+
+        return $this->pool->getAdminServiceIds();
     }
 }

--- a/tests/Route/AdminPoolLoaderTest.php
+++ b/tests/Route/AdminPoolLoaderTest.php
@@ -18,6 +18,7 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Route\AdminPoolLoader;
 use Sonata\AdminBundle\Route\RouteCollection;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Routing\Route as SymfonyRoute;
 use Symfony\Component\Routing\RouteCollection as SymfonyRouteCollection;
@@ -27,12 +28,15 @@ use Symfony\Component\Routing\RouteCollection as SymfonyRouteCollection;
  */
 class AdminPoolLoaderTest extends TestCase
 {
+    // NEXT_MAJOR: Remove next line.
+    use ExpectDeprecationTrait;
+
     public function testSupports(): void
     {
         $container = new Container();
-        $pool = new Pool($container);
+        $pool = new Pool($container, ['foo_admin', 'bar_admin']);
 
-        $adminPoolLoader = new AdminPoolLoader($pool, ['foo_admin', 'bar_admin'], $container);
+        $adminPoolLoader = new AdminPoolLoader($pool);
 
         $this->assertTrue($adminPoolLoader->supports('foo', 'sonata_admin'));
         $this->assertFalse($adminPoolLoader->supports('foo', 'bar'));
@@ -43,7 +47,7 @@ class AdminPoolLoaderTest extends TestCase
         $container = new Container();
         $pool = new Pool($container, ['foo_admin', 'bar_admin']);
 
-        $adminPoolLoader = new AdminPoolLoader($pool, ['foo_admin', 'bar_admin'], $container);
+        $adminPoolLoader = new AdminPoolLoader($pool);
 
         $routeCollection1 = new RouteCollection('base.Code.Route.foo', 'baseRouteNameFoo', 'baseRoutePatternFoo', 'baseControllerNameFoo');
         $routeCollection2 = new RouteCollection('base.Code.Route.bar', 'baseRouteNameBar', 'baseRoutePatternBar', 'baseControllerNameBar');
@@ -72,5 +76,33 @@ class AdminPoolLoaderTest extends TestCase
         $this->assertInstanceOf(SymfonyRoute::class, $collection->get('baseRouteNameFoo_foo'));
         $this->assertInstanceOf(SymfonyRoute::class, $collection->get('baseRouteNameBar_bar'));
         $this->assertInstanceOf(SymfonyRoute::class, $collection->get('baseRouteNameBar_bar'));
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @group legacy
+     */
+    public function testThrowsADeprecationConstructingWithContainer(): void
+    {
+        $container = new Container();
+        $pool = new Pool($container);
+
+        $this->expectDeprecation('Passing more than one argument to "Sonata\AdminBundle\Route\AdminPoolLoader::__construct()" is deprecated since sonata-project/admin-bundle 3.x.');
+        new AdminPoolLoader($pool, ['foo_admin', 'bar_admin'], $container);
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @group legacy
+     */
+    public function testThrowsADeprecationConstructingWithAdminServicesIds(): void
+    {
+        $container = new Container();
+        $pool = new Pool($container);
+
+        $this->expectDeprecation('Passing more than one argument to "Sonata\AdminBundle\Route\AdminPoolLoader::__construct()" is deprecated since sonata-project/admin-bundle 3.x.');
+        new AdminPoolLoader($pool, ['foo_admin', 'bar_admin']);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

The container was added in https://github.com/sonata-project/SonataAdminBundle/commit/eefe79cca5774b612ba8ab32e7bbdf4ec014411f to solve https://github.com/sonata-project/SonataAdminBundle/issues/128, I've marked this PR as draft, as I'm not sure if it is not needed anymore, I'll try to search about this or if someone has some knowledge about this, would be appreciated.

Ref: https://github.com/sonata-project/SonataAdminBundle/issues/6963

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated constructing `AdminPoolLoader` passing more than one argument. 
- Deprecated `AdminPoolLoader` service alias.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
