### PR TITLE
Prepare to remove usages of service_container in version 4

### DIFF
--- a/src/Resources/config/twig.php
+++ b/src/Resources/config/twig.php
@@ -55,7 +55,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->tag('twig.extension')
             ->args([
                 new ReferenceConfigurator('sonata.admin.global_template_registry'),
+                // NEXT_MAJOR: Remove next line.
                 new ReferenceConfigurator('service_container'),
+                new ReferenceConfigurator('sonata.admin.pool'),
             ])
 
         ->set('sonata.admin.group.extension', GroupExtension::class)

--- a/src/Twig/Extension/TemplateRegistryExtension.php
+++ b/src/Twig/Extension/TemplateRegistryExtension.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Twig\Extension;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Exception\AdminCodeNotFoundException;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
@@ -29,14 +31,29 @@ final class TemplateRegistryExtension extends AbstractExtension
     private $globalTemplateRegistry;
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
      * @var ContainerInterface
      */
     private $container;
 
-    public function __construct(TemplateRegistryInterface $globalTemplateRegistry, ContainerInterface $container)
+    /**
+     * NEXT_MAJOR: Remove "null" from var type.
+     *
+     * @var Pool|null
+     */
+    private $pool;
+
+    /**
+     * @internal since sonata-project/admin-bundle 4. This class should only be used through Twig
+     *
+     * NEXT_MAJOR: Remove $container parameter and make Pool mandatory.
+     */
+    public function __construct(TemplateRegistryInterface $globalTemplateRegistry, ContainerInterface $container, ?Pool $pool = null)
     {
         $this->globalTemplateRegistry = $globalTemplateRegistry;
         $this->container = $container;
+        $this->pool = $pool;
     }
 
     /**
@@ -86,18 +103,13 @@ final class TemplateRegistryExtension extends AbstractExtension
     }
 
     /**
-     * @throws ServiceNotFoundException
-     * @throws ServiceCircularReferenceException
+     * @throws AdminCodeNotFoundException
      */
     private function getTemplateRegistry(string $adminCode): TemplateRegistryInterface
     {
-        $serviceId = sprintf('%s.template_registry', $adminCode);
-        $templateRegistry = $this->container->get($serviceId);
-        if ($templateRegistry instanceof TemplateRegistryInterface) {
-            return $templateRegistry;
-        }
+        $admin = $this->pool->getAdminByAdminCode($adminCode);
 
-        throw new ServiceNotFoundException($serviceId);
+        return $admin->getTemplateRegistry();
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I missed this on in https://github.com/sonata-project/SonataAdminBundle/issues/6963

After this and merging with `4.x` (resolving the comment) I think we won't have more `service_container` dependencies.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changed `TemplateRegistryExtension` constructor to `@internal`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
