### PR TITLE
Added new form type - ModelLinkType

### DIFF
--- a/src/Form/Type/AdminType.php
+++ b/src/Form/Type/AdminType.php
@@ -76,6 +76,13 @@ class AdminType extends AbstractType
 
             $builder->add('_delete', $options['delete_options']['type'], $options['delete_options']['type_options']);
         }
+        if ($options['edit'] && $admin->hasAccess('edit')) {
+            if (!array_key_exists('translation_domain', $options['edit_options']['type_options'])) {
+                $options['edit_options']['type_options']['translation_domain'] = $admin->getTranslationDomain();
+            }
+
+            $builder->add('_edit', $options['edit_options']['type'], $options['edit_options']['type_options']);
+        }
 
         // hack to make sure the subject is correctly set
         // https://github.com/sonata-project/SonataAdminBundle/pull/2076
@@ -140,6 +147,7 @@ class AdminType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $view->vars['btn_add'] = $options['btn_add'];
+        $view->vars['btn_edit'] = $options['btn_edit'];
         $view->vars['btn_list'] = $options['btn_list'];
         $view->vars['btn_delete'] = $options['btn_delete'];
         $view->vars['btn_catalogue'] = $options['btn_catalogue'];
@@ -161,8 +169,20 @@ class AdminType extends AbstractType
                     'mapped' => false,
                 ],
             ],
+            'edit' => false,
+            'edit_options' => function (Options $options) {
+                return [
+                    'type' => ModelLinkType::class,
+                    'type_options' => [
+                        'required' => false,
+                        'mapped' => false,
+                        'sonata_field_description' => $options['sonata_field_description'],
+                    ]
+                ];
+            },
             'auto_initialize' => false,
             'btn_add' => 'link_add',
+            'btn_edit' => 'link_edit',
             'btn_list' => 'link_list',
             'btn_delete' => 'link_delete',
             'btn_catalogue' => 'SonataAdminBundle',

--- a/src/Form/Type/ModelLinkType.php
+++ b/src/Form/Type/ModelLinkType.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Form\Type;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionInterface;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\PropertyAccess\Exception\NoSuchIndexException;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+
+/**
+ * This type can be used to select one associated model from a list.
+ *
+ * The associated model must be in a single-valued association relationship (e.g many-to-one)
+ * with the model currently edited in the parent form.
+ * The associated model must have an admin class registered.
+ *
+ * The selected model's identifier is rendered in an hidden input.
+ *
+ * When a model is selected, a short description is displayed by the widget.
+ * This description can be customized by overriding the associated admin's
+ * `short_object_description` template and/or overriding it's `toString` method.
+ *
+ * The widget also provides three action buttons:
+ *  - a button to open the associated admin list view in a dialog,
+ *    in order to select an associated model.
+ *  - a button to open the associated admin create form in a dialog,
+ *    in order to create and select an associated model.
+ *  - a button to unlink the associated model, if any.
+ */
+class ModelLinkType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $admin = clone $this->getAdmin($options);
+
+        if ($admin->hasParentFieldDescription()) {
+            $admin->getParentFieldDescription()->setAssociationAdmin($admin);
+        }
+
+        // hack to make sure the subject is correctly set
+        if ($admin->getSubject() !== null) {
+            $builder->setData($admin->getSubject());
+        }
+        if (isset($options['property_path']) && null === $builder->getData()) {
+            $p = new PropertyAccessor(false, true);
+
+            try {
+                $parentSubject = $admin->getParentFieldDescription()->getAdmin()->getSubject();
+                if (null !== $parentSubject && false !== $parentSubject) {
+                    // this check is to work around duplication issue in property path
+                    // https://github.com/sonata-project/SonataAdminBundle/issues/4425
+                    if ($this->getFieldDescription($options)->getFieldName() === $options['property_path']) {
+                        $path = $options['property_path'];
+                    } else {
+                        $path = $this->getFieldDescription($options)->getFieldName().$options['property_path'];
+                    }
+
+                    $subject = $p->getValue($parentSubject, $path);
+                    $builder->setData($subject);
+                }
+            } catch (NoSuchIndexException $e) {
+                // no object here
+            }
+            $admin->setSubject($builder->getData());
+        }
+    }
+
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        if (isset($view->vars['sonata_admin'])) {
+            // set the correct edit mode
+            $view->vars['sonata_admin']['edit'] = 'list';
+        }
+        $view->vars['btn_edit'] = $options['btn_edit'];
+        $view->vars['btn_catalogue'] = $options['btn_catalogue'];
+    }
+
+    /**
+     * NEXT_MAJOR: Remove method, when bumping requirements to SF 2.7+.
+     *
+     * {@inheritdoc}
+     */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'mapped' => false,
+            'model_manager' => null,
+            'class' => null,
+            'btn_edit' => 'link_edit',
+            'btn_catalogue' => 'SonataAdminBundle',
+        ]);
+    }
+
+    /**
+     * NEXT_MAJOR: Remove when dropping Symfony <2.8 support.
+     *
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->getBlockPrefix();
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'sonata_type_model_link';
+    }
+
+    /**
+     * @throws \RuntimeException
+     *
+     * @return FieldDescriptionInterface
+     */
+    protected function getFieldDescription(array $options)
+    {
+        if (!isset($options['sonata_field_description'])) {
+            throw new \RuntimeException('Please provide a valid `sonata_field_description` option');
+        }
+
+        return $options['sonata_field_description'];
+    }
+
+    /**
+     * @return AdminInterface
+     */
+    protected function getAdmin(array $options)
+    {
+        return $this->getFieldDescription($options)->getAssociationAdmin();
+    }
+}

--- a/src/Resources/views/CRUD/Association/edit_one_to_many_inline_table.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many_inline_table.html.twig
@@ -14,6 +14,8 @@ file that was distributed with this source code.
             {% for field_name, nested_field in form.children|first.children %}
                 {% if field_name == '_delete' %}
                     <th>{{ 'action_delete'|trans({}, 'SonataAdminBundle') }}</th>
+                {% elseif field_name == '_edit' %}
+                    <th>{{ 'action_edit'|trans({}, 'SonataAdminBundle') }}</th>
                 {% else %}
                     <th
                         {% if nested_field.vars['required']|default(false) %}
@@ -69,6 +71,8 @@ file that was distributed with this source code.
                             {% set dummy = nested_group_field.setrendered %}
                         {% else %}
                             {% if field_name == '_delete' %}
+                                {{ form_widget(nested_field, { label: false }) }}
+                            {% elseif field_name == '_edit' %}
                                 {{ form_widget(nested_field, { label: false }) }}
                             {% else %}
                                 {{ form_widget(nested_field) }}

--- a/src/SonataAdminBundle.php
+++ b/src/SonataAdminBundle.php
@@ -36,6 +36,7 @@ use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
 use Sonata\AdminBundle\Form\Type\Filter\NumberType;
 use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
 use Sonata\AdminBundle\Form\Type\ModelHiddenType;
+use Sonata\AdminBundle\Form\Type\ModelLinkType;
 use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\AdminBundle\Form\Type\ModelReferenceType;
 use Sonata\AdminBundle\Form\Type\ModelType;
@@ -85,6 +86,7 @@ class SonataAdminBundle extends Bundle
             'sonata_type_admin' => AdminType::class,
             'sonata_type_model' => ModelType::class,
             'sonata_type_model_list' => ModelListType::class,
+            'sonata_type_model_link' => ModelLinkType::class,
             'sonata_type_model_reference' => ModelReferenceType::class,
             'sonata_type_model_hidden' => ModelHiddenType::class,
             'sonata_type_model_autocomplete' => ModelAutocompleteType::class,


### PR DESCRIPTION
Added 'edit' button to AdminType which leads to entity edit page
ModelLinkType should resolve subject, not rely onto AdminType.
Fixed exception when adding multiple items at once to collection

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added some `Class::newMethod()` to do great stuff.

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
