### PR TITLE
Update addIdentifierToQuery phpdoc

### DIFF
--- a/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
+++ b/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
@@ -119,9 +119,13 @@ class ModelToIdPropertyTransformer implements DataTransformerInterface
             $value[$key] = (string) $id;
         }
 
-        $query = $this->modelManager->createQuery($this->className);
-        $this->modelManager->addIdentifiersToQuery($this->className, $query, $value);
-        $result = $this->modelManager->executeQuery($query);
+        if ([] === $value) {
+            $result = $value;
+        } else {
+            $query = $this->modelManager->createQuery($this->className);
+            $this->modelManager->addIdentifiersToQuery($this->className, $query, $value);
+            $result = $this->modelManager->executeQuery($query);
+        }
 
         return TraversableToCollection::transform($result);
     }

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -362,7 +362,8 @@ interface ModelManagerInterface extends DatagridManagerInterface
      * @param string                 $class
      * @param array<int, int|string> $idx
      *
-     * @phpstan-param class-string<T> $class
+     * @phpstan-param class-string<T>             $class
+     * @phpstan-param non-empty-array<string|int> $idx
      */
     public function addIdentifiersToQuery($class, ProxyQueryInterface $query, array $idx);
 }


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

In the persistence bundle, an empty array isn't allowed.
In this bundle we're doing a empty check before calling this method.

## Changelog

```markdown
### Fixed
- addIdentifierToQuery phpdoc to reflect the fact that it shouldn't be called with an empty array of identifier
```