### PR TITLE
Leverage `AdminInterface::getIdParameter()` and `AdminInterface::getUrlSafeIdentifier()`

### DIFF
--- a/docs/cookbook/recipe_customizing_a_mosaic_list.rst
+++ b/docs/cookbook/recipe_customizing_a_mosaic_list.rst
@@ -89,9 +89,9 @@ The ``list_outer_rows_mosaic.html.twig`` is the name of one mosaic's tile. You s
 
     {% block sonata_mosaic_description %}
         {% if admin.hasAccess('edit', object) and admin.hasRoute('edit') %}
-            <a href="{{ admin.generateUrl('edit', {'id' : object|sonata_urlsafeid(admin) }) }}">{{ meta.title|u.truncate(40) }}</a>
+            <a href="{{ admin.generateObjectUrl('edit', object) }}">{{ meta.title|u.truncate(40) }}</a>
         {% elseif admin.hasAccess('show', object) and admin.hasRoute('show') %}
-            <a href="{{ admin.generateUrl('show', {'id' : object|sonata_urlsafeid(admin) }) }}">{{ meta.title|u.truncate(40) }}</a>
+            <a href="{{ admin.generateObjectUrl('show', object }) }}">{{ meta.title|u.truncate(40) }}</a>
         {% else %}
             {{ meta.title|u.truncate(40) }}
         {% endif %}

--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -259,13 +259,13 @@ The link will still appear unless you manually check it using the ``hasAccess()`
     {
         // Link will always appear even if it is protected by ACL
         $menu->addChild($this->trans('Show'), [
-            'uri' => $admin->generateUrl('show', ['id' => $id])
+            'uri' => $admin->generateUrl('show', [$admin->getIdParameter() => $id])
         ]);
 
         // Link will only appear if access to ACL protected URL is granted
         if ($this->hasAccess('edit')) {
             $menu->addChild($this->trans('Edit'), [
-                'uri' => $admin->generateUrl('edit', ['id' => $id])
+                'uri' => $admin->generateUrl('edit', [$admin->getIdParameter() => $id])
             ]);
         }
     }
@@ -285,10 +285,10 @@ the `'dropdown' => true` attribute::
         $menu->addChild('comments', ['attributes' => ['dropdown' => true]]);
 
         $menu['comments']->addChild('list', [
-            'uri' => $admin->generateUrl('listComment', ['id' => $id])
+            'uri' => $admin->generateUrl('listComment', [$admin->getIdParameter() => $id])
         ]);
         $menu['comments']->addChild('create', [
-            'uri' => $admin->generateUrl('addComment', ['id' => $id])
+            'uri' => $admin->generateUrl('addComment', [$admin->getIdParameter() => $id])
         ]);
     }
 

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1239,7 +1239,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
 
     public function generateObjectUrl($name, $object, array $parameters = [], $referenceType = RoutingUrlGeneratorInterface::ABSOLUTE_PATH)
     {
-        $parameters['id'] = $this->getUrlSafeIdentifier($object);
+        $parameters[$this->getIdParameter()] = $this->getUrlSafeIdentifier($object);
 
         return $this->generateUrl($name, $parameters, $referenceType);
     }

--- a/src/Admin/BreadcrumbsBuilder.php
+++ b/src/Admin/BreadcrumbsBuilder.php
@@ -107,7 +107,7 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
                 $admin->toString($admin->getSubject()),
                 [
                     'uri' => $admin->hasRoute($this->config['child_admin_route']) && $admin->hasAccess($this->config['child_admin_route'], $admin->getSubject()) ?
-                    $admin->generateUrl($this->config['child_admin_route'], ['id' => $id]) :
+                    $admin->generateUrl($this->config['child_admin_route'], [$admin->getIdParameter() => $id]) :
                     null,
                     'extras' => [
                         'translation_domain' => false,

--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -534,7 +534,7 @@ This code manages the many-to-[one|many] association field popup
 
             {% if btn_edit %}
                 var edit_button_url = '{{
-                    associationadmin.generateUrl('edit', {'id' : 'OBJECT_ID'})
+                    associationadmin.generateUrl('edit', {(associationadmin.idParameter) : 'OBJECT_ID'})
                 }}'.replace('OBJECT_ID', objectId);
 
                 jQuery('#field_actions_{{ id }} a.btn-warning').removeClass('hidden').attr('href', edit_button_url);

--- a/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
@@ -19,10 +19,10 @@ file that was distributed with this source code.
     <div id="field_container_{{ id }}" class="field-container">
         {% if sonata_admin.edit == 'list' %}
             <span id="field_widget_{{ id }}" class="field-short-description">
-                {% if sonata_admin.value and sonata_admin.field_description.associationadmin.id(sonata_admin.value) is not null %}
+                {% if sonata_admin.value and sonata_admin.field_description.associationadmin.urlSafeIdentifier(sonata_admin.value) is not null %}
                     {{ render(path('sonata_admin_short_object_information', {
                         'code':     sonata_admin.field_description.associationadmin.code,
-                        'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
+                        'objectId': sonata_admin.field_description.associationadmin.urlSafeIdentifier(sonata_admin.value),
                         'uniqid':   sonata_admin.field_description.associationadmin.uniqid,
                         'linkParameters': sonata_admin.field_description.option('link_parameters')
                     })) }}

--- a/src/Resources/views/CRUD/base_acl_macro.html.twig
+++ b/src/Resources/views/CRUD/base_acl_macro.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% macro render_form(form, permissions, td_type, admin, admin_configuration, object) %}
     <form class="form-horizontal"
-          action="{{ admin.generateUrl('acl', {'id': admin.id(object), 'uniqid': admin.uniqid, 'subclass': app.request.get('subclass')}) }}"
+          action="{{ admin.generateUrl('acl', {(admin.idParameter): admin.id(object), 'uniqid': admin.uniqid, 'subclass': app.request.get('subclass')}) }}"
           {% if form.vars.multipart %} enctype="multipart/form-data"{% endif %}
           method="POST"
             {% if not admin_configuration.getOption('html5_validate') %}novalidate="novalidate"{% endif %}

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -13,7 +13,7 @@
               {% if sonata_config.getOption('form_type') == 'horizontal' %}class="form-horizontal"{% endif %}
               role="form"
               {# NEXT_MAJOR: remove default filter #}
-              action="{% block sonata_form_action_url %}{{ admin.generateUrl(url, {'id': objectId|default(admin.id(object)), 'uniqid': admin.uniqid, 'subclass': app.request.get('subclass')}) }}{% endblock %}"
+              action="{% block sonata_form_action_url %}{{ admin.generateUrl(url, {(admin.idParameter): objectId|default(admin.id(object)), 'uniqid': admin.uniqid, 'subclass': app.request.get('subclass')}) }}{% endblock %}"
               {% if form.vars.multipart %} enctype="multipart/form-data"{% endif %}
               method="POST"
               {% if not sonata_config.getOption('html5_validate') %}novalidate="novalidate"{% endif %}

--- a/src/Resources/views/CRUD/base_list_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_field.html.twig
@@ -49,7 +49,7 @@ file that was distributed with this source code.
                 admin.getPersistentParameters|default([])|merge({
                     'context': 'list',
                     'field': field_description.name,
-                    'objectId': admin.id(object),
+                    'objectId': admin.urlSafeIdentifier(object),
                     'code': admin.code(object)
                 })
             ) %}

--- a/src/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
+++ b/src/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
@@ -73,12 +73,12 @@ This template can be customized to match your needs. You should only extends the
                      objectId="{{ admin.id(object) }}">
                     {% if admin.hasAccess('edit', object) and admin.hasRoute('edit') %}
                         <a class="mosaic-inner-link"
-                           href="{{ admin.generateUrl('edit', {'id' : object|sonata_urlsafeid(admin) }) }}">
+                           href="{{ admin.generateUrl('edit', {(admin.idParameter) : object|sonata_urlsafeid(admin) }) }}">
                             {{ mosaic_content }}
                         </a>
                     {% elseif admin.hasAccess('show', object) and admin.hasRoute('show') %}
                         <a class="mosaic-inner-link"
-                           href="{{ admin.generateUrl('show', {'id' : object|sonata_urlsafeid(admin) }) }}">
+                           href="{{ admin.generateUrl('show', {(admin.idParameter) : object|sonata_urlsafeid(admin) }) }}">
                             {{ mosaic_content }}
                         </a>
                     {% else %}

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -591,10 +591,10 @@ file that was distributed with this source code.
 {% block sonata_type_model_list_widget %}
     <div id="field_container_{{ id }}" class="field-container">
         <span id="field_widget_{{ id }}" class="field-short-description">
-            {% if sonata_admin.value and sonata_admin.field_description.associationadmin.id(sonata_admin.value) is not null %}
+            {% if sonata_admin.value and sonata_admin.field_description.associationadmin.urlSafeIdentifier(sonata_admin.value) is not null %}
                 {{ render(path('sonata_admin_short_object_information', {
                     'code': sonata_admin.field_description.associationadmin.code,
-                    'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
+                    'objectId': sonata_admin.field_description.associationadmin.urlSafeIdentifier(sonata_admin.value),
                     'uniqid': sonata_admin.field_description.associationadmin.uniqid,
                     'linkParameters': sonata_admin.field_description.option('link_parameters')
                 })) }}
@@ -635,7 +635,7 @@ file that was distributed with this source code.
                     and btn_edit
                 %}
                     <a href="{{ sonata_admin.value == null ? '' : sonata_admin.field_description.associationadmin.generateUrl('edit', {
-                        (sonata_admin.field_description.associationadmin.idParameter) : sonata_admin.field_description.associationadmin.normalizedIdentifier(sonata_admin.value)})
+                        (sonata_admin.field_description.associationadmin.idParameter) : sonata_admin.field_description.associationadmin.urlSafeIdentifier(sonata_admin.value)})
                     }}"
                        onclick="return start_field_dialog_form_edit_{{ id }}(this);"
                        class="btn btn-warning btn-sm sonata-ba-action {% if sonata_admin.value == null %}hidden{% endif %}"

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -635,7 +635,7 @@ file that was distributed with this source code.
                     and btn_edit
                 %}
                     <a href="{{ sonata_admin.value == null ? '' : sonata_admin.field_description.associationadmin.generateUrl('edit', {
-                        'id' : sonata_admin.field_description.associationadmin.normalizedIdentifier(sonata_admin.value)})
+                        (sonata_admin.field_description.associationadmin.idParameter) : sonata_admin.field_description.associationadmin.normalizedIdentifier(sonata_admin.value)})
                     }}"
                        onclick="return start_field_dialog_form_edit_{{ id }}(this);"
                        class="btn btn-warning btn-sm sonata-ba-action {% if sonata_admin.value == null %}hidden{% endif %}"

--- a/tests/Admin/BreadcrumbsBuilderTest.php
+++ b/tests/Admin/BreadcrumbsBuilderTest.php
@@ -317,8 +317,8 @@ class BreadcrumbsBuilderTest extends TestCase
             ['edit', null, true],
         ]);
         $admin->method('generateUrl')->willReturnMap([
-            ['show', ['id' => 'my-object'], UrlGeneratorInterface::ABSOLUTE_PATH, '/myadmin/my-object'],
-            ['edit', ['id' => 'my-object'], UrlGeneratorInterface::ABSOLUTE_PATH, '/myadmin/my-object'],
+            ['show', ['slug' => 'my-object'], UrlGeneratorInterface::ABSOLUTE_PATH, '/myadmin/my-object'],
+            ['edit', ['slug' => 'my-object'], UrlGeneratorInterface::ABSOLUTE_PATH, '/myadmin/my-object'],
             ['list', [], UrlGeneratorInterface::ABSOLUTE_PATH, '/myadmin/list'],
         ]);
 

--- a/tests/Twig/Extension/RenderElementExtensionTest.php
+++ b/tests/Twig/Extension/RenderElementExtensionTest.php
@@ -202,6 +202,11 @@ final class RenderElementExtensionTest extends TestCase
             ->willReturn(12345);
 
         $this->admin
+            ->method('getUrlSafeIdentifier')
+            ->with($this->equalTo($this->object))
+            ->willReturn(12345);
+
+        $this->admin
             ->method('getNormalizedIdentifier')
             ->with($this->equalTo($this->object))
             ->willReturn(12345);

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -346,6 +346,11 @@ class SonataAdminExtensionTest extends TestCase
      */
     public function testRenderListElement(string $expected, string $type, $value, array $options): void
     {
+        $this->admin
+            ->method('getUrlSafeIdentifier')
+            ->with($this->equalTo($this->object))
+            ->willReturn(12345);
+
         $this->expectDeprecation('The Sonata\AdminBundle\Twig\Extension\SonataAdminExtension::renderListElement method is deprecated in favor of RenderElementExtension::renderListElement since version 3.87 and will be removed in 4.0.');
 
         $this->expectDeprecation('The Sonata\AdminBundle\Admin\AbstractAdmin::getTemplate method is deprecated (since sonata-project/admin-bundle 3.34, will be dropped in 4.0. Use TemplateRegistry services instead).');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

As suggested by @phansys for `SonataPageBundle`, this PR removes the hardcode `id` parameter in favor of `AdminInterface::getIdParameter()` method. 

Also replaces the use of `AdminInterface::id()` when generating URLs by `AdminInterface::getUrlSafeIdentifier()`.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed using the hardcode `id` parameter instead of calling `AdminInterface::getIdParameter()` method.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
