### PR TITLE
Fix matching filter links in search results

### DIFF
--- a/src/Resources/public/css/layout.css
+++ b/src/Resources/public/css/layout.css
@@ -355,13 +355,13 @@ body.fixed .content-header .navbar.stuck {
     word-wrap: break-word;
 }
 
-.sonata-search-result-list .box .nav-stacked > li.item > span.matches {
+.sonata-search-result-list.nav-stacked > li.item > span.matches {
     position: relative;
     display: block;
     padding: 10px 15px;
 }
 
-.sonata-search-result-list .box .nav-stacked > li.item > span.matches > a.label {
+.sonata-search-result-list.nav-stacked > li.item > span.matches > a.label {
    margin: 0 1px;
 }
 

--- a/src/Resources/views/Block/block_search_result.html.twig
+++ b/src/Resources/views/Block/block_search_result.html.twig
@@ -70,7 +70,7 @@ file that was distributed with this source code.
                                             {% if match and ((filter.option('case_sensitive') is not same as(false) and term in match)
                                                 or filter.option('case_sensitive') is same as(false) and term|lower in match|lower)
                                             %}
-                                                <a class="label label-primary" href="{{ admin.generateUrl('list', {'filter': {(filter.formName): term}}) }}">
+                                                <a class="label label-primary" href="{{ admin.generateUrl('list', {'filter': {(filter.formName): {'value': term}}}) }}">
                                                     {{ filter.option('label')|trans({}, filter.option('translation_domain', admin.translationDomain)) }}
                                                 </a>
                                             {% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Fix matching filters links in search results
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to #7005.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- URLs generated at global search results for the list filtering, which were missing the `value` dimension;
- Layout for the filter links generated at global search results.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
