### PR TITLE
Deprecate class-based aliases

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,30 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.xx to 3.xx
+=========================
+
+### Deprecated services aliases
+
+These service aliases have been deprecated:
+- `Sonata\AdminBundle\Command\ExplainAdminCommand`
+- `Sonata\AdminBundle\Command\GenerateObjectAclCommand`
+- `Sonata\AdminBundle\Command\ListAdminCommand`
+- `Sonata\AdminBundle\Command\SetupAclCommand`
+- `Sonata\AdminBundle\Admin\BreadcrumbsBuilder`
+- `Sonata\AdminBundle\Event\AdminEventExtension`
+- `Sonata\AdminBundle\Filter\FilterFactory`
+- `Sonata\AdminBundle\Filter\Persister\SessionFilterPersister`
+- `Sonata\AdminBundle\Model\AuditManager`
+- `Sonata\AdminBundle\Search\SearchHandler`
+- `Sonata\AdminBundle\Templating\TemplateRegistry`
+- `Sonata\AdminBundle\Translator\BCLabelTranslatorStrategy`
+- `Sonata\AdminBundle\Translator\Extractor\AdminExtractor`
+- `Sonata\AdminBundle\Translator\FormLabelTranslatorStrategy`
+- `Sonata\AdminBundle\Translator\NativeLabelTranslatorStrategy`
+- `Sonata\AdminBundle\Translator\NoopLabelTranslatorStrategy`
+- `Sonata\AdminBundle\Translator\UnderscoreLabelTranslatorStrategy`
+
 UPGRADE FROM 3.94 to 3.95
 =========================
 

--- a/src/DependencyInjection/Compiler/ObjectAclManipulatorCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ObjectAclManipulatorCompilerPass.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\DependencyInjection\Compiler;
 
-use Sonata\AdminBundle\Command\GenerateObjectAclCommand;
 use Sonata\AdminBundle\Util\ObjectAclManipulatorInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -49,7 +48,7 @@ final class ObjectAclManipulatorCompilerPass implements CompilerPassInterface
             $availableManagers[$id] = $container->getDefinition($id);
         }
 
-        $generateAdminCommandDefinition = $container->getDefinition(GenerateObjectAclCommand::class);
+        $generateAdminCommandDefinition = $container->getDefinition('sonata.admin.command.generate_object_acl');
         $generateAdminCommandDefinition->replaceArgument(1, $availableManagers);
     }
 }

--- a/src/Resources/config/commands.php
+++ b/src/Resources/config/commands.php
@@ -40,7 +40,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 '%kernel.debug%',
             ])
 
-        ->set(ExplainAdminCommand::class, ExplainAdminCommand::class)
+        ->set('sonata.admin.command.explain', ExplainAdminCommand::class)
             ->public()
             ->tag('console.command')
             ->args([
@@ -48,8 +48,15 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ReferenceConfigurator('validator'),
             ])
 
+        // NEXT_MAJOR: Remove this alias.
+        ->alias(ExplainAdminCommand::class, 'sonata.admin.command.explain')
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ))
+
         // NEXT_MAJOR: Remove the "setRegistry" call.
-        ->set(GenerateObjectAclCommand::class, GenerateObjectAclCommand::class)
+        ->set('sonata.admin.command.generate_object_acl', GenerateObjectAclCommand::class)
             ->public()
             ->tag('console.command')
             ->args([
@@ -58,18 +65,38 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ])
             ->call('setRegistry', [(new ReferenceConfigurator('doctrine'))->nullOnInvalid()])
 
-        ->set(ListAdminCommand::class, ListAdminCommand::class)
+        ->alias(GenerateObjectAclCommand::class, 'sonata.admin.command.generate_object_acl')
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ))
+
+        ->set('sonata.admin.command.list', ListAdminCommand::class)
             ->public()
             ->tag('console.command')
             ->args([
                 new ReferenceConfigurator('sonata.admin.pool'),
             ])
 
-        ->set(SetupAclCommand::class, SetupAclCommand::class)
+        // NEXT_MAJOR: Remove this alias.
+        ->alias(ListAdminCommand::class, 'sonata.admin.command.list')
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ))
+
+        ->set('sonata.admin.command.setup_acl', SetupAclCommand::class)
             ->public()
             ->tag('console.command')
             ->args([
                 new ReferenceConfigurator('sonata.admin.pool'),
                 new ReferenceConfigurator('sonata.admin.manipulator.acl.admin'),
-            ]);
+            ])
+
+        // NEXT_MAJOR: Remove this alias.
+        ->alias(SetupAclCommand::class, 'sonata.admin.command.setup_acl')
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ));
 };

--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -80,6 +80,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ReferenceConfigurator('sonata.admin.pool'),
             ])
 
+        // NEXT_MAJOR: Remove this alias.
         ->alias(AdminPoolLoader::class, 'sonata.admin.route_loader')
             ->deprecate(...BCDeprecationParameters::forConfig(
                 'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.95 and will be removed in 4.0.',
@@ -103,7 +104,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 [],
             ])
 
+        // NEXT_MAJOR: Remove this alias.
         ->alias(FilterFactory::class, 'sonata.admin.builder.filter.factory')
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ))
 
         ->alias(FilterFactoryInterface::class, 'sonata.admin.builder.filter.factory')
 
@@ -113,7 +119,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 '%sonata.admin.configuration.breadcrumbs%',
             ])
 
+        // NEXT_MAJOR: Remove this alias.
         ->alias(BreadcrumbsBuilder::class, 'sonata.admin.breadcrumbs_builder')
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ))
 
         ->alias(BreadcrumbsBuilderInterface::class, 'sonata.admin.breadcrumbs_builder')
 
@@ -122,29 +133,54 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set('sonata.admin.label.strategy.bc', BCLabelTranslatorStrategy::class)
             ->public()
 
+        // NEXT_MAJOR: Remove this alias.
         ->alias(BCLabelTranslatorStrategy::class, 'sonata.admin.label.strategy.bc')
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ))
 
         ->set('sonata.admin.label.strategy.native', NativeLabelTranslatorStrategy::class)
             ->public()
 
+        // NEXT_MAJOR: Remove this alias.
         ->alias(NativeLabelTranslatorStrategy::class, 'sonata.admin.label.strategy.native')
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ))
 
         ->alias(LabelTranslatorStrategyInterface::class, 'sonata.admin.label.strategy.native')
 
         ->set('sonata.admin.label.strategy.noop', NoopLabelTranslatorStrategy::class)
             ->public()
 
+        // NEXT_MAJOR: Remove this alias.
         ->alias(NoopLabelTranslatorStrategy::class, 'sonata.admin.label.strategy.noop')
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ))
 
         ->set('sonata.admin.label.strategy.underscore', UnderscoreLabelTranslatorStrategy::class)
             ->public()
 
+        // NEXT_MAJOR: Remove this alias.
         ->alias(UnderscoreLabelTranslatorStrategy::class, 'sonata.admin.label.strategy.underscore')
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ))
 
         ->set('sonata.admin.label.strategy.form_component', FormLabelTranslatorStrategy::class)
             ->public()
 
+        // NEXT_MAJOR: Remove this alias.
         ->alias(FormLabelTranslatorStrategy::class, 'sonata.admin.label.strategy.form_component')
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ))
 
         // NEXT_MAJOR: Remove this service.
         ->set('sonata.admin.translator.extractor.jms_translator_bundle', DeprecatedAdminExtractor::class)
@@ -164,7 +200,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ReferenceConfigurator('sonata.admin.breadcrumbs_builder'),
             ])
 
-        ->set(AdminExtractor::class)
+        ->set('sonata.admin.translation_extractor', AdminExtractor::class)
             ->tag('translation.extractor', [
                 'alias' => 'sonata_admin',
             ])
@@ -172,6 +208,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ReferenceConfigurator('sonata.admin.pool'),
                 new ReferenceConfigurator('sonata.admin.breadcrumbs_builder'),
             ])
+
+        // NEXT_MAJOR: Remove this alias.
+        ->alias(AdminExtractor::class, 'sonata.admin.translation_extractor')
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ))
 
         // NEXT_MAJOR: Remove this service.
         ->set('sonata.admin.controller.admin', HelperController::class)
@@ -196,7 +239,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 null, // Service locator
             ])
 
+        // NEXT_MAJOR: Remove this alias.
         ->alias(AuditManager::class, 'sonata.admin.audit.manager')
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ))
 
         ->alias(AuditManagerInterface::class, 'sonata.admin.audit.manager')
 
@@ -214,7 +262,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 '%sonata.admin.configuration.global_search.case_sensitive%',
             ])
 
+        // NEXT_MAJOR: Remove this alias.
         ->alias(SearchHandler::class, 'sonata.admin.search.handler')
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ))
 
         ->set('sonata.admin.event.extension', AdminEventExtension::class)
             ->public()
@@ -223,7 +276,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ReferenceConfigurator('event_dispatcher'),
             ])
 
+        // NEXT_MAJOR: Remove this alias.
         ->alias(AdminEventExtension::class, 'sonata.admin.event.extension')
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ))
 
         ->set('sonata.admin.lock.extension', LockExtension::class)
             ->public()
@@ -244,7 +302,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ReferenceConfigurator('session'),
             ])
 
+        // NEXT_MAJOR: Remove this alias.
         ->alias(SessionFilterPersister::class, 'sonata.admin.filter_persister.session')
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ))
 
         ->alias(FilterPersisterInterface::class, 'sonata.admin.filter_persister.session')
 
@@ -254,7 +317,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 '%sonata.admin.configuration.templates%',
             ])
 
+        // NEXT_MAJOR: Remove this alias.
         ->alias(TemplateRegistry::class, 'sonata.admin.global_template_registry')
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ))
 
         // NEXT_MAJOR: remove this alias, global template registry SHOULD NOT be mutable
         ->alias(MutableTemplateRegistryInterface::class, 'sonata.admin.global_template_registry');

--- a/src/Resources/config/event_listener.php
+++ b/src/Resources/config/event_listener.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
  */
 
 use Sonata\AdminBundle\EventListener\AssetsInstallCommandListener;
+use Sonata\AdminBundle\Util\BCDeprecationParameters;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
@@ -21,7 +22,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     // Use "param" function for creating references to parameters when dropping support for Symfony 5.1
     $containerConfigurator->services()
 
-        ->set(AssetsInstallCommandListener::class)
+        ->set('sonata.admin.listener.assets_install', AssetsInstallCommandListener::class)
             ->tag('kernel.event_listener', [
                 'event' => ConsoleEvents::TERMINATE,
                 'method' => 'copySonataCoreBundleAssets',
@@ -29,5 +30,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->args([
                 new ReferenceConfigurator('filesystem'),
                 '%kernel.project_dir%',
-            ]);
+            ])
+
+        // NEXT_MAJOR: Remove this alias.
+        ->alias(AssetsInstallCommandListener::class, 'sonata.admin.listener.assets_install')
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ));
 };

--- a/tests/DependencyInjection/Compiler/ObjectAclManipulatorCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ObjectAclManipulatorCompilerPassTest.php
@@ -35,7 +35,7 @@ class ObjectAclManipulatorCompilerPassTest extends TestCase
 
         $objectAclManipulatorCompilerPass->process($containerBuilder);
 
-        $availableManagers = $containerBuilder->getDefinition(GenerateObjectAclCommand::class)->getArgument(1);
+        $availableManagers = $containerBuilder->getDefinition('sonata.admin.command.generate_object_acl')->getArgument(1);
 
         $this->assertArrayHasKey($serviceId, $availableManagers);
     }
@@ -66,7 +66,7 @@ class ObjectAclManipulatorCompilerPassTest extends TestCase
         $pool = new Pool(new Container());
         $container = new ContainerBuilder();
         $container
-            ->register(GenerateObjectAclCommand::class)
+            ->register('sonata.admin.command.generate_object_acl')
             ->setClass(GenerateObjectAclCommand::class)
             ->setArguments([$pool, []]);
 

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -47,7 +47,7 @@ use Sonata\AdminBundle\Twig\GlobalVariables;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\Definition\Processor;
 
-class SonataAdminExtensionTest extends AbstractExtensionTestCase
+final class SonataAdminExtensionTest extends AbstractExtensionTestCase
 {
     /**
      * @var array
@@ -67,44 +67,44 @@ class SonataAdminExtensionTest extends AbstractExtensionTestCase
         $this->load();
 
         $this->assertContainerBuilderHasService(Pool::class);
+        // NEXT_MAJOR: Remove next line.
         $this->assertContainerBuilderHasService(AdminPoolLoader::class);
+        // NEXT_MAJOR: Remove next line.
         $this->assertContainerBuilderHasService(AdminHelper::class);
+        // NEXT_MAJOR: Remove next line.
         $this->assertContainerBuilderHasService(FilterFactory::class);
-        $this->assertContainerBuilderHasService(
-            FilterFactoryInterface::class,
-            FilterFactory::class
-        );
+        $this->assertContainerBuilderHasService(FilterFactoryInterface::class);
+        // NEXT_MAJOR: Remove next line.
         $this->assertContainerBuilderHasService(BreadcrumbsBuilder::class);
-        $this->assertContainerBuilderHasService(
-            BreadcrumbsBuilderInterface::class,
-            BreadcrumbsBuilder::class
-        );
+        $this->assertContainerBuilderHasService(BreadcrumbsBuilderInterface::class);
+        // NEXT_MAJOR: Remove next line.
         $this->assertContainerBuilderHasService(BCLabelTranslatorStrategy::class);
+        // NEXT_MAJOR: Remove next line.
         $this->assertContainerBuilderHasService(NativeLabelTranslatorStrategy::class);
-        $this->assertContainerBuilderHasService(
-            LabelTranslatorStrategyInterface::class,
-            NativeLabelTranslatorStrategy::class
-        );
+        $this->assertContainerBuilderHasService(LabelTranslatorStrategyInterface::class);
+        // NEXT_MAJOR: Remove next line.
         $this->assertContainerBuilderHasService(NoopLabelTranslatorStrategy::class);
+        // NEXT_MAJOR: Remove next line.
         $this->assertContainerBuilderHasService(UnderscoreLabelTranslatorStrategy::class);
+        // NEXT_MAJOR: Remove next line.
         $this->assertContainerBuilderHasService(FormLabelTranslatorStrategy::class);
+        // NEXT_MAJOR: Remove next line.
         $this->assertContainerBuilderHasService(AuditManager::class);
-        $this->assertContainerBuilderHasService(AuditManagerInterface::class, AuditManager::class);
+        $this->assertContainerBuilderHasService(AuditManagerInterface::class);
+        // NEXT_MAJOR: Remove next line.
         $this->assertContainerBuilderHasService(SearchHandler::class);
+        // NEXT_MAJOR: Remove next line.
         $this->assertContainerBuilderHasService(AdminEventExtension::class);
         // NEXT_MAJOR: Remove next line.
         $this->assertContainerBuilderHasService(GlobalVariables::class);
         $this->assertContainerBuilderHasService('sonata.admin.group.extension');
+        // NEXT_MAJOR: Remove next line.
         $this->assertContainerBuilderHasService(SessionFilterPersister::class);
-        $this->assertContainerBuilderHasService(
-            FilterPersisterInterface::class,
-            SessionFilterPersister::class
-        );
+        $this->assertContainerBuilderHasService(FilterPersisterInterface::class);
+        // NEXT_MAJOR: Remove next line.
         $this->assertContainerBuilderHasService(TemplateRegistry::class);
-        $this->assertContainerBuilderHasService(
-            MutableTemplateRegistryInterface::class,
-            TemplateRegistry::class
-        );
+        $this->assertContainerBuilderHasService(MutableTemplateRegistryInterface::class);
+        // NEXT_MAJOR: Remove next line.
         $this->assertContainerBuilderHasService(AdminExtractor::class);
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Following https://symfony.com/doc/current/bundles/best_practices.html#services, service names in bundles shouldn't be the FQCN, so I've changes these FQCN with strings prefixed with the bundle alias `sonata.admin`.

The aliases deprecated are based on implementations and some of them shouldn't be part of the public API.

Ref: https://github.com/sonata-project/SonataAdminBundle/issues/7000
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #7000.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `Sonata\AdminBundle\Command\ExplainAdminCommand` service alias.
- Deprecated `Sonata\AdminBundle\Command\GenerateObjectAclCommand` service alias.
- Deprecated `Sonata\AdminBundle\Command\ListAdminCommand` service alias.
- Deprecated `Sonata\AdminBundle\Command\SetupAclCommand` service alias.
- Deprecated `Sonata\AdminBundle\Admin\BreadcrumbsBuilder` service alias.
- Deprecated `Sonata\AdminBundle\Event\AdminEventExtension` service alias.
- Deprecated `Sonata\AdminBundle\Filter\FilterFactory` service alias.
- Deprecated `Sonata\AdminBundle\Filter\Persister\SessionFilterPersister` service alias.
- Deprecated `Sonata\AdminBundle\Model\AuditManager` service alias.
- Deprecated `Sonata\AdminBundle\Search\SearchHandler` service alias.
- Deprecated `Sonata\AdminBundle\Templating\TemplateRegistry` service alias.
- Deprecated `Sonata\AdminBundle\Translator\BCLabelTranslatorStrategy` service alias.
- Deprecated `Sonata\AdminBundle\Translator\Extractor\AdminExtractor` service alias.
- Deprecated `Sonata\AdminBundle\Translator\FormLabelTranslatorStrategy` service alias.
- Deprecated `Sonata\AdminBundle\Translator\NativeLabelTranslatorStrategy` service alias.
- Deprecated `Sonata\AdminBundle\Translator\NoopLabelTranslatorStrategy` service alias.
- Deprecated `Sonata\AdminBundle\Translator\UnderscoreLabelTranslatorStrategy` service alias.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
## To do

- [x] Update the tests;
- [x] Add an upgrade note.
