### PR TITLE
Replace sonata_help block with form_help

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -614,7 +614,7 @@ file that was distributed with this source code.
             {{ form_widget(form, {'required':false}) }}
         </span>
 
-        {{ block('sonata_help') }}
+        {{ form_help(form) }}
 
         <div class="modal fade" id="field_dialog_{{ id }}" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
             <div class="modal-dialog modal-lg">


### PR DESCRIPTION
`sonata_help` was replace with `form_help`.