### PR TITLE
Add tag for audit readers

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,27 @@ UPGRADE 3.x
 UPGRADE FROM 3.xx to 3.xx
 =========================
 
+## Deprecated not setting "sonata.admin.audit_reader" tag in audit reader services
+
+If you are using [autoconfiguration](https://symfony.com/doc/4.4/service_container.html#the-autoconfigure-option),
+all the services implementing `Sonata\AdminBundle\Model\AuditReaderInterface` will
+be automatically tagged. Otherwise, you MUST tag them explicitly.
+
+Before:
+```xml
+<service id="sonata.admin.audit_reader.custom" class="App\Model\AuditReader">
+    <!-- ... -->
+</service>
+```
+
+After:
+```xml
+<service id="sonata.admin.audit_reader.custom" class="App\Model\AuditReader">
+    <!-- ... -->
+    <tag name="sonata.admin.audit_reader"/>
+</service>
+```
+
 ### `Sonata\AdminBundle\Filter\FilterFactory`
 
 Deprecated passing a value which is not registered as a service as argument 2 for `create()` method.

--- a/src/DependencyInjection/Compiler/AddAuditReadersCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddAuditReadersCompilerPass.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\DependencyInjection\Compiler;
+
+use Sonata\AdminBundle\Model\AuditReaderInterface;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class AddAuditReadersCompilerPass implements CompilerPassInterface
+{
+    public const AUDIT_READER_TAG = 'sonata.admin.audit_reader';
+
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has('sonata.admin.audit.manager')) {
+            return;
+        }
+
+        $definition = $container->getDefinition('sonata.admin.audit.manager');
+        $readers = [];
+
+        foreach ($container->findTaggedServiceIds(self::AUDIT_READER_TAG, true) as $id => $attributes) {
+            $serviceDefinition = $container->getDefinition($id);
+
+            if (!is_subclass_of($serviceDefinition->getClass(), AuditReaderInterface::class)) {
+                throw new LogicException(sprintf(
+                    'Service "%s" MUST implement "%s".',
+                    $id,
+                    AuditReaderInterface::class
+                ));
+            }
+
+            $readers[$id] = new Reference($id);
+        }
+
+        // NEXT_MAJOR: Change index from 1 to 0.
+        $definition->replaceArgument(1, ServiceLocatorTagPass::register($container, $readers));
+    }
+}

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\DependencyInjection;
 
+use Sonata\AdminBundle\DependencyInjection\Compiler\AddAuditReadersCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ModelManagerCompilerPass;
+use Sonata\AdminBundle\Model\AuditReaderInterface;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 // NEXT_MAJOR: Uncomment this line.
 //use Sonata\AdminBundle\Util\AdminAclUserManagerInterface;
@@ -224,6 +226,10 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         $container
             ->registerForAutoconfiguration(ModelManagerInterface::class)
             ->addTag(ModelManagerCompilerPass::MANAGER_TAG);
+
+        $container
+            ->registerForAutoconfiguration(AuditReaderInterface::class)
+            ->addTag(AddAuditReadersCompilerPass::AUDIT_READER_TAG);
     }
 
     /**

--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -189,7 +189,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set('sonata.admin.audit.manager', AuditManager::class)
             ->public()
             ->args([
+                // NEXT_MAJOR: Remove next line.
                 new ReferenceConfigurator('service_container'),
+                null, // Service locator
             ])
 
         ->alias(AuditManager::class, 'sonata.admin.audit.manager')

--- a/tests/DependencyInjection/Compiler/AddAuditReadersCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddAuditReadersCompilerPassTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\AdminBundle\DependencyInjection\Compiler\AddAuditReadersCompilerPass;
+use Sonata\AdminBundle\Model\AuditManager;
+use Sonata\AdminBundle\Tests\Fixtures\Model\AuditReader;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class AddAuditReadersCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    public function testProcess(): void
+    {
+        $auditManagerDefinition = new Definition(AuditManager::class, [
+            // NEXT_MAJOR: Remove next line.
+            new Container(),
+            null,
+        ]);
+
+        $this->container
+            ->setDefinition('sonata.admin.audit.manager', $auditManagerDefinition);
+
+        $auditReader = new Definition(AuditReader::class);
+        $auditReader
+            ->addTag(AddAuditReadersCompilerPass::AUDIT_READER_TAG);
+
+        $this->container
+            ->setDefinition('std_audit_reader', $auditReader);
+
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceLocator(
+            // NEXT_MAJOR: Change index from 1 to 0.
+            (string) $this->container->getDefinition('sonata.admin.audit.manager')->getArgument(1),
+            [
+                'std_audit_reader' => new Reference('std_audit_reader'),
+            ]
+        );
+    }
+
+    public function testServiceTaggedMustImplementInterface(): void
+    {
+        $auditManagerDefinition = new Definition(AuditManager::class);
+
+        $this->container
+            ->setDefinition('sonata.admin.audit.manager', $auditManagerDefinition);
+
+        $auditReader = new Definition(\stdClass::class);
+        $auditReader
+            ->addTag(AddAuditReadersCompilerPass::AUDIT_READER_TAG);
+
+        $this->container
+            ->setDefinition('std_audit_reader', $auditReader);
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Service "std_audit_reader" MUST implement "Sonata\AdminBundle\Model\AuditReaderInterface".');
+
+        $this->compile();
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new AddAuditReadersCompilerPass());
+    }
+}

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -19,6 +19,8 @@ use Sonata\AdminBundle\Admin\BreadcrumbsBuilder;
 use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Bridge\Exporter\AdminExporter;
+use Sonata\AdminBundle\DependencyInjection\Compiler\AddAuditReadersCompilerPass;
+use Sonata\AdminBundle\DependencyInjection\Compiler\ModelManagerCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Configuration;
 use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
 use Sonata\AdminBundle\Event\AdminEventExtension;
@@ -28,6 +30,8 @@ use Sonata\AdminBundle\Filter\Persister\FilterPersisterInterface;
 use Sonata\AdminBundle\Filter\Persister\SessionFilterPersister;
 use Sonata\AdminBundle\Model\AuditManager;
 use Sonata\AdminBundle\Model\AuditManagerInterface;
+use Sonata\AdminBundle\Model\AuditReaderInterface;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Route\AdminPoolLoader;
 use Sonata\AdminBundle\Search\SearchHandler;
 use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
@@ -466,6 +470,19 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
                 'skin' => 'skin-invalid',
             ],
         ]);
+    }
+
+    public function testAutoregisterAddingTagsToServices(): void
+    {
+        $this->load();
+
+        $autoconfiguredInstancesOf = $this->container->getAutoconfiguredInstanceof();
+
+        $this->assertArrayHasKey(ModelManagerInterface::class, $autoconfiguredInstancesOf);
+        $this->assertTrue($autoconfiguredInstancesOf[ModelManagerInterface::class]->hasTag(ModelManagerCompilerPass::MANAGER_TAG));
+
+        $this->assertArrayHasKey(AuditReaderInterface::class, $autoconfiguredInstancesOf);
+        $this->assertTrue($autoconfiguredInstancesOf[AuditReaderInterface::class]->hasTag(AddAuditReadersCompilerPass::AUDIT_READER_TAG));
     }
 
     protected function getContainerExtensions(): array

--- a/tests/Fixtures/Model/AuditReader.php
+++ b/tests/Fixtures/Model/AuditReader.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Model;
+
+use Sonata\AdminBundle\Model\AuditReaderInterface;
+
+// NEXT_MAJOR: Add type declarations
+final class AuditReader implements AuditReaderInterface
+{
+    public function find($className, $id, $revision): object
+    {
+        return new \stdClass();
+    }
+
+    public function findRevisionHistory($className, $limit = 20, $offset = 0): array
+    {
+        return [
+            new \stdClass(),
+        ];
+    }
+
+    public function findRevision($classname, $revision): object
+    {
+        return new \stdClass();
+    }
+
+    public function findRevisions($className, $id): array
+    {
+        return [
+            new \stdClass(),
+        ];
+    }
+
+    public function diff($className, $id, $oldRevision, $newRevision): array
+    {
+        return [];
+    }
+}

--- a/tests/Model/AuditManagerTest.php
+++ b/tests/Model/AuditManagerTest.php
@@ -16,21 +16,23 @@ namespace Sonata\AdminBundle\Tests\Model;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Model\AuditManager;
 use Sonata\AdminBundle\Model\AuditReaderInterface;
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\DependencyInjection\Container;
 
 /**
- * Test for AuditManager.
- *
  * @author Andrej Hudec <pulzarraider@gmail.com>
  */
-class AuditManagerTest extends TestCase
+final class AuditManagerTest extends TestCase
 {
+    // NEXT_MAJOR: Remove next line.
+    use ExpectDeprecationTrait;
+
     public function testGetReader(): void
     {
         $container = new Container();
 
-        $fooReader = $this->getMockForAbstractClass(AuditReaderInterface::class);
-        $barReader = $this->getMockForAbstractClass(AuditReaderInterface::class);
+        $fooReader = $this->createStub(AuditReaderInterface::class);
+        $barReader = $this->createStub(AuditReaderInterface::class);
 
         $container->set('foo_reader', $fooReader);
         $container->set('bar_reader', $barReader);
@@ -53,5 +55,25 @@ class AuditManagerTest extends TestCase
         $auditManager = new AuditManager(new Container());
 
         $auditManager->getReader('Foo\Foo');
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
+    public function testReaderShouldBeTagged(): void
+    {
+        $container = new Container();
+
+        $fooReader = $this->createStub(AuditReaderInterface::class);
+
+        $container->set('foo_reader', $fooReader);
+
+        $auditManager = new AuditManager($container, new Container());
+
+        $this->expectDeprecation('Not registering the audit reader "foo_reader" with tag "sonata.admin.audit_reader" is deprecated since sonata-project/admin-bundle 3.x and will not work in 4.0. You MUST add "sonata.admin.audit_reader" tag to the service "foo_reader".');
+
+        $auditManager->setReader('foo_reader', ['Foo\Foo1', 'Foo\Foo2']);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Audit readers MUST be tagged with this tag so we can use a service locator instead of injecting the whole container in the next major version.

Ref: https://github.com/sonata-project/SonataAdminBundle/issues/6963

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `sonata.admin.audit_reader` tag for Audit readers.
### Deprecated
- Deprecated not tagging an audit reader with the tag `sonata.admin.audit_reader`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
