### PR TITLE
Move template param of the ModelManager to the class

### DIFF
--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -58,6 +58,7 @@ use Symfony\Component\HttpFoundation\Request;
  * @phpstan-extends AccessRegistryInterface<T>
  * @phpstan-extends UrlGeneratorInterface<T>
  * @phpstan-extends LifecycleHookProviderInterface<T>
+ * @phpstan-extends TaggedAdminInterface<T>
  */
 interface AdminInterface extends TaggedAdminInterface, AccessRegistryInterface, FieldDescriptionRegistryInterface, LifecycleHookProviderInterface, MenuBuilderInterface, ParentAdminInterface, UrlGeneratorInterface, MutableTemplateRegistryAwareInterface
 {

--- a/src/DependencyInjection/Admin/AbstractTaggedAdmin.php
+++ b/src/DependencyInjection/Admin/AbstractTaggedAdmin.php
@@ -33,6 +33,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 
 /**
  * @phpstan-template T of object
+ * @phpstan-implements TaggedAdminInterface<T>
  */
 abstract class AbstractTaggedAdmin implements TaggedAdminInterface
 {
@@ -117,6 +118,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
      * The Entity or Document manager.
      *
      * @var ModelManagerInterface|null
+     * @phpstan-var ModelManagerInterface<T>|null
      */
     protected $modelManager;
 
@@ -372,7 +374,10 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     }
 
     /**
+     * NEXT_MAJOR: Move the phpdoc to the interface.
+     *
      * @final since sonata-admin/admin-bundle 3.84
+     * @phpstan-param ModelManagerInterface<T> $modelManager
      */
     public function setModelManager(ModelManagerInterface $modelManager)
     {

--- a/src/DependencyInjection/Admin/TaggedAdminInterface.php
+++ b/src/DependencyInjection/Admin/TaggedAdminInterface.php
@@ -63,6 +63,8 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  * @method Pool                             getConfigurationPool()
  * @method void                             setRouteGenerator(RouteGeneratorInterface $routeGenerator)
  * @method RouteGeneratorInterface          getRouteGenerator()
+ *
+ * @phpstan-template T of object
  */
 interface TaggedAdminInterface
 {
@@ -153,11 +155,14 @@ interface TaggedAdminInterface
 
     /**
      * NEXT_MAJOR: Uncomment this method.
+     *
+     * @phpstan-param ModelManagerInterface<T>
      */
 //    public function setModelManager(ModelManagerInterface $modelManager): void;
 
     /**
      * @return ModelManagerInterface
+     * @phpstan-return ModelManagerInterface<T>
      */
     public function getModelManager();
 

--- a/src/Form/DataTransformer/ArrayToModelTransformer.php
+++ b/src/Form/DataTransformer/ArrayToModelTransformer.php
@@ -28,6 +28,7 @@ class ArrayToModelTransformer implements DataTransformerInterface
 {
     /**
      * @var ModelManagerInterface
+     * @phpstan-var ModelManagerInterface<T>
      */
     protected $modelManager;
 
@@ -41,7 +42,8 @@ class ArrayToModelTransformer implements DataTransformerInterface
     /**
      * @param string $className
      *
-     * @phpstan-param class-string<T> $className
+     * @phpstan-param ModelManagerInterface<T> $modelManager
+     * @phpstan-param class-string<T>          $className
      */
     public function __construct(ModelManagerInterface $modelManager, $className)
     {

--- a/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
+++ b/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
@@ -33,6 +33,7 @@ class ModelToIdPropertyTransformer implements DataTransformerInterface
 {
     /**
      * @var ModelManagerInterface
+     * @phpstan-var ModelManagerInterface<T>
      */
     protected $modelManager;
 
@@ -65,7 +66,8 @@ class ModelToIdPropertyTransformer implements DataTransformerInterface
      * @param callable|null   $toStringCallback
      *
      * @phpstan-template P
-     * @phpstan-param class-string<T> $className
+     * @phpstan-param ModelManagerInterface<T>         $modelManager
+     * @phpstan-param class-string<T>                  $className
      * @phpstan-param null|callable(object, P): string $toStringCallback
      */
     public function __construct(

--- a/src/Form/DataTransformer/ModelToIdTransformer.php
+++ b/src/Form/DataTransformer/ModelToIdTransformer.php
@@ -27,6 +27,7 @@ class ModelToIdTransformer implements DataTransformerInterface
 {
     /**
      * @var ModelManagerInterface
+     * @phpstan-var ModelManagerInterface<T>
      */
     protected $modelManager;
 
@@ -40,7 +41,8 @@ class ModelToIdTransformer implements DataTransformerInterface
     /**
      * @param string $className
      *
-     * @phpstan-param class-string<T> $className
+     * @phpstan-param ModelManagerInterface<T> $modelManager
+     * @phpstan-param class-string<T>          $className
      */
     public function __construct(ModelManagerInterface $modelManager, $className)
     {

--- a/src/Form/DataTransformer/ModelsToArrayTransformer.php
+++ b/src/Form/DataTransformer/ModelsToArrayTransformer.php
@@ -37,6 +37,7 @@ class ModelsToArrayTransformer implements DataTransformerInterface
 {
     /**
      * @var ModelManagerInterface
+     * @phpstan-var ModelManagerInterface<T>
      */
     protected $modelManager;
 
@@ -60,7 +61,8 @@ class ModelsToArrayTransformer implements DataTransformerInterface
      * @param ModelManagerInterface            $modelManager
      * @param string                           $class
      *
-     * @phpstan-param class-string<T> $class
+     * @phpstan-param ModelManagerInterface<T> $modelManager
+     * @phpstan-param class-string<T>          $class
      *
      * @throws RuntimeException
      */

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -28,6 +28,8 @@ use Sonata\Exporter\Source\SourceIteratorInterface;
  *
  * @method bool supportsQuery(object $query)
  * @method void reverseTransform(object $object, array $array = [])
+ *
+ * @phpstan-template T of object
  */
 interface ModelManagerInterface extends DatagridManagerInterface
 {
@@ -72,7 +74,6 @@ interface ModelManagerInterface extends DatagridManagerInterface
      *
      * @return object[] all objects matching the criteria
      *
-     * @phpstan-template T of object
      * @phpstan-param class-string<T> $class
      * @phpstan-return T[]
      */
@@ -84,7 +85,6 @@ interface ModelManagerInterface extends DatagridManagerInterface
      *
      * @return object|null an object matching the criteria or null if none match
      *
-     * @phpstan-template T of object
      * @phpstan-param class-string<T> $class
      * @phpstan-return T|null
      */
@@ -96,7 +96,6 @@ interface ModelManagerInterface extends DatagridManagerInterface
      *
      * @return object|null the object with id or null if not found
      *
-     * @phpstan-template T of object
      * @phpstan-param class-string<T> $class
      * @phpstan-return T|null
      */
@@ -204,7 +203,6 @@ interface ModelManagerInterface extends DatagridManagerInterface
      *
      * @return object
      *
-     * @phpstan-template T of object
      * @phpstan-param class-string<T> $class
      * @phpstan-return T
      */
@@ -291,7 +289,6 @@ interface ModelManagerInterface extends DatagridManagerInterface
      *
      * @return object
      *
-     * @phpstan-template T of object
      * @phpstan-param class-string<T> $class
      * @phpstan-return T
      */
@@ -310,7 +307,6 @@ interface ModelManagerInterface extends DatagridManagerInterface
      *
      * @return object
      *
-     * @phpstan-template T of object
      * @phpstan-param class-string<T> $class
      * @phpstan-return T
      */
@@ -346,7 +342,7 @@ interface ModelManagerInterface extends DatagridManagerInterface
      *
      * @return string[]
      *
-     * @phpstan-param class-string $class
+     * @phpstan-param class-string<T> $class
      */
     public function getExportFields($class);
 
@@ -366,7 +362,7 @@ interface ModelManagerInterface extends DatagridManagerInterface
      * @param string                 $class
      * @param array<int, int|string> $idx
      *
-     * @phpstan-param class-string $class
+     * @phpstan-param class-string<T> $class
      */
     public function addIdentifiersToQuery($class, ProxyQueryInterface $query, array $idx);
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because BC.

@franmomu You proposed this change https://github.com/sonata-project/SonataAdminBundle/pull/6721, and I didn't fully understand if it was a good change or not. Now I think I agree with your proposal.

If the modelManager is generic, `ModelManager<object>` or `ModelManager<T>` could be used.
If the modelManager works only for some objects, like https://github.com/sonata-project/SonataAdminBundle/blob/3.x/tests/App/Model/ModelManager.php#L22, it could be `ModelManager<Foo>`.

It could fixed https://github.com/sonata-project/SonataAdminBundle/blob/master/tests/App/Model/ModelManager.php#L56-L60

See https://phpstan.org/r/ab8c0e82-a65c-4b98-9662-18e07a73ce07 Vs https://phpstan.org/r/adc525ad-dadf-4912-af8e-7087ac6b1344

## Changelog

```markdown
### Added
- Added generic for ModelManager class
```