### PR TITLE
Remove deprecations with symfony/http-kernel ^5.1

### DIFF
--- a/src/Route/RouteCollection.php
+++ b/src/Route/RouteCollection.php
@@ -82,10 +82,7 @@ final class RouteCollection implements RouteCollectionInterface
         $code = $this->getCode($name);
 
         if (!isset($defaults['_controller'])) {
-            $actionJoiner = false === strpos($this->baseControllerName, '\\') ? ':' : '::';
-            if (':' !== $actionJoiner && false !== strpos($this->baseControllerName, ':')) {
-                $actionJoiner = ':';
-            }
+            $actionJoiner = false !== strpos($this->baseControllerName, ':') ? ':' : '::';
 
             $defaults['_controller'] = $this->baseControllerName.$actionJoiner.$this->actionify($code);
         }

--- a/tests/Route/RouteCollectionTest.php
+++ b/tests/Route/RouteCollectionTest.php
@@ -192,7 +192,7 @@ class RouteCollectionTest extends TestCase
 
         $route = $routeCollection->get('view');
 
-        $this->assertSame('baseControllerServiceName:viewAction', $route->getDefault('_controller'));
+        $this->assertSame('baseControllerServiceName::viewAction', $route->getDefault('_controller'));
         $this->assertSame('baseCodeRoute', $route->getDefault('_sonata_admin'));
         $this->assertSame('baseRouteName_view', $route->getDefault('_sonata_name'));
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is where the deprecation happens.

```
  2x: Since symfony/http-kernel 5.1: Referencing controllers with a single colon is deprecated. Use "sonata.admin.controller.crud::listAction" instead.
    1x in CRUDControllerTest::testList from Sonata\AdminBundle\Tests\Functional\Controller
    1x in CRUDControllerTest::testUrlIsSuccessful from Sonata\AdminBundle\Tests\Functional\Controller
```

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Remove usage of single colon on actions referenced to service controllers
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
