### PR TITLE
Make compiler passes internal

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,10 @@ UPGRADE 3.x
 UPGRADE FROM 3.xx to 3.xx
 =========================
 
+### Compiler Passes have been marked as internal
+
+All Compiler Passes will be internal in version 4.0 and they will not be covered by our BC promise.
+
 ### Deprecated services aliases
 
 These service aliases have been deprecated:

--- a/src/DependencyInjection/Compiler/AddAuditReadersCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddAuditReadersCompilerPass.php
@@ -20,6 +20,11 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Reference;
 
+/**
+ * NEXT_MAJOR: Remove the "since" part of the internal annotation.
+ *
+ * @internal since sonata-project/admin-bundle version 4.0
+ */
 final class AddAuditReadersCompilerPass implements CompilerPassInterface
 {
     public const AUDIT_READER_TAG = 'sonata.admin.audit_reader';

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -30,6 +30,10 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @final since sonata-project/admin-bundle 3.52
  *
+ * NEXT_MAJOR: Remove the "since" part of the internal annotation.
+ *
+ * @internal since sonata-project/admin-bundle version 4.0
+ *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class AddDependencyCallsCompilerPass implements CompilerPassInterface

--- a/src/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddFilterTypeCompilerPass.php
@@ -23,6 +23,10 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 /**
  * @final since sonata-project/admin-bundle 3.52
  *
+ * NEXT_MAJOR: Remove the "since" part of the internal annotation.
+ *
+ * @internal since sonata-project/admin-bundle version 4.0
+ *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class AddFilterTypeCompilerPass implements CompilerPassInterface

--- a/src/DependencyInjection/Compiler/AdminMakerCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AdminMakerCompilerPass.php
@@ -16,6 +16,11 @@ namespace Sonata\AdminBundle\DependencyInjection\Compiler;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+/**
+ * NEXT_MAJOR: Remove the "since" part of the internal annotation.
+ *
+ * @internal since sonata-project/admin-bundle version 4.0
+ */
 final class AdminMakerCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void

--- a/src/DependencyInjection/Compiler/AdminSearchCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AdminSearchCompilerPass.php
@@ -22,6 +22,10 @@ use Symfony\Component\DependencyInjection\Exception\LogicException;
 /**
  * This class configures which admins must be considered for global search at `SearchHandler`.
  *
+ * NEXT_MAJOR: Remove the "since" part of the internal annotation.
+ *
+ * @internal since sonata-project/admin-bundle version 4.0
+ *
  * @author Javier Spagnoletti <phansys@gmail.com>
  */
 final class AdminSearchCompilerPass implements CompilerPassInterface

--- a/src/DependencyInjection/Compiler/ExtensionCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ExtensionCompilerPass.php
@@ -22,6 +22,10 @@ use Symfony\Component\DependencyInjection\Reference;
 /**
  * @final since sonata-project/admin-bundle 3.52
  *
+ * NEXT_MAJOR: Remove the "since" part of the internal annotation.
+ *
+ * @internal since sonata-project/admin-bundle version 4.0
+ *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class ExtensionCompilerPass implements CompilerPassInterface

--- a/src/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
+++ b/src/DependencyInjection/Compiler/GlobalVariablesCompilerPass.php
@@ -20,6 +20,10 @@ use Symfony\Component\DependencyInjection\Reference;
 /**
  * @final since sonata-project/admin-bundle 3.52
  *
+ * NEXT_MAJOR: Remove the "since" part of the internal annotation.
+ *
+ * @internal since sonata-project/admin-bundle version 4.0
+ *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
 class GlobalVariablesCompilerPass implements CompilerPassInterface

--- a/src/DependencyInjection/Compiler/ModelManagerCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ModelManagerCompilerPass.php
@@ -23,6 +23,10 @@ use Symfony\Component\DependencyInjection\Exception\LogicException;
  *
  * @final since sonata-project/admin-bundle 3.52
  *
+ * NEXT_MAJOR: Remove the "since" part of the internal annotation.
+ *
+ * @internal since sonata-project/admin-bundle version 4.0
+ *
  * @author Gaurav Singh Faudjdar <faujdar@gmail.com>
  */
 final class ModelManagerCompilerPass implements CompilerPassInterface

--- a/src/DependencyInjection/Compiler/ObjectAclManipulatorCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ObjectAclManipulatorCompilerPass.php
@@ -20,6 +20,10 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 /**
  * This class injects available object ACL manipulators to services which depend on them.
  *
+ * NEXT_MAJOR: Remove the "since" part of the internal annotation.
+ *
+ * @internal since sonata-project/admin-bundle version 4.0
+ *
  * @author Javier Spagnoletti <phansys@gmail.com>
  */
 final class ObjectAclManipulatorCompilerPass implements CompilerPassInterface

--- a/src/DependencyInjection/Compiler/TwigStringExtensionCompilerPass.php
+++ b/src/DependencyInjection/Compiler/TwigStringExtensionCompilerPass.php
@@ -18,6 +18,11 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Twig\Extra\String\StringExtension;
 
+/**
+ * NEXT_MAJOR: Remove the "since" part of the internal annotation.
+ *
+ * @internal since sonata-project/admin-bundle version 4.0
+ */
 final class TwigStringExtensionCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This could be another step in our quest of closing public API, IMO Compiler passes are not meant to be directly used by users of the bundle, so we could mark them as internal so we don't have to keep BC on these classes (in `4.x`).

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Compiler Pass classes have been marked as `@internal`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
