### PR TITLE
Deprecate more service aliases

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,8 +1,8 @@
 UPGRADE 3.x
 ===========
 
-UPGRADE FROM 3.xx to 3.xx
-=========================
+UPGRADE FROM 3.x to 3.x
+=======================
 
 ### Deprecated services aliases
 
@@ -11,11 +11,13 @@ These service aliases have been deprecated:
 - `Sonata\AdminBundle\Command\GenerateObjectAclCommand`
 - `Sonata\AdminBundle\Command\ListAdminCommand`
 - `Sonata\AdminBundle\Command\SetupAclCommand`
+- `Sonata\AdminBundle\Admin\AdminHelper`
 - `Sonata\AdminBundle\Admin\BreadcrumbsBuilder`
 - `Sonata\AdminBundle\Event\AdminEventExtension`
 - `Sonata\AdminBundle\Filter\FilterFactory`
 - `Sonata\AdminBundle\Filter\Persister\SessionFilterPersister`
 - `Sonata\AdminBundle\Model\AuditManager`
+- `Sonata\AdminBundle\SonataConfiguration`
 - `Sonata\AdminBundle\Search\SearchHandler`
 - `Sonata\AdminBundle\Templating\TemplateRegistry`
 - `Sonata\AdminBundle\Translator\BCLabelTranslatorStrategy`

--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -72,6 +72,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ])
 
         ->alias(SonataConfiguration::class, 'sonata.admin.configuration')
+            // NEXT_MAJOR: Remove this alias.
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ))
 
         ->set('sonata.admin.route_loader', AdminPoolLoader::class)
             ->public()
@@ -96,6 +101,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ])
 
         ->alias(AdminHelper::class, 'sonata.admin.helper')
+            // NEXT_MAJOR: Remove this alias.
+            ->deprecate(...BCDeprecationParameters::forConfig(
+                'The "%alias_id%" alias is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.',
+                '3.x'
+            ))
 
         ->set('sonata.admin.builder.filter.factory', FilterFactory::class)
             ->public()


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

It should have been included in https://github.com/sonata-project/SonataAdminBundle/pull/7001

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated `Sonata\AdminBundle\Admin\AdminHelper` service alias.
- Deprecated `Sonata\AdminBundle\SonataConfiguration` service alias.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
