### PR TITLE
Deprecate MutableTemplateRegistryAwareInterface

### DIFF
--- a/src/Templating/MutableTemplateRegistryAwareInterface.php
+++ b/src/Templating/MutableTemplateRegistryAwareInterface.php
@@ -14,7 +14,11 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Templating;
 
 /**
+ * NEXT_MAJOR: Remove this interface and move the method to the TaggedAdminInterface.
+ *
  * @author Wojciech Błoszyk <wbloszyk@gmail.com>
+ *
+ * @deprecated since sonata-project/sonata-admin 3.x
  *
  * @method MutableTemplateRegistryInterface getTemplateRegistry()
  * @method bool                             hasTemplateRegistry()


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because BC.

Related to this message: https://github.com/sonata-project/SonataAdminBundle/pull/6977#issuecomment-813014560

Answer from @wbloszyk 
>  IMO We should move this interface to the TaggedAdminInterfsce. In 5.0   i want remove admin_code.template_registry services and replace it by templateRegistyPool in Admin objects. This pool will be simmilar to the AdminPool. Getting current teplate registry will be allow from them. In this case templating will be move to seperate service but will be easy to use.

## Changelog

```markdown
### Deprecated
- MutableTemplateRegistryAwareInterface
```