### PR TITLE
Sidebar menu toggle with admin-lte 2.4

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,18 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.xx to 3.xx
+=========================
+
+### Admin-lte v2.4
+
+Admin-lte was upgraded from 2.3.x to 2.4.x. There are a few BC breaks related to some classes and data-attributes.
+
+Please, make sure you follow this guide if you were overriding Sonata default templates before upgrading: https://adminlte.io/docs/2.4/upgrade-guide
+
+One of the most important ones is the `data-toggle` for the sidebar menu. Before we used `offcanvas` and now it is using `push-menu`, If you are overriding the `standard-layout.html.twig` you might be affected by this change.
+
+
 UPGRADE FROM 3.95 to 3.96
 =========================
 

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -150,7 +150,7 @@ file that was distributed with this source code.
                 {% endblock %}
                 {% block sonata_nav %}
                     <nav class="navbar navbar-static-top">
-                        <a href="#" class="sidebar-toggle" data-toggle="offcanvas"
+                        <a href="#" class="sidebar-toggle" data-toggle="push-menu"
                            role="button" title="{{ 'toggle_navigation'|trans({}, 'SonataAdminBundle') }}">
                             <span class="sr-only">{{ 'toggle_navigation'|trans({}, 'SonataAdminBundle') }}</span>
                         </a>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a bug fix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed main sidebar toggling
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->

The upgrade to admin lte v4: https://github.com/sonata-project/SonataAdminBundle/pull/7032 broke the sidebar menu, we are unable to toggle (open/close) it.

It is kind of bc break on their side: https://github.com/ColorlibHQ/AdminLTE/issues/1666

This change fixes it.
