### PR TITLE
Extract strings to constants

### DIFF
--- a/docs/cookbook/recipe_sortable_listing.rst
+++ b/docs/cookbook/recipe_sortable_listing.rst
@@ -117,6 +117,7 @@ Now we need to define the sort by field to be ``$position``::
     namespace App\Admin;
 
     use Sonata\AdminBundle\Admin\AbstractAdmin;
+    use Sonata\AdminBundle\Datagrid\DatagridInterface;
     use Sonata\AdminBundle\Datagrid\ListMapper;
     use Sonata\AdminBundle\Route\RouteCollection;
 
@@ -124,9 +125,9 @@ Now we need to define the sort by field to be ``$position``::
     {
         protected function configureDefaultSortValues(array &$sortValues): void
         {
-            $sortValues['_page'] = 1;
-            $sortValues['_sort_order'] = 'ASC';
-            $sortValues['_sort_by'] = 'position';
+            $sortValues[DatagridInterface::PAGE] = 1;
+            $sortValues[DatagridInterface::SORT_ORDER] = 'ASC';
+            $sortValues[DatagridInterface::SORT_BY] = 'position';
         }
 
         protected function configureRoutes(RouteCollection $collection)

--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -308,12 +308,13 @@ Configure the default ordering in the list view
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Configuring the default ordering column can be achieved by overriding the
-``configureDefaultSortValues()`` method. All three keys ``_page``, ``_sort_order`` and
-``_sort_by`` can be omitted::
+``configureDefaultSortValues()`` method. All three keys ``DatagridInterface::PAGE``,
+``DatagridInterface::SORT_ORDER`` and ``DatagridInterface::SORT_BY`` can be omitted::
 
     // src/Admin/PostAdmin.php
 
     use Sonata\AdminBundle\Admin\AbstractAdmin;
+    use Sonata\AdminBundle\Datagrid\DatagridInterface;
 
     final class PostAdmin extends AbstractAdmin
     {
@@ -322,13 +323,13 @@ Configuring the default ordering column can be achieved by overriding the
         protected function configureDefaultSortValues(array &$sortValues): void
         {
             // display the first page (default = 1)
-            $sortValues['_page'] = 1;
+            $sortValues[DatagridInterface::PAGE] = 1;
 
             // reverse order (default = 'ASC')
-            $sortValues['_sort_order'] = 'DESC';
+            $sortValues[DatagridInterface::SORT_ORDER] = 'DESC';
 
             // name of the ordered field (default = the model's id field, if any)
-            $sortValues['_sort_by'] = 'updatedAt';
+            $sortValues[DatagridInterface::SORT_BY] = 'updatedAt';
         }
 
         // ...
@@ -336,7 +337,7 @@ Configuring the default ordering column can be achieved by overriding the
 
 .. note::
 
-    The ``_sort_by`` key can be of the form ``mySubModel.mySubSubModel.myField``.
+    The ``DatagridInterface::SORT_BY`` key can be of the form ``mySubModel.mySubSubModel.myField``.
 
 .. note::
 
@@ -347,6 +348,7 @@ Configuring the default ordering column can be achieved by overriding the
         // src/Admin/PostAdmin.php
 
         use Sonata\AdminBundle\Admin\AbstractAdmin;
+        use Sonata\AdminBundle\Datagrid\DatagridInterface;
 
         final class PostAdmin extends AbstractAdmin
         {
@@ -355,13 +357,13 @@ Configuring the default ordering column can be achieved by overriding the
             protected function configureDefaultSortValues(array &$sortValues): void
             {
                 // display the first page (default = 1)
-                $sortValues['_page'] = 1;
+                $sortValues[DatagridInterface::PAGE] = 1;
 
                 // reverse order (default = 'ASC')
-                $sortValues['_sort_order'] = 'DESC';
+                $sortValues[DatagridInterface::SORT_ORDER] = 'DESC';
 
                 // name of the ordered field (default = the model's id field, if any)
-                $sortValues['_sort_by'] = 'updatedAt';
+                $sortValues[DatagridInterface::SORT_BY] = 'updatedAt';
             }
 
             protected function configureQuery(ProxyQueryInterface $query): ProxyQueryInterface

--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Action;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Datagrid\PagerInterface;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 use Sonata\AdminBundle\Filter\FilterInterface;
@@ -66,7 +67,7 @@ final class RetrieveAutocompleteItemsAction
             $callback = $filterAutocomplete->getFieldOption('callback');
             $minimumInputLength = $filterAutocomplete->getFieldOption('minimum_input_length', 3);
             $itemsPerPage = $filterAutocomplete->getFieldOption('items_per_page', 10);
-            $reqParamPageNumber = $filterAutocomplete->getFieldOption('req_param_name_page_number', '_page');
+            $reqParamPageNumber = $filterAutocomplete->getFieldOption('req_param_name_page_number', DatagridInterface::PAGE);
             $toStringCallback = $filterAutocomplete->getFieldOption('to_string_callback');
             $targetAdminAccessAction = $filterAutocomplete->getFieldOption('target_admin_access_action', 'list');
             $responseItemCallback = $filterAutocomplete->getFieldOption('response_item_callback');
@@ -144,8 +145,8 @@ final class RetrieveAutocompleteItemsAction
             }
         }
 
-        $datagrid->setValue('_per_page', null, $itemsPerPage);
-        $datagrid->setValue('_page', null, $request->query->get($reqParamPageNumber, '1'));
+        $datagrid->setValue(DatagridInterface::PER_PAGE, null, $itemsPerPage);
+        $datagrid->setValue(DatagridInterface::PAGE, null, $request->query->get($reqParamPageNumber, '1'));
         $datagrid->buildPager();
 
         $pager = $datagrid->getPager();

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -195,8 +195,8 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
      * @var array
      */
     protected $datagridValues = [
-        '_page' => 1,
-        '_per_page' => 32,
+        DatagridInterface::PAGE => 1,
+        DatagridInterface::PER_PAGE => 32,
     ];
 
     /**
@@ -476,7 +476,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         $this->predefinePerPageOptions();
 
         // NEXT_MAJOR: Remove this line.
-        $this->datagridValues['_per_page'] = $this->maxPerPage;
+        $this->datagridValues[DatagridInterface::PER_PAGE] = $this->maxPerPage;
     }
 
     /**
@@ -722,11 +722,11 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
             } else {
                 $filters = $bag->get('filter', []);
             }
-            if (isset($filters['_page'])) {
-                $filters['_page'] = (int) $filters['_page'];
+            if (isset($filters[DatagridInterface::PAGE])) {
+                $filters[DatagridInterface::PAGE] = (int) $filters[DatagridInterface::PAGE];
             }
-            if (isset($filters['_per_page'])) {
-                $filters['_per_page'] = (int) $filters['_per_page'];
+            if (isset($filters[DatagridInterface::PER_PAGE])) {
+                $filters[DatagridInterface::PER_PAGE] = (int) $filters[DatagridInterface::PER_PAGE];
             }
 
             // if filter persistence is configured
@@ -755,8 +755,8 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
             }
         }
 
-        if (!isset($parameters['_per_page']) || !$this->determinedPerPageValue($parameters['_per_page'])) {
-            $parameters['_per_page'] = $this->getMaxPerPage();
+        if (!isset($parameters[DatagridInterface::PER_PAGE]) || !$this->determinedPerPageValue($parameters[DatagridInterface::PER_PAGE])) {
+            $parameters[DatagridInterface::PER_PAGE] = $this->getMaxPerPage();
         }
 
         $parameters = $this->configureFilterParameters($parameters);
@@ -792,16 +792,16 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
 
         $filterParameters = $this->getFilterParameters();
 
-        // transform _sort_by from a string to a FieldDescriptionInterface for the datagrid.
-        if (isset($filterParameters['_sort_by']) && \is_string($filterParameters['_sort_by'])) {
-            if ($this->hasListFieldDescription($filterParameters['_sort_by'])) {
-                $filterParameters['_sort_by'] = $this->getListFieldDescription($filterParameters['_sort_by']);
+        // transform DatagridInterface::SORT_BY from a string to a FieldDescriptionInterface for the datagrid.
+        if (isset($filterParameters[DatagridInterface::SORT_BY]) && \is_string($filterParameters[DatagridInterface::SORT_BY])) {
+            if ($this->hasListFieldDescription($filterParameters[DatagridInterface::SORT_BY])) {
+                $filterParameters[DatagridInterface::SORT_BY] = $this->getListFieldDescription($filterParameters[DatagridInterface::SORT_BY]);
             } else {
-                $filterParameters['_sort_by'] = $this->createFieldDescription(
-                    $filterParameters['_sort_by']
+                $filterParameters[DatagridInterface::SORT_BY] = $this->createFieldDescription(
+                    $filterParameters[DatagridInterface::SORT_BY]
                 );
 
-                $this->getListBuilder()->buildField(null, $filterParameters['_sort_by'], $this);
+                $this->getListBuilder()->buildField(null, $filterParameters[DatagridInterface::SORT_BY], $this);
             }
         }
 
@@ -1605,7 +1605,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $this->maxPerPage;
         // $sortValues = $this->getDefaultSortValues();
 
-        // return $sortValues['_per_page'] ?? 25;
+        // return $sortValues[DatagridInterface::PER_PAGE] ?? 25;
     }
 
     /**
@@ -3135,13 +3135,18 @@ EOT;
     /**
      * Returns a list of default sort values.
      *
-     * @return array{_page?: int, _per_page?: int, _sort_by?: string, _sort_order?: string}
+     * @phpstan-return array{
+     *     _page?: int,
+     *     _per_page?: int,
+     *     _sort_by?: string,
+     *     _sort_order?: string
+     * }
      */
     final protected function getDefaultSortValues(): array
     {
         // NEXT_MAJOR: Use the next line instead.
         $defaultSortValues = [];
-        // $defaultSortValues = ['_page' => 1, '_per_page' => 25];
+        // $defaultSortValues = [DatagridInterface::PAGE => 1, DatagridInterface::PER_PAGE => 25];
 
         $this->configureDefaultSortValues($defaultSortValues);
 
@@ -3543,10 +3548,15 @@ EOT;
      * Configures a list of default sort values.
      *
      * Example:
-     *   $sortValues['_sort_by'] = 'foo'
-     *   $sortValues['_sort_order'] = 'DESC'
+     *   $sortValues[DatagridInterface::SORT_BY] = 'foo'
+     *   $sortValues[DatagridInterface::SORT_ORDER] = 'DESC'
      *
-     * @phpstan-param array{_page?: int, _per_page?: int, _sort_by?: string, _sort_order?: string} $sortValues
+     * @phpstan-param array{
+     *     _page?: int,
+     *     _per_page?: int,
+     *     _sort_by?: string,
+     *     _sort_order?: string
+     * } $sortValues
      */
     protected function configureDefaultSortValues(array &$sortValues)
     {

--- a/src/Block/AdminStatsBlockService.php
+++ b/src/Block/AdminStatsBlockService.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Block;
 
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractBlockService;
 use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
@@ -95,8 +96,8 @@ class AdminStatsBlockService extends AbstractBlockService
 
         $filters = $blockContext->getSetting('filters');
 
-        if (!isset($filters['_per_page'])) {
-            $filters['_per_page'] = ['value' => $blockContext->getSetting('limit')];
+        if (!isset($filters[DatagridInterface::PER_PAGE])) {
+            $filters[DatagridInterface::PER_PAGE] = ['value' => $blockContext->getSetting('limit')];
         }
 
         foreach ($filters as $name => $data) {

--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -140,8 +140,8 @@ class Datagrid implements DatagridInterface
 
         $hiddenType = HiddenType::class;
 
-        $this->formBuilder->add('_sort_by', $hiddenType);
-        $this->formBuilder->get('_sort_by')->addViewTransformer(new CallbackTransformer(
+        $this->formBuilder->add(DatagridInterface::SORT_BY, $hiddenType);
+        $this->formBuilder->get(DatagridInterface::SORT_BY)->addViewTransformer(new CallbackTransformer(
             static function ($value) {
                 return $value;
             },
@@ -150,16 +150,16 @@ class Datagrid implements DatagridInterface
             }
         ));
 
-        $this->formBuilder->add('_sort_order', $hiddenType);
-        $this->formBuilder->add('_page', $hiddenType);
+        $this->formBuilder->add(DatagridInterface::SORT_ORDER, $hiddenType);
+        $this->formBuilder->add(DatagridInterface::PAGE, $hiddenType);
 
-        if (isset($this->values['_per_page']) && \is_array($this->values['_per_page'])) {
-            $this->formBuilder->add('_per_page', CollectionType::class, [
+        if (isset($this->values[DatagridInterface::PER_PAGE]) && \is_array($this->values[DatagridInterface::PER_PAGE])) {
+            $this->formBuilder->add(DatagridInterface::PER_PAGE, CollectionType::class, [
                 'entry_type' => $hiddenType,
                 'allow_add' => true,
             ]);
         } else {
-            $this->formBuilder->add('_per_page', $hiddenType);
+            $this->formBuilder->add(DatagridInterface::PER_PAGE, $hiddenType);
         }
 
         $this->form = $this->formBuilder->getForm();
@@ -282,16 +282,16 @@ class Datagrid implements DatagridInterface
         $values = $this->getValues();
 
         if ($this->isFieldAlreadySorted($fieldDescription)) {
-            if ('ASC' === $values['_sort_order']) {
-                $values['_sort_order'] = 'DESC';
+            if ('ASC' === $values[DatagridInterface::SORT_ORDER]) {
+                $values[DatagridInterface::SORT_ORDER] = 'DESC';
             } else {
-                $values['_sort_order'] = 'ASC';
+                $values[DatagridInterface::SORT_ORDER] = 'ASC';
             }
         } else {
-            $values['_sort_order'] = 'ASC';
+            $values[DatagridInterface::SORT_ORDER] = 'ASC';
         }
 
-        $values['_sort_by'] = \is_string($fieldDescription->getOption('sortable'))
+        $values[DatagridInterface::SORT_BY] = \is_string($fieldDescription->getOption('sortable'))
             ? $fieldDescription->getOption('sortable')
             : $fieldDescription->getName();
 
@@ -302,10 +302,10 @@ class Datagrid implements DatagridInterface
     {
         $values = $this->getValues();
 
-        if (isset($values['_sort_by']) && $values['_sort_by'] instanceof FieldDescriptionInterface) {
-            $values['_sort_by'] = $values['_sort_by']->getName();
+        if (isset($values[DatagridInterface::SORT_BY]) && $values[DatagridInterface::SORT_BY] instanceof FieldDescriptionInterface) {
+            $values[DatagridInterface::SORT_BY] = $values[DatagridInterface::SORT_BY]->getName();
         }
-        $values['_page'] = $page;
+        $values[DatagridInterface::PAGE] = $page;
 
         return ['filter' => $values];
     }
@@ -327,63 +327,63 @@ class Datagrid implements DatagridInterface
 
     private function applySorting(): void
     {
-        if (!isset($this->values['_sort_by'])) {
+        if (!isset($this->values[DatagridInterface::SORT_BY])) {
             return;
         }
 
-        if (!$this->values['_sort_by'] instanceof FieldDescriptionInterface) {
-            throw new UnexpectedTypeException($this->values['_sort_by'], FieldDescriptionInterface::class);
+        if (!$this->values[DatagridInterface::SORT_BY] instanceof FieldDescriptionInterface) {
+            throw new UnexpectedTypeException($this->values[DatagridInterface::SORT_BY], FieldDescriptionInterface::class);
         }
 
-        if (!$this->values['_sort_by']->isSortable()) {
+        if (!$this->values[DatagridInterface::SORT_BY]->isSortable()) {
             return;
         }
 
         $this->query->setSortBy(
-            $this->values['_sort_by']->getSortParentAssociationMapping(),
-            $this->values['_sort_by']->getSortFieldMapping()
+            $this->values[DatagridInterface::SORT_BY]->getSortParentAssociationMapping(),
+            $this->values[DatagridInterface::SORT_BY]->getSortFieldMapping()
         );
 
-        $this->values['_sort_order'] = $this->values['_sort_order'] ?? 'ASC';
-        $this->query->setSortOrder($this->values['_sort_order']);
+        $this->values[DatagridInterface::SORT_ORDER] = $this->values[DatagridInterface::SORT_ORDER] ?? 'ASC';
+        $this->query->setSortOrder($this->values[DatagridInterface::SORT_ORDER]);
     }
 
     private function getMaxPerPage(int $default): int
     {
-        if (!isset($this->values['_per_page'])) {
+        if (!isset($this->values[DatagridInterface::PER_PAGE])) {
             return $default;
         }
 
-        if (isset($this->values['_per_page']['value'])) {
-            return (int) $this->values['_per_page']['value'];
+        if (isset($this->values[DatagridInterface::PER_PAGE]['value'])) {
+            return (int) $this->values[DatagridInterface::PER_PAGE]['value'];
         }
 
-        return (int) $this->values['_per_page'];
+        return (int) $this->values[DatagridInterface::PER_PAGE];
     }
 
     private function getPage(int $default): int
     {
-        if (!isset($this->values['_page'])) {
+        if (!isset($this->values[DatagridInterface::PAGE])) {
             return $default;
         }
 
-        if (isset($this->values['_page']['value'])) {
-            return (int) $this->values['_page']['value'];
+        if (isset($this->values[DatagridInterface::PAGE]['value'])) {
+            return (int) $this->values[DatagridInterface::PAGE]['value'];
         }
 
-        return (int) $this->values['_page'];
+        return (int) $this->values[DatagridInterface::PAGE];
     }
 
     private function isFieldAlreadySorted(FieldDescriptionInterface $fieldDescription): bool
     {
         $values = $this->getValues();
 
-        if (!isset($values['_sort_by']) || !$values['_sort_by'] instanceof FieldDescriptionInterface) {
+        if (!isset($values[DatagridInterface::SORT_BY]) || !$values[DatagridInterface::SORT_BY] instanceof FieldDescriptionInterface) {
             return false;
         }
 
-        return $values['_sort_by']->getName() === $fieldDescription->getName()
-            || $values['_sort_by']->getName() === $fieldDescription->getOption('sortable');
+        return $values[DatagridInterface::SORT_BY]->getName() === $fieldDescription->getName()
+            || $values[DatagridInterface::SORT_BY]->getName() === $fieldDescription->getOption('sortable');
     }
 }
 

--- a/src/Datagrid/DatagridInterface.php
+++ b/src/Datagrid/DatagridInterface.php
@@ -28,6 +28,11 @@ use Symfony\Component\Form\FormInterface;
  */
 interface DatagridInterface
 {
+    public const SORT_ORDER = '_sort_order';
+    public const SORT_BY = '_sort_by';
+    public const PAGE = '_page';
+    public const PER_PAGE = '_per_page';
+
     /**
      * @return PagerInterface
      *

--- a/src/Form/Type/ModelAutocompleteType.php
+++ b/src/Form/Type/ModelAutocompleteType.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Form\Type;
 
+use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Form\DataTransformer\ModelToIdPropertyTransformer;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\EventListener\ResizeFormListener;
@@ -136,8 +137,8 @@ class ModelAutocompleteType extends AbstractType
             'route' => ['name' => 'sonata_admin_retrieve_autocomplete_items', 'parameters' => []],
             'req_params' => [],
             'req_param_name_search' => 'q',
-            'req_param_name_page_number' => '_page',
-            'req_param_name_items_per_page' => '_per_page',
+            'req_param_name_page_number' => DatagridInterface::PAGE,
+            'req_param_name_items_per_page' => DatagridInterface::PER_PAGE,
 
             // security
             'target_admin_access_action' => 'list',

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -69,11 +69,11 @@ file that was distributed with this source code.
                                                 {# NEXT_MAJOR: Remove next line and uncomment the other one #}
                                                 {% set sort_parameters      = sonata_sort_parameters(field_description, admin) %}
                                                 {# {% set sort_parameters      = admin.datagrid.sortparameters(field_description) %} #}
-                                                {% set current              = admin.datagrid.values._sort_by is defined
-                                                    and (admin.datagrid.values._sort_by == field_description
-                                                        or admin.datagrid.values._sort_by.name == sort_parameters.filter._sort_by) %}
+                                                {% set current              = admin.datagrid.values[constant('Sonata\\AdminBundle\\Datagrid\\DatagridInterface::SORT_BY')] is defined
+                                                    and (admin.datagrid.values[constant('Sonata\\AdminBundle\\Datagrid\\DatagridInterface::SORT_BY')] == field_description
+                                                        or admin.datagrid.values[constant('Sonata\\AdminBundle\\Datagrid\\DatagridInterface::SORT_BY')].name == sort_parameters.filter[constant('Sonata\\AdminBundle\\Datagrid\\DatagridInterface::SORT_BY')]) %}
                                                 {% set sort_active_class    = current ? 'sonata-ba-list-field-order-active' : '' %}
-                                                {% set sort_by              = current ? admin.datagrid.values._sort_order : field_description.option('_sort_order') %}
+                                                {% set sort_by              = current ? admin.datagrid.values[constant('Sonata\\AdminBundle\\Datagrid\\DatagridInterface::SORT_ORDER')] : field_description.option(constant('Sonata\\AdminBundle\\Datagrid\\DatagridInterface::SORT_ORDER')) %}
                                             {% endif %}
 
                                             {% apply spaceless %}
@@ -338,9 +338,9 @@ file that was distributed with this source code.
                                 {% endfor %}
                             </div>
                             <div class="col-sm-3 text-center">
-                                <input type="hidden" name="filter[_page]" id="filter__page" value="1">
+                                <input type="hidden" name="filter[{{ constant('Sonata\\AdminBundle\\Datagrid\\DatagridInterface::PAGE') }}]" id="filter__page" value="1">
 
-                                {% set foo = form['_page'].setRendered() %}
+                                {% set foo = form[constant('Sonata\\AdminBundle\\Datagrid\\DatagridInterface::PAGE')].setRendered() %}
                                 {{ form_rest(form) }}
 
                                 <div class="form-group">

--- a/src/Resources/views/Pager/base_results.html.twig
+++ b/src/Resources/views/Pager/base_results.html.twig
@@ -24,7 +24,10 @@ file that was distributed with this source code.
     <label class="control-label" for="{{ admin.uniqid }}_per_page">{% trans from 'SonataAdminBundle' %}label_per_page{% endtrans %}</label>
     <select class="per-page small form-control" id="{{ admin.uniqid }}_per_page" style="width: auto">
         {% for per_page in admin.getperpageoptions %}
-            <option {% if per_page == admin.datagrid.pager.maxperpage %}selected="selected"{% endif %} value="{{ admin.generateUrl(action, {'filter': admin.datagrid.values|merge({'_page': 1, '_per_page': per_page})}) }}">
+            <option {% if per_page == admin.datagrid.pager.maxperpage %}selected="selected"{% endif %} value="{{ admin.generateUrl(action, {'filter': admin.datagrid.values|merge({
+                (constant('Sonata\\AdminBundle\\Datagrid\\DatagridInterface::PAGE')): 1,
+                (constant('Sonata\\AdminBundle\\Datagrid\\DatagridInterface::PER_PAGE')): per_page})
+            }) }}">
                 {{- per_page -}}
             </option>
         {% endfor %}

--- a/tests/Action/RetrieveAutocompleteItemsActionTest.php
+++ b/tests/Action/RetrieveAutocompleteItemsActionTest.php
@@ -156,8 +156,8 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         $datagrid->method('getFilter')->with('foo')->willReturn($filter);
         $datagrid->expects($this->exactly(3))->method('setValue')->withConsecutive(
             ['foo', null, 'sonata'],
-            ['_per_page', null, 10],
-            ['_page', null, 1]
+            [DatagridInterface::PER_PAGE, null, 10],
+            [DatagridInterface::PAGE, null, 1]
         );
 
         $response = ($this->action)($request);
@@ -195,8 +195,8 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         $datagrid->expects($this->exactly(4))->method('setValue')->withConsecutive(
             ['entity__property', null, 'sonata'],
             ['entity2__property2', null, 'sonata'],
-            ['_per_page', null, 10],
-            ['_page', null, 1]
+            [DatagridInterface::PER_PAGE, null, 10],
+            [DatagridInterface::PAGE, null, 1]
         );
 
         $response = ($this->action)($request);
@@ -224,8 +224,8 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         $datagrid->method('getFilter')->with('entity.property')->willReturn($filter);
         $datagrid->expects($this->exactly(3))->method('setValue')->withConsecutive(
             ['entity__property', null, 'sonata'],
-            ['_per_page', null, 10],
-            ['_page', null, 1]
+            [DatagridInterface::PER_PAGE, null, 10],
+            [DatagridInterface::PAGE, null, 1]
         );
 
         $response = ($this->action)($request);
@@ -289,7 +289,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
             ['callback', null, null],
             ['minimum_input_length', null, 3],
             ['items_per_page', null, 10],
-            ['req_param_name_page_number', null, '_page'],
+            ['req_param_name_page_number', null, DatagridInterface::PAGE],
             ['to_string_callback', null, null],
             ['target_admin_access_action', null, 'list'],
             ['response_item_callback', null, null],
@@ -311,7 +311,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
             ['property', null, 'entity.property'],
             ['minimum_input_length', null, 3],
             ['items_per_page', null, 10],
-            ['req_param_name_page_number', null, '_page'],
+            ['req_param_name_page_number', null, DatagridInterface::PAGE],
             ['target_admin_access_action', null, 'list'],
             ['response_item_callback', null, null],
         ]);
@@ -332,7 +332,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
             ['property', null, ['entity.property', 'entity2.property2']],
             ['minimum_input_length', null, 3],
             ['items_per_page', null, 10],
-            ['req_param_name_page_number', null, '_page'],
+            ['req_param_name_page_number', null, DatagridInterface::PAGE],
             ['target_admin_access_action', null, 'list'],
             ['response_item_callback', null, null],
         ]);

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1841,8 +1841,8 @@ class AdminTest extends TestCase
             ->method('get')
             ->willReturn([
                 'filter' => [
-                    '_page' => '1',
-                    '_per_page' => '32',
+                    DatagridInterface::PAGE => '1',
+                    DatagridInterface::PER_PAGE => '32',
                 ],
             ]);
 
@@ -1878,18 +1878,18 @@ class AdminTest extends TestCase
         $modelManager
             ->method('getDefaultSortValues')
             ->willReturn([
-                '_sort_by' => 'id',
-                '_sort_order' => 'ASC',
+                DatagridInterface::SORT_BY => 'id',
+                DatagridInterface::SORT_ORDER => 'ASC',
             ]);
 
         $commentAdmin->setModelManager($modelManager);
 
         $parameters = $commentAdmin->getFilterParameters();
 
-        $this->assertArrayHasKey('_sort_by', $parameters);
-        $this->assertSame('id', $parameters['_sort_by']);
-        $this->assertArrayHasKey('_sort_order', $parameters);
-        $this->assertSame('ASC', $parameters['_sort_order']);
+        $this->assertArrayHasKey(DatagridInterface::SORT_BY, $parameters);
+        $this->assertSame('id', $parameters[DatagridInterface::SORT_BY]);
+        $this->assertArrayHasKey(DatagridInterface::SORT_ORDER, $parameters);
+        $this->assertSame('ASC', $parameters[DatagridInterface::SORT_ORDER]);
     }
 
     public function testGetFilterFieldDescription(): void
@@ -2391,8 +2391,8 @@ class AdminTest extends TestCase
         $admin->setModelManager($modelManager);
 
         $this->assertSame([
-            '_page' => 1,
-            '_per_page' => 32,
+            DatagridInterface::PAGE => 1,
+            DatagridInterface::PER_PAGE => 32,
             'foo' => [
                 'type' => '1',
                 'value' => 'bar',

--- a/tests/Controller/HelperControllerTest.php
+++ b/tests/Controller/HelperControllerTest.php
@@ -521,8 +521,8 @@ class HelperControllerTest extends TestCase
         $datagrid->method('getFilter')->with('foo')->willReturn($filter);
         $datagrid->expects($this->exactly(3))->method('setValue')->withConsecutive(
             ['foo', null, 'sonata'],
-            ['_per_page', null, 10],
-            ['_page', null, 1]
+            [DatagridInterface::PER_PAGE, null, 10],
+            [DatagridInterface::PAGE, null, 1]
         );
 
         $response = $this->controller->retrieveAutocompleteItemsAction($request);
@@ -562,8 +562,8 @@ class HelperControllerTest extends TestCase
         $datagrid->expects($this->exactly(4))->method('setValue')->withConsecutive(
             ['entity__property', null, 'sonata'],
             ['entity2__property2', null, 'sonata'],
-            ['_per_page', null, 10],
-            ['_page', null, 1]
+            [DatagridInterface::PER_PAGE, null, 10],
+            [DatagridInterface::PAGE, null, 1]
         );
 
         $response = $this->controller->retrieveAutocompleteItemsAction($request);
@@ -593,8 +593,8 @@ class HelperControllerTest extends TestCase
         $datagrid->method('getFilter')->with('entity.property')->willReturn($filter);
         $datagrid->expects($this->exactly(3))->method('setValue')->withConsecutive(
             ['entity__property', null, 'sonata'],
-            ['_per_page', null, 10],
-            ['_page', null, 1]
+            [DatagridInterface::PER_PAGE, null, 10],
+            [DatagridInterface::PAGE, null, 1]
         );
 
         $response = $this->controller->retrieveAutocompleteItemsAction($request);
@@ -657,7 +657,7 @@ class HelperControllerTest extends TestCase
             ['callback', null, null],
             ['minimum_input_length', null, 3],
             ['items_per_page', null, 10],
-            ['req_param_name_page_number', null, '_page'],
+            ['req_param_name_page_number', null, DatagridInterface::PAGE],
             ['to_string_callback', null, null],
             ['target_admin_access_action', null, 'list'],
         ]);
@@ -679,7 +679,7 @@ class HelperControllerTest extends TestCase
             ['callback', null, null],
             ['minimum_input_length', null, 3],
             ['items_per_page', null, 10],
-            ['req_param_name_page_number', null, '_page'],
+            ['req_param_name_page_number', null, DatagridInterface::PAGE],
             ['to_string_callback', null, null],
             ['target_admin_access_action', null, 'list'],
         ]);
@@ -701,7 +701,7 @@ class HelperControllerTest extends TestCase
             ['callback', null, null],
             ['minimum_input_length', null, 3],
             ['items_per_page', null, 10],
-            ['req_param_name_page_number', null, '_page'],
+            ['req_param_name_page_number', null, DatagridInterface::PAGE],
             ['to_string_callback', null, null],
             ['target_admin_access_action', null, 'list'],
         ]);

--- a/tests/Datagrid/DatagridTest.php
+++ b/tests/Datagrid/DatagridTest.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Tests\Datagrid;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Datagrid\Datagrid;
+use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Datagrid\PagerInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionCollection;
@@ -348,10 +349,10 @@ final class DatagridTest extends TestCase
         $this->assertSame(['help' => 'baz1'], $this->formBuilder->get('fooFormName')->getOptions()['operator_options']);
         $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('barFormName'));
         $this->assertSame(['help' => 'baz2'], $this->formBuilder->get('barFormName')->getOptions()['operator_options']);
-        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_sort_by'));
-        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_sort_order'));
-        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_page'));
-        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_per_page'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get(DatagridInterface::SORT_BY));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get(DatagridInterface::SORT_ORDER));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get(DatagridInterface::PAGE));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get(DatagridInterface::PER_PAGE));
     }
 
     /**
@@ -410,7 +411,7 @@ final class DatagridTest extends TestCase
 
         $this->datagrid->addFilter($filter);
 
-        $this->datagrid->setValue('_sort_by', 'foo', 'baz');
+        $this->datagrid->setValue(DatagridInterface::SORT_BY, 'foo', 'baz');
 
         $this->expectException(UnexpectedTypeException::class);
         $this->expectExceptionMessage('Expected argument of type "Sonata\\AdminBundle\\FieldDescription\\FieldDescriptionInterface", "array" given');
@@ -435,7 +436,7 @@ final class DatagridTest extends TestCase
             ->with($this->equalTo('1'))
             ->willReturn(null);
 
-        $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, ['_sort_by' => $sortBy]);
+        $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, [DatagridInterface::SORT_BY => $sortBy]);
 
         $filter = $this->createMock(FilterInterface::class);
         $filter->expects($this->once())
@@ -455,13 +456,13 @@ final class DatagridTest extends TestCase
 
         $this->datagrid->buildPager();
 
-        $this->assertSame(['_sort_by' => $sortBy, 'foo' => null, '_sort_order' => 'ASC'], $this->datagrid->getValues());
+        $this->assertSame([DatagridInterface::SORT_BY => $sortBy, 'foo' => null, DatagridInterface::SORT_ORDER => 'ASC'], $this->datagrid->getValues());
         $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('fooFormName'));
         $this->assertSame(['help' => 'baz'], $this->formBuilder->get('fooFormName')->getOptions()['operator_options']);
-        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_sort_by'));
-        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_sort_order'));
-        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_page'));
-        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_per_page'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get(DatagridInterface::SORT_BY));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get(DatagridInterface::SORT_ORDER));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get(DatagridInterface::PAGE));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get(DatagridInterface::PER_PAGE));
     }
 
     /**
@@ -484,7 +485,7 @@ final class DatagridTest extends TestCase
             ->with($this->equalTo('3'))
             ->willReturn(null);
 
-        $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, ['_sort_by' => $sortBy, '_page' => $page, '_per_page' => $perPage]);
+        $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, [DatagridInterface::SORT_BY => $sortBy, DatagridInterface::PAGE => $page, DatagridInterface::PER_PAGE => $perPage]);
 
         $filter = $this->createMock(FilterInterface::class);
         $filter->expects($this->once())
@@ -505,18 +506,18 @@ final class DatagridTest extends TestCase
         $this->datagrid->buildPager();
 
         $this->assertSame([
-            '_sort_by' => $sortBy,
-            '_page' => $page,
-            '_per_page' => $perPage,
+            DatagridInterface::SORT_BY => $sortBy,
+            DatagridInterface::PAGE => $page,
+            DatagridInterface::PER_PAGE => $perPage,
             'foo' => null,
-            '_sort_order' => 'ASC',
+            DatagridInterface::SORT_ORDER => 'ASC',
         ], $this->datagrid->getValues());
         $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('fooFormName'));
         $this->assertSame(['help' => 'baz'], $this->formBuilder->get('fooFormName')->getOptions()['operator_options']);
-        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_sort_by'));
-        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_sort_order'));
-        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_page'));
-        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_per_page'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get(DatagridInterface::SORT_BY));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get(DatagridInterface::SORT_ORDER));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get(DatagridInterface::PAGE));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get(DatagridInterface::PER_PAGE));
     }
 
     public function getBuildPagerWithPageTests(): array
@@ -548,19 +549,19 @@ final class DatagridTest extends TestCase
             ->willReturn(null);
 
         $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, []);
-        $this->datagrid->setValue('_per_page', null, $perPage);
-        $this->datagrid->setValue('_page', null, $page);
+        $this->datagrid->setValue(DatagridInterface::PER_PAGE, null, $perPage);
+        $this->datagrid->setValue(DatagridInterface::PAGE, null, $page);
 
         $this->datagrid->buildPager();
 
         $this->assertSame([
-            '_per_page' => ['type' => null, 'value' => $perPage],
-            '_page' => ['type' => null, 'value' => $page],
+            DatagridInterface::PER_PAGE => ['type' => null, 'value' => $perPage],
+            DatagridInterface::PAGE => ['type' => null, 'value' => $page],
         ], $this->datagrid->getValues());
-        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_sort_by'));
-        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_sort_order'));
-        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_page'));
-        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get('_per_page'));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get(DatagridInterface::SORT_BY));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get(DatagridInterface::SORT_ORDER));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get(DatagridInterface::PAGE));
+        $this->assertInstanceOf(FormBuilder::class, $this->formBuilder->get(DatagridInterface::PER_PAGE));
     }
 
     public function getBuildPagerWithPage2Tests(): array
@@ -591,36 +592,36 @@ final class DatagridTest extends TestCase
             $this->columns,
             $this->pager,
             $this->formBuilder,
-            ['_sort_by' => $field1, '_sort_order' => 'ASC']
+            [DatagridInterface::SORT_BY => $field1, DatagridInterface::SORT_ORDER => 'ASC']
         );
 
         $parameters = $this->datagrid->getSortParameters($field1);
 
-        $this->assertSame('DESC', $parameters['filter']['_sort_order']);
-        $this->assertSame('field1', $parameters['filter']['_sort_by']);
+        $this->assertSame('DESC', $parameters['filter'][DatagridInterface::SORT_ORDER]);
+        $this->assertSame('field1', $parameters['filter'][DatagridInterface::SORT_BY]);
 
         $parameters = $this->datagrid->getSortParameters($field2);
 
-        $this->assertSame('ASC', $parameters['filter']['_sort_order']);
-        $this->assertSame('field2', $parameters['filter']['_sort_by']);
+        $this->assertSame('ASC', $parameters['filter'][DatagridInterface::SORT_ORDER]);
+        $this->assertSame('field2', $parameters['filter'][DatagridInterface::SORT_BY]);
 
         $parameters = $this->datagrid->getSortParameters($field3);
 
-        $this->assertSame('ASC', $parameters['filter']['_sort_order']);
-        $this->assertSame('field3sortBy', $parameters['filter']['_sort_by']);
+        $this->assertSame('ASC', $parameters['filter'][DatagridInterface::SORT_ORDER]);
+        $this->assertSame('field3sortBy', $parameters['filter'][DatagridInterface::SORT_BY]);
 
         $this->datagrid = new Datagrid(
             $this->query,
             $this->columns,
             $this->pager,
             $this->formBuilder,
-            ['_sort_by' => $field3, '_sort_order' => 'ASC']
+            [DatagridInterface::SORT_BY => $field3, DatagridInterface::SORT_ORDER => 'ASC']
         );
 
         $parameters = $this->datagrid->getSortParameters($field3);
 
-        $this->assertSame('DESC', $parameters['filter']['_sort_order']);
-        $this->assertSame('field3sortBy', $parameters['filter']['_sort_by']);
+        $this->assertSame('DESC', $parameters['filter'][DatagridInterface::SORT_ORDER]);
+        $this->assertSame('field3sortBy', $parameters['filter'][DatagridInterface::SORT_BY]);
     }
 
     public function testGetPaginationParameters(): void
@@ -632,14 +633,14 @@ final class DatagridTest extends TestCase
             $this->columns,
             $this->pager,
             $this->formBuilder,
-            ['_sort_by' => $field, '_sort_order' => 'ASC']
+            [DatagridInterface::SORT_BY => $field, DatagridInterface::SORT_ORDER => 'ASC']
         );
 
         $field->expects($this->once())->method('getName')->willReturn($name = 'test');
 
         $result = $this->datagrid->getPaginationParameters($page = 5);
 
-        $this->assertSame($page, $result['filter']['_page']);
-        $this->assertSame($name, $result['filter']['_sort_by']);
+        $this->assertSame($page, $result['filter'][DatagridInterface::PAGE]);
+        $this->assertSame($name, $result['filter'][DatagridInterface::SORT_BY]);
     }
 }

--- a/tests/Filter/Persister/SessionFilterPersisterTest.php
+++ b/tests/Filter/Persister/SessionFilterPersisterTest.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Tests\Filter\Persister;
 
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Filter\Persister\SessionFilterPersister;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
@@ -48,10 +49,10 @@ class SessionFilterPersisterTest extends TestCase
     {
         $filters = [
             'active' => true,
-            '_page' => 1,
-            '_sort_by' => 'firstName',
-            '_sort_order' => 'ASC',
-            '_per_page' => 25,
+            DatagridInterface::PAGE => 1,
+            DatagridInterface::SORT_BY => 'firstName',
+            DatagridInterface::SORT_ORDER => 'ASC',
+            DatagridInterface::PER_PAGE => 25,
         ];
         $this->session->expects($this->once())->method('get')
             ->with('admin.customer.filter.parameters', [])
@@ -64,10 +65,10 @@ class SessionFilterPersisterTest extends TestCase
     {
         $filters = [
             'active' => true,
-            '_page' => 1,
-            '_sort_by' => 'firstName',
-            '_sort_order' => 'ASC',
-            '_per_page' => 25,
+            DatagridInterface::PAGE => 1,
+            DatagridInterface::SORT_BY => 'firstName',
+            DatagridInterface::SORT_ORDER => 'ASC',
+            DatagridInterface::PER_PAGE => 25,
         ];
         $this->session->expects($this->once())->method('set')
             ->with('admin.customer.filter.parameters', $filters)

--- a/tests/Form/Type/ModelAutocompleteTypeTest.php
+++ b/tests/Form/Type/ModelAutocompleteTypeTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\Form\Type;
 
+use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\Test\TypeTestCase;
@@ -61,8 +62,8 @@ class ModelAutocompleteTypeTest extends TypeTestCase
         $this->assertSame(['name' => 'sonata_admin_retrieve_autocomplete_items', 'parameters' => []], $options['route']);
         $this->assertSame([], $options['req_params']);
         $this->assertSame('q', $options['req_param_name_search']);
-        $this->assertSame('_page', $options['req_param_name_page_number']);
-        $this->assertSame('_per_page', $options['req_param_name_items_per_page']);
+        $this->assertSame(DatagridInterface::PAGE, $options['req_param_name_page_number']);
+        $this->assertSame(DatagridInterface::PER_PAGE, $options['req_param_name_items_per_page']);
 
         $this->assertSame('list', $options['target_admin_access_action']);
         $this->assertNull($options['response_item_callback']);

--- a/tests/Twig/Extension/PaginationExtensionTest.php
+++ b/tests/Twig/Extension/PaginationExtensionTest.php
@@ -29,7 +29,7 @@ final class PaginationExtensionTest extends TestCase
     {
         $paginationParameters = [
             'filter' => [
-                '_page' => 1,
+                DatagridInterface::PAGE => 1,
             ],
         ];
 
@@ -55,7 +55,7 @@ final class PaginationExtensionTest extends TestCase
     {
         $paginationParameters = [
             'filter' => [
-                '_page' => 1,
+                DatagridInterface::PAGE => 1,
             ],
         ];
 
@@ -82,8 +82,8 @@ final class PaginationExtensionTest extends TestCase
     {
         $sortParameters = [
             'filter' => [
-                '_sort_order' => 'ASC',
-                '_sort_by' => 'name',
+                DatagridInterface::SORT_ORDER => 'ASC',
+                DatagridInterface::SORT_BY => 'name',
             ],
         ];
 
@@ -111,8 +111,8 @@ final class PaginationExtensionTest extends TestCase
     {
         $sortParameters = [
             'filter' => [
-                '_sort_order' => 'ASC',
-                '_sort_by' => 'name',
+                DatagridInterface::SORT_ORDER => 'ASC',
+                DatagridInterface::SORT_BY => 'name',
             ],
         ];
 

--- a/tests/Util/ParametersManipulatorTest.php
+++ b/tests/Util/ParametersManipulatorTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Util;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Util\ParametersManipulator;
 
 /**
@@ -26,8 +27,8 @@ class ParametersManipulatorTest extends TestCase
         return [
             [
                 [
-                    '_sort_order' => 'DESC',
-                    '_sort_by' => 'id',
+                    DatagridInterface::SORT_ORDER => 'DESC',
+                    DatagridInterface::SORT_BY => 'id',
                     'status' => [
                         'type' => '1',
                         'value' => 'foo',
@@ -40,8 +41,8 @@ class ParametersManipulatorTest extends TestCase
                     ],
                 ],
                 [
-                    '_sort_order' => 'DESC',
-                    '_sort_by' => 'id',
+                    DatagridInterface::SORT_ORDER => 'DESC',
+                    DatagridInterface::SORT_BY => 'id',
                     'status' => [
                         'type' => '2',
                         'value' => 'foo',
@@ -77,16 +78,16 @@ class ParametersManipulatorTest extends TestCase
                     'status' => [
                         'type' => '2',
                     ],
-                    '_page' => 2,
-                    '_per_page' => 25,
+                    DatagridInterface::PAGE => 2,
+                    DatagridInterface::PER_PAGE => 25,
                 ],
                 [
                     'status' => [
                         'type' => '2',
                         'value' => 'foo',
                     ],
-                    '_page' => 2,
-                    '_per_page' => 25,
+                    DatagridInterface::PAGE => 2,
+                    DatagridInterface::PER_PAGE => 25,
                 ],
             ],
             [


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Some polishing, there are multiples places where these strings are used, this replaces the scalar strings by constants.

Since they seem related to `Datagrid`, I've created them in `DatagridInterface`. ~I've chosen `KEY_` prefix, but any other name is welcome.~

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `DatagridInterface::SORT_ORDER` constant to use it instead of `_sort_order` string.
- Added `DatagridInterface::SORT_BY` constant to use it instead of `_sort_by` string.
- Added `DatagridInterface::PAGE` constant to use it instead of `_page` string.
- Added `DatagridInterface::PER_PAGE` constant to use it instead of `_per_page` string.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
