### PR TITLE
Use `AdminInterface::getTemplateRegistry` instead of fetching the service from the container

### DIFF
--- a/src/Twig/Extension/RenderElementExtension.php
+++ b/src/Twig/Extension/RenderElementExtension.php
@@ -97,15 +97,13 @@ final class RenderElementExtension extends AbstractExtension
      *
      * @param object|mixed[]       $listElement
      * @param array<string, mixed> $params
-     *
-     * @return string
      */
     public function renderListElement(
         Environment $environment,
         $listElement,
         FieldDescriptionInterface $fieldDescription,
-        $params = []
-    ) {
+        array $params = []
+    ): string {
         $template = $this->getTemplate(
             $fieldDescription,
             $this->getTemplateRegistry($fieldDescription->getAdmin()->getCode())->getTemplate('base_list_field'),
@@ -122,18 +120,11 @@ final class RenderElementExtension extends AbstractExtension
         ]), $environment);
     }
 
-    /**
-     * render a view element.
-     *
-     * @param object $object
-     *
-     * @return string
-     */
     public function renderViewElement(
         Environment $environment,
         FieldDescriptionInterface $fieldDescription,
-        $object
-    ) {
+        object $object
+    ): string {
         $template = $this->getTemplate(
             $fieldDescription,
             '@SonataAdmin/CRUD/base_show_field.html.twig',
@@ -153,15 +144,13 @@ final class RenderElementExtension extends AbstractExtension
      *
      * @param mixed $baseObject
      * @param mixed $compareObject
-     *
-     * @return string
      */
     public function renderViewElementCompare(
         Environment $environment,
         FieldDescriptionInterface $fieldDescription,
         $baseObject,
         $compareObject
-    ) {
+    ): string {
         $template = $this->getTemplate(
             $fieldDescription,
             '@SonataAdmin/CRUD/base_show_field.html.twig',

--- a/src/Twig/Extension/RenderElementExtension.php
+++ b/src/Twig/Extension/RenderElementExtension.php
@@ -13,12 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Twig\Extension;
 
-use Psr\Log\LoggerInterface;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
-use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
-use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Twig\Environment;
 use Twig\Extension\AbstractExtension;
@@ -28,16 +23,6 @@ use Twig\TwigFilter;
 final class RenderElementExtension extends AbstractExtension
 {
     /**
-     * @var LoggerInterface|null
-     */
-    private $logger;
-
-    /**
-     * @var ContainerInterface|null
-     */
-    private $templateRegistries;
-
-    /**
      * @var PropertyAccessorInterface
      */
     private $propertyAccessor;
@@ -45,14 +30,9 @@ final class RenderElementExtension extends AbstractExtension
     /**
      * @internal This class should only be used through Twig
      */
-    public function __construct(
-        PropertyAccessorInterface $propertyAccessor,
-        ContainerInterface $templateRegistries,
-        ?LoggerInterface $logger = null
-    ) {
+    public function __construct(PropertyAccessorInterface $propertyAccessor)
+    {
         $this->propertyAccessor = $propertyAccessor;
-        $this->templateRegistries = $templateRegistries;
-        $this->logger = $logger;
     }
 
     /**
@@ -106,7 +86,7 @@ final class RenderElementExtension extends AbstractExtension
     ): string {
         $template = $this->getTemplate(
             $fieldDescription,
-            $this->getTemplateRegistry($fieldDescription->getAdmin()->getCode())->getTemplate('base_list_field'),
+            $fieldDescription->getAdmin()->getTemplateRegistry()->getTemplate('base_list_field'),
             $environment
         );
 
@@ -304,21 +284,5 @@ EOT;
         $templateName = $fieldDescription->getTemplate() ?: $defaultTemplate;
 
         return $environment->load($templateName);
-    }
-
-    /**
-     * @throws ServiceCircularReferenceException
-     * @throws ServiceNotFoundException
-     */
-    private function getTemplateRegistry(string $adminCode): TemplateRegistryInterface
-    {
-        $serviceId = $adminCode.'.template_registry';
-        $templateRegistry = $this->templateRegistries->get($serviceId);
-
-        if ($templateRegistry instanceof TemplateRegistryInterface) {
-            return $templateRegistry;
-        }
-
-        throw new ServiceNotFoundException($serviceId);
     }
 }

--- a/tests/Action/SetObjectFieldValueActionTest.php
+++ b/tests/Action/SetObjectFieldValueActionTest.php
@@ -21,14 +21,13 @@ use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 use Sonata\AdminBundle\Form\DataTransformerResolver;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
-use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
+use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
 use Sonata\AdminBundle\Twig\Extension\RenderElementExtension;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\PropertyAccess\PropertyAccess;
-use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -73,14 +72,14 @@ final class SetObjectFieldValueActionTest extends TestCase
     private $resolver;
 
     /**
-     * @var PropertyAccessor
-     */
-    private $propertyAccessor;
-
-    /**
      * @var string
      */
     private $adminCode;
+
+    /**
+     * @var MockObject&MutableTemplateRegistryInterface
+     */
+    private $templateRegistry;
 
     protected function setUp(): void
     {
@@ -97,15 +96,21 @@ final class SetObjectFieldValueActionTest extends TestCase
         $this->validator = $this->createMock(ValidatorInterface::class);
         $this->modelManager = $this->createMock(ModelManagerInterface::class);
         $this->resolver = new DataTransformerResolver();
-        $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
+        $propertyAccessor = PropertyAccess::createPropertyAccessor();
         $this->action = new SetObjectFieldValueAction(
             $this->twig,
             $this->pool,
             $this->validator,
             $this->resolver,
-            $this->propertyAccessor
+            $propertyAccessor
         );
         $this->admin->method('getModelManager')->willReturn($this->modelManager);
+        $this->twig->addExtension(new RenderElementExtension($propertyAccessor));
+        $this->templateRegistry = $this->createMock(MutableTemplateRegistryInterface::class);
+
+        $this->admin
+            ->method('getTemplateRegistry')
+            ->willReturn($this->templateRegistry);
     }
 
     public function testSetObjectFieldValueAction(): void
@@ -120,8 +125,6 @@ final class SetObjectFieldValueActionTest extends TestCase
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
-        $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
-        $container = new Container();
 
         $this->admin->method('getObject')->with(42)->willReturn($object);
         $this->admin->method('getCode')->willReturn($this->adminCode);
@@ -129,13 +132,7 @@ final class SetObjectFieldValueActionTest extends TestCase
         $this->admin->method('hasListFieldDescription')->with('enabled')->willReturn(true);
         $this->admin->method('getListFieldDescription')->with('enabled')->willReturn($fieldDescription);
         $this->admin->expects($this->once())->method('update')->with($object);
-        $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
-        $container->set('sonata.post.admin.template_registry', $templateRegistry);
-        $this->twig->addExtension(new RenderElementExtension(
-            $this->propertyAccessor,
-            $container,
-            null
-        ));
+        $this->templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $fieldDescription->method('getOption')->willReturnMap([
             ['editable', null, true],
         ]);
@@ -181,8 +178,6 @@ final class SetObjectFieldValueActionTest extends TestCase
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
-        $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
-        $container = new Container();
 
         $this->admin->method('getObject')->with(42)->willReturn($object);
         $this->admin->method('getCode')->willReturn($this->adminCode);
@@ -191,13 +186,7 @@ final class SetObjectFieldValueActionTest extends TestCase
         $this->admin->method('getListFieldDescription')->with('dateProp')->willReturn($fieldDescription);
         $this->admin->expects($this->once())->method('update')->with($object);
 
-        $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
-        $container->set('sonata.post.admin.template_registry', $templateRegistry);
-        $this->twig->addExtension(new RenderElementExtension(
-            $this->propertyAccessor,
-            $container,
-            null
-        ));
+        $this->templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $fieldDescription->method('getOption')->willReturnMap([
             ['timezone', null, $timezone],
             ['data_transformer', null, null],
@@ -235,8 +224,6 @@ final class SetObjectFieldValueActionTest extends TestCase
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
-        $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
-        $container = new Container();
 
         $this->admin->method('getObject')->with(42)->willReturn($object);
         $this->admin->method('getCode')->willReturn($this->adminCode);
@@ -245,13 +232,7 @@ final class SetObjectFieldValueActionTest extends TestCase
         $this->admin->method('getListFieldDescription')->with('bar')->willReturn($fieldDescription);
         $this->admin->method('getClass')->willReturn(\get_class($object));
         $this->admin->expects($this->once())->method('update')->with($object);
-        $container->set('sonata.post.admin.template_registry', $templateRegistry);
-        $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
-        $this->twig->addExtension(new RenderElementExtension(
-            $this->propertyAccessor,
-            $container,
-            null
-        ));
+        $this->templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $fieldDescription->method('getType')->willReturn('choice');
         $fieldDescription->method('getOption')->willReturnMap([
             ['class', null, Bar::class],
@@ -319,8 +300,6 @@ final class SetObjectFieldValueActionTest extends TestCase
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_POST, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
-        $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
-        $container = new Container();
 
         $this->admin->method('getObject')->with(42)->willReturn($object);
         $this->admin->method('getCode')->willReturn($this->adminCode);
@@ -328,13 +307,7 @@ final class SetObjectFieldValueActionTest extends TestCase
         $this->admin->method('hasListFieldDescription')->with('status')->willReturn(true);
         $this->admin->method('getListFieldDescription')->with('status')->willReturn($fieldDescription);
         $this->admin->expects($this->once())->method('update')->with($object);
-        $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
-        $container->set('sonata.post.admin.template_registry', $templateRegistry);
-        $this->twig->addExtension(new RenderElementExtension(
-            $this->propertyAccessor,
-            $container,
-            null
-        ));
+        $this->templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $fieldDescription->method('getOption')->willReturnMap([
             ['data_transformer', null, null],
             ['editable', null, true],
@@ -371,8 +344,6 @@ final class SetObjectFieldValueActionTest extends TestCase
         });
 
         $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
-        $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
-        $container = new Container();
 
         $this->admin->method('getObject')->with(42)->willReturn($object);
         $this->admin->method('getCode')->willReturn($this->adminCode);
@@ -380,13 +351,7 @@ final class SetObjectFieldValueActionTest extends TestCase
         $this->admin->method('hasListFieldDescription')->with('enabled')->willReturn(true);
         $this->admin->method('getListFieldDescription')->with('enabled')->willReturn($fieldDescription);
         $this->admin->expects($this->once())->method('update')->with($object);
-        $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
-        $container->set('sonata.post.admin.template_registry', $templateRegistry);
-        $this->twig->addExtension(new RenderElementExtension(
-            $this->propertyAccessor,
-            $container,
-            null
-        ));
+        $this->templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $fieldDescription->method('getOption')->willReturnMap([
             ['data_transformer', null, $dataTransformer],
             ['editable', null, true],
@@ -425,8 +390,6 @@ final class SetObjectFieldValueActionTest extends TestCase
         });
 
         $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
-        $templateRegistry = $this->createStub(TemplateRegistryInterface::class);
-        $container = new Container();
 
         $this->admin->method('getObject')->with(42)->willReturn($object);
         $this->admin->method('getCode')->willReturn($this->adminCode);
@@ -434,13 +397,7 @@ final class SetObjectFieldValueActionTest extends TestCase
         $this->admin->method('hasListFieldDescription')->with('enabled')->willReturn(true);
         $this->admin->method('getListFieldDescription')->with('enabled')->willReturn($fieldDescription);
         $this->admin->expects($this->once())->method('update')->with($object);
-        $templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
-        $container->set('sonata.post.admin.template_registry', $templateRegistry);
-        $this->twig->addExtension(new RenderElementExtension(
-            $this->propertyAccessor,
-            $container,
-            null
-        ));
+        $this->templateRegistry->method('getTemplate')->with('base_list_field')->willReturn('admin_template');
         $fieldDescription->method('getOption')->willReturnMap([
             ['data_transformer', null, $dataTransformer],
             ['editable', null, true],

--- a/tests/Twig/Extension/RenderElementExtensionTest.php
+++ b/tests/Twig/Extension/RenderElementExtensionTest.php
@@ -19,8 +19,8 @@ use Psr\Log\LoggerInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
-use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Sonata\AdminBundle\Tests\App\Model\Foo;
+use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooToString;
 use Sonata\AdminBundle\Tests\Fixtures\StubFilesystemLoader;
 use Sonata\AdminBundle\Twig\Extension\RenderElementExtension;
@@ -117,7 +117,7 @@ final class RenderElementExtensionTest extends TestCase
     private $container;
 
     /**
-     * @var TemplateRegistryInterface&MockObject
+     * @var MutableTemplateRegistryInterface&MockObject
      */
     private $templateRegistry;
 
@@ -153,9 +153,8 @@ final class RenderElementExtensionTest extends TestCase
 
         $this->translator = $translator;
 
-        $this->templateRegistry = $this->createStub(TemplateRegistryInterface::class);
         $this->container = new Container();
-        $this->container->set('sonata_admin_foo_service.template_registry', $this->templateRegistry);
+        $this->templateRegistry = $this->createMock(MutableTemplateRegistryInterface::class);
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
 
         $request = $this->createMock(Request::class);
@@ -175,11 +174,7 @@ final class RenderElementExtensionTest extends TestCase
             'optimizations' => 0,
         ]);
 
-        $this->twigExtension = new RenderElementExtension(
-            $propertyAccessor,
-            $this->container,
-            $this->logger,
-        );
+        $this->twigExtension = new RenderElementExtension($propertyAccessor);
 
         $this->registerRequiredTwigExtensions();
 
@@ -188,6 +183,10 @@ final class RenderElementExtensionTest extends TestCase
 
         // initialize admin
         $this->admin = $this->createMock(AdminInterface::class);
+
+        $this->admin
+            ->method('getTemplateRegistry')
+            ->willReturn($this->templateRegistry);
 
         $this->admin
             ->method('getCode')

--- a/tests/Twig/Extension/RenderElementExtensionTest.php
+++ b/tests/Twig/Extension/RenderElementExtensionTest.php
@@ -15,24 +15,18 @@ namespace Sonata\AdminBundle\Tests\Twig\Extension;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
-use Sonata\AdminBundle\Tests\App\Model\Foo;
 use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooToString;
 use Sonata\AdminBundle\Tests\Fixtures\StubFilesystemLoader;
 use Sonata\AdminBundle\Twig\Extension\RenderElementExtension;
 use Sonata\AdminBundle\Twig\Extension\XEditableExtension;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Bridge\Twig\Extension\RoutingExtension;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyAccess\PropertyAccess;
-use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Loader\XmlFileLoader;
 use Symfony\Component\Routing\RequestContext;
@@ -47,8 +41,6 @@ use Twig\Extra\String\StringExtension;
  */
 final class RenderElementExtensionTest extends TestCase
 {
-    use ExpectDeprecationTrait;
-
     private const X_EDITABLE_TYPE_MAPPING = [
         'choice' => 'select',
         'boolean' => 'select',
@@ -82,11 +74,6 @@ final class RenderElementExtensionTest extends TestCase
     private $admin;
 
     /**
-     * @var AdminInterface&MockObject
-     */
-    private $adminBar;
-
-    /**
      * @var FieldDescriptionInterface&MockObject
      */
     private $fieldDescription;
@@ -97,49 +84,18 @@ final class RenderElementExtensionTest extends TestCase
     private $object;
 
     /**
-     * @var Pool
-     */
-    private $pool;
-
-    /**
-     * @var LoggerInterface&MockObject
-     */
-    private $logger;
-
-    /**
      * @var TranslatorInterface
      */
     private $translator;
-
-    /**
-     * @var Container
-     */
-    private $container;
 
     /**
      * @var MutableTemplateRegistryInterface&MockObject
      */
     private $templateRegistry;
 
-    /**
-     * @var PropertyAccessor
-     */
-    private $propertyAccessor;
-
     protected function setUp(): void
     {
         date_default_timezone_set('Europe/London');
-
-        $container = new Container();
-
-        $this->pool = new Pool(
-            $container,
-            ['sonata_admin_foo_service'],
-            [],
-            [Foo::class => ['sonata_admin_foo_service']]
-        );
-
-        $this->logger = $this->getMockForAbstractClass(LoggerInterface::class);
 
         // translation extension
         $translator = new Translator('en');
@@ -153,7 +109,6 @@ final class RenderElementExtensionTest extends TestCase
 
         $this->translator = $translator;
 
-        $this->container = new Container();
         $this->templateRegistry = $this->createMock(MutableTemplateRegistryInterface::class);
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
 
@@ -201,18 +156,6 @@ final class RenderElementExtensionTest extends TestCase
             ->method('getNormalizedIdentifier')
             ->with($this->equalTo($this->object))
             ->willReturn('12345');
-
-        $this->adminBar = $this->createMock(AdminInterface::class);
-        $this->adminBar
-            ->method('hasAccess')
-            ->willReturn(true);
-        $this->adminBar
-            ->method('getNormalizedIdentifier')
-            ->with($this->equalTo($this->object))
-            ->willReturn('12345');
-
-        $container->set('sonata_admin_foo_service', $this->admin);
-        $container->set('sonata_admin_bar_service', $this->adminBar);
 
         // initialize field description
         $this->fieldDescription = $this->getMockForAbstractClass(FieldDescriptionInterface::class);


### PR DESCRIPTION
Looking at 

https://github.com/sonata-project/SonataAdminBundle/blob/7f07a8e25b90451125a9820d391747e49dd1f485/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php#L395-L407

seems like we could change this code:

```php
    $serviceId = $adminCode.'.template_registry';
    $templateRegistry = $this->templateRegistries->get($serviceId);

    if ($templateRegistry instanceof TemplateRegistryInterface) {
        return $templateRegistry;
    }
```

And use `AdminInterface::getTemplateRegistry()` method instead, so there is no need of injecting the container to the `RenderElementExtension` service.