### PR TITLE
Use a service locator for FilterFactory

### DIFF
--- a/src/Filter/FilterFactory.php
+++ b/src/Filter/FilterFactory.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Filter;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -25,29 +25,18 @@ final class FilterFactory implements FilterFactoryInterface
      */
     private $container;
 
-    /**
-     * @var array<string, string>
-     */
-    private $types;
-
-    /**
-     * @param array<string, string> $types
-     */
-    public function __construct(ContainerInterface $container, array $types = [])
+    public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
-        $this->types = $types;
     }
 
     public function create(string $name, string $type, array $options = []): FilterInterface
     {
-        $id = $this->types[$type] ?? false;
-
-        if ($id) {
-            $filter = $this->container->get($id);
-        } else {
+        if (!$this->container->has($type)) {
             throw new \RuntimeException(sprintf('No attached service to type named `%s`', $type));
         }
+
+        $filter = $this->container->get($type);
 
         if (!$filter instanceof FilterInterface) {
             throw new \RuntimeException(sprintf('The service `%s` must implement `FilterInterface`', $type));

--- a/src/Filter/FilterFactoryInterface.php
+++ b/src/Filter/FilterFactoryInterface.php
@@ -20,6 +20,7 @@ interface FilterFactoryInterface
 {
     /**
      * @param array<string, mixed> $options
+     * @phpstan-param class-string $type
      */
     public function create(string $name, string $type, array $options = []): FilterInterface;
 }

--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -78,8 +78,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set('sonata.admin.builder.filter.factory', FilterFactory::class)
             ->public()
             ->args([
-                new ReferenceConfigurator('service_container'),
-                [],
+                null, // Service locator
             ])
 
         ->alias(FilterFactoryInterface::class, 'sonata.admin.builder.filter.factory')

--- a/tests/DependencyInjection/Compiler/AddFilterTypeCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddFilterTypeCompilerPassTest.php
@@ -30,7 +30,6 @@ final class AddFilterTypeCompilerPassTest extends AbstractCompilerPassTestCase
 
         $filterFactoryDefinition = new Definition(FilterFactoryInterface::class, [
             null,
-            [],
         ]);
 
         $this->container
@@ -57,9 +56,8 @@ final class AddFilterTypeCompilerPassTest extends AbstractCompilerPassTestCase
 
         $this->compile();
 
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument(
-            'sonata.admin.builder.filter.factory',
-            1,
+        $this->assertContainerBuilderHasServiceLocator(
+            (string) $this->container->getDefinition('sonata.admin.builder.filter.factory')->getArgument(0),
             [
                 FooFilter::class => 'acme.demo.foo_filter',
                 BarFilter::class => 'acme.demo.bar_filter',

--- a/tests/Filter/FilterFactoryTest.php
+++ b/tests/Filter/FilterFactoryTest.php
@@ -21,22 +21,13 @@ use Symfony\Component\DependencyInjection\Container;
 
 class FilterFactoryTest extends TestCase
 {
-    public function testUnknownType(): void
-    {
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('No attached service to type named `mytype`');
-
-        $filter = new FilterFactory(new Container());
-        $filter->create('test', 'mytype');
-    }
-
     public function testUnknownClassType(): void
     {
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage('No attached service to type named `Sonata\AdminBundle\Form\Type\Filter\FooType`');
+        $this->expectExceptionMessage('No attached service to type named `stdClass`');
 
         $filter = new FilterFactory(new Container());
-        $filter->create('test', 'Sonata\AdminBundle\Form\Type\Filter\FooType');
+        $filter->create('test', \stdClass::class);
     }
 
     public function testClassType(): void
@@ -44,9 +35,7 @@ class FilterFactoryTest extends TestCase
         $container = new Container();
         $container
             ->set(DefaultType::class, new DefaultType());
-        $filter = new FilterFactory($container, [
-            DefaultType::class => DefaultType::class,
-        ]);
+        $filter = new FilterFactory($container);
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage(
@@ -63,11 +52,10 @@ class FilterFactoryTest extends TestCase
             ->method('initialize');
 
         $container = new Container();
-        $container->set('my.filter.id', $filter);
-
         $fqcn = \get_class($filter);
+        $container->set($fqcn, $filter);
 
-        $filter = new FilterFactory($container, [$fqcn => 'my.filter.id']);
+        $filter = new FilterFactory($container);
         $filter->create('test', $fqcn);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I think this cannot be done with BC because we are injecting to `FilterFactory` the whole container and this service locator will have only the filter services registered by class name.

Last task of https://github.com/sonata-project/SonataAdminBundle/issues/6963.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is not BC.
