### PR TITLE
Allow silence deprecation in persistence bundles

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -697,7 +697,8 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
     final public function getDefaultFilterParameters(): array
     {
         return array_merge(
-            $this->getModelManager()->getDefaultSortValues($this->getClass()), // NEXT_MAJOR: Remove this line.
+            /* @phpstan-ignore-next-line */
+            $this->getModelManager()->getDefaultSortValues($this->getClass(), 'sonata_deprecation_mute'), // NEXT_MAJOR: Remove this line.
             $this->datagridValues, // NEXT_MAJOR: Remove this line.
             $this->getDefaultSortValues(),
             $this->getDefaultFilterValues()


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

`DatagridManagerInterface::getDefaultSortValues()` was deprecated in `3.79` and the implementations of this method in the persistence bundles where also deprecated. 

The problem is that in `3.x` we have to still use it, so we need a way to not trigger that deprecation, adding the `'sonata_deprecation_mute'` argument allows the persistence bundles to not trigger a deprecation when the call is from this bundle.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed allowing avoid deprecation using `DatagridManagerInterface::getDefaultSortValues()`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
