### PR TITLE
Use translation domain of admin as default for form_help

### DIFF
--- a/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
+++ b/src/Form/Extension/Field/Type/FormTypeFieldExtension.php
@@ -153,6 +153,7 @@ class FormTypeFieldExtension extends AbstractTypeExtension
             $view->vars['sonata_admin_enabled'] = true;
             $view->vars['sonata_admin'] = $sonataAdmin;
             $view->vars['sonata_admin_code'] = $sonataAdmin['admin']->getCode();
+            $view->vars['sonata_admin_translation_domain'] = $sonataAdmin['admin']->getTranslationDomain();
 
             $attr = $view->vars['attr'];
 

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -34,6 +34,9 @@ file that was distributed with this source code.
 {% endblock %}
 
 {% block form_help -%}
+    {% if sonata_admin_translation_domain is defined and translation_domain is null %}
+        {% set translation_domain = sonata_admin_translation_domain %}
+    {% endif %}
     {% if help is not empty %}
         {# NEXT_MAJOR: Remove class sonata-ba-field-widget-help #}
         {% set help_attr = help_attr|merge({class: (help_attr.class|default('') ~ ' help-block sonata-ba-field-widget-help sonata-ba-field-help')}) %}

--- a/tests/Form/AdminLayoutTest.php
+++ b/tests/Form/AdminLayoutTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\Form;
 
+use PHPUnit\Framework\MockObject\Stub;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -81,20 +82,7 @@ EOD;
 
     public function testLabelWithAdminTranslationDomain(): void
     {
-        $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
-
-        $admin = $this->createStub(AdminInterface::class);
-        $admin
-            ->method('getCode')
-            ->willReturn('sonata_code');
-
-        $admin
-            ->method('getTranslationDomain')
-            ->willReturn('sonata_translation_domain');
-
-        $fieldDescription
-            ->method('getAdmin')
-            ->willReturn($admin);
+        $fieldDescription = $this->createFieldDescriptionWithTranslationDomain('sonata_translation_domain');
 
         $form = $this->factory->createNamed('name', TextType::class, null, [
             'sonata_field_description' => $fieldDescription,
@@ -124,6 +112,27 @@ EOD;
     [@id="name_help"]
     [@class="help-block sonata-ba-field-widget-help sonata-ba-field-help help-text"]
     [.="[trans]Help text test![/trans]"]
+EOD;
+
+        $this->assertMatchesXpath($html, $expression);
+    }
+
+    public function testHelpWithAdminTranslationDomain(): void
+    {
+        $fieldDescription = $this->createFieldDescriptionWithTranslationDomain('sonata_translation_domain');
+
+        $form = $this->factory->createNamed('name', TextType::class, null, [
+            'help' => 'Help text test!',
+            'sonata_field_description' => $fieldDescription,
+        ]);
+        $view = $form->createView();
+        $html = $this->renderHelp($view);
+
+        $expression = <<<'EOD'
+/p
+    [@id="name_help"]
+    [@class="help-block sonata-ba-field-widget-help sonata-ba-field-help help-text"]
+    [.="[trans domain=sonata_translation_domain]Help text test![/trans]"]
 EOD;
 
         $this->assertMatchesXpath($html, $expression);
@@ -201,5 +210,28 @@ EOD;
             $html,
             '//div[@class="foo form-group"][@data-value="bar"][@id="sonata-ba-field-container-name"]'
         );
+    }
+
+    /**
+     * @return Stub&FieldDescriptionInterface
+     */
+    private function createFieldDescriptionWithTranslationDomain(string $translationDomain): Stub
+    {
+        $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
+
+        $admin = $this->createStub(AdminInterface::class);
+        $admin
+            ->method('getCode')
+            ->willReturn('sonata_code');
+
+        $admin
+            ->method('getTranslationDomain')
+            ->willReturn($translationDomain);
+
+        $fieldDescription
+            ->method('getAdmin')
+            ->willReturn($admin);
+
+        return $fieldDescription;
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

I'll add tests after https://github.com/sonata-project/SonataAdminBundle/pull/7020

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #7014.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed using the admin translation domain as default for `form_help` twig block.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->

I think we can use the same approach for `form_label` and do not override the entire block, just setting variables, I'll try to have a look.