### PR TITLE
Keep only common option in FieldDescriptionOptions type

### DIFF
--- a/src/FieldDescription/BaseFieldDescription.php
+++ b/src/FieldDescription/BaseFieldDescription.php
@@ -32,33 +32,31 @@ use Symfony\Component\PropertyAccess\PropertyPathInterface;
  * Some options are global across the different contexts, other are
  * context specifics.
  *
- * Global options :
- *   - type (m): define the field type (use to tweak the form or the list)
- *   - template (o) : the template used to render the field
- *   - name (o) : the name used (label in the form, title in the list)
- *   - link_parameters (o) : add link parameter to the related Admin class when
- *                           the Admin.generateUrl is called
- *   - accessor : the method or the property path to retrieve the related value
- *   - associated_tostring : (deprecated, use associated_property option)
- *                           the method to retrieve the "string" representation
- *                           of the collection element.
- *   - associated_property : property path to retrieve the "string" representation
- *                           of the collection element.
+ * Global options:
+ *   - type (m: define the field type (use to tweak the form or the list)
+ *   - template (o): the template used to render the field
+ *   - label (o): the name used (label in the form, title in the list)
+ *   - accessor (o): the method or the property path to retrieve the related value
  *
- * Form Field options :
+ * Show Field options:
+ *   - associated_property (o): the method or the property path to retrieve the "string"
+ *                           representation of the collection element.
+ *
+ * Form Field options:
  *   - field_type (o): the widget class to use to render the field
  *   - field_options (o): the options to give to the widget
- *   - edit (o) : list|inline|standard (only used for associated admin)
- *      - list : open a popup where the user can search, filter and click on one field
+ *   - link_parameters (o): add link parameter to the related Admin class when
+ *                           the Admin.generateUrl is called
+ *   - edit (o): list|inline|standard (only used for associated admin)
+ *      - list: open a popup where the user can search, filter and click on one field
  *               to select one item
- *      - inline : the associated form admin is embedded into the current form
- *      - standard : the associated admin is created through a popup
+ *      - inline: the associated form admin is embedded into the current form
+ *      - standard: the associated admin is created through a popup
  *
- * List Field options :
+ * List Field options:
  *   - identifier (o): if set to true a link appear on to edit the element
  *
- * Filter Field options :
- *   - options (o): options given to the Filter object
+ * Filter Field options:
  *   - field_type (o): the widget class to use to render the field
  *   - field_options (o): the options to give to the widget
  *
@@ -269,11 +267,12 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
             unset($options['help']);
         }
 
-        // set default placeholder
+        // NEXT_MAJOR: Remove this.
         if (!isset($options['placeholder'])) {
             $options['placeholder'] = 'short_object_description_placeholder';
         }
 
+        // NEXT_MAJOR: Remove this.
         if (!isset($options['link_parameters'])) {
             $options['link_parameters'] = [];
         }

--- a/src/FieldDescription/BaseFieldDescription.php
+++ b/src/FieldDescription/BaseFieldDescription.php
@@ -33,20 +33,18 @@ use Symfony\Component\PropertyAccess\PropertyPathInterface;
  * context specifics.
  *
  * Global options:
- *   - type (m: define the field type (use to tweak the form or the list)
+ *   - type (m): define the field type (use to tweak the form or the list)
  *   - template (o): the template used to render the field
  *   - label (o): the name used (label in the form, title in the list)
  *   - accessor (o): the method or the property path to retrieve the related value
- *
- * Show Field options:
  *   - associated_property (o): the method or the property path to retrieve the "string"
  *                           representation of the collection element.
+ *   - link_parameters (o): add link parameter to the related Admin class when
+ *                           the Admin.generateUrl is called
  *
  * Form Field options:
  *   - field_type (o): the widget class to use to render the field
  *   - field_options (o): the options to give to the widget
- *   - link_parameters (o): add link parameter to the related Admin class when
- *                           the Admin.generateUrl is called
  *   - edit (o): list|inline|standard (only used for associated admin)
  *      - list: open a popup where the user can search, filter and click on one field
  *               to select one item

--- a/src/FieldDescription/FieldDescriptionInterface.php
+++ b/src/FieldDescription/FieldDescriptionInterface.php
@@ -15,45 +15,22 @@ namespace Sonata\AdminBundle\FieldDescription;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Exception\NoValueException;
-use Symfony\Component\Form\DataTransformerInterface;
-use Symfony\Component\PropertyAccess\PropertyPathInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
  * @phpstan-type FieldDescriptionOptions = array{
- *  accessor?: string|callable|PropertyPathInterface,
- *  actions?: array,
- *  admin_code?: string,
- *  associated_property?: string,
- *  block_name?: string,
- *  catalogue?: string,
- *  data_transformer?: DataTransformerInterface,
- *  edit?: string,
- *  editable?: bool,
- *  field_name?: string,
- *  field_options?: array,
- *  field_type?: string,
- *  header_class?: string,
- *  identifier?: bool,
- *  inline?: string,
- *  label?: bool|string|null,
- *  link_parameters?: array,
- *  multiple?: bool,
- *  placeholder?: string,
- *  required?: bool,
+ *  accessor?: string|callable|\Symfony\Component\PropertyAccess\PropertyPathInterface,
+ *  label?: string|false|null,
  *  role?: string|string[],
- *  route?: array,
- *  safe?: bool,
- *  sort_field_mapping?: array,
- *  sort_parent_association_mappings?: array,
+ *  sort_field_mapping?: array<string, mixed>,
+ *  sort_parent_association_mappings?: array<array<string, mixed>>,
  *  sortable?: bool,
  *  template?: string,
- *  timezone?: string|\DateTimeZone,
  *  translation_domain?: string,
  *  type?: string,
  *  virtual_field?: bool
- * }
+ * }&array<string, mixed>
  *
  * @method string|null getTargetModel()
  * @method bool        hasAdmin()

--- a/src/FieldDescription/FieldDescriptionInterface.php
+++ b/src/FieldDescription/FieldDescriptionInterface.php
@@ -21,7 +21,9 @@ use Sonata\AdminBundle\Exception\NoValueException;
  *
  * @phpstan-type FieldDescriptionOptions = array{
  *  accessor?: string|callable|\Symfony\Component\PropertyAccess\PropertyPathInterface,
+ *  associated_property?: string|callable|\Symfony\Component\PropertyAccess\PropertyPathInterface,
  *  label?: string|false|null,
+ *  link_parameters?: array<string, mixed>,
  *  role?: string|string[],
  *  sort_field_mapping?: array<string, mixed>,
  *  sort_parent_association_mappings?: array<array<string, mixed>>,
@@ -33,7 +35,9 @@ use Sonata\AdminBundle\Exception\NoValueException;
  * }&array<string, mixed>
  * @psalm-type FieldDescriptionOptions = (array{
  *  accessor?: string|callable|\Symfony\Component\PropertyAccess\PropertyPathInterface,
+ *  associated_property?: string|callable|\Symfony\Component\PropertyAccess\PropertyPathInterface,
  *  label?: string|false|null,
+ *  link_parameters?: array<string, mixed>,
  *  role?: string|string[],
  *  sort_field_mapping?: array<string, mixed>,
  *  sort_parent_association_mappings?: array<array<string, mixed>>,

--- a/src/FieldDescription/FieldDescriptionInterface.php
+++ b/src/FieldDescription/FieldDescriptionInterface.php
@@ -31,6 +31,18 @@ use Sonata\AdminBundle\Exception\NoValueException;
  *  type?: string,
  *  virtual_field?: bool
  * }&array<string, mixed>
+ * @psalm-type FieldDescriptionOptions = (array{
+ *  accessor?: string|callable|\Symfony\Component\PropertyAccess\PropertyPathInterface,
+ *  label?: string|false|null,
+ *  role?: string|string[],
+ *  sort_field_mapping?: array<string, mixed>,
+ *  sort_parent_association_mappings?: array<array<string, mixed>>,
+ *  sortable?: bool,
+ *  template?: string,
+ *  translation_domain?: string,
+ *  type?: string,
+ *  virtual_field?: bool
+ * }&array<string, mixed>)|array<empty, empty>
  *
  * @method string|null getTargetModel()
  * @method bool        hasAdmin()

--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -524,7 +524,7 @@ This code manages the many-to-[one|many] association field popup
                     'objectId': 'OBJECT_ID',
                     'uniqid': associationadmin.uniqid,
                     'code': associationadmin.code,
-                    'linkParameters': sonata_admin.field_description.option('link_parameters')
+                    'linkParameters': sonata_admin.field_description.option('link_parameters', {})
                 })}}'.replace('OBJECT_ID', objectId),
                 dataType: 'html',
                 success: function(html) {

--- a/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
@@ -24,11 +24,11 @@ file that was distributed with this source code.
                         'code':     sonata_admin.field_description.associationadmin.code,
                         'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
                         'uniqid':   sonata_admin.field_description.associationadmin.uniqid,
-                        'linkParameters': sonata_admin.field_description.option('link_parameters')
+                        'linkParameters': sonata_admin.field_description.option('link_parameters', {})
                     })) }}
-                {% elseif sonata_admin.field_description.option('placeholder') %}
+                {% elseif sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder') %}
                     <span class="inner-field-short-description">
-                        {{ sonata_admin.field_description.option('placeholder')|trans({}, 'SonataAdminBundle') }}
+                        {{ sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder')|trans({}, 'SonataAdminBundle') }}
                     </span>
                 {% endif %}
             </span>

--- a/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
@@ -24,11 +24,11 @@ file that was distributed with this source code.
                         'code':     sonata_admin.field_description.associationadmin.code,
                         'objectId': sonata_admin.field_description.associationadmin.urlSafeIdentifier(sonata_admin.value),
                         'uniqid':   sonata_admin.field_description.associationadmin.uniqid,
-                        'linkParameters': sonata_admin.field_description.option('link_parameters')
+                        'linkParameters': sonata_admin.field_description.option('link_parameters', {}))
                     })) }}
-                {% elseif sonata_admin.field_description.option('placeholder') %}
+                {% elseif sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder') %}
                     <span class="inner-field-short-description">
-                        {{ sonata_admin.field_description.option('placeholder')|trans({}, 'SonataAdminBundle') }}
+                        {{ sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder')|trans({}, 'SonataAdminBundle') }}
                     </span>
                 {% endif %}
             </span>

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -600,11 +600,11 @@ file that was distributed with this source code.
                     'code': sonata_admin.field_description.associationadmin.code,
                     'objectId': sonata_admin.field_description.associationadmin.urlSafeIdentifier(sonata_admin.value),
                     'uniqid': sonata_admin.field_description.associationadmin.uniqid,
-                    'linkParameters': sonata_admin.field_description.option('link_parameters')
+                    'linkParameters': sonata_admin.field_description.option('link_parameters', {})
                 })) }}
-            {% elseif sonata_admin.field_description.option('placeholder') %}
+            {% elseif sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder') %}
                 <span class="inner-field-short-description">
-                    {{ sonata_admin.field_description.option('placeholder')|trans({}, 'SonataAdminBundle') }}
+                    {{ sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder')|trans({}, 'SonataAdminBundle') }}
                 </span>
             {% endif %}
         </span>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Follow up of the discussion
https://github.com/sonata-project/SonataAdminBundle/pull/7101

This type is currently not describing correctly the possible options ATM.
Since @franmomu is not agreeing with this, I prefer to wait for his approval before any merge.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- FieldDescriptions options phpdoc to keep only common options.
```