### PR TITLE
Leverage `FieldDescriptionInterface::getOption()` in views

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -524,7 +524,7 @@ This code manages the many-to-[one|many] association field popup
                     'objectId': 'OBJECT_ID',
                     'uniqid': associationadmin.uniqid,
                     'code': associationadmin.code,
-                    'linkParameters': sonata_admin.field_description.options.link_parameters
+                    'linkParameters': sonata_admin.field_description.option('link_parameters')
                 })}}'.replace('OBJECT_ID', objectId),
                 dataType: 'html',
                 success: function(html) {

--- a/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
@@ -24,11 +24,11 @@ file that was distributed with this source code.
                         'code':     sonata_admin.field_description.associationadmin.code,
                         'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
                         'uniqid':   sonata_admin.field_description.associationadmin.uniqid,
-                        'linkParameters': sonata_admin.field_description.options.link_parameters
+                        'linkParameters': sonata_admin.field_description.option('link_parameters')
                     })) }}
-                {% elseif sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
+                {% elseif sonata_admin.field_description.option('placeholder') %}
                     <span class="inner-field-short-description">
-                        {{ sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') }}
+                        {{ sonata_admin.field_description.option('placeholder')|trans({}, 'SonataAdminBundle') }}
                     </span>
                 {% endif %}
             </span>

--- a/src/Resources/views/CRUD/Association/edit_one_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many.html.twig
@@ -36,8 +36,8 @@ file that was distributed with this source code.
             and sonata_admin.field_description.associationadmin.hasAccess('create')
             and btn_add
             and (
-                sonata_admin.field_description.options.limit is not defined or
-                form.children|length < sonata_admin.field_description.options.limit
+                sonata_admin.field_description.option('limit') is null or
+                form.children|length < sonata_admin.field_description.option('limit')
             ) %}
 
         {% if sonata_admin.edit == 'inline' %}
@@ -60,7 +60,7 @@ file that was distributed with this source code.
             {% endif %}
 
             {# add code for the sortable options #}
-            {% if sonata_admin.field_description.options.sortable is defined %}
+            {% if sonata_admin.field_description.option('sortable', false) %}
                 {% if sonata_admin.inline == 'table' %}
                     {% include '@SonataAdmin/CRUD/Association/edit_one_to_many_sortable_script_table.html.twig' %}
                 {% else %}

--- a/src/Resources/views/CRUD/Association/edit_one_to_many_sortable_script_table.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many_sortable_script_table.html.twig
@@ -18,14 +18,14 @@ file that was distributed with this source code.
 
     function apply_position_value_{{ id }}() {
         // update the input value position
-        jQuery('div#field_container_{{ id }} tbody.sonata-ba-tbody td.sonata-ba-td-{{ id }}-{{ sonata_admin.field_description.options.sortable }}').each(function(index, element) {
+        jQuery('div#field_container_{{ id }} tbody.sonata-ba-tbody td.sonata-ba-td-{{ id }}-{{ sonata_admin.field_description.option('sortable') }}').each(function(index, element) {
             // remove the sortable handler and put it back
             jQuery('span.sonata-ba-sortable-handler', element).remove();
             jQuery(element).append('<span class="sonata-ba-sortable-handler ui-icon ui-icon-grip-solid-horizontal"></span>');
             jQuery('input', element).hide();
         });
 
-        jQuery('div#field_container_{{ id }} tbody.sonata-ba-tbody td.sonata-ba-td-{{ id }}-{{ sonata_admin.field_description.options.sortable }} input').each(function(index, value) {
+        jQuery('div#field_container_{{ id }} tbody.sonata-ba-tbody td.sonata-ba-td-{{ id }}-{{ sonata_admin.field_description.option('sortable') }} input').each(function(index, value) {
             jQuery(value).val(index + 1);
         });
     }

--- a/src/Resources/views/CRUD/Association/edit_one_to_many_sortable_script_tabs.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many_sortable_script_tabs.html.twig
@@ -18,7 +18,7 @@ file that was distributed with this source code.
 
     function apply_position_value_{{ id }}() {
         // update the input value position
-        jQuery('div#field_container_{{ id }} .sonata-ba-tabs .sonata-ba-field-{{ id }}-{{ sonata_admin.field_description.options.sortable }}').each(function(index, element) {
+        jQuery('div#field_container_{{ id }} .sonata-ba-tabs .sonata-ba-field-{{ id }}-{{ sonata_admin.field_description.option('sortable') }}').each(function(index, element) {
             // remove the sortable handler and put it back
             var parent = jQuery(element).closest('.nav-tabs-custom');
             var tabs = parent.find('> .nav-tabs');
@@ -29,7 +29,7 @@ file that was distributed with this source code.
             jQuery('input', element).hide();
         });
 
-        jQuery('div#field_container_{{ id }} .sonata-ba-tabs .sonata-ba-field-{{ id }}-{{ sonata_admin.field_description.options.sortable }} input').each(function(index, value) {
+        jQuery('div#field_container_{{ id }} .sonata-ba-tabs .sonata-ba-field-{{ id }}-{{ sonata_admin.field_description.option('sortable') }} input').each(function(index, value) {
             jQuery(value).val(index + 1);
         });
     }

--- a/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
@@ -24,11 +24,11 @@ file that was distributed with this source code.
                         'code':     sonata_admin.field_description.associationadmin.code,
                         'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
                         'uniqid':   sonata_admin.field_description.associationadmin.uniqid,
-                        'linkParameters': sonata_admin.field_description.options.link_parameters
+                        'linkParameters': sonata_admin.field_description.option('link_parameters')
                     })) }}
-                {% elseif sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
+                {% elseif sonata_admin.field_description.option('placeholder') %}
                     <span class="inner-field-short-description">
-                        {{ sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') }}
+                        {{ sonata_admin.field_description.option('placeholder')|trans({}, 'SonataAdminBundle') }}
                     </span>
                 {% endif %}
             </span>

--- a/src/Resources/views/CRUD/Association/list_many_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/list_many_to_many.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
-    {% set route_name = field_description.options.route.name %}
+    {% set route_name = field_description.option('route').name %}
     {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute(route_name) %}
         {% for element in value %}
             {%- if field_description.associationadmin.hasAccess(route_name, element) -%}
@@ -31,7 +31,7 @@ file that was distributed with this source code.
 {% endblock %}
 
 {%- block relation_link -%}
-    <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, element, field_description.options.route.parameters) }}">
+    <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, element, field_description.option('route').parameters) }}">
         {{- element|render_relation_element(field_description) -}}
     </a>
 {%- endblock -%}

--- a/src/Resources/views/CRUD/Association/list_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/list_many_to_one.html.twig
@@ -13,14 +13,14 @@ file that was distributed with this source code.
 
 {% block field %}
     {% if value %}
-        {% set route_name = field_description.options.route.name %}
-        {% if not field_description.options.identifier|default(false)
+        {% set route_name = field_description.option('route').name %}
+        {% if not field_description.option('identifier', false)
             and field_description.hasAssociationAdmin
             and field_description.associationadmin.hasRoute(route_name)
             and field_description.associationadmin.hasAccess(route_name, value)
             and field_description.associationadmin.id(value) is not null
         %}
-            <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.options.route.parameters) }}">
+            <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.option('route').parameters) }}">
                 {{ value|render_relation_element(field_description) }}
             </a>
         {% else %}

--- a/src/Resources/views/CRUD/Association/list_one_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/list_one_to_many.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
-    {% set route_name = field_description.options.route.name %}
+    {% set route_name = field_description.option('route').name %}
     {% if field_description.hasassociationadmin and field_description.associationadmin.hasRoute(route_name) %}
         {% for element in value %}
             {%- if field_description.associationadmin.hasAccess(route_name, element) -%}
@@ -30,7 +30,7 @@ file that was distributed with this source code.
 {% endblock %}
 
 {%- block relation_link -%}
-    <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, element, field_description.options.route.parameters) }}">
+    <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, element, field_description.option('route').parameters) }}">
         {{- element|render_relation_element(field_description) -}}
     </a>
 {%- endblock -%}

--- a/src/Resources/views/CRUD/Association/list_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/list_one_to_one.html.twig
@@ -13,13 +13,13 @@ file that was distributed with this source code.
 
 {% block field %}
     {% if value %}
-        {% set route_name = field_description.options.route.name %}
+        {% set route_name = field_description.option('route').name %}
         {% if field_description.hasAssociationAdmin
             and field_description.associationadmin.id(value) is not null
             and field_description.associationadmin.hasRoute(route_name)
             and field_description.associationadmin.hasAccess(route_name, value)
         %}
-            <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.options.route.parameters) }}">
+            <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.option('route').parameters) }}">
                 {{ value|render_relation_element(field_description) }}
             </a>
         {% else %}

--- a/src/Resources/views/CRUD/Association/show_many_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/show_many_to_many.html.twig
@@ -13,13 +13,13 @@ file that was distributed with this source code.
 
 {% block field %}
     <ul class="sonata-ba-show-many-to-many">
-    {% set route_name = field_description.options.route.name %}
+    {% set route_name = field_description.option('route').name %}
         {% for element in value %}
             <li>
                 {% if field_description.hasassociationadmin
                 and field_description.associationadmin.hasRoute(route_name)
                 and field_description.associationadmin.hasAccess(route_name, element) %}
-                    <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, element, field_description.options.route.parameters) }}">
+                    <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, element, field_description.option('route').parameters) }}">
                         {{ element|render_relation_element(field_description) }}
                     </a>
                 {% else %}

--- a/src/Resources/views/CRUD/Association/show_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/show_many_to_one.html.twig
@@ -13,11 +13,11 @@ file that was distributed with this source code.
 
 {% block field %}
     {% if value %}
-        {% set route_name = field_description.options.route.name %}
+        {% set route_name = field_description.option('route').name %}
         {% if field_description.hasAssociationAdmin
         and field_description.associationadmin.hasRoute(route_name)
         and field_description.associationadmin.hasAccess(route_name, value) %}
-            <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.options.route.parameters) }}">
+            <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.option('route').parameters) }}">
                 {{ value|render_relation_element(field_description) }}
             </a>
         {% else %}

--- a/src/Resources/views/CRUD/Association/show_one_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/show_one_to_many.html.twig
@@ -13,13 +13,13 @@ file that was distributed with this source code.
 
 {% block field %}
     <ul class="sonata-ba-show-one-to-many">
-    {% set route_name = field_description.options.route.name %}
+    {% set route_name = field_description.option('route').name %}
     {% for element in value %}
         {% if field_description.hasassociationadmin
         and field_description.associationadmin.hasRoute(route_name)
         and field_description.associationadmin.hasAccess(route_name, element) %}
             <li>
-                <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, element, field_description.options.route.parameters) }}">
+                <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, element, field_description.option('route').parameters) }}">
                     {{ element|render_relation_element(field_description) }}
                 </a>
             </li>

--- a/src/Resources/views/CRUD/Association/show_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/show_one_to_one.html.twig
@@ -13,13 +13,13 @@ file that was distributed with this source code.
 
 {% block field %}
     {% if value %}
-        {% set route_name = field_description.options.route.name %}
+        {% set route_name = field_description.option('route').name %}
         {% if field_description.hasAssociationAdmin
             and field_description.associationadmin.id(value) is not null
             and field_description.associationadmin.hasRoute(route_name)
             and field_description.associationadmin.hasAccess(route_name, value)
         %}
-            <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.options.route.parameters) }}">
+            <a href="{{ field_description.associationadmin.generateObjectUrl(route_name, value, field_description.option('route').parameters) }}">
                 {{ value|render_relation_element(field_description) }}
             </a>
         {% else %}

--- a/src/Resources/views/CRUD/_email_link.html.twig
+++ b/src/Resources/views/CRUD/_email_link.html.twig
@@ -1,12 +1,12 @@
 
 {%- if value is empty -%}
     &nbsp;
-{%- elseif field_description.options.as_string is defined and field_description.options.as_string -%}
+{%- elseif field_description.option('as_string', false) -%}
     {{ value }}
 {%- else -%}
     {% set parameters = {} %}
-    {% set subject = field_description.options.subject|default('') %}
-    {% set body = field_description.options.body|default('') %}
+    {% set subject = field_description.option('subject', '') %}
+    {% set body = field_description.option('body', '') %}
 
     {% if subject is not empty %}
         {% set parameters = parameters|merge({'subject': subject}) %}

--- a/src/Resources/views/CRUD/base_filter_field.html.twig
+++ b/src/Resources/views/CRUD/base_filter_field.html.twig
@@ -13,8 +13,8 @@ file that was distributed with this source code.
 
 <div>
     {% block label %}
-        {% if filter.fielddescription.options.name is defined %}
-            {{ form_label(filter_form, filter.fielddescription.options.name) }}
+        {% if filter.fielddescription.option('name') %}
+            {{ form_label(filter_form, filter.fielddescription.option('name')) }}
         {% else %}
             {{ form_label(filter_form) }}
         {% endif %}

--- a/src/Resources/views/CRUD/base_inline_edit_field.html.twig
+++ b/src/Resources/views/CRUD/base_inline_edit_field.html.twig
@@ -15,8 +15,8 @@ file that was distributed with this source code.
 
     {% block label %}
         {% if inline == 'natural' %}
-            {% if field_description.options.name is defined %}
-                {{ form_label(field_element, field_description.options.name) }}
+            {% if field_description.option('name') %}
+                {{ form_label(field_element, field_description.option('name')) }}
             {% else %}
                 {{ form_label(field_element) }}
             {% endif %}

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -64,7 +64,7 @@ file that was distributed with this source code.
                                             {# Disable fields with 'ajax_hidden' option set to true #}
                                         {% else %}
                                             {% set sortable = false %}
-                                            {% if field_description.options.sortable is defined and field_description.options.sortable %}
+                                            {% if field_description.option('sortable', false) %}
                                                 {% set sortable             = true %}
                                                 {# NEXT_MAJOR: Remove next line and uncomment the other one #}
                                                 {% set sort_parameters      = sonata_sort_parameters(field_description, admin) %}
@@ -73,11 +73,11 @@ file that was distributed with this source code.
                                                     and (admin.datagrid.values._sort_by == field_description
                                                         or admin.datagrid.values._sort_by.name == sort_parameters.filter._sort_by) %}
                                                 {% set sort_active_class    = current ? 'sonata-ba-list-field-order-active' : '' %}
-                                                {% set sort_by              = current ? admin.datagrid.values._sort_order : field_description.options._sort_order %}
+                                                {% set sort_by              = current ? admin.datagrid.values._sort_order : field_description.option('_sort_order') %}
                                             {% endif %}
 
                                             {% apply spaceless %}
-                                                <th class="sonata-ba-list-field-header-{{ field_description.type }}{% if sortable %} sonata-ba-list-field-header-order-{{ sort_by|lower }} {{ sort_active_class }}{% endif %}{% if field_description.options.header_class is defined %} {{ field_description.options.header_class }}{% endif %}"{% if field_description.options.header_style is defined %} style="{{ field_description.options.header_style }}"{% endif %}>
+                                                <th class="sonata-ba-list-field-header-{{ field_description.type }}{% if sortable %} sonata-ba-list-field-header-order-{{ sort_by|lower }} {{ sort_active_class }}{% endif %}{% if field_description.option('header_class') %} {{ field_description.option('header_class') }}{% endif %}"{% if field_description.option('header_style') %} style="{{ field_description.option('header_style') }}"{% endif %}>
                                                     {% if sortable %}<a href="{{ admin.generateUrl('list', sort_parameters|merge({_list_mode: admin.getListMode()})) }}">{% endif %}
                                                     {% if field_description.getOption('label_icon') %}
                                                         <i class="sonata-ba-list-field-header-label-icon {{ field_description.getOption('label_icon') }}" aria-hidden="true"></i>

--- a/src/Resources/views/CRUD/base_list_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_field.html.twig
@@ -9,20 +9,20 @@ file that was distributed with this source code.
 
 #}
 
-<td class="sonata-ba-list-field sonata-ba-list-field-{{ field_description.type }}" objectId="{{ admin.id(object) }}"{% if field_description.options.row_align is defined %} style="text-align:{{ field_description.options.row_align }}"{% endif %}>
-    {% set route = field_description.options.route.name|default(null) %}
+<td class="sonata-ba-list-field sonata-ba-list-field-{{ field_description.type }}" objectId="{{ admin.id(object) }}"{% if field_description.option('row_align') %} style="text-align:{{ field_description.option('row_align') }}"{% endif %}>
+    {% set route = field_description.option('route').name|default(null) %}
 
     {% if
-        field_description.options.identifier|default(false)
+        field_description.option('identifier', false)
         and route
         and admin.hasRoute(route)
         and admin.hasAccess(route, route in ['show', 'edit'] ? object : null)
     %}
-        <a class="sonata-link-identifier" href="{{ admin.generateObjectUrl(route, object, field_description.options.route.parameters) }}">
+        <a class="sonata-link-identifier" href="{{ admin.generateObjectUrl(route, object, field_description.option('route').parameters) }}">
             {%- block field %}
                 {% apply spaceless %}
-                {% if field_description.options.collapse is defined %}
-                    {% set collapse = field_description.options.collapse %}
+                {% if field_description.option('collapse') is not null %}
+                    {% set collapse = field_description.option('collapse') %}
                     <div class="sonata-readmore"
                           data-readmore-height="{{ collapse.height|default(40) }}"
                           data-readmore-more="{{ collapse.more|default('read_more')|trans({}, 'SonataAdminBundle') }}"
@@ -34,8 +34,8 @@ file that was distributed with this source code.
             {% endblock -%}
         </a>
     {% else %}
-        {% set is_editable = field_description.options.editable is defined and field_description.options.editable and admin.hasAccess('edit', object) %}
-        {% if is_editable and field_description.options.multiple is defined and field_description.options.multiple and value is iterable %}
+        {% set is_editable = field_description.option('editable', false) and admin.hasAccess('edit', object) %}
+        {% if is_editable and field_description.option('multiple', false) and value is iterable %}
             {# multiple editable field should be real multiple #}
             {# https://vitalets.github.io/x-editable/docs.html#checklist #}
             {% set x_editable_type = 'checklist' %}

--- a/src/Resources/views/CRUD/base_list_flat_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_flat_field.html.twig
@@ -11,12 +11,12 @@ file that was distributed with this source code.
 
 <span class="sonata-ba-list-field sonata-ba-list-field-{{ field_description.type }}" objectId="{{ admin.id(object) }}">
     {% if
-        field_description.options.identifier|default(false)
-        and field_description.options.route is defined
-        and admin.hasAccess(field_description.options.route.name, object)
-        and admin.hasRoute(field_description.options.route.name)
+        field_description.option('identifier', false)
+        and field_description.option('route')
+        and admin.hasAccess(field_description.option('route').name, object)
+        and admin.hasRoute(field_description.option('route').name)
     %}
-        <a href="{{ admin.generateObjectUrl(field_description.options.route.name, object, field_description.options.route.parameters) }}">
+        <a href="{{ admin.generateObjectUrl(field_description.option('route').name, object, field_description.option('route').parameters) }}">
             {%- block field %}{{ value }}{% endblock -%}
         </a>
     {% else %}

--- a/src/Resources/views/CRUD/base_show_field.html.twig
+++ b/src/Resources/views/CRUD/base_show_field.html.twig
@@ -21,14 +21,14 @@ file that was distributed with this source code.
 <td>
     {%- block field -%}
         {% apply spaceless %}
-            {% set collapse = field_description.options.collapse|default(false) %}
+            {% set collapse = field_description.option('collapse') %}
             {% if collapse %}
                 <div class="sonata-readmore"
                       data-readmore-height="{{ collapse.height|default(40) }}"
                       data-readmore-more="{{ collapse.more|default('read_more')|trans({}, 'SonataAdminBundle') }}"
                       data-readmore-less="{{ collapse.less|default('read_less')|trans({}, 'SonataAdminBundle') }}">
                     {% block field_value %}
-                        {% if field_description.options.safe %}{{ value|raw }}{% else %}{{ value|nl2br }}{% endif %}
+                        {% if field_description.option('safe', false) %}{{ value|raw }}{% else %}{{ value|nl2br }}{% endif %}
                     {% endblock %}
                 </div>
             {% else %}
@@ -40,7 +40,7 @@ file that was distributed with this source code.
 
 {%- block field_compare -%}
     {% apply spaceless %}
-        {% if(value_compare is defined) %}
+        {% if value_compare is defined %}
             {% set value = value_compare %}
             {% set object = object_compare %}
             <td>{{ block('field') }}</td>

--- a/src/Resources/views/CRUD/base_standard_edit_field.html.twig
+++ b/src/Resources/views/CRUD/base_standard_edit_field.html.twig
@@ -13,8 +13,8 @@ file that was distributed with this source code.
 
 <div class="form-group{% if field_element.var.errors|length > 0 %} has-error{% endif %}" id="sonata-ba-field-container-{{ field_element.vars.id }}">
     {% block label %}
-        {% if field_description.options.name is defined %}
-            {{ form_label(field_element, field_description.options.name) }}
+        {% if field_description.option('name') %}
+            {{ form_label(field_element, field_description.option('name')) }}
         {% else %}
             {{ form_label(field_element) }}
         {% endif %}

--- a/src/Resources/views/CRUD/display_boolean.html.twig
+++ b/src/Resources/views/CRUD/display_boolean.html.twig
@@ -16,7 +16,7 @@ file that was distributed with this source code.
         {% set text = 'label_type_no'|trans({}, 'SonataAdminBundle') %}
     {% endif %}
 
-    {% if field_description.options.inverse|default(false) ? not value : value %}
+    {% if field_description.option('inverse', false) ? not value : value %}
         {% set class = 'label-success' %}
     {% else %}
         {% set class = 'label-danger' %}

--- a/src/Resources/views/CRUD/display_currency.html.twig
+++ b/src/Resources/views/CRUD/display_currency.html.twig
@@ -13,6 +13,6 @@ file that was distributed with this source code.
     {%- if value is null -%}
         &nbsp;
     {%- else -%}
-        {{ field_description.options.currency }} {{ value }}
+        {{ field_description.option('currency') }} {{ value }}
     {%- endif -%}
 {% endapply -%}

--- a/src/Resources/views/CRUD/display_date.html.twig
+++ b/src/Resources/views/CRUD/display_date.html.twig
@@ -13,9 +13,8 @@ file that was distributed with this source code.
     {%- if value is empty -%}
         &nbsp;
     {%- else -%}
-        {% set options = field_description.options %}
         <time datetime="{{ value|date('Y-m-d', 'UTC') }}" title="{{ value|date('Y-m-d', 'UTC') }}">
-            {{ value|date(options.format|default('F j, Y'), options.timezone|default(null)) }}
+            {{ value|date(field_description.option('format', 'F j, Y'), field_description.option('timezone')) }}
         </time>
     {%- endif -%}
 {% endapply -%}

--- a/src/Resources/views/CRUD/display_time.html.twig
+++ b/src/Resources/views/CRUD/display_time.html.twig
@@ -14,7 +14,7 @@ file that was distributed with this source code.
         &nbsp;
     {%- else -%}
         <time datetime="{{ value|date('H:i:sP', 'UTC') }}" title="{{ value|date('H:i:sP', 'UTC') }}">
-            {{ value|date(field_description.options.format|default('H:i:s'), field_description.options.timezone|default(null)) }}
+            {{ value|date(field_description.option('format', 'H:i:s'), field_description.option('timezone')) }}
         </time>
     {%- endif -%}
 {% endapply -%}

--- a/src/Resources/views/CRUD/edit_boolean.html.twig
+++ b/src/Resources/views/CRUD/edit_boolean.html.twig
@@ -15,8 +15,8 @@ file that was distributed with this source code.
     <div class="sonata-ba-field{% if field_element.vars.errors|length > 0 %} sonata-ba-field-error{% endif %}">
         {% block field %}{{ form_widget(field_element) }}{% endblock %}
         {% block label %}
-            {% if field_description.options.name is defined %}
-                {{ form_label(field_element, field_description.options.name) }}
+            {% if field_description.option('name') %}
+                {{ form_label(field_element, field_description.option('name')) }}
             {% else %}
                 {{ form_label(field_element) }}
             {% endif %}

--- a/src/Resources/views/CRUD/list__action.html.twig
+++ b/src/Resources/views/CRUD/list__action.html.twig
@@ -13,7 +13,7 @@ file that was distributed with this source code.
 
 {% block field %}
     <div class="btn-group">
-        {% for actions in field_description.options.actions %}
+        {% for actions in field_description.option('actions') %}
             {% include actions.template %}
         {% endfor %}
     </div>

--- a/src/Resources/views/CRUD/list_array.html.twig
+++ b/src/Resources/views/CRUD/list_array.html.twig
@@ -15,7 +15,7 @@ file that was distributed with this source code.
 {% block field %}
     {{ list.render_array(
         value,
-        field_description.options.inline is not defined or field_description.options.inline,
+        field_description.option('inline', true),
         { default_translation_domain : admin.translationDomain }|merge(field_description.options)
     ) }}
 {% endblock %}

--- a/src/Resources/views/CRUD/list_boolean.html.twig
+++ b/src/Resources/views/CRUD/list_boolean.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% extends get_admin_template('base_list_field', admin.code) %}
 
-{% set is_editable = field_description.options.editable is defined and field_description.options.editable and admin.hasAccess('edit', object) %}
+{% set is_editable = field_description.option('editable', false) and admin.hasAccess('edit', object) %}
 {% set x_editable_type = field_description.type|sonata_xeditable_type %}
 
 {% block field_span_attributes %}

--- a/src/Resources/views/CRUD/list_choice.html.twig
+++ b/src/Resources/views/CRUD/list_choice.html.twig
@@ -12,8 +12,7 @@ file that was distributed with this source code.
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {% set is_editable =
-    field_description.options.editable is defined and
-    field_description.options.editable and
+    field_description.option('editable', false) and
     admin.hasAccess('edit', object)
 %}
 {% set x_editable_type = field_description.type|sonata_xeditable_type %}
@@ -29,24 +28,24 @@ file that was distributed with this source code.
 
 {% block field %}
 {% apply spaceless %}
-    {% if field_description.options.choices is defined %}
-        {% if field_description.options.multiple is defined and field_description.options.multiple==true and value is iterable %}
+    {% if field_description.option('choices') is not null %}
+        {% if field_description.option('multiple', false) and value is iterable %}
 
             {% set result = '' %}
-            {% set delimiter = field_description.options.delimiter|default(', ') %}
+            {% set delimiter = field_description.option('delimiter', ', ') %}
 
             {% for val in value %}
                 {% if result is not empty %}
                     {% set result = result ~ delimiter %}
                 {% endif %}
 
-                {% if val in field_description.options.choices|keys %}
-                    {% set choice = field_description.options.choices[val] %}
+                {% if val in field_description.option('choices')|keys %}
+                    {% set choice = field_description.option('choices')[val] %}
                 {% else %}
                     {% set choice = val %}
                 {% endif %}
-                {% if field_description.options.catalogue is defined %}
-                    {% set result = result ~ choice|trans({}, field_description.options.catalogue) %}
+                {% if field_description.option('catalogue') %}
+                    {% set result = result ~ choice|trans({}, field_description.option('catalogue')) %}
                 {% else %}
                     {% set result = result ~ choice %}
                 {% endif %}
@@ -54,11 +53,11 @@ file that was distributed with this source code.
 
             {% set value = result %}
 
-        {% elseif value in field_description.options.choices|keys %}
-            {% if field_description.options.catalogue is not defined %}
-                {% set value = field_description.options.choices[value] %}
+        {% elseif value in field_description.option('choices')|keys %}
+            {% if field_description.option('catalogue') is null %}
+                {% set value = field_description.option('choices')[value] %}
             {% else %}
-                {% set value = field_description.options.choices[value]|trans({}, field_description.options.catalogue) %}
+                {% set value = field_description.option('choices')[value]|trans({}, field_description.option('catalogue')) %}
             {% endif %}
         {% endif %}
     {% endif %}

--- a/src/Resources/views/CRUD/list_html.html.twig
+++ b/src/Resources/views/CRUD/list_html.html.twig
@@ -4,8 +4,8 @@
     {%- if value is empty -%}
         &nbsp;
     {% else %}
-        {%- if field_description.options.truncate is defined -%}
-            {% set truncate = field_description.options.truncate %}
+        {%- if field_description.option('truncate') -%}
+            {% set truncate = field_description.option('truncate') %}
             {% set length = truncate.length|default(30) %}
             {% if truncate.preserve is defined %}
                 {% deprecated 'The "truncate.preserve" option is deprecated since sonata-project/admin-bundle 3.65, to be removed in 4.0. Use "truncate.cut" instead.' %}
@@ -17,7 +17,7 @@
             {% set ellipsis = truncate.ellipsis is defined ? truncate.ellipsis : (truncate.separator is defined ? truncate.separator : '...') %}
             {{ value|striptags|u.truncate(length, ellipsis, cut)|raw }}
         {%- else -%}
-            {%- if field_description.options.strip is defined -%}
+            {%- if field_description.option('strip', false) -%}
                 {% set value = value|striptags %}
             {%- endif -%}
             {{ value|raw }}

--- a/src/Resources/views/CRUD/list_trans.html.twig
+++ b/src/Resources/views/CRUD/list_trans.html.twig
@@ -12,8 +12,8 @@ file that was distributed with this source code.
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
-    {% set translation_domain = field_description.options.catalogue|default(admin.translationDomain) %}
-    {% set value_format = field_description.options.format|default('%s') %}
+    {% set translation_domain = field_description.option('catalogue', admin.translationDomain) %}
+    {% set value_format = field_description.option('format', '%s') %}
 
     {{ value_format|format(value)|trans({}, translation_domain) }}
 {% endblock %}

--- a/src/Resources/views/CRUD/list_url.html.twig
+++ b/src/Resources/views/CRUD/list_url.html.twig
@@ -16,35 +16,35 @@ file that was distributed with this source code.
     {% if value is empty %}
         &nbsp;
     {% else %}
-        {% if field_description.options.url is defined %}
+        {% if field_description.option('url') %}
             {# target url is string #}
-            {% set url_address = field_description.options.url %}
-        {% elseif field_description.options.route is defined and field_description.options.route.name not in ['edit', 'show'] %}
+            {% set url_address = field_description.option('url') %}
+        {% elseif field_description.option('route') and field_description.option('route').name not in ['edit', 'show'] %}
             {# target url is Symfony route #}
-            {% set parameters = field_description.options.route.parameters|default([]) %}
+            {% set parameters = field_description.option('route').parameters|default([]) %}
 
             {# route with paramter related to object ID #}
-            {% if field_description.options.route.identifier_parameter_name is defined %}
-                {% set parameters = parameters|merge({(field_description.options.route.identifier_parameter_name):(admin.normalizedidentifier(object))}) %}
+            {% if field_description.option('route').identifier_parameter_name is defined %}
+                {% set parameters = parameters|merge({(field_description.option('route').identifier_parameter_name):(admin.normalizedidentifier(object))}) %}
             {% endif %}
 
-            {% if field_description.options.route.absolute|default(false) %}
-                {% set url_address = url(field_description.options.route.name, parameters) %}
+            {% if field_description.option('route').absolute|default(false) %}
+                {% set url_address = url(field_description.option('route').name, parameters) %}
             {% else %}
-                {% set url_address = path(field_description.options.route.name, parameters) %}
+                {% set url_address = path(field_description.option('route').name, parameters) %}
             {% endif %}
         {% else %}
             {# value is url #}
             {% set url_address = value %}
         {% endif %}
 
-        {% if field_description.options.hide_protocol|default(false) %}
+        {% if field_description.option('hide_protocol', false) %}
             {% set value = value|replace({'http://': '', 'https://': ''}) %}
         {% endif %}
 
         <a
             href="{{ url_address }}"
-            {%- for attribute, value in field_description.options.attributes|default([]) %}
+            {%- for attribute, value in field_description.option('attributes', []) %}
                 {{ attribute }}="{{ value|escape('html_attr') }}"
             {%- endfor -%}
         >

--- a/src/Resources/views/CRUD/show_array.html.twig
+++ b/src/Resources/views/CRUD/show_array.html.twig
@@ -15,7 +15,7 @@ file that was distributed with this source code.
 {% block field %}
     {{ show.render_array(
         value,
-        field_description.options.inline|default(false),
+        field_description.option('inline', false),
         { default_translation_domain : admin.translationDomain }|merge(field_description.options)
     ) }}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_choice.html.twig
+++ b/src/Resources/views/CRUD/show_choice.html.twig
@@ -12,22 +12,22 @@ file that was distributed with this source code.
 
 {% block field %}
 {% apply spaceless %}
-    {% if field_description.options.choices  is defined %}
-        {% if field_description.options.multiple is defined and field_description.options.multiple==true and value is iterable %}
+    {% if field_description.option('choices') is not null %}
+        {% if field_description.option('multiple', false) and value is iterable %}
 
             {% set result = '' %}
-            {% set delimiter = field_description.options.delimiter|default(', ') %}
+            {% set delimiter = field_description.option('delimiter', ', ') %}
 
             {% for val in value %}
                 {% if result is not empty %}
                     {% set result = result ~ delimiter %}
                 {% endif %}
 
-                {% if field_description.options.choices[val] is defined %}
-                    {% if field_description.options.catalogue is not defined %}
-                        {% set result = result ~ field_description.options.choices[val] %}
+                {% if field_description.option('choices')[val] is defined %}
+                    {% if field_description.option('catalogue') is null %}
+                        {% set result = result ~ field_description.option('choices')[val] %}
                     {% else %}
-                        {% set result = result ~ field_description.options.choices[val]|trans({}, field_description.options.catalogue) %}
+                        {% set result = result ~ field_description.option('choices')[val]|trans({}, field_description.option('catalogue')) %}
                     {% endif %}
                 {% else %}
                     {% set result = result ~ val %}
@@ -36,16 +36,16 @@ file that was distributed with this source code.
 
             {% set value = result %}
 
-        {% elseif value in field_description.options.choices|keys %}
-            {% if field_description.options.catalogue is not defined %}
-                {% set value = field_description.options.choices[value] %}
+        {% elseif value in field_description.option('choices')|keys %}
+            {% if field_description.option('catalogue') is null %}
+                {% set value = field_description.option('choices')[value] %}
             {% else %}
-                {% set value = field_description.options.choices[value]|trans({}, field_description.options.catalogue) %}
+                {% set value = field_description.option('choices')[value]|trans({}, field_description.option('catalogue')) %}
             {% endif %}
         {% endif %}
     {% endif %}
 
-    {% if field_description.options.safe %}
+    {% if field_description.option('safe', false) %}
         {{ value|raw }}
     {% else %}
         {{ value }}

--- a/src/Resources/views/CRUD/show_html.html.twig
+++ b/src/Resources/views/CRUD/show_html.html.twig
@@ -4,8 +4,8 @@
     {%- if value is empty -%}
         &nbsp;
     {% else %}
-        {%- if field_description.options.truncate is defined -%}
-            {% set truncate = field_description.options.truncate %}
+        {%- if field_description.option('truncate') -%}
+            {% set truncate = field_description.option('truncate') %}
             {% set length = truncate.length|default(30) %}
             {% if truncate.preserve is defined %}
                 {% deprecated 'The "truncate.preserve" option is deprecated since sonata-project/admin-bundle 3.65, to be removed in 4.0. Use "truncate.cut" instead.' %}
@@ -17,7 +17,7 @@
             {% set ellipsis = truncate.ellipsis is defined ? truncate.ellipsis : (truncate.separator is defined ? truncate.separator : '...') %}
             {{ value|striptags|u.truncate(length, ellipsis, cut)|raw }}
         {%- else -%}
-            {%- if field_description.options.strip is defined -%}
+            {%- if field_description.option('strip', false) -%}
                 {% set value = value|striptags %}
             {%- endif -%}
             {{ value|raw }}

--- a/src/Resources/views/CRUD/show_trans.html.twig
+++ b/src/Resources/views/CRUD/show_trans.html.twig
@@ -11,15 +11,15 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
-    {% set value_format = field_description.options.format|default('%s') %}
+    {% set value_format = field_description.option('format', '%s') %}
 
-    {% if field_description.options.catalogue is not defined %}
+    {% if field_description.option('catalogue') is null %}
         {% set value = value_format|format(value)|trans %}
     {% else %}
-        {% set value = value_format|format(value)|trans({}, field_description.options.catalogue|default(admin.translationDomain)) %}
+        {% set value = value_format|format(value)|trans({}, field_description.option('catalogue', admin.translationDomain)) %}
     {% endif %}
 
-    {% if field_description.options.safe %}
+    {% if field_description.option('safe', false) %}
         {{ value|raw }}
     {% else %}
         {{ value }}

--- a/src/Resources/views/CRUD/show_url.html.twig
+++ b/src/Resources/views/CRUD/show_url.html.twig
@@ -16,39 +16,39 @@ file that was distributed with this source code.
     {% if value is empty %}
         &nbsp;
     {% else %}
-        {% if field_description.options.url is defined %}
+        {% if field_description.option('url') %}
             {# target url is string #}
-            {% set url_address = field_description.options.url %}
-        {% elseif field_description.options.route is defined and field_description.options.route.name not in ['edit', 'show'] %}
+            {% set url_address = field_description.option('url') %}
+        {% elseif field_description.option('route') is not null and field_description.option('route').name not in ['edit', 'show'] %}
             {# target url is Symfony route #}
-            {% set parameters = field_description.options.route.parameters|default([]) %}
+            {% set parameters = field_description.option('route').parameters|default([]) %}
 
             {# route with paramter related to object ID #}
-            {% if field_description.options.route.identifier_parameter_name is defined %}
-                {% set parameters = parameters|merge({(field_description.options.route.identifier_parameter_name):(admin.normalizedidentifier(object))}) %}
+            {% if field_description.option('route').identifier_parameter_name is defined %}
+                {% set parameters = parameters|merge({(field_description.option('route').identifier_parameter_name):(admin.normalizedidentifier(object))}) %}
             {% endif %}
 
-            {% if field_description.options.route.absolute|default(false) %}
-                {% set url_address = url(field_description.options.route.name, parameters) %}
+            {% if field_description.option('route').absolute|default(false) %}
+                {% set url_address = url(field_description.option('route').name, parameters) %}
             {% else %}
-                {% set url_address = path(field_description.options.route.name, parameters) %}
+                {% set url_address = path(field_description.option('route').name, parameters) %}
             {% endif %}
         {% else %}
             {# value is url #}
             {% set url_address = value %}
         {% endif %}
 
-        {% if field_description.options.hide_protocol|default(false) %}
+        {% if field_description.option('hide_protocol', false) %}
             {% set value = value|replace({'http://': '', 'https://': ''}) %}
         {% endif %}
 
         <a
             href="{{ url_address }}"
-            {%- for attribute, value in field_description.options.attributes|default([]) %}
+            {%- for attribute, value in field_description.option('attributes', []) %}
                 {{ attribute }}="{{ value|escape('html_attr') }}"
             {%- endfor -%}
         >
-            {%- if field_description.options.safe -%}
+            {%- if field_description.option('safe', false) -%}
                 {{- value|raw -}}
             {%- else -%}
                 {{- value -}}

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -361,9 +361,9 @@ file that was distributed with this source code.
     {% set row_class = (row_attr.class|default('') ~ ' form-group' ~ (errors|length > 0 ? ' has-error'))|trim %}
     <div{% with {attr: row_attr|merge({id: row_id, class: row_class})} %}{{ block('attributes') }}{% endwith %}>
         {# NEXT_MAJOR: Remove this block #}
-        {% if sonata_admin.field_description.options.name is defined %}
+        {% if sonata_admin.field_description|default(null) is not null and sonata_admin.field_description.option('name') %}
             {% deprecated 'The "name" option is deprecated in field description since sonata-project/admin-bundle 3.91, to be removed in 4.0.' %}
-            {% set label = sonata_admin.field_description.options.name|default(label) %}
+            {% set label = sonata_admin.field_description.option('name', label) %}
         {% endif %}
 
         {% set div_class = 'sonata-ba-field' %}
@@ -596,11 +596,11 @@ file that was distributed with this source code.
                     'code': sonata_admin.field_description.associationadmin.code,
                     'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
                     'uniqid': sonata_admin.field_description.associationadmin.uniqid,
-                    'linkParameters': sonata_admin.field_description.options.link_parameters
+                    'linkParameters': sonata_admin.field_description.option('link_parameters')
                 })) }}
-            {% elseif sonata_admin.field_description.options.placeholder is defined and sonata_admin.field_description.options.placeholder %}
+            {% elseif sonata_admin.field_description.option('placeholder') %}
                 <span class="inner-field-short-description">
-                    {{ sonata_admin.field_description.options.placeholder|trans({}, 'SonataAdminBundle') }}
+                    {{ sonata_admin.field_description.option('placeholder')|trans({}, 'SonataAdminBundle') }}
                 </span>
             {% endif %}
         </span>

--- a/tests/Twig/Extension/RenderElementExtensionTest.php
+++ b/tests/Twig/Extension/RenderElementExtensionTest.php
@@ -273,7 +273,7 @@ final class RenderElementExtensionTest extends TestCase
 
         $this->fieldDescription
             ->method('getOption')
-            ->willReturnCallback(static function ($name, $default = null) use ($options) {
+            ->willReturnCallback(static function (string $name, $default = null) use ($options) {
                 return $options[$name] ?? $default;
             });
 
@@ -431,7 +431,7 @@ final class RenderElementExtensionTest extends TestCase
 
         $this->fieldDescription
             ->method('getOption')
-            ->willReturnCallback(static function ($name, $default = null) use ($options) {
+            ->willReturnCallback(static function (string $name, $default = null) use ($options) {
                 return $options[$name] ?? $default;
             });
 
@@ -583,6 +583,12 @@ EOT
             ->willReturn($options);
 
         $this->fieldDescription
+            ->method('getOption')
+            ->willReturnCallback(static function (string $name, $default = null) use ($options) {
+                return $options[$name] ?? $default;
+            });
+
+        $this->fieldDescription
             ->method('getTemplate')
             ->willReturnCallback(static function () use ($type): ?string {
                 switch ($type) {
@@ -650,6 +656,12 @@ EOT
         $this->fieldDescription
             ->method('getOptions')
             ->willReturn($options);
+
+        $this->fieldDescription
+            ->method('getOption')
+            ->willReturnCallback(static function (string $name, $default = null) use ($options) {
+                return $options[$name] ?? $default;
+            });
 
         $this->fieldDescription
             ->method('getTemplate')
@@ -772,6 +784,12 @@ EOT
         $this->fieldDescription
             ->method('getOptions')
             ->willReturn($options);
+
+        $this->fieldDescription
+            ->method('getOption')
+            ->willReturnCallback(static function (string $name, $default = null) use ($options) {
+                return $options[$name] ?? $default;
+            });
 
         $this->fieldDescription
             ->method('getTemplate')

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -376,14 +376,14 @@ class SonataAdminExtensionTest extends TestCase
             ->willReturn($type);
 
         $this->fieldDescription
-            ->method('getOptions')
-            ->willReturn($options);
-
-        $this->fieldDescription
             ->method('getOption')
-            ->willReturnCallback(static function ($name, $default = null) use ($options) {
+            ->willReturnCallback(static function (string $name, $default = null) use ($options) {
                 return $options[$name] ?? $default;
             });
+
+        $this->fieldDescription
+            ->method('getOptions')
+            ->willReturn($options);
 
         $this->fieldDescription
             ->method('getTemplate')
@@ -1651,6 +1651,12 @@ EOT
             ->willReturn($type);
 
         $this->fieldDescription
+            ->method('getOption')
+            ->willReturnCallback(static function (string $name, $default = null) use ($options) {
+                return $options[$name] ?? $default;
+            });
+
+        $this->fieldDescription
             ->method('getOptions')
             ->willReturn($options);
 
@@ -2232,6 +2238,12 @@ EOT
             ->willReturn($options);
 
         $this->fieldDescription
+            ->method('getOption')
+            ->willReturnCallback(static function (string $name, $default = null) use ($options) {
+                return $options[$name] ?? $default;
+            });
+
+        $this->fieldDescription
             ->method('getTemplate')
             ->willReturnCallback(static function () use ($type): ?string {
                 switch ($type) {
@@ -2381,6 +2393,12 @@ EOT
         $this->fieldDescription
             ->method('getOptions')
             ->willReturn($options);
+
+        $this->fieldDescription
+            ->method('getOption')
+            ->willReturnCallback(static function (string $name, $default = null) use ($options) {
+                return $options[$name] ?? $default;
+            });
 
         $this->fieldDescription
             ->method('getTemplate')
@@ -3219,6 +3237,12 @@ EOT
         $this->fieldDescription
             ->method('getOptions')
             ->willReturn($options);
+
+        $this->fieldDescription
+            ->method('getOption')
+            ->willReturnCallback(static function (string $name, $default = null) use ($options) {
+                return $options[$name] ?? $default;
+            });
 
         $this->fieldDescription
             ->method('getTemplate')


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Leverage `FieldDescriptionInterface::getOption()` in views.

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

Many usages of the Twig's `default` filter were removed, leveraging the argument 2 of `FieldDescriptionInterface::getOption()`.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Calls to `FieldDescriptionInterface::getOptions()` by calls to `FieldDescriptionInterface::getOption()` in views.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
