### PR TITLE
Add tests for label and help blocks

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -160,7 +160,8 @@ file that was distributed with this source code.
             {%- elseif not sonata_admin.admin -%}
                 {{- label|trans(label_translation_parameters, translation_domain) -}}
             {%- else -%}
-                {{- label|trans(label_translation_parameters, sonata_admin.field_description.translationDomain ?: admin.translationDomain) -}}
+                {# NEXT_MAJOR: Remove "admin.translationDomain" #}
+                {{- label|trans(label_translation_parameters, sonata_admin.field_description.translationDomain|default(admin.translationDomain|default(sonata_admin.admin.translationDomain))) -}}
             {%- endif -%}
         </label>
     {% endif %}

--- a/tests/Fixtures/StubTranslator.php
+++ b/tests/Fixtures/StubTranslator.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Fixtures;
+
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+final class StubTranslator implements TranslatorInterface
+{
+    public function trans($id, array $parameters = [], $domain = null, $locale = null): string
+    {
+        $transOpeningTag = '[trans]';
+
+        if (null !== $domain) {
+            $transOpeningTag = sprintf('[trans domain=%s]', $domain);
+        }
+
+        return $transOpeningTag.strtr($id, $parameters).'[/trans]';
+    }
+}

--- a/tests/Form/AbstractLayoutTestCase.php
+++ b/tests/Form/AbstractLayoutTestCase.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Form;
 
 use Sonata\AdminBundle\Form\Extension\Field\Type\FormTypeFieldExtension;
-use Sonata\Form\Fixtures\StubTranslator;
+use Sonata\AdminBundle\Tests\Fixtures\StubTranslator;
 use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Bridge\Twig\Extension\HttpKernelExtension;
 use Symfony\Bridge\Twig\Extension\RoutingExtension;
@@ -117,6 +117,24 @@ abstract class AbstractLayoutTestCase extends FormIntegrationTestCase
     protected function renderRow(FormView $view, array $vars = []): string
     {
         return (string) $this->renderer->searchAndRenderBlock($view, 'row', $vars);
+    }
+
+    protected function renderHelp(FormView $view): string
+    {
+        return (string) $this->renderer->searchAndRenderBlock($view, 'help');
+    }
+
+    /**
+     * @param string|false|null $label
+     * @phpstan-param array<string, mixed> $vars
+     */
+    protected function renderLabel(FormView $view, $label = null, array $vars = []): string
+    {
+        if (null !== $label) {
+            $vars += ['label' => $label];
+        }
+
+        return (string) $this->renderer->searchAndRenderBlock($view, 'label', $vars);
     }
 
     protected function renderErrors(FormView $view): string

--- a/tests/Form/AdminLayoutTest.php
+++ b/tests/Form/AdminLayoutTest.php
@@ -13,11 +13,122 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\Form;
 
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormError;
 
 final class AdminLayoutTest extends AbstractLayoutTestCase
 {
+    public function testLabel(): void
+    {
+        $form = $this->factory->createNamed('name', TextType::class);
+        $html = $this->renderLabel($form->createView());
+
+        $expression = <<<'EOD'
+/label
+    [@class="col-sm-3 control-label required"]
+    [@for="name"]
+    [.="[trans]Name[/trans]"]
+EOD;
+
+        $this->assertMatchesXpath($html, $expression);
+    }
+
+    public function testLabelWithoutTranslation(): void
+    {
+        $form = $this->factory->createNamed(
+            'name',
+            TextType::class,
+            null,
+            [
+            'translation_domain' => false,
+        ]
+        );
+        $html = $this->renderLabel($form->createView());
+
+        $expression = <<<'EOD'
+/label
+    [@class="col-sm-3 control-label required"]
+    [@for="name"]
+    [.="Name"]
+EOD;
+
+        $this->assertMatchesXpath($html, $expression);
+    }
+
+    public function testLabelWithCustomTranslationDomain(): void
+    {
+        $form = $this->factory->createNamed(
+            'name',
+            TextType::class,
+            null,
+            [
+            'translation_domain' => 'custom_domain',
+        ]
+        );
+        $html = $this->renderLabel($form->createView());
+
+        $expression = <<<'EOD'
+/label
+    [@class="col-sm-3 control-label required"]
+    [@for="name"]
+    [.="[trans domain=custom_domain]Name[/trans]"]
+EOD;
+
+        $this->assertMatchesXpath($html, $expression);
+    }
+
+    public function testLabelWithAdminTranslationDomain(): void
+    {
+        $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
+
+        $admin = $this->createStub(AdminInterface::class);
+        $admin
+            ->method('getCode')
+            ->willReturn('sonata_code');
+
+        $admin
+            ->method('getTranslationDomain')
+            ->willReturn('sonata_translation_domain');
+
+        $fieldDescription
+            ->method('getAdmin')
+            ->willReturn($admin);
+
+        $form = $this->factory->createNamed('name', TextType::class, null, [
+            'sonata_field_description' => $fieldDescription,
+        ]);
+        $html = $this->renderLabel($form->createView());
+
+        $expression = <<<'EOD'
+/label
+    [@class="col-sm-3 control-label required"]
+    [@for="name"]
+    [.="[trans domain=sonata_translation_domain]Name[/trans]"]
+EOD;
+
+        $this->assertMatchesXpath($html, $expression);
+    }
+
+    public function testHelp(): void
+    {
+        $form = $this->factory->createNamed('name', TextType::class, null, [
+            'help' => 'Help text test!',
+        ]);
+        $view = $form->createView();
+        $html = $this->renderHelp($view);
+
+        $expression = <<<'EOD'
+/p
+    [@id="name_help"]
+    [@class="help-block sonata-ba-field-widget-help sonata-ba-field-help help-text"]
+    [.="[trans]Help text test![/trans]"]
+EOD;
+
+        $this->assertMatchesXpath($html, $expression);
+    }
+
     public function testRowSetId(): void
     {
         $form = $this->factory->createNamed('name', TextType::class);


### PR DESCRIPTION
This PR add some tests for `form_label` and `form_help` blocks, this will be helpful also for fixing https://github.com/sonata-project/SonataAdminBundle/issues/7014.

It failed for `form_label` when using the admin translation domain because `admin.translationDomain` does not exist in:

https://github.com/sonata-project/SonataAdminBundle/blob/db09b03adee7ae24379d0462af329467b4a83e29/src/Resources/views/Form/form_admin_fields.html.twig#L163

to solve this I added a `|default` filter (to not break anything) just in case this `admin` variable is defined somewhere (I haven't found it).

I've also replaced `StubTranslator` to our own to add this `domain` value.