### PR TITLE
Add FilterData

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -9,7 +9,7 @@ If you still need it, please set it up on your own!
 
 Frontend dependencies are handled with NPM. Bower is not used anymore.
 
-A lot of assets that were previously public are handled with NPM and placed in a private `node_modules/` directory. 
+A lot of assets that were previously public are handled with NPM and placed in a private `node_modules/` directory.
 From these dependencies, only the necessary files are exposed publicly through Webpack Encore.
 
 Please check the `src/Resources/public/dist` and the documentation to see the used CSS, JavaScript, images and fonts.
@@ -172,6 +172,19 @@ When there is no searchable filters, `SearchHandler::search()` returns `null`. P
 
 ## Sonata\AdminBundle\Controller\CRUDController
 When the service `security.csrf.token_manager` is not available, `getCsrfToken()` returns `null`. Previously, it was returning `false`.
+
+## FilterInterface
+
+The type for argument 4 in `apply()` method has been changed from `array` to `Sonata\AdminBundle\Filter\Model\FilterData`.
+
+Before:
+```php
+public function apply(ProxyQueryInterface $query, array $filterData): void;
+```
+After:
+```php
+public function apply(ProxyQueryInterface $query, FilterData $filterData): void;
+```
 
 ## FormMapper labels
 The form label are now correctly using the label translator strategy for field with `.`

--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -537,6 +537,7 @@ If you have the **SonataDoctrineORMAdminBundle** installed you can use the
 ``CallbackFilter`` filter type e.g. for creating a full text filter::
 
     use Sonata\AdminBundle\Datagrid\DatagridMapper;
+    use Sonata\AdminBundle\Filter\Model\FilterData;
 
     final class UserAdmin extends Sonata\UserBundle\Admin\Model\UserAdmin
     {
@@ -549,17 +550,17 @@ If you have the **SonataDoctrineORMAdminBundle** installed you can use the
                 ]);
         }
 
-        public function getFullTextFilter(ProxyQueryInterface $query, string $alias, string $field, array $data): void
+        public function getFullTextFilter(ProxyQueryInterface $query, string $alias, string $field, FilterData $data): void
         {
-            if (!$data['value']) {
+            if (!$data->hasValue()) {
                 return false;
             }
 
             // Use `andWhere` instead of `where` to prevent overriding existing `where` conditions
             $query->andWhere($query->expr()->orX(
-                $query->expr()->like($alias.'.username', $query->expr()->literal('%' . $data['value'] . '%')),
-                $query->expr()->like($alias.'.firstName', $query->expr()->literal('%' . $data['value'] . '%')),
-                $query->expr()->like($alias.'.lastName', $query->expr()->literal('%' . $data['value'] . '%'))
+                $query->expr()->like($alias.'.username', $query->expr()->literal('%' . $data->getValue() . '%')),
+                $query->expr()->like($alias.'.firstName', $query->expr()->literal('%' . $data->getValue() . '%')),
+                $query->expr()->like($alias.'.lastName', $query->expr()->literal('%' . $data->getValue() . '%'))
             ));
 
             return true;
@@ -571,21 +572,22 @@ The callback function should return a boolean indicating whether it is active.
 You can also get the filter type which can be helpful to change the operator
 type of your condition(s)::
 
+    use Sonata\AdminBundle\Filter\Model\FilterData;
     use Sonata\Form\Type\EqualType;
 
     final class UserAdmin extends Sonata\UserBundle\Admin\Model\UserAdmin
     {
-        public function getFullTextFilter(ProxyQueryInterface $query, string $alias, string $field, array $data): void
+        public function getFullTextFilter(ProxyQueryInterface $query, string $alias, string $field, FilterData $data): void
         {
-            if (!$data['value']) {
+            if (!$data->hasValue()) {
                 return;
             }
 
-            $operator = $data['type'] == EqualType::TYPE_IS_EQUAL ? '=' : '!=';
+            $operator = $data->isType(EqualType::TYPE_IS_EQUAL) ? '=' : '!=';
 
             $query
                 ->andWhere($alias.'.username '.$operator.' :username')
-                ->setParameter('username', $data['value'])
+                ->setParameter('username', $data->getValue())
             ;
 
             return true;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9,3 +9,7 @@ parameters:
         - # This error is made on purpose for php version < 8
             message: '#^Method Sonata\\AdminBundle\\Tests\\Fixtures\\Entity\\FooToStringNull\:\:__toString\(\) should return string but returns null\.$#'
             path: tests/Fixtures/Entity/FooToStringNull.php
+        - # It is on purpose because it throws an exception
+            message: "#^Call to static method Sonata\\\\AdminBundle\\\\Filter\\\\Model\\\\FilterData\\:\\:fromArray\\(\\) on a separate line has no effect\\.$#"
+            count: 1
+            path: tests/Filter/Model/FilterDataTest.php

--- a/psalm.xml
+++ b/psalm.xml
@@ -16,5 +16,11 @@
         <InternalClass errorLevel="suppress"/>
         <InternalMethod errorLevel="suppress"/>
         <InternalProperty errorLevel="suppress"/>
+        <InvalidArgument>
+            <errorLevel type="suppress">
+                <!-- On purpose for test throwing exceptions -->
+                <file name="tests/Filter/Model/FilterDataTest.php"/>
+            </errorLevel>
+        </InvalidArgument>
     </issueHandlers>
 </psalm>

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Filter\Model\FilterData;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -24,10 +25,7 @@ interface FilterInterface
 
     public const CONDITION_AND = 'AND';
 
-    /**
-     * @phpstan-param array{type?: int|null, value?: mixed} $filterData
-     */
-    public function apply(ProxyQueryInterface $query, array $filterData): void;
+    public function apply(ProxyQueryInterface $query, FilterData $filterData): void;
 
     /**
      * @throws \LogicException if the filter is not initialized

--- a/src/Filter/Model/FilterData.php
+++ b/src/Filter/Model/FilterData.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Filter\Model;
+
+/**
+ * @psalm-immutable
+ */
+final class FilterData
+{
+    /**
+     * @var ?int
+     */
+    private $type;
+
+    /**
+     * @var mixed
+     */
+    private $value;
+
+    /**
+     * @var bool
+     */
+    private $hasValue;
+
+    private function __construct()
+    {
+        $this->hasValue = false;
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @phpstan-param array{type?: int|numeric-string|null, value?: mixed} $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $filterData = new self();
+
+        if (isset($data['type'])) {
+            if (!\is_int($data['type']) && (!\is_string($data['type']) || !is_numeric($data['type']))) {
+                throw new \InvalidArgumentException(sprintf(
+                    'The "type" parameter MUST be of type "integer" or "null", %s given.',
+                    \is_object($data['type']) ? 'instance of "'.\get_class($data['type']).'"' : '"'.\gettype($data['type']).'"'
+                ));
+            }
+
+            $filterData->type = (int) $data['type'];
+        }
+
+        if (\array_key_exists('value', $data)) {
+            $filterData->value = $data['value'];
+            $filterData->hasValue = true;
+        }
+
+        return $filterData;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        if (!$this->hasValue) {
+            throw new \LogicException('The FilterData object does not have a value.');
+        }
+
+        return $this->value;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function changeValue($value): self
+    {
+        return self::fromArray([
+            'type' => $this->getType(),
+            'value' => $value,
+        ]);
+    }
+
+    public function getType(): ?int
+    {
+        return $this->type;
+    }
+
+    public function isType(int $type): bool
+    {
+        return $this->type === $type;
+    }
+
+    public function hasValue(): bool
+    {
+        return $this->hasValue;
+    }
+}

--- a/src/Form/DataTransformer/FilterDataTransformer.php
+++ b/src/Form/DataTransformer/FilterDataTransformer.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Form\DataTransformer;
+
+use Sonata\AdminBundle\Filter\Model\FilterData;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+
+final class FilterDataTransformer implements DataTransformerInterface
+{
+    public function reverseTransform($value): FilterData
+    {
+        if (!\is_array($value)) {
+            throw new UnexpectedTypeException($value, 'array');
+        }
+
+        return FilterData::fromArray($value);
+    }
+
+    /**
+     * @param FilterData|null $value
+     */
+    public function transform($value)
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        $data = [
+            'type' => $value->getType(),
+        ];
+
+        if ($value->hasValue()) {
+            $data['value'] = $value->getValue();
+        }
+
+        return $data;
+    }
+}

--- a/src/Form/Type/Filter/ChoiceType.php
+++ b/src/Form/Type/Filter/ChoiceType.php
@@ -16,7 +16,6 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 use Sonata\AdminBundle\Form\Type\Operator\ContainsOperatorType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as FormChoiceType;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -29,23 +28,16 @@ final class ChoiceType extends AbstractType
         return 'sonata_type_filter_choice';
     }
 
-    /**
-     * @param array<string, mixed> $options
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options): void
+    public function getParent(): string
     {
-        $builder
-            ->add('type', $options['operator_type'], $options['operator_options'] + ['required' => false])
-            ->add('value', $options['field_type'], $options['field_options'] + ['required' => false]);
+        return FilterDataType::class;
     }
 
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'field_type' => FormChoiceType::class,
-            'field_options' => [],
             'operator_type' => ContainsOperatorType::class,
-            'operator_options' => [],
         ]);
     }
 }

--- a/src/Form/Type/Filter/DateRangeType.php
+++ b/src/Form/Type/Filter/DateRangeType.php
@@ -17,7 +17,6 @@ use Sonata\AdminBundle\Form\Type\Operator\DateRangeOperatorType;
 use Sonata\Form\Type\DateRangeType as FormDateRangeType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -30,19 +29,15 @@ final class DateRangeType extends AbstractType
         return 'sonata_type_filter_date_range';
     }
 
-    /**
-     * @param array<string, mixed> $options
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options): void
+    public function getParent(): string
     {
-        $builder
-            ->add('type', DateRangeOperatorType::class, ['required' => false])
-            ->add('value', $options['field_type'], $options['field_options'] + ['required' => false]);
+        return FilterDataType::class;
     }
 
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
+            'operator_type' => DateRangeOperatorType::class,
             'field_type' => FormDateRangeType::class,
             'field_options' => [
                 'field_options' => [

--- a/src/Form/Type/Filter/DateTimeRangeType.php
+++ b/src/Form/Type/Filter/DateTimeRangeType.php
@@ -17,7 +17,6 @@ use Sonata\AdminBundle\Form\Type\Operator\DateRangeOperatorType;
 use Sonata\Form\Type\DateTimeRangeType as FormDateTimeRangeType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -30,19 +29,15 @@ final class DateTimeRangeType extends AbstractType
         return 'sonata_type_filter_datetime_range';
     }
 
-    /**
-     * @param array<string, mixed> $options
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options): void
+    public function getParent(): string
     {
-        $builder
-            ->add('type', DateRangeOperatorType::class, ['required' => false])
-            ->add('value', $options['field_type'], $options['field_options'] + ['required' => false]);
+        return FilterDataType::class;
     }
 
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
+            'operator_type' => DateRangeOperatorType::class,
             'field_type' => FormDateTimeRangeType::class,
             'field_options' => [
                 'field_options' => ['date_format' => DateTimeType::HTML5_FORMAT],

--- a/src/Form/Type/Filter/DateTimeType.php
+++ b/src/Form/Type/Filter/DateTimeType.php
@@ -17,7 +17,6 @@ use Sonata\AdminBundle\Form\Type\Operator\DateOperatorType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType as FormDateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -30,19 +29,15 @@ final class DateTimeType extends AbstractType
         return 'sonata_type_filter_datetime';
     }
 
-    /**
-     * @param array<string, mixed> $options
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options): void
+    public function getParent(): string
     {
-        $builder
-            ->add('type', DateOperatorType::class, ['required' => false])
-            ->add('value', $options['field_type'], $options['field_options'] + ['required' => false]);
+        return FilterDataType::class;
     }
 
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
+            'operator_type' => DateOperatorType::class,
             'field_type' => FormDateTimeType::class,
             'field_options' => ['date_format' => DateType::HTML5_FORMAT],
         ]);

--- a/src/Form/Type/Filter/DateType.php
+++ b/src/Form/Type/Filter/DateType.php
@@ -16,7 +16,6 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 use Sonata\AdminBundle\Form\Type\Operator\DateOperatorType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateType as FormDateType;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -29,19 +28,15 @@ final class DateType extends AbstractType
         return 'sonata_type_filter_date';
     }
 
-    /**
-     * @param array<string, mixed> $options
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options): void
+    public function getParent(): string
     {
-        $builder
-            ->add('type', DateOperatorType::class, ['required' => false])
-            ->add('value', $options['field_type'], $options['field_options'] + ['required' => false]);
+        return FilterDataType::class;
     }
 
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
+            'operator_type' => DateOperatorType::class,
             'field_type' => FormDateType::class,
             'field_options' => ['format' => FormDateType::HTML5_FORMAT],
         ]);

--- a/src/Form/Type/Filter/DefaultType.php
+++ b/src/Form/Type/Filter/DefaultType.php
@@ -16,7 +16,6 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -29,23 +28,16 @@ final class DefaultType extends AbstractType
         return 'sonata_type_filter_default';
     }
 
-    /**
-     * @param array<string, mixed> $options
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options): void
+    public function getParent(): string
     {
-        $builder
-            ->add('type', $options['operator_type'], $options['operator_options'] + ['required' => false])
-            ->add('value', $options['field_type'], $options['field_options'] + ['required' => false]);
+        return FilterDataType::class;
     }
 
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
             'operator_type' => HiddenType::class,
-            'operator_options' => [],
             'field_type' => TextType::class,
-            'field_options' => [],
         ]);
     }
 }

--- a/src/Form/Type/Filter/FilterDataType.php
+++ b/src/Form/Type/Filter/FilterDataType.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Form\Type\Filter;
+
+use Sonata\AdminBundle\Form\DataTransformer\FilterDataTransformer;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class FilterDataType extends AbstractType
+{
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('type', $options['operator_type'], $options['operator_options'] + ['required' => false])
+            ->add('value', $options['field_type'], $options['field_options'] + ['required' => false]);
+
+        $builder
+            ->addModelTransformer(new FilterDataTransformer());
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'operator_options' => [],
+            'field_options' => [],
+        ]);
+        $resolver
+            ->setRequired(['operator_type', 'field_type'])
+            ->setAllowedTypes('operator_type', 'string')
+            ->setAllowedTypes('field_type', 'string')
+            ->setAllowedTypes('operator_options', 'array')
+            ->setAllowedTypes('field_options', 'array');
+    }
+}

--- a/src/Form/Type/Filter/NumberType.php
+++ b/src/Form/Type/Filter/NumberType.php
@@ -16,7 +16,6 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 use Sonata\AdminBundle\Form\Type\Operator\NumberOperatorType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType as FormNumberType;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -29,19 +28,15 @@ final class NumberType extends AbstractType
         return 'sonata_type_filter_number';
     }
 
-    /**
-     * @param array<string, mixed> $options
-     */
-    public function buildForm(FormBuilderInterface $builder, array $options): void
+    public function getParent(): string
     {
-        $builder
-            ->add('type', NumberOperatorType::class, ['required' => false])
-            ->add('value', $options['field_type'], $options['field_options'] + ['required' => false]);
+        return FilterDataType::class;
     }
 
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
+            'operator_type' => NumberOperatorType::class,
             'field_type' => FormNumberType::class,
             'field_options' => [],
         ]);

--- a/tests/Datagrid/DatagridTest.php
+++ b/tests/Datagrid/DatagridTest.php
@@ -374,13 +374,13 @@ final class DatagridTest extends TestCase
      */
     public function applyFilterDataProvider(): iterable
     {
-        yield ['fakeType', 'fakeValue', 1];
-        yield ['', 'fakeValue', 1];
+        yield ['3', 'fakeValue', 1];
         yield [null, 'fakeValue', 1];
-        yield ['fakeType', '', 1];
-        yield ['fakeType', null, 1];
-        yield ['', '', 0];
-        yield ['', null, 0];
+        yield [null, 'fakeValue', 1];
+        yield ['3', '', 1];
+        yield ['3', null, 1];
+        yield [null, '', 0];
+        yield [null, null, 0];
         yield [null, '', 0];
         yield [null, null, 0];
     }

--- a/tests/Filter/Model/FilterDataTest.php
+++ b/tests/Filter/Model/FilterDataTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Filter\Model;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Filter\Model\FilterData;
+
+final class FilterDataTest extends TestCase
+{
+    /**
+     * @dataProvider getInvalidTypes
+     *
+     * @param mixed $type
+     */
+    public function testTypeMustBeNumericOrNull($type): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
+            'The "type" parameter MUST be of type "integer" or "null", %s given.',
+            \is_object($type) ? 'instance of "'.\get_class($type).'"' : '"'.\gettype($type).'"'
+        ));
+
+        FilterData::fromArray(['type' => $type]);
+    }
+
+    /**
+     * @return iterable<array<mixed>>
+     */
+    public function getInvalidTypes(): iterable
+    {
+        yield ['string'];
+        yield [new \stdClass()];
+        yield [[]];
+        yield [42.0];
+    }
+
+    public function testEmptyArray(): void
+    {
+        $filterData = FilterData::fromArray([]);
+        $this->assertFalse($filterData->hasValue());
+        $this->assertNull($filterData->getType());
+    }
+
+    public function testHasValue(): void
+    {
+        $this->assertFalse(FilterData::fromArray([])->hasValue());
+        $this->assertTrue(FilterData::fromArray(['value' => ''])->hasValue());
+        $this->assertTrue(FilterData::fromArray(['value' => null])->hasValue());
+    }
+
+    /**
+     * @dataProvider getTypes
+     *
+     * @param int|string|null $type
+     */
+    public function testGetType(?int $expected, $type): void
+    {
+        $this->assertSame($expected, FilterData::fromArray(['type' => $type])->getType());
+    }
+
+    /**
+     * @return iterable<array<string|int|null>>
+     */
+    public function getTypes(): iterable
+    {
+        yield 'nullable' => [null, null];
+        yield 'int' => [3, 3];
+        yield 'numeric string' => [3, '3'];
+    }
+
+    /**
+     * @dataProvider getValues
+     *
+     * @param mixed $value
+     */
+    public function testGetValue($value): void
+    {
+        $this->assertSame($value, FilterData::fromArray(['value' => $value])->getValue());
+    }
+
+    /**
+     * @return iterable<array<mixed>>
+     */
+    public function getValues(): iterable
+    {
+        yield [null];
+        yield [new \stdClass()];
+        yield [3];
+        yield ['3'];
+    }
+
+    public function testSetValue(): void
+    {
+        $filterData = FilterData::fromArray(['type' => 1, 'value' => 'value']);
+        $newFilterData = $filterData->changeValue('new_value');
+
+        $this->assertSame(1, $newFilterData->getType());
+        $this->assertSame('new_value', $newFilterData->getValue());
+    }
+
+    public function testGetValueThrowsExceptionIfValueNotPresent(): void
+    {
+        $filterData = FilterData::fromArray([]);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The FilterData object does not have a value.');
+
+        $filterData->getValue();
+    }
+}

--- a/tests/Fixtures/Filter/BarFilter.php
+++ b/tests/Fixtures/Filter/BarFilter.php
@@ -15,11 +15,12 @@ namespace Sonata\AdminBundle\Tests\Fixtures\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Filter\Filter;
+use Sonata\AdminBundle\Filter\Model\FilterData;
 use Sonata\AdminBundle\Form\Type\Filter\DefaultType;
 
 final class BarFilter extends Filter
 {
-    public function apply(ProxyQueryInterface $query, array $filterData): void
+    public function apply(ProxyQueryInterface $query, FilterData $filterData): void
     {
     }
 

--- a/tests/Fixtures/Filter/FooFilter.php
+++ b/tests/Fixtures/Filter/FooFilter.php
@@ -15,10 +15,11 @@ namespace Sonata\AdminBundle\Tests\Fixtures\Filter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Filter\Filter;
+use Sonata\AdminBundle\Filter\Model\FilterData;
 
 class FooFilter extends Filter
 {
-    public function apply(ProxyQueryInterface $query, array $filterData): void
+    public function apply(ProxyQueryInterface $query, FilterData $filterData): void
     {
     }
 

--- a/tests/Form/DataTransformer/FilterDataTransformerTest.php
+++ b/tests/Form/DataTransformer/FilterDataTransformerTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Form\DataTransformer;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Filter\Model\FilterData;
+use Sonata\AdminBundle\Form\DataTransformer\FilterDataTransformer;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+
+final class FilterDataTransformerTest extends TestCase
+{
+    public function testReverseTransformThrowsExceptionIfValueIsNotArray(): void
+    {
+        $transformer = new FilterDataTransformer();
+
+        $this->expectException(UnexpectedTypeException::class);
+
+        $transformer->reverseTransform(1);
+    }
+
+    /**
+     * @dataProvider getDataValues
+     * @phpstan-param array{type: int, value: mixed} $value
+     */
+    public function testReverseTransform(array $value): void
+    {
+        $transformer = new FilterDataTransformer();
+
+        $filterData = $transformer->reverseTransform($value);
+
+        $this->assertSame($value['type'], $filterData->getType());
+        $this->assertSame($value['value'], $filterData->getValue());
+    }
+
+    public function testTransformReturnsNullOnNull(): void
+    {
+        $transformer = new FilterDataTransformer();
+
+        $this->assertNull($transformer->transform(null));
+    }
+
+    /**
+     * @dataProvider getDataValues
+     * @phpstan-param array{type: int, value: mixed} $value
+     */
+    public function testTransform(array $value): void
+    {
+        $transformer = new FilterDataTransformer();
+
+        $this->assertSame($value, $transformer->transform(FilterData::fromArray($value)));
+    }
+
+    /**
+     * @phpstan-return iterable<array<array{type: int, value: mixed}>>
+     */
+    public function getDataValues(): iterable
+    {
+        yield [[
+            'type' => 1,
+            'value' => 'value',
+        ]];
+
+        yield [[
+            'type' => 1,
+            'value' => null,
+        ]];
+    }
+}

--- a/tests/Form/Type/Filter/DateTimeRangeTypeTest.php
+++ b/tests/Form/Type/Filter/DateTimeRangeTypeTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Form\Type\Filter;
 
 use Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType;
+use Sonata\AdminBundle\Form\Type\Operator\DateRangeOperatorType;
 use Sonata\Form\Type\DateTimeRangeType as FormDateTimeRangeType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -41,6 +42,7 @@ final class DateTimeRangeTypeTest extends BaseTypeTest
         $options = $optionsResolver->resolve();
 
         $expected = [
+            'operator_type' => DateRangeOperatorType::class,
             'field_type' => FormDateTimeRangeType::class,
             'field_options' => ['field_options' => ['date_format' => DateTimeType::HTML5_FORMAT]],
         ];


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I have doubts on where to do this, the easy way is to do it in `4.x`, I thought about adding `FilterDataType` in `3.x`, but removing `buildForm` from types is BC break, so not sure if is worth it to do it in `3.x`.


My idea with filters was:

### `FilterDataType`

This type will be used as a base of filter types, it contains `type` and `value` fields and it defines `operator_type`, `field_type`, `operator_options` and `field_options` options.

The idea is that other types will override `getParent()` method returning `FilterDataType`, so there is no need for them to override `buildForm` with `type` and `value` and only have to configure the `operator_type` and `field_type` options (and other options if they have).

The datatransform transforms from `array` to `FilterData` (I'll extract the `CallbackTransformer` to a class).

### `FilterData`

This VO (ref: https://github.com/sonata-project/SonataAdminBundle/issues/6658) will be used instead of `array` for filters, this cannot be done with BC (at first I thought that implementing `ArrayAccess` could work, but `array_key_exists` does not work with objects and will break implementations).

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is not BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6658.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `FilterData` to model the data from a filter
### Changed
- Changed `FilterInterface::apply()` to accept a `FilterData` instance instead of `array` in argument 4
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

## To do

- [x] Extract `CallbackTransformer` to a class.
- [x] Add tests.
