### PR TITLE
Add "block.admin_preview" block

### DIFF
--- a/docs/reference/dashboard.rst
+++ b/docs/reference/dashboard.rst
@@ -347,6 +347,33 @@ which could also have a pluralized translation target:
         <target>{count, plural, =0 {results} one {result} other {results}}</target>
     </trans-unit>
 
+Preview Block
+~~~~~~~~~~~~~
+
+A preview block can be used to display a brief of an admin list.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/packages/sonata_admin.yaml
+
+        sonata_admin:
+            dashboard:
+                blocks:
+                    -
+                        position: top                              # zone in the dashboard
+                        type:     sonata.admin.block.admin_preview # block id
+                        settings:
+                            code:  sonata.page.admin.page          # admin code - service id
+                            icon:  fa-magic                        # font awesome icon
+                            limit: 10
+                            text:  Latest Edited Pages
+                            filters:                               # filter values
+                                edited:      { value: 1 }
+                                _sort_by:    updatedAt
+                                _sort_order: DESC
+
 Dashboard Layout
 ~~~~~~~~~~~~~~~~
 

--- a/src/Block/AdminPreviewBlockService.php
+++ b/src/Block/AdminPreviewBlockService.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Block;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractBlockService;
@@ -96,20 +97,20 @@ final class AdminPreviewBlockService extends AbstractBlockService
     {
         $filters = $blockContext->getSetting('filters');
 
-        if ($sortBy = $filters['_sort_by'] ?? null) {
-            $sortFilters = ['_sort_by' => $sortBy];
-            if ($sortOrder = $filters['_sort_order'] ?? null) {
-                $sortFilters['_sort_order'] = $sortOrder;
-                unset($filters['_sort_order']);
+        if ($sortBy = $filters[DatagridInterface::SORT_BY] ?? null) {
+            $sortFilters = [DatagridInterface::SORT_BY => $sortBy];
+            if ($sortOrder = $filters[DatagridInterface::SORT_ORDER] ?? null) {
+                $sortFilters[DatagridInterface::SORT_ORDER] = $sortOrder;
+                unset($filters[DatagridInterface::SORT_ORDER]);
             }
             // Setting a request to the admin is a workaround since the admin only
-            // can handle the "_sort_by" parameter from the query string.
+            // can handle the "DatagridInterface::SORT_BY" parameter from the query string.
             $admin->setRequest(new Request(['filter' => $sortFilters]));
-            unset($filters['_sort_by']);
+            unset($filters[DatagridInterface::SORT_BY]);
         }
 
-        if (!isset($filters['_per_page'])) {
-            $filters['_per_page'] = ['value' => $blockContext->getSetting('limit')];
+        if (!isset($filters[DatagridInterface::PER_PAGE])) {
+            $filters[DatagridInterface::PER_PAGE] = ['value' => $blockContext->getSetting('limit')];
         }
 
         $datagrid = $admin->getDatagrid();

--- a/src/Block/AdminPreviewBlockService.php
+++ b/src/Block/AdminPreviewBlockService.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Block;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\BlockBundle\Block\BlockContextInterface;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Twig\Environment;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+final class AdminPreviewBlockService extends AbstractBlockService
+{
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    public function __construct(Environment $twig, Pool $pool)
+    {
+        parent::__construct($twig);
+
+        $this->pool = $pool;
+    }
+
+    public function execute(BlockContextInterface $blockContext, ?Response $response = null): Response
+    {
+        $admin = $this->getAdmin($blockContext->getSetting('code'));
+        $this->handleFilters($admin, $blockContext);
+
+        foreach ($blockContext->getSetting('remove_list_fields') as $listField) {
+            $admin->getList()->remove($listField);
+        }
+
+        $datagrid = $admin->getDatagrid();
+
+        return $this->renderPrivateResponse($blockContext->getTemplate(), [
+            'block' => $blockContext->getBlock(),
+            'settings' => $blockContext->getSettings(),
+            'admin' => $admin,
+            'datagrid' => $datagrid,
+        ], $response);
+    }
+
+    public function getName()
+    {
+        return 'Admin preview';
+    }
+
+    public function configureSettings(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'text' => 'Preview',
+            'filters' => [],
+            'icon' => false,
+            'limit' => 10,
+            'code' => false,
+            'template' => '@SonataAdmin/Block/block_admin_preview.html.twig',
+            'remove_list_fields' => [ListMapper::NAME_ACTIONS],
+        ]);
+    }
+
+    /**
+     * @throws \InvalidArgumentException if the provided admin code is invalid
+     */
+    private function getAdmin(string $code): AdminInterface
+    {
+        $admin = $this->pool->getAdminByAdminCode($code);
+
+        $admin->checkAccess('list');
+
+        return $admin;
+    }
+
+    /**
+     * Maps the block filters to standard admin filters.
+     */
+    private function handleFilters(AdminInterface $admin, BlockContextInterface $blockContext): void
+    {
+        $filters = $blockContext->getSetting('filters');
+
+        if ($sortBy = $filters['_sort_by'] ?? null) {
+            $sortFilters = ['_sort_by' => $sortBy];
+            if ($sortOrder = $filters['_sort_order'] ?? null) {
+                $sortFilters['_sort_order'] = $sortOrder;
+                unset($filters['_sort_order']);
+            }
+            // Setting a request to the admin is a workaround since the admin only
+            // can handle the "_sort_by" parameter from the query string.
+            $admin->setRequest(new Request(['filter' => $sortFilters]));
+            unset($filters['_sort_by']);
+        }
+
+        if (!isset($filters['_per_page'])) {
+            $filters['_per_page'] = ['value' => $blockContext->getSetting('limit')];
+        }
+
+        $datagrid = $admin->getDatagrid();
+
+        foreach ($filters as $name => $data) {
+            $datagrid->setValue($name, $data['type'] ?? null, $data['value']);
+        }
+
+        $datagrid->buildPager();
+    }
+}

--- a/src/Resources/config/block.php
+++ b/src/Resources/config/block.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
  */
 
 use Sonata\AdminBundle\Block\AdminListBlockService;
+use Sonata\AdminBundle\Block\AdminPreviewBlockService;
 use Sonata\AdminBundle\Block\AdminSearchBlockService;
 use Sonata\AdminBundle\Block\AdminStatsBlockService;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
@@ -42,6 +43,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ])
 
         ->set('sonata.admin.block.stats', AdminStatsBlockService::class)
+            ->public()
+            ->tag('sonata.block')
+            ->args([
+                new ReferenceConfigurator('twig'),
+                new ReferenceConfigurator('sonata.admin.pool'),
+            ])
+
+        ->set('sonata.admin.block.admin_preview', AdminPreviewBlockService::class)
             ->public()
             ->tag('sonata.block')
             ->args([

--- a/src/Resources/translations/SonataAdminBundle.ar.xliff
+++ b/src/Resources/translations/SonataAdminBundle.ar.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>عرض المزيد</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>stats_view_more</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>حدد نوع الكائن</target>

--- a/src/Resources/translations/SonataAdminBundle.bg.xliff
+++ b/src/Resources/translations/SonataAdminBundle.bg.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Показване на още</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Показване на още</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Избор на тип обект</target>

--- a/src/Resources/translations/SonataAdminBundle.ca.xliff
+++ b/src/Resources/translations/SonataAdminBundle.ca.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Veure més</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Veure més</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Escull el tipus d'element</target>

--- a/src/Resources/translations/SonataAdminBundle.cs.xliff
+++ b/src/Resources/translations/SonataAdminBundle.cs.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Zobrazit více</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Zobrazit více</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Vyberte typ objektu</target>

--- a/src/Resources/translations/SonataAdminBundle.de.xliff
+++ b/src/Resources/translations/SonataAdminBundle.de.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>mehr</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>mehr</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Typ auswählen</target>

--- a/src/Resources/translations/SonataAdminBundle.en.xliff
+++ b/src/Resources/translations/SonataAdminBundle.en.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>View more</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>View more</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Select object type</target>

--- a/src/Resources/translations/SonataAdminBundle.es.xliff
+++ b/src/Resources/translations/SonataAdminBundle.es.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Ver más</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Ver más</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Selecciona el tipo de elemento</target>

--- a/src/Resources/translations/SonataAdminBundle.eu.xliff
+++ b/src/Resources/translations/SonataAdminBundle.eu.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Ikusi gehiago</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>stats_view_more</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Aukeratu objektu mota</target>

--- a/src/Resources/translations/SonataAdminBundle.fa.xliff
+++ b/src/Resources/translations/SonataAdminBundle.fa.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>مشاهده بیشتر</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>مشاهده بیشتر</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>انتخاب نوع شی</target>

--- a/src/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/src/Resources/translations/SonataAdminBundle.fr.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Voir plus</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Voir plus</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Sélectionnez le type d'objet</target>

--- a/src/Resources/translations/SonataAdminBundle.hr.xliff
+++ b/src/Resources/translations/SonataAdminBundle.hr.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Vidi više</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>stats_view_more</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Odaberite vrstu objekta</target>

--- a/src/Resources/translations/SonataAdminBundle.hu.xliff
+++ b/src/Resources/translations/SonataAdminBundle.hu.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Több megjelenítése</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Több megjelenítése</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Objektum típus kiválasztása</target>

--- a/src/Resources/translations/SonataAdminBundle.it.xliff
+++ b/src/Resources/translations/SonataAdminBundle.it.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Mostra dettagli</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Mostra dettagli</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Seleziona il tipo</target>

--- a/src/Resources/translations/SonataAdminBundle.ja.xliff
+++ b/src/Resources/translations/SonataAdminBundle.ja.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>詳細を表示</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>詳細を表示</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>オブジェクトの種類を選択</target>

--- a/src/Resources/translations/SonataAdminBundle.lb.xliff
+++ b/src/Resources/translations/SonataAdminBundle.lb.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Méi</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Méi</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Typ auswielen</target>

--- a/src/Resources/translations/SonataAdminBundle.lt.xliff
+++ b/src/Resources/translations/SonataAdminBundle.lt.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Peržiūrėti daugiau</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>stats_view_more</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Pasirinkite objekto tipą</target>

--- a/src/Resources/translations/SonataAdminBundle.lv.xliff
+++ b/src/Resources/translations/SonataAdminBundle.lv.xliff
@@ -468,6 +468,10 @@
                 <source>stats_view_more</source>
                 <target>Skatīt vēl</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Skatīt vēl</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Izvēlieties objekta veidu</target>

--- a/src/Resources/translations/SonataAdminBundle.nl.xliff
+++ b/src/Resources/translations/SonataAdminBundle.nl.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Bekijk meer</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Bekijk meer</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Selecteer object type</target>

--- a/src/Resources/translations/SonataAdminBundle.no.xliff
+++ b/src/Resources/translations/SonataAdminBundle.no.xliff
@@ -467,6 +467,10 @@
                 <source>stats_view_more</source>
                 <target>Se mer</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>stats_view_more</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Velg objekttype</target>

--- a/src/Resources/translations/SonataAdminBundle.pl.xliff
+++ b/src/Resources/translations/SonataAdminBundle.pl.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Zobacz więcej</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Zobacz więcej</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Wybierz podtyp obiektu</target>

--- a/src/Resources/translations/SonataAdminBundle.pt.xliff
+++ b/src/Resources/translations/SonataAdminBundle.pt.xliff
@@ -467,6 +467,10 @@
                 <source>stats_view_more</source>
                 <target>Veja mais</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>stats_view_more</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Selecionar o tipo de objeto</target>

--- a/src/Resources/translations/SonataAdminBundle.pt_BR.xliff
+++ b/src/Resources/translations/SonataAdminBundle.pt_BR.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Ver mais</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Ver mais</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Selecione o tipo do objeto</target>

--- a/src/Resources/translations/SonataAdminBundle.ro.xliff
+++ b/src/Resources/translations/SonataAdminBundle.ro.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Vezi mai mult</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>stats_view_more</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Selectați tipul obiectului</target>

--- a/src/Resources/translations/SonataAdminBundle.ru.xliff
+++ b/src/Resources/translations/SonataAdminBundle.ru.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Показать еще</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Показать еще</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Выберите тип объекта</target>

--- a/src/Resources/translations/SonataAdminBundle.sk.xliff
+++ b/src/Resources/translations/SonataAdminBundle.sk.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Zobraziť viac</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Zobraziť viac</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Vyberte typ objektu</target>

--- a/src/Resources/translations/SonataAdminBundle.sl.xliff
+++ b/src/Resources/translations/SonataAdminBundle.sl.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Poglej več</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Poglej več</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Izberi tip objekta</target>

--- a/src/Resources/translations/SonataAdminBundle.sv_SE.xliff
+++ b/src/Resources/translations/SonataAdminBundle.sv_SE.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Visa mer</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>stats_view_more</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Välj objekttyp</target>

--- a/src/Resources/translations/SonataAdminBundle.tr.xliff
+++ b/src/Resources/translations/SonataAdminBundle.tr.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Devamını göster</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Devamını göster</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Nesne türünü seç</target>

--- a/src/Resources/translations/SonataAdminBundle.uk.xliff
+++ b/src/Resources/translations/SonataAdminBundle.uk.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>Показати ще</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>Показати ще</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>Оберіть тип об'єкта</target>

--- a/src/Resources/translations/SonataAdminBundle.zh_CN.xliff
+++ b/src/Resources/translations/SonataAdminBundle.zh_CN.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>查看更多</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>stats_view_more</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>选择对象类型</target>

--- a/src/Resources/translations/SonataAdminBundle.zh_HK.xliff
+++ b/src/Resources/translations/SonataAdminBundle.zh_HK.xliff
@@ -466,6 +466,10 @@
                 <source>stats_view_more</source>
                 <target>顯示更多</target>
             </trans-unit>
+            <trans-unit id="preview_view_more">
+                <source>preview_view_more</source>
+                <target>顯示更多</target>
+            </trans-unit>
             <trans-unit id="title_select_subclass">
                 <source>title_select_subclass</source>
                 <target>選擇物件類別</target>

--- a/src/Resources/views/Block/block_admin_preview.html.twig
+++ b/src/Resources/views/Block/block_admin_preview.html.twig
@@ -1,0 +1,87 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends sonata_block.templates.block_base %}
+
+{% set translation_domain = settings.translation_domain ?? admin.translationDomain %}
+
+{% block block %}
+    {% set inlineAnchor = settings.text|replace({'.':'_'}) %}
+    {# NEXT_MAJOR: Remove the attribute check and use `admin.datagrid.pager.countResults` #}
+    {% set results_count = attribute(admin.datagrid.pager, 'countResults') is defined ? admin.datagrid.pager.countResults : admin.datagrid.pager.nbResults %}
+    <div class="box box-primary" id="{{ inlineAnchor }}">
+        <div class="box-header with-border">
+            {% set icon = settings.icon|default('') %}
+            {% if icon %}
+                <i class="fa {{ icon|raw }}"></i>
+            {% endif %}
+            <h3 class="box-title">
+                <a href="#{{ inlineAnchor }}">{{ settings.text|trans({}, translation_domain) }}</a>
+            </h3>
+        </div>
+        <div class="box-body {% if results_count > 0 %}table-responsive no-padding{% endif %}">
+            {{ sonata_block_render_event('sonata.admin.list.table.top', { 'admin': admin }) }}
+
+            {% block list_header %}{% endblock %}
+
+            {% if results_count > 0 %}
+                <table class="table table-bordered table-striped table-hover sonata-ba-list">
+                    {% block table_header %}
+                        <thead>
+                            <tr class="sonata-ba-list-field-header">
+                                {% for field_description in admin.list.elements %}
+                                    {% if field_description.name == constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_SELECT') %}
+                                        <th class="sonata-ba-list-field-header sonata-ba-list-field-header-select"></th>
+                                    {% else %}
+                                        {% filter spaceless %}
+                                            <th class="sonata-ba-list-field-header-{{ field_description.type}} {% if field_description.option('header_class') is not null %} {{ field_description.option('header_class') }}{% endif %}"{% if field_description.option('header_style') is not null %} style="{{ field_description.option('header_style') }}"{% endif %}>
+                                                {% if field_description.option('label_icon') %}
+                                                    <i class="sonata-ba-list-field-header-label-icon {{ field_description.option('label_icon') }}" aria-hidden="true"></i>
+                                                {% endif %}
+                                                {{ field_description.label|trans({}, field_description.translationDomain) }}
+                                            </th>
+                                        {% endfilter %}
+                                    {% endif %}
+                                {% endfor %}
+                            </tr>
+                        </thead>
+                    {% endblock %}
+
+                    {% block table_body %}
+                        <tbody>
+                            {% include get_admin_template('outer_list_rows_' ~ admin.getListMode(), admin.code) %}
+                        </tbody>
+                    {% endblock %}
+
+                    {% block table_footer %}
+                    {% endblock %}
+                </table>
+                <div class="box-footer">
+                    {% if admin.hasAccess('list') %}
+                        <a href="{{ admin.generateUrl('list', {filter: settings.filters}) }}" class="btn btn-primary btn-block">
+                            <i class="fa fa-list" aria-hidden="true"></i> {{ 'preview_view_more'|trans({}, 'SonataAdminBundle') }}
+                        </a>
+                    {% endif %}
+                </div>
+            {% else %}
+                {% block no_result_content %}
+                    <div class="info-box">
+                        <div class="info-box">
+                            <span class="info-box-text">{{ 'no_result'|trans({}, 'SonataAdminBundle') }}</span>
+                        </div><!-- /.info-box-content -->
+                    </div>
+                {% endblock %}
+            {% endif %}
+
+            {{ sonata_block_render_event('sonata.admin.list.table.bottom', { 'admin': admin }) }}
+        </div>
+    </div>
+{% endblock %}

--- a/tests/Block/AdminPreviewBlockServiceTest.php
+++ b/tests/Block/AdminPreviewBlockServiceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Block;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\FieldDescriptionCollection;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Block\AdminPreviewBlockService;
+use Sonata\AdminBundle\Datagrid\Datagrid;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\BlockBundle\Test\BlockServiceTestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Twig\Environment;
+
+/**
+ * @author Javier Spagnoletti <phansys@gmail.com>
+ */
+final class AdminPreviewBlockServiceTest extends BlockServiceTestCase
+{
+    /**
+     * @var Pool
+     */
+    private $pool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->pool = new Pool(new Container());
+    }
+
+    public function testDefaultSettings(): void
+    {
+        $blockService = new AdminPreviewBlockService($this->createStub(Environment::class), $this->pool);
+        $blockContext = $this->getBlockContext($blockService);
+
+        $this->assertSettings([
+            'text' => 'Preview',
+            'filters' => [],
+            'icon' => false,
+            'limit' => 10,
+            'code' => false,
+            'template' => '@SonataAdmin/Block/block_admin_preview.html.twig',
+            'remove_list_fields' => [ListMapper::NAME_ACTIONS],
+        ], $blockContext);
+    }
+
+    public function testBlockExecution(): void
+    {
+        $adminCode = 'admin.bar';
+        $responseContent = '<div>AdminBlockPreview</div>';
+
+        $admin = $this->createMock(AdminInterface::class);
+        $admin
+            ->method('getCode')
+            ->willReturn($adminCode);
+
+        $container = new Container();
+        $container->set($adminCode, $admin);
+        $pool = new Pool($container, [$adminCode]);
+        $datagrid = $this->createStub(Datagrid::class);
+        $twig = $this->createMock(Environment::class);
+
+        $blockService = new AdminPreviewBlockService($twig, $pool);
+        $blockContext = $this->getBlockContext($blockService)->setSetting('code', 'admin.bar');
+
+        $admin->expects(self::once())->method('checkAccess')->with('list')->willReturn(true);
+        $admin->expects(self::exactly(2))->method('getDatagrid')->willReturn($datagrid);
+        $admin->expects(self::once())->method('getList')->willReturn(new FieldDescriptionCollection());
+        $twig->expects(self::once())->method('render')->willReturn($responseContent);
+
+        $response = $blockService->execute($blockContext);
+
+        static::assertSame($responseContent, $response->getContent());
+        static::assertSame(200, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Add "block.admin_preview" block in order to show a preview for admin lists in dashboard

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because this feature respects BC.

Rebase from #5530.

This is an example of how this block looks like:

![image](https://user-images.githubusercontent.com/1231441/56470222-4a4d0680-641a-11e9-9563-7d38cc047d9d.png)

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added "block.admin_preview" block in order to show a preview for admin lists in dashboard
```
## To do
    
- [ ] Find a way to set "_sort_by" and "_sort_order" params out of a request context.