### PR TITLE
Improve php doc

### DIFF
--- a/src/Admin/LifecycleHookProviderInterface.php
+++ b/src/Admin/LifecycleHookProviderInterface.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Admin;
 
+use Sonata\AdminBundle\Exception\LockException;
+use Sonata\AdminBundle\Exception\ModelManagerException;
+
 /**
  * This interface can be implemented to provide hooks that will be called
  * during the lifecycle of the object.
@@ -28,6 +31,9 @@ interface LifecycleHookProviderInterface
      *
      * @param object $object
      *
+     * @throws ModelManagerException
+     * @throws LockException
+     *
      * @return object
      *
      * @phpstan-param T $object
@@ -40,6 +46,8 @@ interface LifecycleHookProviderInterface
      *
      * @param object $object
      *
+     * @throws ModelManagerException
+     *
      * @return object
      *
      * @phpstan-param T $object
@@ -51,6 +59,8 @@ interface LifecycleHookProviderInterface
      * This method should call preRemove, do the removal, and call postRemove.
      *
      * @param object $object
+     *
+     * @throws ModelManagerException
      *
      * @phpstan-param T $object
      */

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -35,7 +35,7 @@ interface FilterInterface
      * @param string  $field
      * @param mixed[] $data
      *
-     * @phpstan-param array{type?: string|int|null, value?: mixed} $data
+     * @phpstan-param array{type?: int|null, value?: mixed} $data
      */
     public function filter(ProxyQueryInterface $query, $alias, $field, $data);
 
@@ -43,7 +43,7 @@ interface FilterInterface
      * @param ProxyQueryInterface $query
      * @param mixed[]             $filterData
      *
-     * @phpstan-param array{type?: string|int|null, value?: mixed} $filterData
+     * @phpstan-param array{type?: int|null, value?: mixed} $filterData
      */
     public function apply($query, $filterData);
 


### PR DESCRIPTION
Pedantic

We're try-catch-ing the method of LifecycleHookProviderInterface, so adding the `@throws` tag to the method  seems nice.

We're always using `int` for the filter type, so I think we can restrict the type.
It avoid some static analysis errors in the persistence bundle.
```
 Parameter #1 $type of method Sonata\DoctrineORMAdminBundle\Filter\ClassFilter::getOperator() expects int, int|string given.
```