### PR TITLE
Add render_breadcrumbs and render_breadcrumbs_for_title twig functions

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,14 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=======================
+
+### Deprecated overriding `breadcrumbs_builder` variable in templates
+
+This variable will not be used anymore for creating breadcrumbs, you MUST decorate or override
+`sonata.admin.breadcrumbs_builder` service instead.
+
 UPGRADE FROM 3.96 to 3.97
 =========================
 
@@ -11,7 +19,6 @@ Admin-lte was upgraded from 2.3.x to 2.4.x. There are a few BC breaks related to
 Please, make sure you follow this guide if you were overriding Sonata default templates before upgrading: https://adminlte.io/docs/2.4/upgrade-guide
 
 One of the most important ones is the `data-toggle` for the sidebar menu. Before we used `offcanvas` and now it is using `push-menu`, If you are overriding the `standard-layout.html.twig` you might be affected by this change.
-
 
 UPGRADE FROM 3.95 to 3.96
 =========================

--- a/src/Action/DashboardAction.php
+++ b/src/Action/DashboardAction.php
@@ -28,6 +28,8 @@ final class DashboardAction
     private $dashboardBlocks = [];
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
      * @var BreadcrumbsBuilderInterface
      */
     private $breadcrumbsBuilder;
@@ -49,12 +51,14 @@ final class DashboardAction
 
     public function __construct(
         array $dashboardBlocks,
+        // NEXT_MAJOR: Remove next line.
         BreadcrumbsBuilderInterface $breadcrumbsBuilder,
         TemplateRegistryInterface $templateRegistry,
         Pool $pool,
         Environment $twig
     ) {
         $this->dashboardBlocks = $dashboardBlocks;
+        // NEXT_MAJOR: Remove next line.
         $this->breadcrumbsBuilder = $breadcrumbsBuilder;
         $this->templateRegistry = $templateRegistry;
         $this->pool = $pool;
@@ -84,6 +88,7 @@ final class DashboardAction
             'blocks' => $blocks,
         ];
 
+        // NEXT_MAJOR: Remove the entire if block.
         if (!$request->isXmlHttpRequest()) {
             $parameters['breadcrumbs_builder'] = $this->breadcrumbsBuilder;
         }

--- a/src/Action/SearchAction.php
+++ b/src/Action/SearchAction.php
@@ -38,6 +38,8 @@ final class SearchAction
     private $searchHandler;
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
      * @var TemplateRegistryInterface
      */
     private $templateRegistry;
@@ -56,12 +58,14 @@ final class SearchAction
         Pool $pool,
         SearchHandler $searchHandler,
         TemplateRegistryInterface $templateRegistry,
+        // NEXT_MAJOR: Remove next line.
         BreadcrumbsBuilderInterface $breadcrumbsBuilder,
         Environment $twig
     ) {
         $this->pool = $pool;
         $this->searchHandler = $searchHandler;
         $this->templateRegistry = $templateRegistry;
+        // NEXT_MAJOR: Remove next line.
         $this->breadcrumbsBuilder = $breadcrumbsBuilder;
         $this->twig = $twig;
     }
@@ -79,6 +83,7 @@ final class SearchAction
                 'base_template' => $request->isXmlHttpRequest() ?
                     $this->templateRegistry->getTemplate('ajax') :
                     $this->templateRegistry->getTemplate('layout'),
+                // NEXT_MAJOR: Remove next line.
                 'breadcrumbs_builder' => $this->breadcrumbsBuilder,
                 // NEXT_MAJOR: Remove next line.
                 'admin_pool' => $this->pool,

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1142,6 +1142,7 @@ class CRUDController implements ContainerAwareInterface
      */
     protected function addRenderExtraParams(array $parameters = []): array
     {
+        // NEXT_MAJOR: Remove the entire if block.
         if (!$this->isXmlHttpRequest()) {
             $parameters['breadcrumbs_builder'] = $this->get('sonata.admin.breadcrumbs_builder');
         }

--- a/src/Resources/config/actions.php
+++ b/src/Resources/config/actions.php
@@ -31,6 +31,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->public()
             ->args([
                 '%sonata.admin.configuration.dashboard_blocks%',
+                // NEXT_MAJOR: Remove next line.
                 new ReferenceConfigurator('sonata.admin.breadcrumbs_builder'),
                 new ReferenceConfigurator('sonata.admin.global_template_registry'),
                 new ReferenceConfigurator('sonata.admin.pool'),
@@ -49,6 +50,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ReferenceConfigurator('sonata.admin.pool'),
                 new ReferenceConfigurator('sonata.admin.search.handler'),
                 new ReferenceConfigurator('sonata.admin.global_template_registry'),
+                // NEXT_MAJOR: Remove next line.
                 new ReferenceConfigurator('sonata.admin.breadcrumbs_builder'),
                 new ReferenceConfigurator('twig'),
             ])

--- a/src/Resources/config/twig.php
+++ b/src/Resources/config/twig.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+use Sonata\AdminBundle\Twig\Extension\BreadcrumbsExtension;
 use Sonata\AdminBundle\Twig\Extension\CanonicalizeExtension;
 use Sonata\AdminBundle\Twig\Extension\GroupExtension;
 use Sonata\AdminBundle\Twig\Extension\PaginationExtension;
@@ -95,5 +96,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ReferenceConfigurator('property_accessor'),
                 new ReferenceConfigurator('service_container'),
                 (new ReferenceConfigurator('logger'))->nullOnInvalid(),
+            ])
+
+        ->set('sonata.admin.twig.breadcrumbs_extension', BreadcrumbsExtension::class)
+            ->tag('twig.extension')
+            ->args([
+                new ReferenceConfigurator('sonata.admin.breadcrumbs_builder'),
             ]);
 };

--- a/src/Resources/views/Breadcrumb/breadcrumb.html.twig
+++ b/src/Resources/views/Breadcrumb/breadcrumb.html.twig
@@ -1,0 +1,28 @@
+{% apply spaceless %}
+{% for menu in items %}
+    {%- set translation_domain = menu.extra('translation_domain', 'messages') -%}
+    {# We use method accessor instead of ".label" since `menu` implements `ArrayAccess` and could have a property called "label". #}
+    {%- set label = menu.getLabel() -%}
+    {%- if translation_domain is not same as(false) -%}
+        {%- set label = label|trans(menu.extra('translation_params', {}), translation_domain) -%}
+    {%- endif -%}
+
+    {% if not loop.last %}
+        <li>
+            {% if menu.uri is not empty %}
+                <a href="{{ menu.uri }}">
+                    {% if menu.extra('safe_label', true) %}
+                        {{- label|raw -}}
+                    {% else %}
+                        {{- label|u.truncate(100, '...') -}}
+                    {% endif %}
+                </a>
+            {% else %}
+                <span>{{ label|u.truncate(100, '...') }}</span>
+            {% endif %}
+        </li>
+    {% else %}
+        <li class="active"><span>{{ label|u.truncate(100, '...') }}</span></li>
+    {% endif %}
+{% endfor %}
+{% endapply %}

--- a/src/Resources/views/Breadcrumb/breadcrumb_title.html.twig
+++ b/src/Resources/views/Breadcrumb/breadcrumb_title.html.twig
@@ -1,0 +1,16 @@
+{% for menu in items %}
+    {% if not loop.first %}
+        {% if loop.index != 2 %}
+            &gt;
+        {% endif %}
+
+        {%- set translation_domain = menu.extra('translation_domain', 'messages') -%}
+        {# We use method accessor instead of ".label" since `menu` implements `ArrayAccess` and could have a property called "label". #}
+        {%- set label = menu.getLabel() -%}
+        {%- if translation_domain is not same as(false) -%}
+            {%- set label = label|trans(menu.extra('translation_params', {}), translation_domain) -%}
+        {%- endif -%}
+
+        {{ label }}
+    {% endif %}
+{% endfor %}

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -93,22 +93,8 @@ file that was distributed with this source code.
             {% else %}
                 {% if action is defined %}
                     -
-                    {% for menu in breadcrumbs_builder.breadcrumbs(admin, action) %}
-                        {% if not loop.first %}
-                            {% if loop.index != 2 %}
-                                &gt;
-                            {% endif %}
-
-                            {%- set translation_domain = menu.extra('translation_domain', 'messages') -%}
-                            {# We use method accessor instead of ".label" since `menu` implements `ArrayAccess` and could have a property called "label". #}
-                            {%- set label = menu.getLabel() -%}
-                            {%- if translation_domain is not same as(false) -%}
-                                {%- set label = label|trans(menu.extra('translation_params', {}), translation_domain) -%}
-                            {%- endif -%}
-
-                            {{ label }}
-                        {% endif %}
-                    {% endfor %}
+                    {# NEXT_MAJOR: Remove breadcrumbs_builder argument. #}
+                    {{ render_breadcrumbs_for_title(admin, action, breadcrumbs_builder|default(null)) }}
                 {% endif %}
             {% endif %}
         {% endblock %}
@@ -162,32 +148,8 @@ file that was distributed with this source code.
                                         <ol class="nav navbar-top-links breadcrumb">
                                             {% if _breadcrumb is empty %}
                                                 {% if action is defined %}
-                                                    {% for menu in breadcrumbs_builder.breadcrumbs(admin, action) %}
-                                                        {%- set translation_domain = menu.extra('translation_domain', 'messages') -%}
-                                                        {# We use method accessor instead of ".label" since `menu` implements `ArrayAccess` and could have a property called "label". #}
-                                                        {%- set label = menu.getLabel() -%}
-                                                        {%- if translation_domain is not same as(false) -%}
-                                                            {%- set label = label|trans(menu.extra('translation_params', {}), translation_domain) -%}
-                                                        {%- endif -%}
-
-                                                        {% if not loop.last %}
-                                                            <li>
-                                                                {% if menu.uri is not empty %}
-                                                                    <a href="{{ menu.uri }}">
-                                                                        {% if menu.extra('safe_label', true) %}
-                                                                            {{- label|raw -}}
-                                                                        {% else %}
-                                                                            {{- label|u.truncate(100, '...') -}}
-                                                                        {% endif %}
-                                                                    </a>
-                                                                {% else %}
-                                                                    <span>{{ label|u.truncate(100, '...') }}</span>
-                                                                {% endif %}
-                                                            </li>
-                                                        {% else %}
-                                                            <li class="active"><span>{{ label|u.truncate(100, '...') }}</span></li>
-                                                        {% endif %}
-                                                    {% endfor %}
+                                                    {# NEXT_MAJOR: Remove breadcrumbs_builder argument. #}
+                                                    {{ render_breadcrumbs(admin, action, breadcrumbs_builder|default(null)) }}
                                                 {% endif %}
                                             {% else %}
                                                 {{ _breadcrumb|raw }}

--- a/src/Twig/Extension/BreadcrumbsExtension.php
+++ b/src/Twig/Extension/BreadcrumbsExtension.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Twig\Extension;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class BreadcrumbsExtension extends AbstractExtension
+{
+    /**
+     * @var BreadcrumbsBuilderInterface
+     */
+    private $breadcrumbsBuilder;
+
+    /**
+     * @internal
+     */
+    public function __construct(BreadcrumbsBuilderInterface $breadcrumbsBuilder)
+    {
+        $this->breadcrumbsBuilder = $breadcrumbsBuilder;
+    }
+
+    /**
+     * @return TwigFunction[]
+     */
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('render_breadcrumbs', [$this, 'renderBreadcrumbs'], [
+                'is_safe' => ['html'],
+                'needs_environment' => true,
+            ]),
+            new TwigFunction('render_breadcrumbs_for_title', [$this, 'renderBreadcrumbsForTitle'], [
+                'is_safe' => ['html'],
+                'needs_environment' => true,
+            ]),
+        ];
+    }
+
+    // NEXT_MAJOR: Remove $breadcrumbsBuilder parameter;
+    public function renderBreadcrumbs(
+        Environment $environment,
+        AdminInterface $admin,
+        string $action,
+        ?BreadcrumbsBuilderInterface $breadcrumbsBuilderForBC = null
+    ): string {
+        // NEXT_MAJOR: Remove next line.
+        $breadcrumbsBuilder = $this->breadcrumbsBuilder;
+
+        // NEXT_MAJOR: Remove the entire if block.
+        if (null !== $breadcrumbsBuilderForBC && \get_class($breadcrumbsBuilderForBC) !== \get_class($this->breadcrumbsBuilder)) {
+            @trigger_error(
+                'Overriding "breadcrumbs_builder" parameter in twig templates is deprecated since'
+                .' sonata-project/admin-bundle version 3.x. Use "sonata.admin.breadcrumbs_builder" service instead.',
+                \E_USER_DEPRECATED
+            );
+
+            $breadcrumbsBuilder = $breadcrumbsBuilderForBC;
+        }
+
+        return $environment->render('@SonataAdmin/Breadcrumb/breadcrumb.html.twig', [
+            // NEXT_MAJOR: Use $this->breadcrumbsBuilder.
+            'items' => $breadcrumbsBuilder->getBreadcrumbs($admin, $action),
+        ]);
+    }
+
+    // NEXT_MAJOR: Remove $breadcrumbsBuilder parameter;
+    public function renderBreadcrumbsForTitle(
+        Environment $environment,
+        AdminInterface $admin,
+        string $action,
+        ?BreadcrumbsBuilderInterface $breadcrumbsBuilderForBC = null
+    ): string {
+        // NEXT_MAJOR: Remove next line.
+        $breadcrumbsBuilder = $this->breadcrumbsBuilder;
+
+        // NEXT_MAJOR: Remove the entire if block.
+        if (null !== $breadcrumbsBuilderForBC && \get_class($breadcrumbsBuilderForBC) !== \get_class($this->breadcrumbsBuilder)) {
+            @trigger_error(
+                'Overriding "breadcrumbs_builder" parameter in twig templates is deprecated since'
+                .' sonata-project/admin-bundle version 3.x. Use "sonata.admin.breadcrumbs_builder" service instead.',
+                \E_USER_DEPRECATED
+            );
+
+            $breadcrumbsBuilder = $breadcrumbsBuilderForBC;
+        }
+
+        return $environment->render('@SonataAdmin/Breadcrumb/breadcrumb_title.html.twig', [
+            // NEXT_MAJOR: Use $this->breadcrumbsBuilder.
+            'items' => $breadcrumbsBuilder->getBreadcrumbs($admin, $action),
+        ]);
+    }
+}

--- a/tests/Action/SearchActionTest.php
+++ b/tests/Action/SearchActionTest.php
@@ -87,6 +87,7 @@ final class SearchActionTest extends TestCase
         $request = new Request(['q' => 'some search']);
         $this->twig->method('render')->with('search.html.twig', [
             'base_template' => 'layout.html.twig',
+            // NEXT_MAJOR: Remove next line.
             'breadcrumbs_builder' => $this->breadcrumbsBuilder,
             // NEXT_MAJOR: Remove next line.
             'admin_pool' => $this->pool,

--- a/tests/Twig/Extension/BreadcrumbsExtensionTest.php
+++ b/tests/Twig/Extension/BreadcrumbsExtensionTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Twig\Extension;
+
+use Knp\Menu\ItemInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
+use Sonata\AdminBundle\Tests\Fixtures\StubFilesystemLoader;
+use Sonata\AdminBundle\Tests\Fixtures\StubTranslator;
+use Sonata\AdminBundle\Twig\Extension\BreadcrumbsExtension;
+// NEXT_MAJOR: Remove next line.
+use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
+use Symfony\Bridge\Twig\Extension\TranslationExtension;
+use Twig\Environment;
+use Twig\Extra\String\StringExtension;
+
+final class BreadcrumbsExtensionTest extends TestCase
+{
+    // NEXT_MAJOR: Remove next line.
+    use ExpectDeprecationTrait;
+
+    /**
+     * @var BreadcrumbsExtension
+     */
+    private $breadcrumbsExtension;
+
+    /**
+     * @var Environment
+     */
+    private $environment;
+
+    /**
+     * NEXT_MAJOR: Replace to MockObject by Stub.
+     *
+     * @var MockObject&BreadcrumbsBuilderInterface
+     */
+    private $breadcrumbBuilder;
+
+    protected function setUp(): void
+    {
+        $loader = new StubFilesystemLoader();
+        $loader->addPath(__DIR__.'/../../../src/Resources/views/', 'SonataAdmin');
+
+        $this->environment = new Environment($loader, [
+            'strict_variables' => true,
+            'cache' => false,
+            'autoescape' => 'html',
+            'optimizations' => 0,
+        ]);
+        $this->environment->addExtension(new TranslationExtension(new StubTranslator()));
+        $this->environment->addExtension(new StringExtension());
+
+        // NEXT_MAJOR: Use $this->createStub instead.
+        $this->breadcrumbBuilder = $this->createMock(BreadcrumbsBuilderInterface::class);
+
+        $this->breadcrumbsExtension = new BreadcrumbsExtension($this->breadcrumbBuilder);
+    }
+
+    public function testBreadcrumbsForTitle(): void
+    {
+        $item = $this->createMock(ItemInterface::class);
+        $item2 = $this->createMock(ItemInterface::class);
+        $item2
+            ->method('getLabel')
+            ->willReturn('Label for item 2');
+        $item2
+            ->method('getExtra')
+            ->withConsecutive(
+                ['translation_domain'],
+                ['translation_params']
+            )
+            ->willReturnOnConsecutiveCalls(
+                false,
+                []
+            );
+
+        $item3 = $this->createMock(ItemInterface::class);
+        $item3
+            ->method('getLabel')
+            ->willReturn('Label for item 3 with %parameter%');
+        $item3
+            ->method('getExtra')
+            ->withConsecutive(
+                ['translation_domain'],
+                ['translation_params']
+            )
+            ->willReturnOnConsecutiveCalls(
+                'custom_translation_domain',
+                ['%parameter%' => 'custom_parameter']
+            );
+
+        $this->breadcrumbBuilder
+            ->method('getBreadcrumbs')
+            ->willReturn([$item, $item2, $item3]);
+
+        $this->assertSame(
+            'Label for item 2 &gt; [trans domain=custom_translation_domain]Label for item 3 with custom_parameter[/trans]',
+            $this->removeExtraWhitespace($this->breadcrumbsExtension->renderBreadcrumbsForTitle(
+                $this->environment,
+                $this->createStub(AdminInterface::class),
+                'not_important',
+            ))
+        );
+    }
+
+    public function testBreadcrumbs(): void
+    {
+        $item = $this->createMock(ItemInterface::class);
+        $item
+            ->method('getLabel')
+            ->willReturn('Label for item 1');
+        $item
+            ->method('getExtra')
+            ->withConsecutive(
+                ['translation_domain'],
+                ['translation_params']
+            )
+            ->willReturnOnConsecutiveCalls(
+                false,
+                []
+            );
+
+        $item2 = $this->createMock(ItemInterface::class);
+        $item2
+            ->method('getLabel')
+            ->willReturn('Label for item 2 with %parameter%');
+        $item2
+            ->method('getUri')
+            ->willReturn('https://sonata-project.org');
+        $item2
+            ->method('getExtra')
+            ->withConsecutive(
+                ['translation_domain'],
+                ['translation_params']
+            )
+            ->willReturnOnConsecutiveCalls(
+                'custom_translation_domain',
+                ['%parameter%' => 'custom_parameter']
+            );
+
+        $item3 = $this->createMock(ItemInterface::class);
+        $item3
+            ->method('getLabel')
+            ->willReturn('Label for item 3');
+        $item3
+            ->method('getExtra')
+            ->withConsecutive(
+                ['translation_domain'],
+                ['translation_params']
+            )
+            ->willReturnOnConsecutiveCalls(
+                false,
+                []
+            );
+
+        $this->breadcrumbBuilder
+            ->method('getBreadcrumbs')
+            ->willReturn([$item, $item2, $item3]);
+
+        $expected =
+            '<li><span>Label for item 1</span></li>'
+            .'<li>'
+                .'<a href="https://sonata-project.org"> '
+                    .'[trans domain=custom_translation_domain]Label for item 2 with custom_parameter[/trans] '
+                .'</a>'
+            .'</li>'
+            .'<li class="active"><span>Label for item 3</span></li>';
+
+        $this->assertSame(
+            $expected,
+            $this->removeExtraWhitespace($this->breadcrumbsExtension->renderBreadcrumbs(
+                $this->environment,
+                $this->createStub(AdminInterface::class),
+                'not_important',
+            ))
+        );
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
+    public function testUsingExternalBreadcrumbsBuilderForBC(): void
+    {
+        $customBreadcrumbsBuilder = new class() implements BreadcrumbsBuilderInterface {
+            /**
+             * @var int
+             */
+            public $numberOfCalls = 0;
+
+            public function getBreadcrumbs(AdminInterface $admin, $action): array
+            {
+                ++$this->numberOfCalls;
+
+                return [];
+            }
+
+            public function buildBreadcrumbs(AdminInterface $admin, $action, ?ItemInterface $menu = null): void
+            {
+            }
+        };
+
+        $this->breadcrumbBuilder
+            ->expects($this->never())
+            ->method('getBreadcrumbs');
+
+        $this->expectDeprecation('Overriding "breadcrumbs_builder" parameter in twig templates is deprecated since sonata-project/admin-bundle version 3.x. Use "sonata.admin.breadcrumbs_builder" service instead.');
+
+        $this->breadcrumbsExtension->renderBreadcrumbs(
+            $this->environment,
+            $this->createStub(AdminInterface::class),
+            'not_important',
+            $customBreadcrumbsBuilder
+        );
+
+        $this->breadcrumbsExtension->renderBreadcrumbsForTitle(
+            $this->environment,
+            $this->createStub(AdminInterface::class),
+            'not_important',
+            $customBreadcrumbsBuilder
+        );
+
+        $this->assertSame(2, $customBreadcrumbsBuilder->numberOfCalls);
+    }
+
+    private function removeExtraWhitespace(string $string): string
+    {
+        return trim(preg_replace(
+            '/\s+/',
+            ' ',
+            $string
+        ));
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Instead of passing `breadcrumbs_builder` parameter to all templates, the new `render_breadcrumbs` and `render_breadcrumbs_for_title` Twig functions will render the breadcrumbs.

For keeping BC, these functions accept the breadcrumbs builder from Twig as last argument.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6832.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `render_breadcrumbs` and `render_breadcrumbs_for_title` Twig functions to render breadcrumbs.
### Deprecated
- Deprecated overriding the `breadcrumbs_builder` variable passed to Twig templates.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
