### PR TITLE
Deprecate MenuBuilderInterface

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,11 @@ UPGRADE 3.x
 UPGRADE FROM 3.xx to 3.xx
 =========================
 
+### Deprecated MenuBuilderInterface
+
+Deprecated `AbstractAdmin::getSideMenu()`
+Deprecated `AbstractAdmin::getTabMenu()`
+
 ### Deprecated `Sonata\AdminBundle\Admin\BaseFieldDescription` class.
 
 Use `Sonata\AdminBundle\FieldDescription\BaseFieldDescription` instead.

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1423,8 +1423,20 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $this->datagrid;
     }
 
+    /**
+     * NEXT_MAJOR: Change the visibility to private and return type to void.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     */
     public function buildTabMenu($action, ?AdminInterface $childAdmin = null)
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
+            @trigger_error(sprintf(
+                'The "%s()" method is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.',
+                __METHOD__
+            ), \E_USER_DEPRECATED);
+        }
+
         if ($this->loaded['tab_menu']) {
             return $this->menu;
         }
@@ -1451,9 +1463,21 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $this->menu;
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
+     */
     public function buildSideMenu($action, ?AdminInterface $childAdmin = null)
     {
-        return $this->buildTabMenu($action, $childAdmin);
+        if ('sonata_deprecation_mute' !== (\func_get_args()[2] ?? null)) {
+            @trigger_error(sprintf(
+                'The "%s()" method is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.',
+                __METHOD__
+            ), \E_USER_DEPRECATED);
+        }
+
+        return $this->buildTabMenu($action, $childAdmin, 'sonata_deprecation_mute');
     }
 
     /**
@@ -1469,7 +1493,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
             return $this->getParent()->getSideMenu($action, $this);
         }
 
-        $this->buildSideMenu($action, $childAdmin);
+        $this->buildSideMenu($action, $childAdmin, 'sonata_deprecation_mute');
 
         return $this->menu;
     }

--- a/src/Admin/MenuBuilderInterface.php
+++ b/src/Admin/MenuBuilderInterface.php
@@ -19,6 +19,10 @@ use Knp\Menu\ItemInterface;
  * This interface can be implemented by admins that need to build menus.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * NEXT_MAJOR: Remove this interface.
+ *
+ * @deprecated since sonata-project/admin-bundle 3.x
  */
 interface MenuBuilderInterface
 {
@@ -29,7 +33,7 @@ interface MenuBuilderInterface
      *
      * @return ItemInterface|bool
      *
-     * @deprecated Use buildTabMenu instead
+     * @deprecated since sonata-project/admin-bundle 3.24
      *
      * @phpstan-param AdminInterface<object>|null $childAdmin
      */
@@ -41,6 +45,8 @@ interface MenuBuilderInterface
      * @param string $action
      *
      * @return ItemInterface|bool
+     *
+     * @deprecated since sonata-project/admin-bundle 3.x
      *
      * @phpstan-param AdminInterface<object>|null $childAdmin
      */


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because BC.

`buildSideMenu` was already removed in master.
`buildTabMenu` is only used in AbstractAdmin so shouldn't be in the public API.
All other build method are private so this will be consistent.

## Changelog

```markdown
### Deprecated
- `MenuBuilderInterface` interface.
- `AbstractAdmin::buildSideMenu()`
- `AbstractAdmin::buildTabMenu()`
```