### PR TITLE
Add tests to filter types and fix options

### DIFF
--- a/src/Form/Type/Filter/DateRangeType.php
+++ b/src/Form/Type/Filter/DateRangeType.php
@@ -84,7 +84,11 @@ class DateRangeType extends AbstractType
     {
         $resolver->setDefaults([
             'field_type' => FormDateRangeType::class,
-            'field_options' => ['format' => DateType::HTML5_FORMAT],
+            'field_options' => [
+                'field_options' => [
+                    'format' => DateType::HTML5_FORMAT,
+                ],
+            ],
         ]);
     }
 }

--- a/src/Form/Type/Filter/DateTimeRangeType.php
+++ b/src/Form/Type/Filter/DateTimeRangeType.php
@@ -16,7 +16,7 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 use Sonata\AdminBundle\Form\Type\Operator\DateRangeOperatorType;
 use Sonata\Form\Type\DateTimeRangeType as FormDateTimeRangeType;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
@@ -84,7 +84,9 @@ class DateTimeRangeType extends AbstractType
     {
         $resolver->setDefaults([
             'field_type' => FormDateTimeRangeType::class,
-            'field_options' => ['date_format' => DateType::HTML5_FORMAT],
+            'field_options' => [
+                'field_options' => ['date_format' => DateTimeType::HTML5_FORMAT],
+            ],
         ]);
     }
 }

--- a/src/Form/Type/Filter/DateType.php
+++ b/src/Form/Type/Filter/DateType.php
@@ -108,7 +108,7 @@ class DateType extends AbstractType
     {
         $resolver->setDefaults([
             'field_type' => FormDateType::class,
-            'field_options' => ['date_format' => FormDateType::HTML5_FORMAT],
+            'field_options' => ['format' => FormDateType::HTML5_FORMAT],
         ]);
     }
 }

--- a/tests/Form/Type/Filter/BaseTypeTest.php
+++ b/tests/Form/Type/Filter/BaseTypeTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Form\Type\Filter;
+
+use Symfony\Component\Form\Test\TypeTestCase;
+
+abstract class BaseTypeTest extends TypeTestCase
+{
+    public function testHasTypeAndValue(): void
+    {
+        $form = $this->factory->create($this->getTestedType());
+
+        $this->assertTrue($form->has('type'));
+        $this->assertTrue($form->has('value'));
+    }
+
+    public function testHasFieldTypeAndOptions(): void
+    {
+        $form = $this->factory->create($this->getTestedType());
+
+        $this->assertTrue($form->getConfig()->hasOption('field_type'));
+        $this->assertTrue($form->getConfig()->hasOption('field_options'));
+    }
+
+    /**
+     * @phpstan-return class-string
+     */
+    abstract protected function getTestedType(): string;
+}

--- a/tests/Form/Type/Filter/ChoiceTypeTest.php
+++ b/tests/Form/Type/Filter/ChoiceTypeTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Form\Type\Filter;
+
+use Sonata\AdminBundle\Form\Type\Filter\ChoiceType;
+use Symfony\Component\Translation\TranslatorInterface;
+
+final class ChoiceTypeTest extends BaseTypeTest
+{
+    public function testDefaultOptions(): void
+    {
+        $form = $this->factory->create($this->getTestedType());
+
+        $view = $form->createView();
+
+        $this->assertFalse($view->children['type']->vars['required']);
+        $this->assertFalse($view->children['value']->vars['required']);
+    }
+
+    protected function getTestedType(): string
+    {
+        return ChoiceType::class;
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @return ChoiceType[]
+     */
+    protected function getTypes(): array
+    {
+        return [
+            new ChoiceType($this->createStub(TranslatorInterface::class)),
+        ];
+    }
+}

--- a/tests/Form/Type/Filter/DateRangeTypeTest.php
+++ b/tests/Form/Type/Filter/DateRangeTypeTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Form\Type\Filter;
+
+use Sonata\AdminBundle\Form\Type\Filter\DateRangeType;
+use Symfony\Component\Translation\TranslatorInterface;
+
+final class DateRangeTypeTest extends BaseTypeTest
+{
+    public function testDefaultOptions(): void
+    {
+        $form = $this->factory->create($this->getTestedType());
+
+        $view = $form->createView();
+
+        $this->assertFalse($view->children['type']->vars['required']);
+        $this->assertTrue($view->children['value']->vars['required']);
+    }
+
+    protected function getTestedType(): string
+    {
+        return DateRangeType::class;
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @return DateRangeType[]
+     */
+    protected function getTypes(): array
+    {
+        return [
+            new DateRangeType($this->createStub(TranslatorInterface::class)),
+        ];
+    }
+}

--- a/tests/Form/Type/Filter/DateTimeRangeTypeTest.php
+++ b/tests/Form/Type/Filter/DateTimeRangeTypeTest.php
@@ -15,13 +15,22 @@ namespace Sonata\AdminBundle\Tests\Form\Type\Filter;
 
 use Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType;
 use Sonata\Form\Type\DateTimeRangeType as FormDateTimeRangeType;
-use Symfony\Component\Form\Extension\Core\Type\DateType;
-use Symfony\Component\Form\Test\TypeTestCase;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
 
-final class DateTimeRangeTypeTest extends TypeTestCase
+final class DateTimeRangeTypeTest extends BaseTypeTest
 {
+    public function testDefaultOptions(): void
+    {
+        $form = $this->factory->create($this->getTestedType());
+
+        $view = $form->createView();
+
+        $this->assertFalse($view->children['type']->vars['required']);
+        $this->assertTrue($view->children['value']->vars['required']);
+    }
+
     public function testGetDefaultOptions(): void
     {
         $translator = $this->createStub(TranslatorInterface::class);
@@ -36,8 +45,25 @@ final class DateTimeRangeTypeTest extends TypeTestCase
 
         $expected = [
             'field_type' => FormDateTimeRangeType::class,
-            'field_options' => ['date_format' => DateType::HTML5_FORMAT],
+            'field_options' => ['field_options' => ['date_format' => DateTimeType::HTML5_FORMAT]],
         ];
         $this->assertSame($expected, $options);
+    }
+
+    protected function getTestedType(): string
+    {
+        return DateTimeRangeType::class;
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @return DateTimeRangeType[]
+     */
+    protected function getTypes(): array
+    {
+        return [
+            new DateTimeRangeType($this->createStub(TranslatorInterface::class)),
+        ];
     }
 }

--- a/tests/Form/Type/Filter/DateTimeTypeTest.php
+++ b/tests/Form/Type/Filter/DateTimeTypeTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Form\Type\Filter;
+
+use Sonata\AdminBundle\Form\Type\Filter\DateTimeType;
+use Symfony\Component\Translation\TranslatorInterface;
+
+final class DateTimeTypeTest extends BaseTypeTest
+{
+    public function testDefaultOptions(): void
+    {
+        $form = $this->factory->create($this->getTestedType());
+
+        $view = $form->createView();
+
+        $this->assertFalse($view->children['type']->vars['required']);
+        $this->assertFalse($view->children['value']->vars['required']);
+    }
+
+    protected function getTestedType(): string
+    {
+        return DateTimeType::class;
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @return DateTimeType[]
+     */
+    protected function getTypes(): array
+    {
+        return [
+            new DateTimeType($this->createStub(TranslatorInterface::class)),
+        ];
+    }
+}

--- a/tests/Form/Type/Filter/DateTypeTest.php
+++ b/tests/Form/Type/Filter/DateTypeTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Form\Type\Filter;
+
+use Sonata\AdminBundle\Form\Type\Filter\DateType;
+use Symfony\Component\Translation\TranslatorInterface;
+
+final class DateTypeTest extends BaseTypeTest
+{
+    public function testDefaultOptions(): void
+    {
+        $form = $this->factory->create($this->getTestedType());
+
+        $view = $form->createView();
+
+        $this->assertFalse($view->children['type']->vars['required']);
+        $this->assertFalse($view->children['value']->vars['required']);
+    }
+
+    protected function getTestedType(): string
+    {
+        return DateType::class;
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @return DateType[]
+     */
+    protected function getTypes(): array
+    {
+        return [
+            new DateType($this->createStub(TranslatorInterface::class)),
+        ];
+    }
+}

--- a/tests/Form/Type/Filter/DefaultTypeTest.php
+++ b/tests/Form/Type/Filter/DefaultTypeTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Form\Type\Filter;
+
+use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
+
+final class DefaultTypeTest extends BaseTypeTest
+{
+    public function testDefaultOptions(): void
+    {
+        $form = $this->factory->create($this->getTestedType());
+
+        $view = $form->createView();
+
+        $this->assertFalse($view->children['type']->vars['required']);
+        $this->assertFalse($view->children['value']->vars['required']);
+    }
+
+    protected function getTestedType(): string
+    {
+        return DefaultType::class;
+    }
+}

--- a/tests/Form/Type/Filter/NumberTypeTest.php
+++ b/tests/Form/Type/Filter/NumberTypeTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Form\Type\Filter;
+
+use Sonata\AdminBundle\Form\Type\Filter\NumberType;
+use Symfony\Component\Translation\TranslatorInterface;
+
+final class NumberTypeTest extends BaseTypeTest
+{
+    public function testDefaultOptions(): void
+    {
+        $form = $this->factory->create($this->getTestedType());
+
+        $view = $form->createView();
+
+        $this->assertFalse($view->children['type']->vars['required']);
+        $this->assertFalse($view->children['value']->vars['required']);
+    }
+
+    protected function getTestedType(): string
+    {
+        return NumberType::class;
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @return NumberType[]
+     */
+    protected function getTypes(): array
+    {
+        return [
+            new NumberType($this->createStub(TranslatorInterface::class)),
+        ];
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I wanted to work a bit with filters, but before starting, better to have some tests.

Adding them showed that:
- `format` is not valid for `DateTimeRangeType` because this Type adds two `DateTimeType` that have that configuration (not `DateTimeRangeType` itself), so I've added the `format` option in the `field_options` option so is passed to those `DateTimeType` and changed from `DateType::HTML5_FORMAT` to `DateTimeType::HTML5_FORMAT`.
- `date_format` is not valid for `DateType`, so I've changed it to `format`.

Another interesting part I was thinking was... why has it worked so far? Because having:

```php
public function configureOptions(OptionsResolver $resolver)
{
    $resolver->setDefaults([
        'field_type' => FormDateType::class,
        'field_options' => ['date_format' => FormDateType::HTML5_FORMAT],
    ]);
}
```

The `field_options` option is an array and we always override this array ([here for example](https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/795f277683c9552448c46fcacfc217eead676db8/src/Filter/AbstractDateFilter.php#L200)), and by doing this, it does not merge the values, so this `date_format` always gets lost.

If we want to allow nested options we should use [a closure instead](https://symfony.com/doc/4.4/components/options_resolver.html#nested-options) (useful also for https://github.com/sonata-project/SonataAdminBundle/pull/6078), but that's another issue (that I think we should consider).


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed using invalid values in `field_options` of filters.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
