### PR TITLE
RFC: Remove deprecation for preValidate method

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -648,9 +648,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
     }
 
     /**
-     * NEXT_MAJOR: Remove this method.
-     *
-     * @deprecated since sonata-project/admin-bundle 3.82, will be removed in 4.0.
+     * NEXT_MAJOR: Change visibility to protected.
      *
      * @param object $object
      *
@@ -658,12 +656,6 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
      */
     public function preValidate($object)
     {
-        if ('sonata_deprecation_mute' !== \func_get_args()[1] ?? null) {
-            @trigger_error(sprintf(
-                'The %s method is deprecated since version 3.82 and will be removed in 4.0.',
-                __METHOD__
-            ), \E_USER_DEPRECATED);
-        }
     }
 
     public function preUpdate($object)
@@ -3401,9 +3393,8 @@ EOT;
         $this->loaded['form'] = true;
 
         $formBuilder = $this->getFormBuilder();
-        // NEXT_MAJOR: Remove this call.
         $formBuilder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event) {
-            $this->preValidate($event->getData(), 'sonata_deprecation_mute');
+            $this->preValidate($event->getData());
         }, 100);
 
         $this->form = $formBuilder->getForm();


### PR DESCRIPTION
## Subject

The preValidate method was deprecated in 3.82 version, but I recently had the need to update the data before the form validation. I tried using this method and it works fine. 

In the PR: https://github.com/sonata-project/SonataAdminBundle/commit/eddec2648cc1d3bb15f3343a2dc0e1156885244c, we deprecated (and remove in master) all the validation related method. IMHO it's a good thing to remove our own validator, but it should be allowed to add an event in order to do things before the symfony form validators.

WDYT @sonata-project/contributors ?

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Remove deprecation for `AbstractAdmin::preValidate()` method
```