### PR TITLE
Restrict datagridBuilder type to class-string and add Template

### DIFF
--- a/src/Builder/DatagridBuilderInterface.php
+++ b/src/Builder/DatagridBuilderInterface.php
@@ -15,10 +15,13 @@ namespace Sonata\AdminBundle\Builder;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @phpstan-template T of \Sonata\AdminBundle\Datagrid\ProxyQueryInterface
  */
 interface DatagridBuilderInterface extends BuilderInterface
 {
@@ -26,7 +29,8 @@ interface DatagridBuilderInterface extends BuilderInterface
      * @param string|null            $type
      * @param AdminInterface<object> $admin
      *
-     * @phpstan-param class-string $type
+     * @phpstan-param DatagridInterface<T> $datagrid
+     * @phpstan-param class-string         $type
      */
     public function addFilter(
         DatagridInterface $datagrid,
@@ -40,6 +44,8 @@ interface DatagridBuilderInterface extends BuilderInterface
      * @param array<string, mixed>   $values
      *
      * @return DatagridInterface
+     *
+     * @phpstan-return DatagridInterface<T>
      */
     public function getBaseDatagrid(AdminInterface $admin, array $values = []);
 }

--- a/src/Builder/DatagridBuilderInterface.php
+++ b/src/Builder/DatagridBuilderInterface.php
@@ -15,7 +15,6 @@ namespace Sonata\AdminBundle\Builder;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
-use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 
 /**

--- a/src/Builder/DatagridBuilderInterface.php
+++ b/src/Builder/DatagridBuilderInterface.php
@@ -25,6 +25,8 @@ interface DatagridBuilderInterface extends BuilderInterface
     /**
      * @param string|null            $type
      * @param AdminInterface<object> $admin
+     *
+     * @phpstan-param class-string $type
      */
     public function addFilter(
         DatagridInterface $datagrid,

--- a/src/Builder/FormContractorInterface.php
+++ b/src/Builder/FormContractorInterface.php
@@ -24,6 +24,9 @@ use Symfony\Component\Form\FormFactoryInterface;
  */
 interface FormContractorInterface extends BuilderInterface
 {
+    /**
+     * NEXT_MAJOR: Remove the __construct from the interface.
+     */
     public function __construct(FormFactoryInterface $formFactory);
 
     /**

--- a/src/Builder/FormContractorInterface.php
+++ b/src/Builder/FormContractorInterface.php
@@ -25,7 +25,7 @@ use Symfony\Component\Form\FormFactoryInterface;
 interface FormContractorInterface extends BuilderInterface
 {
     /**
-     * NEXT_MAJOR: Remove the __construct from the interface.
+     * NEXT_MAJOR: Remove the `__construct()` method from the interface.
      */
     public function __construct(FormFactoryInterface $formFactory);
 

--- a/src/Datagrid/DatagridMapper.php
+++ b/src/Datagrid/DatagridMapper.php
@@ -74,6 +74,8 @@ class DatagridMapper extends BaseMapper implements MapperInterface
      * @throws \LogicException
      *
      * @return DatagridMapper
+     *
+     * @phpstan-param class-string|null $type
      */
     public function add(
         $name,

--- a/src/Model/LockInterface.php
+++ b/src/Model/LockInterface.php
@@ -17,6 +17,8 @@ use Sonata\AdminBundle\Exception\LockException;
 
 /**
  * @author Emmanuel Vella <vella.emmanuel@gmail.com>
+ *
+ * @phpstan-template T of object
  */
 interface LockInterface
 {
@@ -24,6 +26,8 @@ interface LockInterface
      * @param object $object
      *
      * @return mixed|null
+     *
+     * @phpstan-param T $object
      */
     public function getLockVersion($object);
 
@@ -32,6 +36,8 @@ interface LockInterface
      * @param mixed  $expectedVersion
      *
      * @throws LockException
+     *
+     * @phpstan-param T $object
      */
     public function lock($object, $expectedVersion);
 }

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -51,6 +51,8 @@ interface ModelManagerInterface extends DatagridManagerInterface
      * @param object $object
      *
      * @throws ModelManagerException
+     *
+     * @phpstan-param T $object
      */
     public function create($object);
 
@@ -58,6 +60,8 @@ interface ModelManagerInterface extends DatagridManagerInterface
      * @param object $object
      *
      * @throws ModelManagerException
+     *
+     * @phpstan-param T $object
      */
     public function update($object);
 
@@ -65,6 +69,8 @@ interface ModelManagerInterface extends DatagridManagerInterface
      * @param object $object
      *
      * @throws ModelManagerException
+     *
+     * @phpstan-param T $object
      */
     public function delete($object);
 
@@ -106,7 +112,7 @@ interface ModelManagerInterface extends DatagridManagerInterface
      *
      * @throws ModelManagerException
      *
-     * @phpstan-param class-string $class
+     * @phpstan-param class-string<T> $class
      */
     public function batchDelete($class, ProxyQueryInterface $query);
 
@@ -128,7 +134,7 @@ interface ModelManagerInterface extends DatagridManagerInterface
      *
      * @return ProxyQueryInterface
      *
-     * @phpstan-param class-string $class
+     * @phpstan-param class-string<T> $class
      */
     public function createQuery($class);
 
@@ -157,6 +163,8 @@ interface ModelManagerInterface extends DatagridManagerInterface
      * @param object $model
      *
      * @return array<int|string> list of all identifiers of this model
+     *
+     * @phpstan-param T $model
      */
     public function getIdentifierValues($model);
 
@@ -168,7 +176,7 @@ interface ModelManagerInterface extends DatagridManagerInterface
      *
      * @return string[]
      *
-     * @phpstan-param class-string $class
+     * @phpstan-param class-string<T> $class
      */
     public function getIdentifierFieldNames($class);
 
@@ -179,6 +187,8 @@ interface ModelManagerInterface extends DatagridManagerInterface
      *
      * @return string|null a string representation of the identifiers for this
      *                     instance
+     *
+     * @phpstan-param T $model
      */
     public function getNormalizedIdentifier($model);
 
@@ -191,6 +201,8 @@ interface ModelManagerInterface extends DatagridManagerInterface
      * @param object $model
      *
      * @return string|null string representation of the id that is safe to use in a url
+     *
+     * @phpstan-param T $model
      */
     public function getUrlSafeIdentifier($model);
 
@@ -295,6 +307,9 @@ interface ModelManagerInterface extends DatagridManagerInterface
     public function modelReverseTransform($class, array $array = []);
 
     // NEXT_MAJOR: Uncomment this.
+    /**
+     * @phpstan-param T $object
+     */
 //    public function reverseTransform(object $object, array $array = []): void;
 
     /**


### PR DESCRIPTION
## Subject

BC

Fix 
```
ArgumentTypeCoercion - src/Builder/DatagridBuilder.php:135:78 - Argument 2 of Sonata\AdminBundle\Filter\FilterFactoryInterface::create expects class-string, parent type string provided (see https://psalm.dev/193)
        $filter = $this->filterFactory->create($fieldDescription->getName(), $type, $fieldDescription->getOptions());
```
And
```
Method Sonata\DoctrineORMAdminBundle\Builder\DatagridBuilder::getBaseDatagrid() should return Sonata\AdminBundle\Datagrid\DatagridInterface<Sonata\AdminBundle\Datagrid\ProxyQueryInterface> but returns  
         Sonata\AdminBundle\Datagrid\Datagrid<Sonata\DoctrineORMAdminBundle\Datagrid\ProxyQueryInterface>.
```
And I'm trying to solve other issue in https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1421

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Generic template for DatagridBuilderInterface
- Generic template for LockInterface

### Fixed
- `DatagridBuilderInterface::addFilter` phpdoc: The `$type` MUST be a class-string.
- Missing generic template for ModelManagerInterface
```