### PR TITLE
Allow to use display_* templates without field_description

### DIFF
--- a/src/Resources/views/CRUD/_email_link.html.twig
+++ b/src/Resources/views/CRUD/_email_link.html.twig
@@ -1,4 +1,5 @@
-
+{# NEXT_MAJOR: Remove this template #}
+{% deprecated 'The "_email_link.html.twig" is deprecated since sonata-project/admin-bundle 3.x and will be removed in 4.0.' %}
 {%- if value is empty -%}
     &nbsp;
 {%- elseif field_description.option('as_string', false) -%}

--- a/src/Resources/views/CRUD/display_boolean.html.twig
+++ b/src/Resources/views/CRUD/display_boolean.html.twig
@@ -10,13 +10,18 @@ file that was distributed with this source code.
 #}
 
 {%- apply spaceless %}
+    {# NEXT_MAJOR: Remove this BC-layer #}
+    {% if field_description is defined %}
+        {% set inverse = inverse|default(field_description.option('inverse', false)) %}
+    {% endif %}
+
     {% if value %}
         {% set text = 'label_type_yes'|trans({}, 'SonataAdminBundle') %}
     {% else %}
         {% set text = 'label_type_no'|trans({}, 'SonataAdminBundle') %}
     {% endif %}
 
-    {% if field_description.option('inverse', false) ? not value : value %}
+    {% if inverse|default(false) ? not value : value %}
         {% set class = 'label-success' %}
     {% else %}
         {% set class = 'label-danger' %}

--- a/src/Resources/views/CRUD/display_choice.html.twig
+++ b/src/Resources/views/CRUD/display_choice.html.twig
@@ -1,39 +1,56 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
 {%- apply spaceless %}
-    {% if field_description.option('choices') is not null %}
-        {% if field_description.option('multiple', false) and value is iterable %}
+    {# NEXT_MAJOR: Remove this BC-layer #}
+    {% if field_description is defined %}
+        {% set choices = choices|default(field_description.option('choices')) %}
+        {% set multiple = multiple|default(field_description.option('multiple', false)) %}
+        {% set delimiter = delimiter|default(field_description.option('delimiter', ', ')) %}
+        {% set translation_domain = translation_domain|default(field_description.option('catalogue')) %}
+        {% set safe = safe|default(field_description.option('safe', false)) %}
+    {% endif %}
 
-            {% set result = '' %}
-            {% set delimiter = field_description.option('delimiter', ', ') %}
+    {% set choices = choices|default([]) %}
+    {% if multiple|default(false) and value is iterable %}
 
-            {% for val in value %}
-                {% if result is not empty %}
-                    {% set result = result ~ delimiter %}
-                {% endif %}
-
-                {% if field_description.option('choices')[val] is defined %}
-                    {% set choice = field_description.option('choices')[val] %}
-                {% else %}
-                    {% set choice = val %}
-                {% endif %}
-                {% if field_description.option('catalogue') %}
-                    {% set result = result ~ choice|trans({}, field_description.option('catalogue')) %}
-                {% else %}
-                    {% set result = result ~ choice %}
-                {% endif %}
-            {% endfor %}
-
-            {% set value = result %}
-
-        {% elseif value in field_description.option('choices')|keys %}
-            {% if field_description.option('catalogue') is null %}
-                {% set value = field_description.option('choices')[value] %}
-            {% else %}
-                {% set value = field_description.option('choices')[value]|trans({}, field_description.option('catalogue')) %}
+        {% set result = '' %}
+        {% for val in value %}
+            {% if result is not empty %}
+                {% set result = result ~ delimiter|default(', ') %}
             {% endif %}
+
+            {% if choices[val] is defined %}
+                {% set choice = choices[val] %}
+            {% else %}
+                {% set choice = val %}
+            {% endif %}
+            {% if translation_domain|default(null) is null %}
+                {% set result = result ~ choice %}
+            {% else %}
+                {% set result = result ~ choice|trans({}, translation_domain) %}
+            {% endif %}
+        {% endfor %}
+
+        {% set value = result %}
+
+    {% elseif value in choices|keys %}
+        {% if translation_domain|default(null) is null %}
+            {% set value = choices[value] %}
+        {% else %}
+            {% set value = choices[value]|trans({}, translation_domain) %}
         {% endif %}
     {% endif %}
 
-    {% if field_description.option('safe', false) %}
+    {% if safe|default(false) %}
         {{ value|raw }}
     {% else %}
         {{ value }}

--- a/src/Resources/views/CRUD/display_currency.html.twig
+++ b/src/Resources/views/CRUD/display_currency.html.twig
@@ -10,9 +10,14 @@ file that was distributed with this source code.
 #}
 
 {%- apply spaceless %}
+    {# NEXT_MAJOR: Remove this BC-layer #}
+    {% if field_description is defined %}
+        {% set currency = currency|default(field_description.option('currency')) %}
+    {% endif %}
+
     {%- if value is null -%}
         &nbsp;
     {%- else -%}
-        {{ field_description.option('currency') }} {{ value }}
+        {{ currency|default(null) }} {{ value }}
     {%- endif -%}
 {% endapply -%}

--- a/src/Resources/views/CRUD/display_date.html.twig
+++ b/src/Resources/views/CRUD/display_date.html.twig
@@ -10,11 +10,17 @@ file that was distributed with this source code.
 #}
 
 {%- apply spaceless %}
+    {# NEXT_MAJOR: Remove this BC-layer #}
+    {% if field_description is defined %}
+        {% set format = format|default(field_description.option('format', 'F j, Y')) %}
+        {% set timezone = timezone|default(field_description.option('timezone')) %}
+    {% endif %}
+
     {%- if value is empty -%}
         &nbsp;
     {%- else -%}
         <time datetime="{{ value|date('Y-m-d', 'UTC') }}" title="{{ value|date('Y-m-d', 'UTC') }}">
-            {{ value|date(field_description.option('format', 'F j, Y'), field_description.option('timezone')) }}
+            {{ value|date(format|default('F j, Y'), timezone|default(null)) }}
         </time>
     {%- endif -%}
 {% endapply -%}

--- a/src/Resources/views/CRUD/display_datetime.html.twig
+++ b/src/Resources/views/CRUD/display_datetime.html.twig
@@ -10,13 +10,17 @@ file that was distributed with this source code.
 #}
 
 {%- apply spaceless %}
+    {# NEXT_MAJOR: Remove this BC-layer #}
+    {% if field_description is defined %}
+        {% set format = format|default(field_description.option('format')) %}
+        {% set timezone = timezone|default(field_description.option('timezone')) %}
+    {% endif %}
+
     {%- if value is empty -%}
         &nbsp;
     {%- else -%}
-        {% set format = field_description.option('format') %}
-        {% set timezone = field_description.option('timezone') %}
         <time datetime="{{ value|date('c', 'UTC') }}" title="{{ value|date('c', 'UTC') }}">
-            {{ value|date(format, timezone) }}
+            {{ value|date(format|default(null), timezone|default(null)) }}
         </time>
     {%- endif -%}
 {% endapply -%}

--- a/src/Resources/views/CRUD/display_email.html.twig
+++ b/src/Resources/views/CRUD/display_email.html.twig
@@ -1,0 +1,38 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{%- apply spaceless %}
+    {# NEXT_MAJOR: Remove this BC-layer #}
+    {% if field_description is defined %}
+        {% set as_string = format|default(field_description.option('as_string')) %}
+        {% set subject = subject|default(field_description.option('subject')) %}
+        {% set body = body|default(field_description.option('body')) %}
+    {% endif %}
+
+    {%- if value is empty -%}
+        &nbsp;
+    {%- elseif as_string|default(false) -%}
+        {{ value }}
+    {%- else -%}
+        {% set parameters = {} %}
+
+        {% if subject|default(null) is not empty %}
+            {% set parameters = parameters|merge({'subject': subject}) %}
+        {% endif %}
+        {% if body|default(null) is not empty %}
+            {% set parameters = parameters|merge({'body': body}) %}
+        {% endif %}
+
+        <a href="mailto:{{ value }}{% if parameters|length > 0 %}?{{- parameters|url_encode -}}{% endif %}">
+            {{- value -}}
+        </a>
+    {%- endif -%}
+{% endapply -%}

--- a/src/Resources/views/CRUD/display_html.html.twig
+++ b/src/Resources/views/CRUD/display_html.html.twig
@@ -1,21 +1,43 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
 {%- apply spaceless %}
+    {# NEXT_MAJOR: Remove this BC-layer #}
+    {% if field_description is defined %}
+        {% set truncate = truncate|default(field_description.option('truncate')) %}
+        {% set strip = strip|default(field_description.option('strip', false)) %}
+    {% endif %}
+
     {%- if value is empty -%}
         &nbsp;
     {% else %}
-        {%- if field_description.option('truncate') -%}
-            {% set truncate = field_description.option('truncate') %}
+        {%- if truncate|default(null) -%}
             {% set length = truncate.length|default(30) %}
+            {# NEXT_MAJOR: Remove this #}
             {% if truncate.preserve is defined %}
                 {% deprecated 'The "truncate.preserve" option is deprecated since sonata-project/admin-bundle 3.65, to be removed in 4.0. Use "truncate.cut" instead.' %}
             {% endif %}
+            {# NEXT_MAJOR: Remove this and uncomment the following line #}
             {% set cut = truncate.cut is defined ? truncate.cut : (truncate.preserve is defined ? truncate.preserve != true : true) %}
+            {# {% set cut = truncate.cut|default(true) %} #}
+            {# NEXT_MAJOR: Remove this #}
             {% if truncate.separator is defined %}
                 {% deprecated 'The "truncate.separator" option is deprecated since sonata-project/admin-bundle 3.65, to be removed in 4.0. Use "truncate.ellipsis" instead.' %}
             {% endif %}
+            {# NEXT_MAJOR: Remove this and uncomment the following line #}
             {% set ellipsis = truncate.ellipsis is defined ? truncate.ellipsis : (truncate.separator is defined ? truncate.separator : '...') %}
+            {# {% set ellipsis = truncate.ellipsis|default('...') %} #}
             {{ value|striptags|u.truncate(length, ellipsis, cut)|raw }}
         {%- else -%}
-            {%- if field_description.option('strip', false) -%}
+            {%- if strip|default(false) -%}
                 {% set value = value|striptags %}
             {%- endif -%}
             {{ value|raw }}

--- a/src/Resources/views/CRUD/display_time.html.twig
+++ b/src/Resources/views/CRUD/display_time.html.twig
@@ -10,11 +10,17 @@ file that was distributed with this source code.
 #}
 
 {%- apply spaceless %}
+    {# NEXT_MAJOR: Remove this BC-layer #}
+    {% if field_description is defined %}
+        {% set format = format|default(field_description.option('format', 'H:i:s')) %}
+        {% set timezone = timezone|default(field_description.option('timezone')) %}
+    {% endif %}
+
     {%- if value is empty -%}
         &nbsp;
     {%- else -%}
         <time datetime="{{ value|date('H:i:sP', 'UTC') }}" title="{{ value|date('H:i:sP', 'UTC') }}">
-            {{ value|date(field_description.option('format', 'H:i:s'), field_description.option('timezone')) }}
+            {{ value|date(format|default('H:i:s'), timezone|default(null)) }}
         </time>
     {%- endif -%}
 {% endapply -%}

--- a/src/Resources/views/CRUD/display_trans.html.twig
+++ b/src/Resources/views/CRUD/display_trans.html.twig
@@ -1,10 +1,25 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
 {%- apply spaceless %}
-    {% set value_format = field_description.option('format', '%s') %}
-    {% set translation_domain = field_description.option('catalogue', admin.translationDomain) %}
+    {# NEXT_MAJOR: Remove this BC-layer #}
+    {% if field_description is defined %}
+        {% set value_format = value_format|default(field_description.option('format', '%s')) %}
+        {% set translation_domain = translation_domain|default(field_description.option('catalogue', admin.translationDomain)) %}
+        {% set safe = safe|default(field_description.option('safe', false)) %}
+    {% endif %}
 
-    {% set value = value_format|format(value)|trans({}, translation_domain) %}
+    {% set value = value_format|default('%s')|format(value)|trans({}, translation_domain|default('messages')) %}
 
-    {% if field_description.option('safe', false) %}
+    {% if safe|default(false) %}
         {{ value|raw }}
     {% else %}
         {{ value }}

--- a/src/Resources/views/CRUD/display_url.html.twig
+++ b/src/Resources/views/CRUD/display_url.html.twig
@@ -1,40 +1,55 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
 {%- apply spaceless %}
+    {# NEXT_MAJOR: Remove this BC-layer #}
+    {% if field_description is defined %}
+        {% set url = url|default(field_description.option('url')) %}
+        {% set route = route|default(field_description.option('route')) %}
+        {% set hide_protocol = hide_protocol|default(field_description.option('hide_protocol', false)) %}
+        {% set attributes = attributes|default(field_description.option('attributes', [])) %}
+        {% set safe = safe|default(field_description.option('safe', false)) %}
+    {% endif %}
+
     {% if value is empty %}
         &nbsp;
     {% else %}
-        {% if field_description.option('url') %}
+        {% if url|default(null) %}
             {# target url is string #}
-            {% set url_address = field_description.option('url') %}
-        {% elseif field_description.option('route') is not null and field_description.option('route').name not in ['edit', 'show'] %}
+            {% set url_address = url %}
+        {% elseif route|default(null) is not null %}
             {# target url is Symfony route #}
-            {% set parameters = field_description.option('route').parameters|default([]) %}
+            {% set parameters = route.parameters|default([]) %}
 
-            {# route with paramter related to object ID #}
-            {% if field_description.option('route').identifier_parameter_name is defined %}
-                {% set parameters = parameters|merge({(field_description.option('route').identifier_parameter_name):(admin.normalizedidentifier(object))}) %}
-            {% endif %}
-
-            {% if field_description.option('route').absolute|default(false) %}
-                {% set url_address = url(field_description.option('route').name, parameters) %}
+            {% if route.absolute|default(false) %}
+                {% set url_address = url(route.name, parameters) %}
             {% else %}
-                {% set url_address = path(field_description.option('route').name, parameters) %}
+                {% set url_address = path(route.name, parameters) %}
             {% endif %}
         {% else %}
             {# value is url #}
             {% set url_address = value %}
         {% endif %}
 
-        {% if field_description.option('hide_protocol', false) %}
+        {% if hide_protocol|default(false) %}
             {% set value = value|replace({'http://': '', 'https://': ''}) %}
         {% endif %}
 
         <a
             href="{{ url_address }}"
-        {%- for attribute, value in field_description.option('attributes', []) %}
+        {%- for attribute, value in attributes|default([]) %}
             {{ attribute }}="{{ value|escape('html_attr') }}"
         {%- endfor -%}
         >
-        {%- if field_description.option('safe', false) -%}
+        {%- if safe|default(false) -%}
             {{- value|raw -}}
         {%- else -%}
             {{- value -}}

--- a/src/Resources/views/CRUD/history_revision_timestamp.html.twig
+++ b/src/Resources/views/CRUD/history_revision_timestamp.html.twig
@@ -9,4 +9,8 @@ file that was distributed with this source code.
 
 #}
 
-{%- include '@SonataAdmin/CRUD/display_datetime.html.twig' with { value: revision.timestamp } -%}
+{%- include '@SonataAdmin/CRUD/display_datetime.html.twig' with {
+    value: revision.timestamp,
+    format: field_description.option('format'),
+    timezone: field_description.option('timezone'),
+} only -%}

--- a/src/Resources/views/CRUD/list_boolean.html.twig
+++ b/src/Resources/views/CRUD/list_boolean.html.twig
@@ -24,5 +24,8 @@ file that was distributed with this source code.
 {% endblock %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_boolean.html.twig' -%}
+    {%- include '@SonataAdmin/CRUD/display_boolean.html.twig' with {
+        value: value,
+        inverse: field_description.option('inverse'),
+    } only -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/list_choice.html.twig
+++ b/src/Resources/views/CRUD/list_choice.html.twig
@@ -27,5 +27,12 @@ file that was distributed with this source code.
 {% endblock %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_choice.html.twig' -%}
+    {%- include '@SonataAdmin/CRUD/display_choice.html.twig' with {
+        value: value,
+        choices: field_description.option('choices'),
+        multiple: field_description.option('multiple'),
+        delimiter: field_description.option('delimiter'),
+        translation_domain: field_description.option('catalogue'),
+        safe: field_description.option('safe'),
+    } only -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/list_currency.html.twig
+++ b/src/Resources/views/CRUD/list_currency.html.twig
@@ -12,5 +12,8 @@ file that was distributed with this source code.
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_currency.html.twig' -%}
+    {%- include '@SonataAdmin/CRUD/display_currency.html.twig' with {
+        value: value,
+        currency: field_description.option('currency'),
+    } only -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/list_date.html.twig
+++ b/src/Resources/views/CRUD/list_date.html.twig
@@ -12,5 +12,9 @@ file that was distributed with this source code.
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_date.html.twig' -%}
+    {%- include '@SonataAdmin/CRUD/display_date.html.twig' with {
+        value: value,
+        format: field_description.option('format'),
+        timezone: field_description.option('timezone'),
+    } only -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/list_datetime.html.twig
+++ b/src/Resources/views/CRUD/list_datetime.html.twig
@@ -12,5 +12,9 @@ file that was distributed with this source code.
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_datetime.html.twig' -%}
+    {%- include '@SonataAdmin/CRUD/display_datetime.html.twig' with {
+        value: value,
+        format: field_description.option('format'),
+        timezone: field_description.option('timezone'),
+    } only -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/list_email.html.twig
+++ b/src/Resources/views/CRUD/list_email.html.twig
@@ -12,5 +12,10 @@ file that was distributed with this source code.
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
-    {% include '@SonataAdmin/CRUD/_email_link.html.twig' %}
+    {% include '@SonataAdmin/CRUD/display_email.html.twig' with {
+        value: value,
+        as_string: field_description.option('as_string'),
+        subject: field_description.option('subject'),
+        body: field_description.option('body'),
+    } only %}
 {% endblock %}

--- a/src/Resources/views/CRUD/list_html.html.twig
+++ b/src/Resources/views/CRUD/list_html.html.twig
@@ -1,5 +1,9 @@
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_html.html.twig' -%}
+    {%- include '@SonataAdmin/CRUD/display_html.html.twig' with {
+        value: value,
+        truncate: field_description.option('truncate'),
+        strip: field_description.option('strip'),
+    } only -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/list_percent.html.twig
+++ b/src/Resources/views/CRUD/list_percent.html.twig
@@ -12,5 +12,5 @@ file that was distributed with this source code.
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_percent.html.twig' -%}
+    {%- include '@SonataAdmin/CRUD/display_percent.html.twig' with { value: value } only -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/list_time.html.twig
+++ b/src/Resources/views/CRUD/list_time.html.twig
@@ -12,5 +12,9 @@ file that was distributed with this source code.
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_time.html.twig' -%}
+    {%- include '@SonataAdmin/CRUD/display_time.html.twig' with {
+        value: value,
+        format: field_description.option('format'),
+        timezone: field_description.option('timezone'),
+    } only -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/list_trans.html.twig
+++ b/src/Resources/views/CRUD/list_trans.html.twig
@@ -12,5 +12,10 @@ file that was distributed with this source code.
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_trans.html.twig' -%}
+    {%- include '@SonataAdmin/CRUD/display_trans.html.twig' with {
+        value: value,
+        value_format: field_description.option('format'),
+        translation_domain: field_description.option('catalogue', admin.translationDomain),
+        safe: field_description.option('safe'),
+    } only -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/list_url.html.twig
+++ b/src/Resources/views/CRUD/list_url.html.twig
@@ -12,5 +12,18 @@ file that was distributed with this source code.
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_url.html.twig' -%}
+    {%- set route = field_description.option('route') -%}
+    {%- if route is not null and route.identifier_parameter_name is defined -%}
+        {%- set newParameters = {(route.identifier_parameter_name):(admin.normalizedidentifier(object))} -%}
+        {%- set route = route|merge({parameters: route.parameters|default([])|merge(newParameters)}) -%}
+    {%- endif -%}
+
+    {%- include '@SonataAdmin/CRUD/display_url.html.twig' with {
+        value: value,
+        url: field_description.option('url'),
+        route: route,
+        hide_protocol: field_description.option('hide_protocol'),
+        attributes: field_description.option('attributes'),
+        safe: field_description.option('safe'),
+    } only -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_boolean.html.twig
+++ b/src/Resources/views/CRUD/show_boolean.html.twig
@@ -12,5 +12,8 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_boolean.html.twig' -%}
+    {%- include '@SonataAdmin/CRUD/display_boolean.html.twig' with {
+        value: value,
+        inverse: field_description.option('inverse'),
+    } only -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_choice.html.twig
+++ b/src/Resources/views/CRUD/show_choice.html.twig
@@ -11,5 +11,12 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_choice.html.twig' -%}
+    {%- include '@SonataAdmin/CRUD/display_choice.html.twig' with {
+        value: value,
+        choices: field_description.option('choices'),
+        multiple: field_description.option('multiple'),
+        delimiter: field_description.option('delimiter'),
+        translation_domain: field_description.option('catalogue'),
+        safe: field_description.option('safe'),
+    } only -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_currency.html.twig
+++ b/src/Resources/views/CRUD/show_currency.html.twig
@@ -12,5 +12,8 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_currency.html.twig' -%}
+    {%- include '@SonataAdmin/CRUD/display_currency.html.twig' with {
+        value: value,
+        currency: field_description.option('currency'),
+    } only -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_date.html.twig
+++ b/src/Resources/views/CRUD/show_date.html.twig
@@ -12,5 +12,9 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_date.html.twig' -%}
+    {%- include '@SonataAdmin/CRUD/display_date.html.twig' with {
+        value: value,
+        format: field_description.option('format'),
+        timezone: field_description.option('timezone'),
+    } only -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_datetime.html.twig
+++ b/src/Resources/views/CRUD/show_datetime.html.twig
@@ -12,5 +12,9 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_datetime.html.twig' -%}
+    {%- include '@SonataAdmin/CRUD/display_datetime.html.twig' with {
+        value: value,
+        format: field_description.option('format'),
+        timezone: field_description.option('timezone'),
+    } only -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_email.html.twig
+++ b/src/Resources/views/CRUD/show_email.html.twig
@@ -1,5 +1,10 @@
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
-    {% include '@SonataAdmin/CRUD/_email_link.html.twig' %}
+    {% include '@SonataAdmin/CRUD/display_email.html.twig' with {
+        value: value,
+        as_string: field_description.option('as_string'),
+        subject: field_description.option('subject'),
+        body: field_description.option('body'),
+    } only %}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_html.html.twig
+++ b/src/Resources/views/CRUD/show_html.html.twig
@@ -1,5 +1,9 @@
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_html.html.twig' -%}
+    {%- include '@SonataAdmin/CRUD/display_html.html.twig' with {
+        value: value,
+        truncate: field_description.option('truncate'),
+        strip: field_description.option('strip'),
+    } only -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_percent.html.twig
+++ b/src/Resources/views/CRUD/show_percent.html.twig
@@ -12,5 +12,5 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_percent.html.twig' -%}
+    {%- include '@SonataAdmin/CRUD/display_percent.html.twig' with { value: value } only -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_time.html.twig
+++ b/src/Resources/views/CRUD/show_time.html.twig
@@ -12,5 +12,9 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_time.html.twig' -%}
+    {%- include '@SonataAdmin/CRUD/display_time.html.twig' with {
+        value: value,
+        format: field_description.option('format'),
+        timezone: field_description.option('timezone'),
+    } only -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_trans.html.twig
+++ b/src/Resources/views/CRUD/show_trans.html.twig
@@ -11,5 +11,10 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_trans.html.twig' -%}
+    {%- include '@SonataAdmin/CRUD/display_trans.html.twig' with {
+        value: value,
+        value_format: field_description.option('format'),
+        translation_domain: field_description.option('catalogue', admin.translationDomain),
+        safe: field_description.option('safe'),
+    } only -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_url.html.twig
+++ b/src/Resources/views/CRUD/show_url.html.twig
@@ -12,5 +12,18 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_url.html.twig' -%}
+    {%- set route = field_description.option('route') -%}
+    {%- if route is not null and route.identifier_parameter_name is defined -%}
+        {%- set newParameters = {(route.identifier_parameter_name):(admin.normalizedidentifier(object))} -%}
+        {%- set route = route|merge({parameters: route.parameters|default([])|merge(newParameters)}) -%}
+    {%- endif -%}
+
+    {%- include '@SonataAdmin/CRUD/display_url.html.twig' with {
+        value: value,
+        url: field_description.option('url'),
+        route: route,
+        hide_protocol: field_description.option('hide_protocol'),
+        attributes: field_description.option('attributes'),
+        safe: field_description.option('safe'),
+    } only -%}
 {% endblock %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `_email_link.html.twig` template, use `display_email.html.twig` instead.
- Using a `display_*` templates passing a field_description. You should passed the option directly instead.

### Fixed
- Stop throwing an error when using a `display_*` templates without passing a field_description.
```