### PR TITLE
Add template for datagrid

### DIFF
--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -27,6 +27,9 @@ use Symfony\Component\Form\FormInterface;
  * @final since sonata-project/admin-bundle 3.52
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @phpstan-template T of ProxyQueryInterface
+ * @phpstan-implements DatagridInterface<T>
  */
 class Datagrid implements DatagridInterface
 {
@@ -49,6 +52,7 @@ class Datagrid implements DatagridInterface
 
     /**
      * @var PagerInterface
+     * @phpstan-var PagerInterface<T>
      */
     protected $pager;
 
@@ -59,6 +63,7 @@ class Datagrid implements DatagridInterface
 
     /**
      * @var ProxyQueryInterface
+     * @phpstan-var T
      */
     protected $query;
 
@@ -77,6 +82,10 @@ class Datagrid implements DatagridInterface
      */
     protected $results;
 
+    /**
+     * @phpstan-param T                 $query
+     * @phpstan-param PagerInterface<T> $pager
+     */
     public function __construct(
         ProxyQueryInterface $query,
         FieldDescriptionCollection $columns,

--- a/src/Datagrid/DatagridInterface.php
+++ b/src/Datagrid/DatagridInterface.php
@@ -23,16 +23,22 @@ use Symfony\Component\Form\FormInterface;
  *
  * @method array getSortParameters(FieldDescriptionInterface $fieldDescription)
  * @method array getPaginationParameters(int $page)
+ *
+ * @phpstan-template T of ProxyQueryInterface
  */
 interface DatagridInterface
 {
     /**
      * @return PagerInterface
+     *
+     * @phpstan-return PagerInterface<T>
      */
     public function getPager();
 
     /**
      * @return ProxyQueryInterface
+     *
+     * @phpstan-return T
      */
     public function getQuery();
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because it's a minor.

Fixed an error on SonataDoctrineORMAdminBundle:
```
ERROR: InvalidArgument - src/Builder/DatagridBuilder.php:150:71 - Argument 3 of Sonata\AdminBundle\Datagrid\Datagrid::__construct expects Sonata\AdminBundle\Datagrid\PagerInterface<Sonata\AdminBundle\Datagrid\ProxyQueryInterface>, Sonata\AdminBundle\Datagrid\PagerInterface<Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface> provided (see https://psalm.dev/004)
        return new Datagrid($admin->createQuery(), $admin->getList(), $pager, $formBuilder, $values);
```

## Changelog

```markdown
### Added
- Generics for Datagrid and DatagridInterface
```