### PR TITLE
Fix bug "Field "FIELD" has already been rendered" in /CRUD/Associatio…

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_many_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_many.html.twig
@@ -106,10 +106,6 @@ file that was distributed with this source code.
 
         {% else %}
             <div id="field_container_{{ id }}" class="field-container">
-                <span id="field_widget_{{ id }}" >
-                    {{ form_widget(form) }}
-                </span>
-
                 <span id="field_actions_{{ id }}" class="field-actions">
                     {% if sonata_admin.field_description.associationadmin.hasRoute('create')
                         and sonata_admin.field_description.associationadmin.hasAccess('create')

--- a/src/Resources/views/CRUD/Association/edit_many_to_many.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_many.html.twig
@@ -105,25 +105,23 @@ file that was distributed with this source code.
             {% include '@SonataAdmin/CRUD/Association/edit_one_script.html.twig' %}
 
         {% else %}
-            <div id="field_container_{{ id }}" class="field-container">
-                <span id="field_actions_{{ id }}" class="field-actions">
-                    {% if sonata_admin.field_description.associationadmin.hasRoute('create')
-                        and sonata_admin.field_description.associationadmin.hasAccess('create')
-                        and btn_add %}
-                        <a
-                            href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) }}"
-                            onclick="return start_field_dialog_form_add_{{ id }}(this);"
-                            class="btn btn-success btn-sm sonata-ba-action"
-                            title="{{ btn_add|trans({}, btn_catalogue) }}"
-                            >
-                            <i class="fa fa-plus-circle"></i>
-                            {{ btn_add|trans({}, btn_catalogue) }}
-                        </a>
-                        {% include '@SonataAdmin/CRUD/Association/edit_modal.html.twig' %}
-                        {% include '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
-                    {% endif %}
-                </span>
-            </div>
+            <span id="field_actions_{{ id }}" class="field-actions">
+                {% if sonata_admin.field_description.associationadmin.hasRoute('create')
+                    and sonata_admin.field_description.associationadmin.hasAccess('create')
+                    and btn_add %}
+                    <a
+                        href="{{ sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) }}"
+                        onclick="return start_field_dialog_form_add_{{ id }}(this);"
+                        class="btn btn-success btn-sm sonata-ba-action"
+                        title="{{ btn_add|trans({}, btn_catalogue) }}"
+                        >
+                        <i class="fa fa-plus-circle"></i>
+                        {{ btn_add|trans({}, btn_catalogue) }}
+                    </a>
+                    {% include '@SonataAdmin/CRUD/Association/edit_modal.html.twig' %}
+                    {% include '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
+                {% endif %}
+            </span>
         {% endif %}
     </div>
 {% endif %}


### PR DESCRIPTION
## Fix bug "Field "FIELD" has already been rendered" in /CRUD/Association/edit_many_to_many.html.twig (line 111)

Closes #7059.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!-- 
    If you are updating something that doesn't require
    a release, you can delete the whole Changelog section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed "Field "FIELD" has already been rendered" error message when using ModelType
```