### PR TITLE
Use field description constants

### DIFF
--- a/src/Resources/config/twig.php
+++ b/src/Resources/config/twig.php
@@ -25,23 +25,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigura
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->parameters()
 
-        ->set('sonata.admin.twig.extension.x_editable_type_mapping', [
-            'choice' => 'select',
-            'boolean' => 'select',
-            'text' => 'text',
-            'textarea' => 'textarea',
-            'html' => 'textarea',
-            'email' => 'email',
-            'string' => 'text',
-            'smallint' => 'text',
-            'bigint' => 'text',
-            'integer' => 'number',
-            'decimal' => 'number',
-            'currency' => 'number',
-            'percent' => 'number',
-            'url' => 'url',
-            'date' => 'date',
-        ]);
+        ->set('sonata.admin.twig.extension.x_editable_type_mapping', XEditableExtension::FIELD_DESCRIPTION_MAPPING);
 
     // Use "service" function for creating references to services when dropping support for Symfony 4.4
     // Use "param" function for creating references to parameters when dropping support for Symfony 5.1

--- a/src/Twig/Extension/XEditableExtension.php
+++ b/src/Twig/Extension/XEditableExtension.php
@@ -14,12 +14,31 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Twig\Extension;
 
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
 final class XEditableExtension extends AbstractExtension
 {
+    public const FIELD_DESCRIPTION_MAPPING = [
+        FieldDescriptionInterface::TYPE_CHOICE => 'select',
+        FieldDescriptionInterface::TYPE_BOOLEAN => 'select',
+        TemplateRegistryInterface::TYPE_TEXT => 'text', // NEXT_MAJOR: Remove this line.
+        FieldDescriptionInterface::TYPE_TEXTAREA => 'textarea',
+        FieldDescriptionInterface::TYPE_HTML => 'textarea',
+        FieldDescriptionInterface::TYPE_EMAIL => 'email',
+        FieldDescriptionInterface::TYPE_STRING => 'text',
+        TemplateRegistryInterface::TYPE_SMALLINT => 'text', // NEXT_MAJOR: Remove this line.
+        TemplateRegistryInterface::TYPE_BIGINT => 'text', // NEXT_MAJOR: Remove this line.
+        FieldDescriptionInterface::TYPE_INTEGER => 'number',
+        FieldDescriptionInterface::TYPE_FLOAT => 'number',
+        TemplateRegistryInterface::TYPE_DECIMAL => 'number', // NEXT_MAJOR: Remove this line.
+        FieldDescriptionInterface::TYPE_CURRENCY => 'number',
+        FieldDescriptionInterface::TYPE_PERCENT => 'number',
+        FieldDescriptionInterface::TYPE_URL => 'url',
+    ];
+
     /**
      * @var string[]
      */
@@ -37,7 +56,7 @@ final class XEditableExtension extends AbstractExtension
      */
     public function __construct(
         TranslatorInterface $translator,
-        array $xEditableTypeMapping
+        array $xEditableTypeMapping = self::FIELD_DESCRIPTION_MAPPING
     ) {
         $this->translator = $translator;
         $this->xEditableTypeMapping = $xEditableTypeMapping;

--- a/tests/Twig/Extension/RenderElementExtensionTest.php
+++ b/tests/Twig/Extension/RenderElementExtensionTest.php
@@ -52,22 +52,6 @@ use Twig\Extra\String\StringExtension;
 final class RenderElementExtensionTest extends TestCase
 {
     use ExpectDeprecationTrait;
-    private const X_EDITABLE_TYPE_MAPPING = [
-        'choice' => 'select',
-        'boolean' => 'select',
-        'text' => 'text',
-        'textarea' => 'textarea',
-        'html' => 'textarea',
-        'email' => 'email',
-        'string' => 'text',
-        'smallint' => 'text',
-        'bigint' => 'text',
-        'integer' => 'number',
-        'decimal' => 'number',
-        'currency' => 'number',
-        'percent' => 'number',
-        'url' => 'url',
-    ];
 
     /**
      * @var RenderElementExtension
@@ -2565,7 +2549,7 @@ EOT
         $this->registerSonataAdminExtension($propertyAccessor);
 
         $this->environment->addExtension($this->twigExtension);
-        $this->environment->addExtension(new XEditableExtension($this->translator, self::X_EDITABLE_TYPE_MAPPING));
+        $this->environment->addExtension(new XEditableExtension($this->translator));
         $this->environment->addExtension(new TranslationExtension($this->translator));
         $this->environment->addExtension(new FakeTemplateRegistryExtension());
         $this->environment->addExtension(new StringExtension());
@@ -2588,7 +2572,7 @@ EOT
             $propertyAccessor,
             $securityChecker
         );
-        $sonataAdminExtension->setXEditableTypeMapping(self::X_EDITABLE_TYPE_MAPPING, 'sonata_deprecation_mute');
+        $sonataAdminExtension->setXEditableTypeMapping(XEditableExtension::FIELD_DESCRIPTION_MAPPING, 'sonata_deprecation_mute');
         $this->environment->addExtension($sonataAdminExtension);
     }
 

--- a/tests/Twig/Extension/RenderElementExtensionTest.php
+++ b/tests/Twig/Extension/RenderElementExtensionTest.php
@@ -270,31 +270,31 @@ final class RenderElementExtensionTest extends TestCase
             ->method('getTemplate')
             ->willReturnCallback(static function () use ($type): ?string {
                 switch ($type) {
-                    case 'string':
+                    case FieldDescriptionInterface::TYPE_STRING:
                         return '@SonataAdmin/CRUD/list_string.html.twig';
-                    case 'boolean':
+                    case FieldDescriptionInterface::TYPE_BOOLEAN:
                         return '@SonataAdmin/CRUD/list_boolean.html.twig';
-                    case 'datetime':
+                    case FieldDescriptionInterface::TYPE_DATETIME:
                         return '@SonataAdmin/CRUD/list_datetime.html.twig';
-                    case 'date':
+                    case FieldDescriptionInterface::TYPE_DATE:
                         return '@SonataAdmin/CRUD/list_date.html.twig';
-                    case 'time':
+                    case FieldDescriptionInterface::TYPE_TIME:
                         return '@SonataAdmin/CRUD/list_time.html.twig';
-                    case 'currency':
+                    case FieldDescriptionInterface::TYPE_CURRENCY:
                         return '@SonataAdmin/CRUD/list_currency.html.twig';
-                    case 'percent':
+                    case FieldDescriptionInterface::TYPE_PERCENT:
                         return '@SonataAdmin/CRUD/list_percent.html.twig';
-                    case 'email':
+                    case FieldDescriptionInterface::TYPE_EMAIL:
                         return '@SonataAdmin/CRUD/list_email.html.twig';
-                    case 'choice':
+                    case FieldDescriptionInterface::TYPE_CHOICE:
                         return '@SonataAdmin/CRUD/list_choice.html.twig';
-                    case 'array':
+                    case FieldDescriptionInterface::TYPE_ARRAY:
                         return '@SonataAdmin/CRUD/list_array.html.twig';
-                    case 'trans':
+                    case FieldDescriptionInterface::TYPE_TRANS:
                         return '@SonataAdmin/CRUD/list_trans.html.twig';
-                    case 'url':
+                    case FieldDescriptionInterface::TYPE_URL:
                         return '@SonataAdmin/CRUD/list_url.html.twig';
-                    case 'html':
+                    case FieldDescriptionInterface::TYPE_HTML:
                         return '@SonataAdmin/CRUD/list_html.html.twig';
                     case 'nonexistent':
                         // template doesn`t exist
@@ -581,29 +581,29 @@ EOT
             ->method('getTemplate')
             ->willReturnCallback(static function () use ($type): ?string {
                 switch ($type) {
-                    case 'boolean':
+                    case FieldDescriptionInterface::TYPE_BOOLEAN:
                         return '@SonataAdmin/CRUD/show_boolean.html.twig';
-                    case 'datetime':
+                    case FieldDescriptionInterface::TYPE_DATETIME:
                         return '@SonataAdmin/CRUD/show_datetime.html.twig';
-                    case 'date':
+                    case FieldDescriptionInterface::TYPE_DATE:
                         return '@SonataAdmin/CRUD/show_date.html.twig';
-                    case 'time':
+                    case FieldDescriptionInterface::TYPE_TIME:
                         return '@SonataAdmin/CRUD/show_time.html.twig';
-                    case 'currency':
+                    case FieldDescriptionInterface::TYPE_CURRENCY:
                         return '@SonataAdmin/CRUD/show_currency.html.twig';
-                    case 'percent':
+                    case FieldDescriptionInterface::TYPE_PERCENT:
                         return '@SonataAdmin/CRUD/show_percent.html.twig';
-                    case 'email':
+                    case FieldDescriptionInterface::TYPE_EMAIL:
                         return '@SonataAdmin/CRUD/show_email.html.twig';
-                    case 'choice':
+                    case FieldDescriptionInterface::TYPE_CHOICE:
                         return '@SonataAdmin/CRUD/show_choice.html.twig';
-                    case 'array':
+                    case FieldDescriptionInterface::TYPE_ARRAY:
                         return '@SonataAdmin/CRUD/show_array.html.twig';
-                    case 'trans':
+                    case FieldDescriptionInterface::TYPE_TRANS:
                         return '@SonataAdmin/CRUD/show_trans.html.twig';
-                    case 'url':
+                    case FieldDescriptionInterface::TYPE_URL:
                         return '@SonataAdmin/CRUD/show_url.html.twig';
-                    case 'html':
+                    case FieldDescriptionInterface::TYPE_HTML:
                         return '@SonataAdmin/CRUD/show_html.html.twig';
                     default:
                         return null;
@@ -656,29 +656,29 @@ EOT
             ->method('getTemplate')
             ->willReturnCallback(static function () use ($type): ?string {
                 switch ($type) {
-                    case 'boolean':
+                    case FieldDescriptionInterface::TYPE_BOOLEAN:
                         return '@SonataAdmin/CRUD/show_boolean.html.twig';
-                    case 'datetime':
+                    case FieldDescriptionInterface::TYPE_DATETIME:
                         return '@SonataAdmin/CRUD/show_datetime.html.twig';
-                    case 'date':
+                    case FieldDescriptionInterface::TYPE_DATE:
                         return '@SonataAdmin/CRUD/show_date.html.twig';
-                    case 'time':
+                    case FieldDescriptionInterface::TYPE_TIME:
                         return '@SonataAdmin/CRUD/show_time.html.twig';
-                    case 'currency':
+                    case FieldDescriptionInterface::TYPE_CURRENCY:
                         return '@SonataAdmin/CRUD/show_currency.html.twig';
-                    case 'percent':
+                    case FieldDescriptionInterface::TYPE_PERCENT:
                         return '@SonataAdmin/CRUD/show_percent.html.twig';
-                    case 'email':
+                    case FieldDescriptionInterface::TYPE_EMAIL:
                         return '@SonataAdmin/CRUD/show_email.html.twig';
-                    case 'choice':
+                    case FieldDescriptionInterface::TYPE_CHOICE:
                         return '@SonataAdmin/CRUD/show_choice.html.twig';
-                    case 'array':
+                    case FieldDescriptionInterface::TYPE_ARRAY:
                         return '@SonataAdmin/CRUD/show_array.html.twig';
-                    case 'trans':
+                    case FieldDescriptionInterface::TYPE_TRANS:
                         return '@SonataAdmin/CRUD/show_trans.html.twig';
-                    case 'url':
+                    case FieldDescriptionInterface::TYPE_URL:
                         return '@SonataAdmin/CRUD/show_url.html.twig';
-                    case 'html':
+                    case FieldDescriptionInterface::TYPE_HTML:
                         return '@SonataAdmin/CRUD/show_html.html.twig';
                     default:
                         return null;
@@ -701,42 +701,42 @@ EOT
     {
         return [
             // NoValueException
-            ['<th>Data</th> <td></td>', 'string', ['safe' => false]],
+            ['<th>Data</th> <td></td>', FieldDescriptionInterface::TYPE_STRING, ['safe' => false]],
             ['<th>Data</th> <td></td>', 'text', ['safe' => false]],
-            ['<th>Data</th> <td></td>', 'textarea', ['safe' => false]],
-            ['<th>Data</th> <td>&nbsp;</td>', 'datetime', []],
+            ['<th>Data</th> <td></td>', FieldDescriptionInterface::TYPE_TEXTAREA, ['safe' => false]],
+            ['<th>Data</th> <td>&nbsp;</td>', FieldDescriptionInterface::TYPE_DATETIME, []],
             [
                 '<th>Data</th> <td>&nbsp;</td>',
-                'datetime',
+                FieldDescriptionInterface::TYPE_DATETIME,
                 ['format' => 'd.m.Y H:i:s'],
             ],
-            ['<th>Data</th> <td>&nbsp;</td>', 'date', []],
-            ['<th>Data</th> <td>&nbsp;</td>', 'date', ['format' => 'd.m.Y']],
-            ['<th>Data</th> <td>&nbsp;</td>', 'time', []],
+            ['<th>Data</th> <td>&nbsp;</td>', FieldDescriptionInterface::TYPE_DATE, []],
+            ['<th>Data</th> <td>&nbsp;</td>', FieldDescriptionInterface::TYPE_DATE, ['format' => 'd.m.Y']],
+            ['<th>Data</th> <td>&nbsp;</td>', FieldDescriptionInterface::TYPE_TIME, []],
             ['<th>Data</th> <td></td>', 'number', ['safe' => false]],
-            ['<th>Data</th> <td></td>', 'integer', ['safe' => false]],
-            ['<th>Data</th> <td>&nbsp;</td>', 'percent', []],
-            ['<th>Data</th> <td>&nbsp;</td>', 'currency', ['currency' => 'EUR']],
-            ['<th>Data</th> <td>&nbsp;</td>', 'currency', ['currency' => 'GBP']],
-            ['<th>Data</th> <td> <ul></ul> </td>', 'array', ['safe' => false]],
+            ['<th>Data</th> <td></td>', FieldDescriptionInterface::TYPE_INTEGER, ['safe' => false]],
+            ['<th>Data</th> <td>&nbsp;</td>', FieldDescriptionInterface::TYPE_PERCENT, []],
+            ['<th>Data</th> <td>&nbsp;</td>', FieldDescriptionInterface::TYPE_CURRENCY, ['currency' => 'EUR']],
+            ['<th>Data</th> <td>&nbsp;</td>', FieldDescriptionInterface::TYPE_CURRENCY, ['currency' => 'GBP']],
+            ['<th>Data</th> <td> <ul></ul> </td>', FieldDescriptionInterface::TYPE_ARRAY, ['safe' => false]],
             [
                 '<th>Data</th> <td><span class="label label-danger">no</span></td>',
-                'boolean',
+                FieldDescriptionInterface::TYPE_BOOLEAN,
                 [],
             ],
             [
                 '<th>Data</th> <td> </td>',
-                'trans',
+                FieldDescriptionInterface::TYPE_TRANS,
                 ['safe' => false, 'catalogue' => 'SonataAdminBundle'],
             ],
             [
                 '<th>Data</th> <td></td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 ['safe' => false, 'choices' => []],
             ],
             [
                 '<th>Data</th> <td></td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 ['safe' => false, 'choices' => [], 'multiple' => true],
             ],
             ['<th>Data</th> <td>&nbsp;</td>', 'url', []],
@@ -788,29 +788,29 @@ EOT
                 }
 
                 switch ($type) {
-                    case 'boolean':
+                    case FieldDescriptionInterface::TYPE_BOOLEAN:
                         return '@SonataAdmin/CRUD/show_boolean.html.twig';
-                    case 'datetime':
+                    case FieldDescriptionInterface::TYPE_DATETIME:
                         return '@SonataAdmin/CRUD/show_datetime.html.twig';
-                    case 'date':
+                    case FieldDescriptionInterface::TYPE_DATE:
                         return '@SonataAdmin/CRUD/show_date.html.twig';
-                    case 'time':
+                    case FieldDescriptionInterface::TYPE_TIME:
                         return '@SonataAdmin/CRUD/show_time.html.twig';
-                    case 'currency':
+                    case FieldDescriptionInterface::TYPE_CURRENCY:
                         return '@SonataAdmin/CRUD/show_currency.html.twig';
-                    case 'percent':
+                    case FieldDescriptionInterface::TYPE_PERCENT:
                         return '@SonataAdmin/CRUD/show_percent.html.twig';
-                    case 'email':
+                    case FieldDescriptionInterface::TYPE_EMAIL:
                         return '@SonataAdmin/CRUD/show_email.html.twig';
-                    case 'choice':
+                    case FieldDescriptionInterface::TYPE_CHOICE:
                         return '@SonataAdmin/CRUD/show_choice.html.twig';
-                    case 'array':
+                    case FieldDescriptionInterface::TYPE_ARRAY:
                         return '@SonataAdmin/CRUD/show_array.html.twig';
-                    case 'trans':
+                    case FieldDescriptionInterface::TYPE_TRANS:
                         return '@SonataAdmin/CRUD/show_trans.html.twig';
-                    case 'url':
+                    case FieldDescriptionInterface::TYPE_URL:
                         return '@SonataAdmin/CRUD/show_url.html.twig';
-                    case 'html':
+                    case FieldDescriptionInterface::TYPE_HTML:
                         return '@SonataAdmin/CRUD/show_html.html.twig';
                     default:
                         return null;
@@ -1000,37 +1000,37 @@ EOT
         return [
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-string" objectId="12345"> Example </td>',
-                'string',
+                FieldDescriptionInterface::TYPE_STRING,
                 'Example',
                 [],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-string" objectId="12345"> </td>',
-                'string',
+                FieldDescriptionInterface::TYPE_STRING,
                 null,
                 [],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-text" objectId="12345"> Example </td>',
-                'text',
+                'text', // NEXT_MAJOR: Change to FieldDescriptionInterface::TYPE_STRING
                 'Example',
                 [],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-text" objectId="12345"> </td>',
-                'text',
+                'text', // NEXT_MAJOR: Change to FieldDescriptionInterface::TYPE_STRING
                 null,
                 [],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-textarea" objectId="12345"> Example </td>',
-                'textarea',
+                FieldDescriptionInterface::TYPE_TEXTAREA,
                 'Example',
                 [],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-textarea" objectId="12345"> </td>',
-                'textarea',
+                FieldDescriptionInterface::TYPE_TEXTAREA,
                 null,
                 [],
             ],
@@ -1040,7 +1040,7 @@ EOT
                         December 24, 2013 10:11
                     </time>
                 </td>',
-                'datetime',
+                FieldDescriptionInterface::TYPE_DATETIME,
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')),
                 [],
             ],
@@ -1050,13 +1050,13 @@ EOT
                         December 24, 2013 18:11
                     </time>
                 </td>',
-                'datetime',
+                FieldDescriptionInterface::TYPE_DATETIME,
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('UTC')),
                 ['timezone' => 'Asia/Hong_Kong'],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-datetime" objectId="12345"> &nbsp; </td>',
-                'datetime',
+                FieldDescriptionInterface::TYPE_DATETIME,
                 null,
                 [],
             ],
@@ -1066,13 +1066,13 @@ EOT
                         24.12.2013 10:11:12
                     </time>
                 </td>',
-                'datetime',
+                FieldDescriptionInterface::TYPE_DATETIME,
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')),
                 ['format' => 'd.m.Y H:i:s'],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-datetime" objectId="12345"> &nbsp; </td>',
-                'datetime',
+                FieldDescriptionInterface::TYPE_DATETIME,
                 null,
                 ['format' => 'd.m.Y H:i:s'],
             ],
@@ -1082,13 +1082,13 @@ EOT
                         24.12.2013 18:11:12
                     </time>
                 </td>',
-                'datetime',
+                FieldDescriptionInterface::TYPE_DATETIME,
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('UTC')),
                 ['format' => 'd.m.Y H:i:s', 'timezone' => 'Asia/Hong_Kong'],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-datetime" objectId="12345"> &nbsp; </td>',
-                'datetime',
+                FieldDescriptionInterface::TYPE_DATETIME,
                 null,
                 ['format' => 'd.m.Y H:i:s', 'timezone' => 'Asia/Hong_Kong'],
             ],
@@ -1098,13 +1098,13 @@ EOT
                         December 24, 2013
                     </time>
                 </td>',
-                'date',
+                FieldDescriptionInterface::TYPE_DATE,
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')),
                 [],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-date" objectId="12345"> &nbsp; </td>',
-                'date',
+                FieldDescriptionInterface::TYPE_DATE,
                 null,
                 [],
             ],
@@ -1114,13 +1114,13 @@ EOT
                         24.12.2013
                     </time>
                 </td>',
-                'date',
+                FieldDescriptionInterface::TYPE_DATE,
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')),
                 ['format' => 'd.m.Y'],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-date" objectId="12345"> &nbsp; </td>',
-                'date',
+                FieldDescriptionInterface::TYPE_DATE,
                 null,
                 ['format' => 'd.m.Y'],
             ],
@@ -1130,7 +1130,7 @@ EOT
                         10:11:12
                     </time>
                 </td>',
-                'time',
+                FieldDescriptionInterface::TYPE_TIME,
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')),
                 [],
             ],
@@ -1140,142 +1140,143 @@ EOT
                         18:11:12
                     </time>
                 </td>',
-                'time',
+                FieldDescriptionInterface::TYPE_TIME,
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('UTC')),
                 ['timezone' => 'Asia/Hong_Kong'],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-time" objectId="12345"> &nbsp; </td>',
-                'time',
+                FieldDescriptionInterface::TYPE_TIME,
                 null,
                 [],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-number" objectId="12345"> 10.746135 </td>',
-                'number', 10.746135,
+                'number', // NEXT_MAJOR: Change to FieldDescriptionInterface::TYPE_FLOAT
+                10.746135,
                 [],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-number" objectId="12345"> </td>',
-                'number',
+                'number', // NEXT_MAJOR: Change to FieldDescriptionInterface::TYPE_FLOAT
                 null,
                 [],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-integer" objectId="12345"> 5678 </td>',
-                'integer',
+                FieldDescriptionInterface::TYPE_INTEGER,
                 5678,
                 [],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-integer" objectId="12345"> </td>',
-                'integer',
+                FieldDescriptionInterface::TYPE_INTEGER,
                 null,
                 [],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-percent" objectId="12345"> 1074.6135 % </td>',
-                'percent',
+                FieldDescriptionInterface::TYPE_PERCENT,
                 10.746135,
                 [],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-percent" objectId="12345"> 0 % </td>',
-                'percent',
+                FieldDescriptionInterface::TYPE_PERCENT,
                 0,
                 [],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-percent" objectId="12345"> &nbsp; </td>',
-                'percent',
+                FieldDescriptionInterface::TYPE_PERCENT,
                 null,
                 [],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-currency" objectId="12345"> EUR 10.746135 </td>',
-                'currency',
+                FieldDescriptionInterface::TYPE_CURRENCY,
                 10.746135,
                 ['currency' => 'EUR'],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-currency" objectId="12345"> EUR 0 </td>',
-                'currency',
+                FieldDescriptionInterface::TYPE_CURRENCY,
                 0,
                 ['currency' => 'EUR'],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-currency" objectId="12345"> GBP 51.23456 </td>',
-                'currency',
+                FieldDescriptionInterface::TYPE_CURRENCY,
                 51.23456,
                 ['currency' => 'GBP'],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-currency" objectId="12345"> &nbsp; </td>',
-                'currency',
+                FieldDescriptionInterface::TYPE_CURRENCY,
                 null,
                 ['currency' => 'GBP'],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-email" objectId="12345"> &nbsp; </td>',
-                'email',
+                FieldDescriptionInterface::TYPE_EMAIL,
                 null,
                 [],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-email" objectId="12345"> <a href="mailto:admin@admin.com">admin@admin.com</a> </td>',
-                'email',
+                FieldDescriptionInterface::TYPE_EMAIL,
                 'admin@admin.com',
                 [],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-email" objectId="12345">
                     <a href="mailto:admin@admin.com">admin@admin.com</a> </td>',
-                'email',
+                FieldDescriptionInterface::TYPE_EMAIL,
                 'admin@admin.com',
                 ['as_string' => false],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-email" objectId="12345"> admin@admin.com </td>',
-                'email',
+                FieldDescriptionInterface::TYPE_EMAIL,
                 'admin@admin.com',
                 ['as_string' => true],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-email" objectId="12345">
                     <a href="mailto:admin@admin.com?'.$this->buildTwigLikeUrl(['subject' => 'Main Theme', 'body' => 'Message Body']).'">admin@admin.com</a>  </td>',
-                'email',
+                FieldDescriptionInterface::TYPE_EMAIL,
                 'admin@admin.com',
                 ['subject' => 'Main Theme', 'body' => 'Message Body'],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-email" objectId="12345">
                     <a href="mailto:admin@admin.com?'.$this->buildTwigLikeUrl(['subject' => 'Main Theme']).'">admin@admin.com</a>  </td>',
-                'email',
+                FieldDescriptionInterface::TYPE_EMAIL,
                 'admin@admin.com',
                 ['subject' => 'Main Theme'],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-email" objectId="12345">
                     <a href="mailto:admin@admin.com?'.$this->buildTwigLikeUrl(['body' => 'Message Body']).'">admin@admin.com</a>  </td>',
-                'email',
+                FieldDescriptionInterface::TYPE_EMAIL,
                 'admin@admin.com',
                 ['body' => 'Message Body'],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-email" objectId="12345"> admin@admin.com </td>',
-                'email',
+                FieldDescriptionInterface::TYPE_EMAIL,
                 'admin@admin.com',
                 ['as_string' => true, 'subject' => 'Main Theme', 'body' => 'Message Body'],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-email" objectId="12345"> admin@admin.com </td>',
-                'email',
+                FieldDescriptionInterface::TYPE_EMAIL,
                 'admin@admin.com',
                 ['as_string' => true, 'body' => 'Message Body'],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-email" objectId="12345"> admin@admin.com </td>',
-                'email',
+                FieldDescriptionInterface::TYPE_EMAIL,
                 'admin@admin.com',
                 ['as_string' => true, 'subject' => 'Main Theme'],
             ],
@@ -1283,13 +1284,13 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-array" objectId="12345">
                     [1&nbsp;=>&nbsp;First, 2&nbsp;=>&nbsp;Second]
                 </td>',
-                'array',
+                FieldDescriptionInterface::TYPE_ARRAY,
                 [1 => 'First', 2 => 'Second'],
                 [],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-array" objectId="12345"> [] </td>',
-                'array',
+                FieldDescriptionInterface::TYPE_ARRAY,
                 null,
                 [],
             ],
@@ -1297,7 +1298,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-boolean" objectId="12345">
                     <span class="label label-success">yes</span>
                 </td>',
-                'boolean',
+                FieldDescriptionInterface::TYPE_BOOLEAN,
                 true,
                 ['editable' => false],
             ],
@@ -1305,7 +1306,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-boolean" objectId="12345">
                     <span class="label label-danger">no</span>
                 </td>',
-                'boolean',
+                FieldDescriptionInterface::TYPE_BOOLEAN,
                 false,
                 ['editable' => false],
             ],
@@ -1313,7 +1314,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-boolean" objectId="12345">
                     <span class="label label-danger">no</span>
                 </td>',
-                'boolean',
+                FieldDescriptionInterface::TYPE_BOOLEAN,
                 null,
                 ['editable' => false],
             ],
@@ -1334,7 +1335,7 @@ EOT
 </td>
 EOT
             ,
-                'boolean',
+                FieldDescriptionInterface::TYPE_BOOLEAN,
                 true,
                 ['editable' => true],
             ],
@@ -1354,7 +1355,7 @@ EOT
 </td>
 EOT
                 ,
-                'boolean',
+                FieldDescriptionInterface::TYPE_BOOLEAN,
                 false,
                 ['editable' => true],
             ],
@@ -1373,25 +1374,25 @@ EOT
 </td>
 EOT
                 ,
-                'boolean',
+                FieldDescriptionInterface::TYPE_BOOLEAN,
                 null,
                 ['editable' => true],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-trans" objectId="12345"> Delete </td>',
-                'trans',
+                FieldDescriptionInterface::TYPE_TRANS,
                 'action_delete',
                 ['catalogue' => 'SonataAdminBundle'],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-trans" objectId="12345"> </td>',
-                'trans',
+                FieldDescriptionInterface::TYPE_TRANS,
                 null,
                 ['catalogue' => 'SonataAdminBundle'],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-trans" objectId="12345"> Delete </td>',
-                'trans',
+                FieldDescriptionInterface::TYPE_TRANS,
                 'action_delete',
                 ['format' => '%s', 'catalogue' => 'SonataAdminBundle'],
             ],
@@ -1399,7 +1400,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-trans" objectId="12345">
                 action.action_delete
                 </td>',
-                'trans',
+                FieldDescriptionInterface::TYPE_TRANS,
                 'action_delete',
                 ['format' => 'action.%s'],
             ],
@@ -1407,31 +1408,31 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-trans" objectId="12345">
                 action.action_delete
                 </td>',
-                'trans',
+                FieldDescriptionInterface::TYPE_TRANS,
                 'action_delete',
                 ['format' => 'action.%s', 'catalogue' => 'SonataAdminBundle'],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-choice" objectId="12345"> Status1 </td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 'Status1',
                 [],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-choice" objectId="12345"> Status1 </td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 ['Status1'],
                 ['choices' => [], 'multiple' => true],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-choice" objectId="12345"> Alias1 </td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 'Status1',
                 ['choices' => ['Status1' => 'Alias1', 'Status2' => 'Alias2', 'Status3' => 'Alias3']],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-choice" objectId="12345"> </td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 null,
                 ['choices' => ['Status1' => 'Alias1', 'Status2' => 'Alias2', 'Status3' => 'Alias3']],
             ],
@@ -1439,13 +1440,13 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-choice" objectId="12345">
                 NoValidKeyInChoices
                 </td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 'NoValidKeyInChoices',
                 ['choices' => ['Status1' => 'Alias1', 'Status2' => 'Alias2', 'Status3' => 'Alias3']],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-choice" objectId="12345"> Delete </td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 'Foo',
                 ['catalogue' => 'SonataAdminBundle', 'choices' => [
                     'Foo' => 'action_delete',
@@ -1455,7 +1456,7 @@ EOT
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-choice" objectId="12345"> Alias1, Alias3 </td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 ['Status1', 'Status3'],
                 ['choices' => [
                     'Status1' => 'Alias1',
@@ -1464,7 +1465,7 @@ EOT
                 ], 'multiple' => true], ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-choice" objectId="12345"> Alias1 | Alias3 </td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 ['Status1', 'Status3'],
                 ['choices' => [
                     'Status1' => 'Alias1',
@@ -1473,7 +1474,7 @@ EOT
                 ], 'multiple' => true, 'delimiter' => ' | '], ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-choice" objectId="12345"> </td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 null,
                 ['choices' => [
                     'Status1' => 'Alias1',
@@ -1485,7 +1486,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-choice" objectId="12345">
                 NoValidKeyInChoices
                 </td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 ['NoValidKeyInChoices'],
                 ['choices' => [
                     'Status1' => 'Alias1',
@@ -1497,7 +1498,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-choice" objectId="12345">
                 NoValidKeyInChoices, Alias2
                 </td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 ['NoValidKeyInChoices', 'Status2'],
                 ['choices' => [
                     'Status1' => 'Alias1',
@@ -1507,7 +1508,7 @@ EOT
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-choice" objectId="12345"> Delete, Alias3 </td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 ['Foo', 'Status3'],
                 ['catalogue' => 'SonataAdminBundle', 'choices' => [
                     'Foo' => 'action_delete',
@@ -1519,7 +1520,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-choice" objectId="12345">
                 &lt;b&gt;Alias1&lt;/b&gt;, &lt;b&gt;Alias3&lt;/b&gt;
             </td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 ['Status1', 'Status3'],
                 ['choices' => [
                     'Status1' => '<b>Alias1</b>',
@@ -1543,7 +1544,7 @@ EOT
 </td>
 EOT
                 ,
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 'Status1',
                 ['editable' => true],
             ],
@@ -1562,7 +1563,7 @@ EOT
 </td>
 EOT
                 ,
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 'Status1',
                 [
                     'editable' => true,
@@ -1589,7 +1590,7 @@ EOT
 </td>
 EOT
                 ,
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 null,
                 [
                     'editable' => true,
@@ -1615,7 +1616,7 @@ EOT
 </td>
 EOT
                 ,
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 'NoValidKeyInChoices',
                 [
                     'editable' => true,
@@ -1642,7 +1643,7 @@ EOT
 </td>
 EOT
                 ,
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 'Foo',
                 [
                     'editable' => true,
@@ -1656,19 +1657,19 @@ EOT
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345"> &nbsp; </td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 null,
                 [],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345"> &nbsp; </td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 null,
                 ['url' => 'http://example.com'],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345"> &nbsp; </td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 null,
                 ['route' => ['name' => 'sonata_admin_foo']],
             ],
@@ -1676,7 +1677,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
                 <a href="http://example.com">http://example.com</a>
                 </td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'http://example.com',
                 [],
             ],
@@ -1684,7 +1685,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
                 <a href="https://example.com">https://example.com</a>
                 </td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'https://example.com',
                 [],
             ],
@@ -1692,7 +1693,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
                 <a href="https://example.com" target="_blank">https://example.com</a>
                 </td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'https://example.com',
                 ['attributes' => ['target' => '_blank']],
             ],
@@ -1700,7 +1701,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
                 <a href="https://example.com" target="_blank" class="fooLink">https://example.com</a>
                 </td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'https://example.com',
                 ['attributes' => ['target' => '_blank', 'class' => 'fooLink']],
             ],
@@ -1708,7 +1709,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
                 <a href="http://example.com">example.com</a>
                 </td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'http://example.com',
                 ['hide_protocol' => true],
             ],
@@ -1716,7 +1717,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
                 <a href="https://example.com">example.com</a>
                 </td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'https://example.com',
                 ['hide_protocol' => true],
             ],
@@ -1724,7 +1725,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
                 <a href="http://example.com">http://example.com</a>
                 </td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'http://example.com',
                 ['hide_protocol' => false],
             ],
@@ -1732,7 +1733,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
                 <a href="https://example.com">https://example.com</a>
                 </td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'https://example.com',
                 ['hide_protocol' => false],
             ],
@@ -1740,7 +1741,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
                 <a href="http://example.com">Foo</a>
                 </td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'Foo',
                 ['url' => 'http://example.com'],
             ],
@@ -1748,7 +1749,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
                 <a href="http://example.com">&lt;b&gt;Foo&lt;/b&gt;</a>
                 </td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 '<b>Foo</b>',
                 ['url' => 'http://example.com'],
             ],
@@ -1756,7 +1757,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
                 <a href="/foo">Foo</a>
                 </td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'Foo',
                 ['route' => ['name' => 'sonata_admin_foo']],
             ],
@@ -1764,7 +1765,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
                 <a href="http://localhost/foo">Foo</a>
                 </td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'Foo',
                 ['route' => ['name' => 'sonata_admin_foo', 'absolute' => true]],
             ],
@@ -1772,7 +1773,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
                 <a href="/foo">foo/bar?a=b&amp;c=123456789</a>
                 </td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'http://foo/bar?a=b&c=123456789',
                 ['route' => ['name' => 'sonata_admin_foo'],
                 'hide_protocol' => true, ],
@@ -1781,7 +1782,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
                 <a href="http://localhost/foo">foo/bar?a=b&amp;c=123456789</a>
                 </td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'http://foo/bar?a=b&c=123456789',
                 [
                     'route' => ['name' => 'sonata_admin_foo', 'absolute' => true],
@@ -1792,7 +1793,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
                 <a href="/foo/abcd/efgh?param3=ijkl">Foo</a>
                 </td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'Foo',
                 [
                     'route' => ['name' => 'sonata_admin_foo_param',
@@ -1803,7 +1804,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
                 <a href="http://localhost/foo/abcd/efgh?param3=ijkl">Foo</a>
                 </td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'Foo',
                 [
                     'route' => ['name' => 'sonata_admin_foo_param',
@@ -1815,7 +1816,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
                 <a href="/foo/obj/abcd/12345/efgh?param3=ijkl">Foo</a>
                 </td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'Foo',
                 [
                     'route' => ['name' => 'sonata_admin_foo_object',
@@ -1827,7 +1828,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-url" objectId="12345">
                 <a href="http://localhost/foo/obj/abcd/12345/efgh?param3=ijkl">Foo</a>
                 </td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'Foo',
                 [
                     'route' => ['name' => 'sonata_admin_foo_object',
@@ -1840,7 +1841,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-html" objectId="12345">
                 <p><strong>Creating a Template for the Field</strong> and form</p>
                 </td>',
-                'html',
+                FieldDescriptionInterface::TYPE_HTML,
                 '<p><strong>Creating a Template for the Field</strong> and form</p>',
                 [],
             ],
@@ -1848,7 +1849,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-html" objectId="12345">
                 Creating a Template for the Field and form
                 </td>',
-                'html',
+                FieldDescriptionInterface::TYPE_HTML,
                 '<p><strong>Creating a Template for the Field</strong> and form</p>',
                 ['strip' => true],
             ],
@@ -1856,13 +1857,13 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-html" objectId="12345">
                 Creating a Template for the...
                 </td>',
-                'html',
+                FieldDescriptionInterface::TYPE_HTML,
                 '<p><strong>Creating a Template for the Field</strong> and form</p>',
                 ['truncate' => true],
             ],
             [
                 '<td class="sonata-ba-list-field sonata-ba-list-field-html" objectId="12345"> Creatin... </td>',
-                'html',
+                FieldDescriptionInterface::TYPE_HTML,
                 '<p><strong>Creating a Template for the Field</strong> and form</p>',
                 ['truncate' => ['length' => 10]],
             ],
@@ -1870,7 +1871,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-html" objectId="12345">
                 Creating a Template for the Field...
                 </td>',
-                'html',
+                FieldDescriptionInterface::TYPE_HTML,
                 '<p><strong>Creating a Template for the Field</strong> and form</p>',
                 ['truncate' => ['cut' => false]],
             ],
@@ -1878,7 +1879,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-html" objectId="12345">
                 Creating a Template for t etc.
                 </td>',
-                'html',
+                FieldDescriptionInterface::TYPE_HTML,
                 '<p><strong>Creating a Template for the Field</strong> and form</p>',
                 ['truncate' => ['ellipsis' => ' etc.']],
             ],
@@ -1886,7 +1887,7 @@ EOT
                 '<td class="sonata-ba-list-field sonata-ba-list-field-html" objectId="12345">
                 Creating a Template[...]
                 </td>',
-                'html',
+                FieldDescriptionInterface::TYPE_HTML,
                 '<p><strong>Creating a Template for the Field</strong> and form</p>',
                 [
                     'truncate' => [
@@ -1908,7 +1909,7 @@ EOT
 </td>
 EOT
                 ,
-                'text',
+                'text', // NEXT_MAJOR: Change to FieldDescriptionInterface::TYPE_STRING
                 'A very long string',
                 [
                     'collapse' => true,
@@ -1925,7 +1926,7 @@ EOT
 </td>
 EOT
                 ,
-                'text',
+                'text', // NEXT_MAJOR: Change to FieldDescriptionInterface::TYPE_STRING
                 'A very long string',
                 [
                     'collapse' => [
@@ -1951,7 +1952,7 @@ EOT
 </td>
 EOT
                 ,
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 [
                     'Status1',
                     'Status2',
@@ -1990,104 +1991,106 @@ EOT
     public function getRenderViewElementTests(): array
     {
         return [
-            ['<th>Data</th> <td>Example</td>', 'string', 'Example', ['safe' => false]],
+            ['<th>Data</th> <td>Example</td>', FieldDescriptionInterface::TYPE_STRING, 'Example', ['safe' => false]],
+            // NEXT_MAJOR: Replace "text" by FieldDescriptionInterface::TYPE_STRING
             ['<th>Data</th> <td>Example</td>', 'text', 'Example', ['safe' => false]],
-            ['<th>Data</th> <td>Example</td>', 'textarea', 'Example', ['safe' => false]],
+            ['<th>Data</th> <td>Example</td>', FieldDescriptionInterface::TYPE_TEXTAREA, 'Example', ['safe' => false]],
             [
                 '<th>Data</th> <td><time datetime="2013-12-24T10:11:12+00:00" title="2013-12-24T10:11:12+00:00"> December 24, 2013 10:11 </time></td>',
-                'datetime',
+                FieldDescriptionInterface::TYPE_DATETIME,
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')), [],
             ],
             [
                 '<th>Data</th> <td><time datetime="2013-12-24T10:11:12+00:00" title="2013-12-24T10:11:12+00:00"> 24.12.2013 10:11:12 </time></td>',
-                'datetime',
+                FieldDescriptionInterface::TYPE_DATETIME,
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')),
                 ['format' => 'd.m.Y H:i:s'],
             ],
             [
                 '<th>Data</th> <td><time datetime="2013-12-24T10:11:12+00:00" title="2013-12-24T10:11:12+00:00"> December 24, 2013 18:11 </time></td>',
-                'datetime',
+                FieldDescriptionInterface::TYPE_DATETIME,
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('UTC')),
                 ['timezone' => 'Asia/Hong_Kong'],
             ],
             [
                 '<th>Data</th> <td><time datetime="2013-12-24" title="2013-12-24"> December 24, 2013 </time></td>',
-                'date',
+                FieldDescriptionInterface::TYPE_DATE,
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')),
                 [],
             ],
             [
                 '<th>Data</th> <td><time datetime="2013-12-24" title="2013-12-24"> 24.12.2013 </time></td>',
-                'date',
+                FieldDescriptionInterface::TYPE_DATE,
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')),
                 ['format' => 'd.m.Y'],
             ],
             [
                 '<th>Data</th> <td><time datetime="10:11:12+00:00" title="10:11:12+00:00"> 10:11:12 </time></td>',
-                'time',
+                FieldDescriptionInterface::TYPE_TIME,
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('Europe/London')),
                 [],
             ],
             [
                 '<th>Data</th> <td><time datetime="10:11:12+00:00" title="10:11:12+00:00"> 18:11:12 </time></td>',
-                'time',
+                FieldDescriptionInterface::TYPE_TIME,
                 new \DateTime('2013-12-24 10:11:12', new \DateTimeZone('UTC')),
                 ['timezone' => 'Asia/Hong_Kong'],
             ],
+            // NEXT_MAJOR: Replace "number" by FieldDescriptionInterface::TYPE_FLOAT
             ['<th>Data</th> <td>10.746135</td>', 'number', 10.746135, ['safe' => false]],
-            ['<th>Data</th> <td>5678</td>', 'integer', 5678, ['safe' => false]],
-            ['<th>Data</th> <td>1074.6135 %</td>', 'percent', 10.746135, []],
-            ['<th>Data</th> <td>0 %</td>', 'percent', 0, []],
-            ['<th>Data</th> <td>EUR 10.746135</td>', 'currency', 10.746135, ['currency' => 'EUR']],
-            ['<th>Data</th> <td>GBP 51.23456</td>', 'currency', 51.23456, ['currency' => 'GBP']],
-            ['<th>Data</th> <td>EUR 0</td>', 'currency', 0, ['currency' => 'EUR']],
+            ['<th>Data</th> <td>5678</td>', FieldDescriptionInterface::TYPE_INTEGER, 5678, ['safe' => false]],
+            ['<th>Data</th> <td>1074.6135 %</td>', FieldDescriptionInterface::TYPE_PERCENT, 10.746135, []],
+            ['<th>Data</th> <td>0 %</td>', FieldDescriptionInterface::TYPE_PERCENT, 0, []],
+            ['<th>Data</th> <td>EUR 10.746135</td>', FieldDescriptionInterface::TYPE_CURRENCY, 10.746135, ['currency' => 'EUR']],
+            ['<th>Data</th> <td>GBP 51.23456</td>', FieldDescriptionInterface::TYPE_CURRENCY, 51.23456, ['currency' => 'GBP']],
+            ['<th>Data</th> <td>EUR 0</td>', FieldDescriptionInterface::TYPE_CURRENCY, 0, ['currency' => 'EUR']],
             [
                 '<th>Data</th> <td> <ul><li>1&nbsp;=>&nbsp;First</li><li>2&nbsp;=>&nbsp;Second</li></ul> </td>',
-                'array',
+                FieldDescriptionInterface::TYPE_ARRAY,
                 [1 => 'First', 2 => 'Second'],
                 ['safe' => false],
             ],
             [
                 '<th>Data</th> <td> [1&nbsp;=>&nbsp;First, 2&nbsp;=>&nbsp;Second] </td>',
-                'array',
+                FieldDescriptionInterface::TYPE_ARRAY,
                 [1 => 'First', 2 => 'Second'],
                 ['safe' => false, 'inline' => true],
             ],
             [
                 '<th>Data</th> <td><span class="label label-success">yes</span></td>',
-                'boolean',
+                FieldDescriptionInterface::TYPE_BOOLEAN,
                 true,
                 [],
             ],
             [
                 '<th>Data</th> <td><span class="label label-danger">yes</span></td>',
-                'boolean',
+                FieldDescriptionInterface::TYPE_BOOLEAN,
                 true,
                 ['inverse' => true],
             ],
-            ['<th>Data</th> <td><span class="label label-danger">no</span></td>', 'boolean', false, []],
+            ['<th>Data</th> <td><span class="label label-danger">no</span></td>', FieldDescriptionInterface::TYPE_BOOLEAN, false, []],
             [
                 '<th>Data</th> <td><span class="label label-success">no</span></td>',
-                'boolean',
+                FieldDescriptionInterface::TYPE_BOOLEAN,
                 false,
                 ['inverse' => true],
             ],
             [
                 '<th>Data</th> <td> Delete </td>',
-                'trans',
+                FieldDescriptionInterface::TYPE_TRANS,
                 'action_delete',
                 ['safe' => false, 'catalogue' => 'SonataAdminBundle'],
             ],
             [
                 '<th>Data</th> <td> Delete </td>',
-                'trans',
+                FieldDescriptionInterface::TYPE_TRANS,
                 'delete',
                 ['safe' => false, 'catalogue' => 'SonataAdminBundle', 'format' => 'action_%s'],
             ],
-            ['<th>Data</th> <td>Status1</td>', 'choice', 'Status1', ['safe' => false]],
+            ['<th>Data</th> <td>Status1</td>', FieldDescriptionInterface::TYPE_CHOICE, 'Status1', ['safe' => false]],
             [
                 '<th>Data</th> <td>Alias1</td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 'Status1',
                 ['safe' => false, 'choices' => [
                     'Status1' => 'Alias1',
@@ -2097,7 +2100,7 @@ EOT
             ],
             [
                 '<th>Data</th> <td>NoValidKeyInChoices</td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 'NoValidKeyInChoices',
                 ['safe' => false, 'choices' => [
                     'Status1' => 'Alias1',
@@ -2107,7 +2110,7 @@ EOT
             ],
             [
                 '<th>Data</th> <td>Delete</td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 'Foo',
                 ['safe' => false, 'catalogue' => 'SonataAdminBundle', 'choices' => [
                     'Foo' => 'action_delete',
@@ -2117,7 +2120,7 @@ EOT
             ],
             [
                 '<th>Data</th> <td>NoValidKeyInChoices</td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 ['NoValidKeyInChoices'],
                 ['safe' => false, 'choices' => [
                     'Status1' => 'Alias1',
@@ -2127,7 +2130,7 @@ EOT
             ],
             [
                 '<th>Data</th> <td>NoValidKeyInChoices, Alias2</td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 ['NoValidKeyInChoices', 'Status2'],
                 ['safe' => false, 'choices' => [
                     'Status1' => 'Alias1',
@@ -2137,7 +2140,7 @@ EOT
             ],
             [
                 '<th>Data</th> <td>Alias1, Alias3</td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 ['Status1', 'Status3'],
                 ['safe' => false, 'choices' => [
                     'Status1' => 'Alias1',
@@ -2147,7 +2150,7 @@ EOT
             ],
             [
                 '<th>Data</th> <td>Alias1 | Alias3</td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 ['Status1', 'Status3'], ['safe' => false, 'choices' => [
                     'Status1' => 'Alias1',
                     'Status2' => 'Alias2',
@@ -2156,7 +2159,7 @@ EOT
             ],
             [
                 '<th>Data</th> <td>Delete, Alias3</td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 ['Foo', 'Status3'],
                 ['safe' => false, 'catalogue' => 'SonataAdminBundle', 'choices' => [
                     'Foo' => 'action_delete',
@@ -2166,7 +2169,7 @@ EOT
             ],
             [
                 '<th>Data</th> <td><b>Alias1</b>, <b>Alias3</b></td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 ['Status1', 'Status3'],
                 ['safe' => true, 'choices' => [
                     'Status1' => '<b>Alias1</b>',
@@ -2176,7 +2179,7 @@ EOT
             ],
             [
                 '<th>Data</th> <td>&lt;b&gt;Alias1&lt;/b&gt;, &lt;b&gt;Alias3&lt;/b&gt;</td>',
-                'choice',
+                FieldDescriptionInterface::TYPE_CHOICE,
                 ['Status1', 'Status3'],
                 ['safe' => false, 'choices' => [
                     'Status1' => '<b>Alias1</b>',
@@ -2186,80 +2189,80 @@ EOT
             ],
             [
                 '<th>Data</th> <td><a href="http://example.com">http://example.com</a></td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'http://example.com',
                 ['safe' => false],
             ],
             [
                 '<th>Data</th> <td><a href="http://example.com" target="_blank">http://example.com</a></td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'http://example.com',
                 ['safe' => false, 'attributes' => ['target' => '_blank']],
             ],
             [
                 '<th>Data</th> <td><a href="http://example.com" target="_blank" class="fooLink">http://example.com</a></td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'http://example.com',
                 ['safe' => false, 'attributes' => ['target' => '_blank', 'class' => 'fooLink']],
             ],
             [
                 '<th>Data</th> <td><a href="https://example.com">https://example.com</a></td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'https://example.com',
                 ['safe' => false],
             ],
             [
                 '<th>Data</th> <td><a href="http://example.com">example.com</a></td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'http://example.com',
                 ['safe' => false, 'hide_protocol' => true],
             ],
             [
                 '<th>Data</th> <td><a href="https://example.com">example.com</a></td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'https://example.com',
                 ['safe' => false, 'hide_protocol' => true],
             ],
             [
                 '<th>Data</th> <td><a href="http://example.com">http://example.com</a></td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'http://example.com',
                 ['safe' => false, 'hide_protocol' => false],
             ],
             [
                 '<th>Data</th> <td><a href="https://example.com">https://example.com</a></td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'https://example.com',
                 ['safe' => false,
                 'hide_protocol' => false, ],
             ],
             [
                 '<th>Data</th> <td><a href="http://example.com">Foo</a></td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'Foo',
                 ['safe' => false, 'url' => 'http://example.com'],
             ],
             [
                 '<th>Data</th> <td><a href="http://example.com">&lt;b&gt;Foo&lt;/b&gt;</a></td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 '<b>Foo</b>',
                 ['safe' => false, 'url' => 'http://example.com'],
             ],
             [
                 '<th>Data</th> <td><a href="http://example.com"><b>Foo</b></a></td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 '<b>Foo</b>',
                 ['safe' => true, 'url' => 'http://example.com'],
             ],
             [
                 '<th>Data</th> <td><a href="/foo">Foo</a></td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'Foo',
                 ['safe' => false, 'route' => ['name' => 'sonata_admin_foo']],
             ],
             [
                 '<th>Data</th> <td><a href="http://localhost/foo">Foo</a></td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'Foo',
                 ['safe' => false, 'route' => [
                     'name' => 'sonata_admin_foo',
@@ -2268,7 +2271,7 @@ EOT
             ],
             [
                 '<th>Data</th> <td><a href="/foo">foo/bar?a=b&amp;c=123456789</a></td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'http://foo/bar?a=b&c=123456789',
                 [
                     'safe' => false,
@@ -2278,7 +2281,7 @@ EOT
             ],
             [
                 '<th>Data</th> <td><a href="http://localhost/foo">foo/bar?a=b&amp;c=123456789</a></td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'http://foo/bar?a=b&c=123456789',
                 ['safe' => false, 'route' => [
                     'name' => 'sonata_admin_foo',
@@ -2287,7 +2290,7 @@ EOT
             ],
             [
                 '<th>Data</th> <td><a href="/foo/abcd/efgh?param3=ijkl">Foo</a></td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'Foo',
                 ['safe' => false, 'route' => [
                     'name' => 'sonata_admin_foo_param',
@@ -2296,7 +2299,7 @@ EOT
             ],
             [
                 '<th>Data</th> <td><a href="http://localhost/foo/abcd/efgh?param3=ijkl">Foo</a></td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'Foo',
                 ['safe' => false, 'route' => [
                     'name' => 'sonata_admin_foo_param',
@@ -2310,7 +2313,7 @@ EOT
             ],
             [
                 '<th>Data</th> <td><a href="/foo/obj/abcd/12345/efgh?param3=ijkl">Foo</a></td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'Foo',
                 ['safe' => false, 'route' => [
                     'name' => 'sonata_admin_foo_object',
@@ -2324,7 +2327,7 @@ EOT
             ],
             [
                 '<th>Data</th> <td><a href="http://localhost/foo/obj/abcd/12345/efgh?param3=ijkl">Foo</a></td>',
-                'url',
+                FieldDescriptionInterface::TYPE_URL,
                 'Foo',
                 ['safe' => false, 'route' => [
                     'name' => 'sonata_admin_foo_object',
@@ -2339,103 +2342,103 @@ EOT
             ],
             [
                 '<th>Data</th> <td> &nbsp;</td>',
-                'email',
+                FieldDescriptionInterface::TYPE_EMAIL,
                 null,
                 [],
             ],
             [
                 '<th>Data</th> <td> <a href="mailto:admin@admin.com">admin@admin.com</a></td>',
-                'email',
+                FieldDescriptionInterface::TYPE_EMAIL,
                 'admin@admin.com',
                 [],
             ],
             [
                 '<th>Data</th> <td> <a href="mailto:admin@admin.com?'.$this->buildTwigLikeUrl(['subject' => 'Main Theme', 'body' => 'Message Body']).'">admin@admin.com</a></td>',
-                'email',
+                FieldDescriptionInterface::TYPE_EMAIL,
                 'admin@admin.com',
                 ['subject' => 'Main Theme', 'body' => 'Message Body'],
             ],
             [
                 '<th>Data</th> <td> <a href="mailto:admin@admin.com?'.$this->buildTwigLikeUrl(['subject' => 'Main Theme']).'">admin@admin.com</a></td>',
-                'email',
+                FieldDescriptionInterface::TYPE_EMAIL,
                 'admin@admin.com',
                 ['subject' => 'Main Theme'],
             ],
             [
                 '<th>Data</th> <td> <a href="mailto:admin@admin.com?'.$this->buildTwigLikeUrl(['body' => 'Message Body']).'">admin@admin.com</a></td>',
-                'email',
+                FieldDescriptionInterface::TYPE_EMAIL,
                 'admin@admin.com',
                 ['body' => 'Message Body'],
             ],
             [
                 '<th>Data</th> <td> admin@admin.com</td>',
-                'email',
+                FieldDescriptionInterface::TYPE_EMAIL,
                 'admin@admin.com',
                 ['as_string' => true, 'subject' => 'Main Theme', 'body' => 'Message Body'],
             ],
             [
                 '<th>Data</th> <td> admin@admin.com</td>',
-                'email',
+                FieldDescriptionInterface::TYPE_EMAIL,
                 'admin@admin.com',
                 ['as_string' => true, 'subject' => 'Main Theme'],
             ],
             [
                 '<th>Data</th> <td> admin@admin.com</td>',
-                'email',
+                FieldDescriptionInterface::TYPE_EMAIL,
                 'admin@admin.com',
                 ['as_string' => true, 'body' => 'Message Body'],
             ],
             [
                 '<th>Data</th> <td> <a href="mailto:admin@admin.com">admin@admin.com</a></td>',
-                'email',
+                FieldDescriptionInterface::TYPE_EMAIL,
                 'admin@admin.com',
                 ['as_string' => false],
             ],
             [
                 '<th>Data</th> <td> admin@admin.com</td>',
-                'email',
+                FieldDescriptionInterface::TYPE_EMAIL,
                 'admin@admin.com',
                 ['as_string' => true],
             ],
             [
                 '<th>Data</th> <td><p><strong>Creating a Template for the Field</strong> and form</p> </td>',
-                'html',
+                FieldDescriptionInterface::TYPE_HTML,
                 '<p><strong>Creating a Template for the Field</strong> and form</p>',
                 [],
             ],
             [
                 '<th>Data</th> <td>Creating a Template for the Field and form </td>',
-                'html',
+                FieldDescriptionInterface::TYPE_HTML,
                 '<p><strong>Creating a Template for the Field</strong> and form</p>',
                 ['strip' => true],
             ],
             [
                 '<th>Data</th> <td> Creating a Template for the... </td>',
-                'html',
+                FieldDescriptionInterface::TYPE_HTML,
                 '<p><strong>Creating a Template for the Field</strong> and form</p>',
                 ['truncate' => true],
             ],
             [
                 '<th>Data</th> <td> Creatin... </td>',
-                'html',
+                FieldDescriptionInterface::TYPE_HTML,
                 '<p><strong>Creating a Template for the Field</strong> and form</p>',
                 ['truncate' => ['length' => 10]],
             ],
             [
                 '<th>Data</th> <td> Creating a Template for the Field... </td>',
-                'html',
+                FieldDescriptionInterface::TYPE_HTML,
                 '<p><strong>Creating a Template for the Field</strong> and form</p>',
                 ['truncate' => ['cut' => false]],
             ],
             [
                 '<th>Data</th> <td> Creating a Template for t etc. </td>',
-                'html',
+                FieldDescriptionInterface::TYPE_HTML,
                 '<p><strong>Creating a Template for the Field</strong> and form</p>',
                 ['truncate' => ['ellipsis' => ' etc.']],
             ],
             [
                 '<th>Data</th> <td> Creating a Template[...] </td>',
-                'html',
+                FieldDescriptionInterface::TYPE_HTML,
                 '<p><strong>Creating a Template for the Field</strong> and form</p>',
                 [
                     'truncate' => [
@@ -2456,7 +2459,7 @@ EOT
 </div></td>
 EOT
                 ,
-                'text',
+                'text', // NEXT_MAJOR: Change it do FieldDescription::TYPE_STRING
                 ' A very long string ',
                 [
                     'collapse' => true,
@@ -2474,7 +2477,7 @@ EOT
 </div></td>
 EOT
                 ,
-                'text',
+                'text', // NEXT_MAJOR: Change it do FieldDescription::TYPE_STRING
                 ' A very long string ',
                 [
                     'collapse' => [
@@ -2491,35 +2494,36 @@ EOT
     public function getRenderViewElementCompareTests(): iterable
     {
         return [
-            ['<th>Data</th> <td>Example</td><td>Example</td>', 'string', 'Example', ['safe' => false]],
+            ['<th>Data</th> <td>Example</td><td>Example</td>', FieldDescriptionInterface::TYPE_STRING, 'Example', ['safe' => false]],
+            // NEXT_MAJOR: Replace "text" by FieldDescription::TYPE_STRING
             ['<th>Data</th> <td>Example</td><td>Example</td>', 'text', 'Example', ['safe' => false]],
-            ['<th>Data</th> <td>Example</td><td>Example</td>', 'textarea', 'Example', ['safe' => false]],
+            ['<th>Data</th> <td>Example</td><td>Example</td>', FieldDescriptionInterface::TYPE_TEXTAREA, 'Example', ['safe' => false]],
             ['<th>Data</th> <td>SonataAdmin<br/>Example</td><td>SonataAdmin<br/>Example</td>', 'virtual_field', 'Example', ['template' => 'custom_show_field.html.twig', 'safe' => false, 'SonataAdmin']],
             ['<th class="diff">Data</th> <td>SonataAdmin<br/>Example</td><td>sonata-project/admin-bundle<br/>Example</td>', 'virtual_field', 'Example', ['template' => 'custom_show_field.html.twig', 'safe' => false], 'sonata-project/admin-bundle'],
             [
                 '<th>Data</th> <td><time datetime="2020-05-27T09:11:12+00:00" title="2020-05-27T09:11:12+00:00"> May 27, 2020 10:11 </time></td>'
                 .'<td><time datetime="2020-05-27T09:11:12+00:00" title="2020-05-27T09:11:12+00:00"> May 27, 2020 10:11 </time></td>',
-                'datetime',
+                FieldDescriptionInterface::TYPE_DATETIME,
                 new \DateTime('2020-05-27 10:11:12', new \DateTimeZone('Europe/London')), [],
             ],
             [
                 '<th>Data</th> <td><time datetime="2020-05-27T09:11:12+00:00" title="2020-05-27T09:11:12+00:00"> 27.05.2020 10:11:12 </time></td>'
                 .'<td><time datetime="2020-05-27T09:11:12+00:00" title="2020-05-27T09:11:12+00:00"> 27.05.2020 10:11:12 </time></td>',
-                'datetime',
+                FieldDescriptionInterface::TYPE_DATETIME,
                 new \DateTime('2020-05-27 10:11:12', new \DateTimeZone('Europe/London')),
                 ['format' => 'd.m.Y H:i:s'],
             ],
             [
                 '<th>Data</th> <td><time datetime="2020-05-27T10:11:12+00:00" title="2020-05-27T10:11:12+00:00"> May 27, 2020 18:11 </time></td>'
                 .'<td><time datetime="2020-05-27T10:11:12+00:00" title="2020-05-27T10:11:12+00:00"> May 27, 2020 18:11 </time></td>',
-                'datetime',
+                FieldDescriptionInterface::TYPE_DATETIME,
                 new \DateTime('2020-05-27 10:11:12', new \DateTimeZone('UTC')),
                 ['timezone' => 'Asia/Hong_Kong'],
             ],
             [
                 '<th>Data</th> <td><time datetime="2020-05-27" title="2020-05-27"> May 27, 2020 </time></td>'
                 .'<td><time datetime="2020-05-27" title="2020-05-27"> May 27, 2020 </time></td>',
-                'date',
+                FieldDescriptionInterface::TYPE_DATE,
                 new \DateTime('2020-05-27 10:11:12', new \DateTimeZone('Europe/London')),
                 [],
             ],

--- a/tests/Twig/Extension/XEditableExtensionTest.php
+++ b/tests/Twig/Extension/XEditableExtensionTest.php
@@ -28,24 +28,7 @@ final class XEditableExtensionTest extends TestCase
      */
     public function testGetXEditableChoicesIsIdempotent(array $options, array $expectedChoices): void
     {
-        $xEditableTypeMapping = [
-            'choice' => 'select',
-            'boolean' => 'select',
-            'text' => 'text',
-            'textarea' => 'textarea',
-            'html' => 'textarea',
-            'email' => 'email',
-            'string' => 'text',
-            'smallint' => 'text',
-            'bigint' => 'text',
-            'integer' => 'number',
-            'decimal' => 'number',
-            'currency' => 'number',
-            'percent' => 'number',
-            'url' => 'url',
-        ];
-
-        $twigExtension = new XEditableExtension(new Translator('en'), $xEditableTypeMapping);
+        $twigExtension = new XEditableExtension(new Translator('en'));
 
         $fieldDescription = $this->getMockForAbstractClass(FieldDescriptionInterface::class);
         $fieldDescription
@@ -71,7 +54,7 @@ final class XEditableExtensionTest extends TestCase
      *	array<array{value: string, text: string}>
      * }>
      */
-    public function xEditableChoicesProvider()
+    public function xEditableChoicesProvider(): iterable
     {
         return [
             'needs processing' => [


### PR DESCRIPTION
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `XEditableExtension::FIELD_DESCRIPTION_MAPPING` to expose mapping between FieldDescription types and xEditable types
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
