### PR TITLE
[Docs] Minor tweaks in RST syntax

### DIFF
--- a/docs/reference/field_types.rst
+++ b/docs/reference/field_types.rst
@@ -80,14 +80,12 @@ Option                                  Description
                                         Available options are: ``'both'``, ``'keys'``, ``'values'``.
 **key_translation_domain**              This option determines if the keys should be translated and
                                         in which translation domain.
-
                                         The values of this option can be ``true`` (use admin
                                         translation domain), ``false`` (disable translation), ``null``
                                         (uses the parent translation domain or the default domain)
                                         or a string which represents the exact translation domain to use.
 **value_translation_domain**            This option determines if the values should be translated and
                                         in which translation domain.
-
                                         The values of this option can be ``true`` (use admin
                                         translation domain), ``false`` (disable translation), ``null``
                                         (uses the parent translation domain or the default domain)

--- a/docs/reference/security.rst
+++ b/docs/reference/security.rst
@@ -142,6 +142,8 @@ service), Sonata will check if the user has the ``ROLE_APP_ADMIN_FOO_EDIT`` or `
 The role name will be based on the name of your admin service.
 
 ========================   ======================================================
+Service name               Role name
+========================   ======================================================
 app.admin.foo              ROLE_APP_ADMIN_FOO_{PERMISSION}
 my.blog.admin.foo_bar      ROLE_MY_BLOG_ADMIN_FOO_BAR_{PERMISSION}
 App\\Admin\\FooAdmin       ROLE_APP\\ADMIN\\FOOADMIN_{PERMISSION}


### PR DESCRIPTION
When building Sonata docs with the new Symfony Docs Builder, we found some issues related to tables (see https://github.com/weaverryan/docs-builder/issues/89).

Strictly speaking, it's not a mistake of your docs, so I'll understand if you prefer to not change this ... but making these minor changes would make your doc publishable again on symfony.com. Thanks! 