### PR TITLE
Introduce MapperInterface

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -92,24 +92,6 @@ parameters:
 
         -
             # will be fixed in v4. Currently BC break
-            message: "#^Method Sonata\\\\AdminBundle\\\\FieldDescription\\\\FieldDescriptionInterface\\:\\:getLabel\\(\\) invoked with 1 parameter, 0 required\\.$#"
-            count: 1
-            path: src/Show/ShowMapper.php
-
-        -
-            # will be fixed in v4. Currently BC break
-            message: "#^Method Sonata\\\\AdminBundle\\\\Admin\\\\AdminInterface\\<object\\>\\:\\:getShowGroups\\(\\) invoked with 1 parameter, 0 required\\.$#"
-            count: 1
-            path: src/Show/ShowMapper.php
-
-        -
-            # will be fixed in v4. Currently BC break
-            message: "#^Method Sonata\\\\AdminBundle\\\\Admin\\\\AdminInterface\\<object\\>\\:\\:getShowTabs\\(\\) invoked with 1 parameter, 0 required\\.$#"
-            count: 1
-            path: src/Show/ShowMapper.php
-
-        -
-            # will be fixed in v4. Currently BC break
             message: "#^Method Sonata\\\\AdminBundle\\\\Translator\\\\Extractor\\\\JMSTranslatorBundle\\\\AdminExtractor\\:\\:buildSecurityInformation\\(\\) should return array\\<string, array<string>\\> but return statement is missing\\.$#"
             count: 1
             path: src/Translator/Extractor/JMSTranslatorBundle/AdminExtractor.php

--- a/src/Event/ConfigureEvent.php
+++ b/src/Event/ConfigureEvent.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Event;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Mapper\BaseMapper;
+use Sonata\AdminBundle\Mapper\MapperInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
@@ -45,7 +46,7 @@ class ConfigureEvent extends Event
     protected $admin;
 
     /**
-     * @var BaseMapper
+     * @var MapperInterface
      */
     protected $mapper;
 
@@ -57,7 +58,7 @@ class ConfigureEvent extends Event
     /**
      * @param string $type
      */
-    public function __construct(AdminInterface $admin, BaseMapper $mapper, $type)
+    public function __construct(AdminInterface $admin, MapperInterface $mapper, $type)
     {
         $this->admin = $admin;
         $this->mapper = $mapper;
@@ -81,7 +82,7 @@ class ConfigureEvent extends Event
     }
 
     /**
-     * @return BaseMapper
+     * @return MapperInterface
      */
     public function getMapper()
     {

--- a/src/Event/ConfigureEvent.php
+++ b/src/Event/ConfigureEvent.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Event;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Mapper\BaseMapper;
 use Sonata\AdminBundle\Mapper\MapperInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -40,18 +40,31 @@ class FormMapper extends BaseGroupedMapper
      */
     protected $builder;
 
+    /**
+     * NEXT_MAJOR: Make the property private.
+     *
+     * @var AdminInterface
+     */
+    protected $admin;
+
     public function __construct(
         FormContractorInterface $formContractor,
         FormBuilderInterface $formBuilder,
         AdminInterface $admin
     ) {
-        parent::__construct($formContractor, $admin);
+        $this->builder = $formContractor;
+        $this->admin = $admin;
         $this->formBuilder = $formBuilder;
+    }
+
+    public function getAdmin()
+    {
+        return $this->admin;
     }
 
     public function reorder(array $keys)
     {
-        $this->admin->reorderFormGroup($this->getCurrentGroupName(), $keys);
+        $this->getAdmin()->reorderFormGroup($this->getCurrentGroupName(), $keys);
 
         return $this;
     }
@@ -70,7 +83,7 @@ class FormMapper extends BaseGroupedMapper
             return $this;
         }
 
-        if (isset($fieldDescriptionOptions['role']) && !$this->admin->isGranted($fieldDescriptionOptions['role'])) {
+        if (isset($fieldDescriptionOptions['role']) && !$this->getAdmin()->isGranted($fieldDescriptionOptions['role'])) {
             return $this;
         }
 
@@ -110,21 +123,21 @@ class FormMapper extends BaseGroupedMapper
         }
 
         // NEXT_MAJOR: Remove the check and use `createFieldDescription`.
-        if (method_exists($this->admin, 'createFieldDescription')) {
-            $fieldDescription = $this->admin->createFieldDescription(
+        if (method_exists($this->getAdmin(), 'createFieldDescription')) {
+            $fieldDescription = $this->getAdmin()->createFieldDescription(
                 $name instanceof FormBuilderInterface ? $name->getName() : $name,
                 $fieldDescriptionOptions
             );
         } else {
-            $fieldDescription = $this->admin->getModelManager()->getNewFieldDescriptionInstance(
-                $this->admin->getClass(),
+            $fieldDescription = $this->getAdmin()->getModelManager()->getNewFieldDescriptionInstance(
+                $this->getAdmin()->getClass(),
                 $name instanceof FormBuilderInterface ? $name->getName() : $name,
                 $fieldDescriptionOptions
             );
         }
 
         // Note that the builder var is actually the formContractor:
-        $this->builder->fixFieldDescription($this->admin, $fieldDescription);
+        $this->builder->fixFieldDescription($this->getAdmin(), $fieldDescription);
 
         if ($fieldName !== $name) {
             $fieldDescription->setName($fieldName);
@@ -160,7 +173,7 @@ class FormMapper extends BaseGroupedMapper
                  * previously `form.label_foo__bar_baz` and now is `form.label_foo_bar_baz`
                  * to be consistent with others labels like `show.label_foo_bar_baz`.
                  */
-                $options['label'] = $this->admin->getLabelTranslatorStrategy()->getLabel($child, 'form', 'label');
+                $options['label'] = $this->getAdmin()->getLabelTranslatorStrategy()->getLabel($child, 'form', 'label');
             }
 
             // NEXT_MAJOR: Remove this block.
@@ -179,7 +192,7 @@ class FormMapper extends BaseGroupedMapper
             }
         }
 
-        $this->admin->addFormFieldDescription($fieldName, $fieldDescription);
+        $this->getAdmin()->addFormFieldDescription($fieldName, $fieldDescription);
         $this->formBuilder->add($child, $type, $options);
 
         return $this;
@@ -210,8 +223,8 @@ class FormMapper extends BaseGroupedMapper
     public function remove($key)
     {
         $key = $this->sanitizeFieldName($key);
-        $this->admin->removeFormFieldDescription($key);
-        $this->admin->removeFieldFromFormGroup($key);
+        $this->getAdmin()->removeFormFieldDescription($key);
+        $this->getAdmin()->removeFieldFromFormGroup($key);
         $this->formBuilder->remove($key);
 
         return $this;
@@ -302,24 +315,24 @@ class FormMapper extends BaseGroupedMapper
     {
         // NEXT_MAJOR: Remove the argument "sonata_deprecation_mute" in the following call.
 
-        return $this->admin->getFormGroups('sonata_deprecation_mute');
+        return $this->getAdmin()->getFormGroups('sonata_deprecation_mute');
     }
 
     protected function setGroups(array $groups)
     {
-        $this->admin->setFormGroups($groups);
+        $this->getAdmin()->setFormGroups($groups);
     }
 
     protected function getTabs()
     {
         // NEXT_MAJOR: Remove the argument "sonata_deprecation_mute" in the following call.
 
-        return $this->admin->getFormTabs('sonata_deprecation_mute');
+        return $this->getAdmin()->getFormTabs('sonata_deprecation_mute');
     }
 
     protected function setTabs(array $tabs)
     {
-        $this->admin->setFormTabs($tabs);
+        $this->getAdmin()->setFormTabs($tabs);
     }
 
     protected function getName()

--- a/src/Mapper/BaseGroupedMapper.php
+++ b/src/Mapper/BaseGroupedMapper.php
@@ -16,11 +16,13 @@ namespace Sonata\AdminBundle\Mapper;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 
 /**
+ * NEXT_MAJOR: Stop extending BaseMapper.
+ *
  * This class is used to simulate the Form API.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-abstract class BaseGroupedMapper extends BaseMapper
+abstract class BaseGroupedMapper extends BaseMapper implements MapperInterface
 {
     /**
      * @var string|null
@@ -78,7 +80,7 @@ abstract class BaseGroupedMapper extends BaseMapper
             'class' => false,
             'description' => false,
             'label' => $name, // NEXT_MAJOR: Remove this line and uncomment the next one
-//            'label' => $this->admin->getLabelTranslatorStrategy()->getLabel($name, $this->getName(), 'group'),
+//            'label' => $this->getAdmin()->getLabelTranslatorStrategy()->getLabel($name, $this->getName(), 'group'),
             'translation_domain' => null,
             'name' => $name,
             'box_class' => 'box box-primary',
@@ -398,14 +400,14 @@ abstract class BaseGroupedMapper extends BaseMapper
     protected function getCurrentGroupName()
     {
         if (!$this->currentGroup) {
-            $label = $this->admin->getLabel();
+            $label = $this->getAdmin()->getLabel();
 
             if (null === $label) {
                 $this->with('default', ['auto_created' => true]);
             } else {
                 $this->with($label, [
                     'auto_created' => true,
-                    'translation_domain' => $this->admin->getTranslationDomain(),
+                    'translation_domain' => $this->getAdmin()->getTranslationDomain(),
                 ]);
             }
         }

--- a/src/Mapper/BaseMapper.php
+++ b/src/Mapper/BaseMapper.php
@@ -17,11 +17,13 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Builder\BuilderInterface;
 
 /**
+ * NEXT_MAJOR: Remove this class.
+ *
  * This class is used to simulate the Form API.
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-abstract class BaseMapper implements MapperInterface
+abstract class BaseMapper
 {
     /**
      * @var AdminInterface
@@ -35,6 +37,11 @@ abstract class BaseMapper implements MapperInterface
 
     public function __construct(BuilderInterface $builder, AdminInterface $admin)
     {
+        @trigger_error(sprintf(
+            'The %s class is deprecated since sonata-project/admin-bundle 3.x and will be removed in version 4.0.',
+            __CLASS__
+        ), \E_USER_DEPRECATED);
+
         $this->builder = $builder;
         $this->admin = $admin;
     }

--- a/src/Mapper/BaseMapper.php
+++ b/src/Mapper/BaseMapper.php
@@ -21,7 +21,7 @@ use Sonata\AdminBundle\Builder\BuilderInterface;
  *
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  */
-abstract class BaseMapper
+abstract class BaseMapper implements MapperInterface
 {
     /**
      * @var AdminInterface
@@ -39,47 +39,8 @@ abstract class BaseMapper
         $this->admin = $admin;
     }
 
-    /**
-     * @return AdminInterface
-     */
     public function getAdmin()
     {
         return $this->admin;
     }
-
-    /**
-     * @param string $key
-     *
-     * @return mixed
-     */
-    abstract public function get($key);
-
-    /**
-     * @param string $key
-     *
-     * @return bool
-     */
-    abstract public function has($key);
-
-    /**
-     * @param string $key
-     *
-     * @return static
-     */
-    abstract public function remove($key);
-
-    // To be uncommented on 4.0.
-    /**
-     * Returns configured keys.
-     *
-     * @return string[]
-     */
-    //abstract public function keys();
-
-    /**
-     * @param array $keys field names
-     *
-     * @return static
-     */
-    abstract public function reorder(array $keys);
 }

--- a/src/Mapper/MapperInterface.php
+++ b/src/Mapper/MapperInterface.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Mapper;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+
+/**
+ * This interface is used to simulate the Form API.
+ *
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @method array keys()
+ */
+interface MapperInterface
+{
+    /**
+     * @return AdminInterface
+     */
+    public function getAdmin();
+
+    /**
+     * @param string $key
+     *
+     * @return mixed
+     */
+    public function get($key);
+
+    /**
+     * @param string $key
+     *
+     * @return bool
+     */
+    public function has($key);
+
+    /**
+     * @param string $key
+     *
+     * @return static
+     */
+    public function remove($key);
+
+    /**
+     * NEXT_MAJOR: Uncomment this.
+     *
+     * Returns configured keys.
+     *
+     * @return string[]
+     */
+    //public function keys(): array;
+
+    /**
+     * @param array $keys field names
+     *
+     * @return static
+     */
+    public function reorder(array $keys);
+}

--- a/src/Show/ShowMapper.php
+++ b/src/Show/ShowMapper.php
@@ -38,12 +38,20 @@ class ShowMapper extends BaseGroupedMapper
      */
     protected $builder;
 
+    /**
+     * NEXT_MAJOR: Make the property private.
+     *
+     * @var AdminInterface
+     */
+    protected $admin;
+
     public function __construct(
         ShowBuilderInterface $showBuilder,
         FieldDescriptionCollection $list,
         AdminInterface $admin
     ) {
-        parent::__construct($showBuilder, $admin);
+        $this->admin = $admin;
+        $this->builder = $showBuilder;
         $this->list = $list;
     }
 
@@ -70,17 +78,17 @@ class ShowMapper extends BaseGroupedMapper
             $fieldDescription = $name;
             $fieldDescription->mergeOptions($fieldDescriptionOptions);
         } elseif (\is_string($name)) {
-            if (!$this->admin->hasShowFieldDescription($name)) {
+            if (!$this->getAdmin()->hasShowFieldDescription($name)) {
 
                 // NEXT_MAJOR: Remove the check and use `createFieldDescription`.
-                if (method_exists($this->admin, 'createFieldDescription')) {
-                    $fieldDescription = $this->admin->createFieldDescription(
+                if (method_exists($this->getAdmin(), 'createFieldDescription')) {
+                    $fieldDescription = $this->getAdmin()->createFieldDescription(
                         $name,
                         $fieldDescriptionOptions
                     );
                 } else {
-                    $fieldDescription = $this->admin->getModelManager()->getNewFieldDescriptionInstance(
-                        $this->admin->getClass(),
+                    $fieldDescription = $this->getAdmin()->getModelManager()->getNewFieldDescriptionInstance(
+                        $this->getAdmin()->getClass(),
                         $name,
                         $fieldDescriptionOptions
                     );
@@ -100,14 +108,14 @@ class ShowMapper extends BaseGroupedMapper
 
         // NEXT_MAJOR: Remove the argument "sonata_deprecation_mute" in the following call.
         if (null === $fieldDescription->getLabel('sonata_deprecation_mute')) {
-            $fieldDescription->setOption('label', $this->admin->getLabelTranslatorStrategy()->getLabel($fieldDescription->getName(), 'show', 'label'));
+            $fieldDescription->setOption('label', $this->getAdmin()->getLabelTranslatorStrategy()->getLabel($fieldDescription->getName(), 'show', 'label'));
         }
 
         $fieldDescription->setOption('safe', $fieldDescription->getOption('safe', false));
 
-        if (!isset($fieldDescriptionOptions['role']) || $this->admin->isGranted($fieldDescriptionOptions['role'])) {
+        if (!isset($fieldDescriptionOptions['role']) || $this->getAdmin()->isGranted($fieldDescriptionOptions['role'])) {
             // add the field with the FormBuilder
-            $this->builder->addField($this->list, $type, $fieldDescription, $this->admin);
+            $this->builder->addField($this->list, $type, $fieldDescription, $this->getAdmin());
         }
 
         return $this;
@@ -125,7 +133,7 @@ class ShowMapper extends BaseGroupedMapper
 
     public function remove($key)
     {
-        $this->admin->removeShowFieldDescription($key);
+        $this->getAdmin()->removeShowFieldDescription($key);
         $this->list->remove($key);
 
         return $this;
@@ -138,7 +146,7 @@ class ShowMapper extends BaseGroupedMapper
 
     public function reorder(array $keys)
     {
-        $this->admin->reorderShowGroup($this->getCurrentGroupName(), $keys);
+        $this->getAdmin()->reorderShowGroup($this->getCurrentGroupName(), $keys);
 
         return $this;
     }
@@ -147,24 +155,24 @@ class ShowMapper extends BaseGroupedMapper
     {
         // NEXT_MAJOR: Remove the argument "sonata_deprecation_mute" in the following call.
 
-        return $this->admin->getShowGroups('sonata_deprecation_mute');
+        return $this->getAdmin()->getShowGroups('sonata_deprecation_mute');
     }
 
     protected function setGroups(array $groups)
     {
-        $this->admin->setShowGroups($groups);
+        $this->getAdmin()->setShowGroups($groups);
     }
 
     protected function getTabs()
     {
         // NEXT_MAJOR: Remove the argument "sonata_deprecation_mute" in the following call.
 
-        return $this->admin->getShowTabs('sonata_deprecation_mute');
+        return $this->getAdmin()->getShowTabs('sonata_deprecation_mute');
     }
 
     protected function setTabs(array $tabs)
     {
-        $this->admin->setShowTabs($tabs);
+        $this->getAdmin()->setShowTabs($tabs);
     }
 
     protected function getName()

--- a/tests/Event/ConfigureEventTest.php
+++ b/tests/Event/ConfigureEventTest.php
@@ -16,7 +16,7 @@ namespace Sonata\AdminBundle\Tests\Event;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Event\ConfigureEvent;
-use Sonata\AdminBundle\Mapper\BaseMapper;
+use Sonata\AdminBundle\Mapper\MapperInterface;
 
 class ConfigureEventTest extends TestCase
 {
@@ -31,16 +31,14 @@ class ConfigureEventTest extends TestCase
     private $admin;
 
     /**
-     * @var BaseMapper
+     * @var MapperInterface
      */
     private $mapper;
 
     protected function setUp(): void
     {
         $this->admin = $this->createMock(AdminInterface::class);
-        $this->mapper = $this->getMockBuilder(BaseMapper::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $this->mapper = $this->createMock(MapperInterface::class);
 
         $this->event = new ConfigureEvent($this->admin, $this->mapper, 'Foo');
     }
@@ -62,7 +60,7 @@ class ConfigureEventTest extends TestCase
     {
         $result = $this->event->getMapper();
 
-        $this->assertInstanceOf(BaseMapper::class, $result);
+        $this->assertInstanceOf(MapperInterface::class, $result);
         $this->assertSame($this->mapper, $result);
     }
 }

--- a/tests/Fixtures/Admin/AbstractDummyGroupedMapper.php
+++ b/tests/Fixtures/Admin/AbstractDummyGroupedMapper.php
@@ -13,10 +13,26 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\Fixtures\Admin;
 
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Mapper\BaseGroupedMapper;
 
 abstract class AbstractDummyGroupedMapper extends BaseGroupedMapper
 {
+    /**
+     * @var AdminInterface
+     */
+    protected $admin;
+
+    public function __construct(AdminInterface $admin)
+    {
+        $this->admin = $admin;
+    }
+
+    public function getAdmin()
+    {
+        return $this->admin;
+    }
+
     protected function getName()
     {
         return 'dummy';

--- a/tests/Mapper/BaseGroupedMapperTest.php
+++ b/tests/Mapper/BaseGroupedMapperTest.php
@@ -16,7 +16,6 @@ namespace Sonata\AdminBundle\Tests\Mapper;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\Pool;
-use Sonata\AdminBundle\Builder\BuilderInterface;
 use Sonata\AdminBundle\Mapper\BaseGroupedMapper;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\AbstractDummyGroupedMapper;
 use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
@@ -62,11 +61,9 @@ class BaseGroupedMapperTest extends TestCase
             ->method('getConfigurationPool')
             ->willReturn($configurationPool);
 
-        $builder = $this->getMockForAbstractClass(BuilderInterface::class);
-
         $this->baseGroupedMapper = $this->getMockForAbstractClass(
             AbstractDummyGroupedMapper::class,
-            [$builder, $admin]
+            [$admin]
         );
 
         $this->tabs = [];

--- a/tests/Mapper/BaseMapperTest.php
+++ b/tests/Mapper/BaseMapperTest.php
@@ -19,6 +19,10 @@ use Sonata\AdminBundle\Builder\BuilderInterface;
 use Sonata\AdminBundle\Mapper\BaseMapper;
 
 /**
+ * NEXT_MAJOR: Remove this tests.
+ *
+ * @group legacy
+ *
  * Test for BaseMapperTest.
  *
  * @author Andrej Hudec <pulzarraider@gmail.com>


### PR DESCRIPTION
## Subject

We're using `BaseMapper` as a typehint somewhere, which is an abstract class.
Isn't better to use an interface instead ?

## Changelog

```markdown
### Added
- Added `MapperInterface`
```