### PR TITLE
Restrict return type of execute method

### DIFF
--- a/src/Datagrid/ProxyQueryInterface.php
+++ b/src/Datagrid/ProxyQueryInterface.php
@@ -29,7 +29,7 @@ interface ProxyQueryInterface
     public function __call($name, $args);
 
     /**
-     * @return mixed
+     * @return array<object>|(\Traversable<object>&\Countable)
      */
     public function execute();
 

--- a/src/Datagrid/SimplePager.php
+++ b/src/Datagrid/SimplePager.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Datagrid;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Sonata\AdminBundle\Util\TraversableToCollection;
 
 /**
  * @final since sonata-project/admin-bundle 3.52
@@ -27,7 +29,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 class SimplePager extends Pager
 {
     /**
-     * @var iterable<object>|null
+     * @var Collection<array-key, object>|null
      */
     protected $results;
 
@@ -95,16 +97,13 @@ class SimplePager extends Pager
             return $this->results;
         }
 
-        $this->results = $this->getQuery()->execute();
-        $this->thresholdCount = \count($this->results);
-        if (\count($this->results) > $this->getMaxPerPage()) {
+        $this->results = TraversableToCollection::transform($this->getQuery()->execute());
+        $this->thresholdCount = $this->results->count();
+
+        if ($this->thresholdCount > $this->getMaxPerPage()) {
             $this->haveToPaginate = true;
 
-            if ($this->results instanceof ArrayCollection) {
-                $this->results = new ArrayCollection($this->results->slice(0, $this->getMaxPerPage()));
-            } else {
-                $this->results = new ArrayCollection(\array_slice($this->results, 0, $this->getMaxPerPage()));
-            }
+            $this->results = new ArrayCollection($this->results->slice(0, $this->getMaxPerPage()));
         } else {
             $this->haveToPaginate = false;
         }
@@ -129,16 +128,13 @@ class SimplePager extends Pager
         }
 
         // @phpstan-ignore-next-line
-        $this->results = $this->getQuery()->execute([], $hydrationMode);
-        $this->thresholdCount = \count($this->results);
-        if (\count($this->results) > $this->getMaxPerPage()) {
+        $this->results = TraversableToCollection::transform($this->getQuery()->execute([], $hydrationMode));
+        $this->thresholdCount = $this->results->count();
+
+        if ($this->thresholdCount > $this->getMaxPerPage()) {
             $this->haveToPaginate = true;
 
-            if ($this->results instanceof ArrayCollection) {
-                $this->results = new ArrayCollection($this->results->slice(0, $this->getMaxPerPage()));
-            } else {
-                $this->results = new ArrayCollection(\array_slice($this->results, 0, $this->getMaxPerPage()));
-            }
+            $this->results = new ArrayCollection($this->results->slice(0, $this->getMaxPerPage()));
         } else {
             $this->haveToPaginate = false;
         }

--- a/src/Form/ChoiceList/ModelChoiceLoader.php
+++ b/src/Form/ChoiceList/ModelChoiceLoader.php
@@ -145,8 +145,8 @@ class ModelChoiceLoader implements ChoiceLoaderInterface
                 } else {
                     // NEXT_MAJOR: Change for a LogicException instead.
                     throw new RuntimeException(sprintf(
-                        'Unable to convert the entity "%s" to string, provide "property" option'
-                        .' or implement "__toString()" method in your entity.',
+                        'Unable to convert the model "%s" to string, provide "property" option'
+                        .' or implement "__toString()" method in your model.',
                         ClassUtils::getClass($model)
                     ));
                 }

--- a/src/Form/ChoiceList/ModelChoiceLoader.php
+++ b/src/Form/ChoiceList/ModelChoiceLoader.php
@@ -139,17 +139,16 @@ class ModelChoiceLoader implements ChoiceLoaderInterface
                 if ($this->propertyPath) {
                     // If the property option was given, use it
                     $valueObject = $this->propertyAccessor->getValue($model, $this->propertyPath);
-                } else {
+                } elseif (method_exists($model, '__toString')) {
                     // Otherwise expect a __toString() method in the entity
-                    try {
-                        $valueObject = (string) $model;
-                    } catch (\Exception $e) {
-                        throw new RuntimeException(sprintf(
-                            'Unable to convert the entity "%s" to string, provide "property" option'
-                            .' or implement "__toString()" method in your entity.',
-                            ClassUtils::getClass($model)
-                        ), 0, $e);
-                    }
+                    $valueObject = (string) $model;
+                } else {
+                    // NEXT_MAJOR: Change for a LogicException instead.
+                    throw new RuntimeException(sprintf(
+                        'Unable to convert the entity "%s" to string, provide "property" option'
+                        .' or implement "__toString()" method in your entity.',
+                        ClassUtils::getClass($model)
+                    ));
                 }
 
                 $id = implode(AdapterInterface::ID_SEPARATOR, $this->getIdentifierValues($model));

--- a/src/Form/DataTransformer/ModelsToArrayTransformer.php
+++ b/src/Form/DataTransformer/ModelsToArrayTransformer.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Form\DataTransformer;
 
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Util\ClassUtils;
 use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader;
@@ -178,7 +177,6 @@ class ModelsToArrayTransformer implements DataTransformerInterface
             $result = $this->modelManager->executeQuery($query);
         }
 
-        /** @phpstan-var ArrayCollection<array-key, T> $collection */
         $collection = TraversableToCollection::transform($result);
 
         $diffCount = \count($value) - $collection->count();

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -317,6 +317,10 @@ interface ModelManagerInterface extends DatagridManagerInterface
 
     /**
      * @param object $query
+     *
+     * @return array<object>|(\Traversable<object>&\Countable)
+     *
+     * @phpstan-return array<T>|(\Traversable<T>&\Countable)
      */
     public function executeQuery($query);
 

--- a/src/Util/TraversableToCollection.php
+++ b/src/Util/TraversableToCollection.php
@@ -22,13 +22,15 @@ use Doctrine\Common\Collections\Collection;
 final class TraversableToCollection
 {
     /**
-     * @param mixed $value
+     * @param \Traversable|array $value
      *
      * @throws \TypeError
      *
      * @return Collection<int|string, mixed>
      *
-     * @phpstan-return Collection<array-key, mixed>
+     * @phpstan-template T
+     * @phpstan-param \Traversable<T>|array<T> $value
+     * @phpstan-return Collection<array-key, T>
      */
     public static function transform($value): Collection
     {

--- a/tests/Datagrid/SimplePagerTest.php
+++ b/tests/Datagrid/SimplePagerTest.php
@@ -122,32 +122,9 @@ class SimplePagerTest extends TestCase
     }
 
     /**
-     * NEXT_MAJOR: Remove this test along with fixes to SimplePager.
-     */
-    public function testGetCurrentPageResultsReturnTypeArrayCollection(): void
-    {
-        $this->proxyQuery->expects($this->once())
-            ->method('execute')
-            ->willReturn(['foo', 'bar']);
-
-        $this->pager->setQuery($this->proxyQuery);
-        $this->pager->setMaxPerPage(1);
-
-        $this->assertInstanceOf(ArrayCollection::class, $this->pager->getCurrentPageResults());
-    }
-
-    public function getCurrentPageResultsReturnType(): array
-    {
-        return [
-            [['foo', 'bar'], 2],
-            [[], null],
-        ];
-    }
-
-    /**
      * @dataProvider getCurrentPageResultsReturnType
      */
-    public function testGetCurrentPageResultsReturnTypeArray(array $queryReturnValues, ?int $maxPerPage): void
+    public function testGetCurrentPageResultsReturnTypeArrayCollection(array $queryReturnValues, ?int $maxPerPage): void
     {
         $this->proxyQuery->expects($this->once())
             ->method('execute')
@@ -156,6 +133,15 @@ class SimplePagerTest extends TestCase
         $this->pager->setQuery($this->proxyQuery);
         $this->pager->setMaxPerPage($maxPerPage);
 
-        $this->assertIsArray($this->pager->getCurrentPageResults());
+        $this->assertInstanceOf(ArrayCollection::class, $this->pager->getCurrentPageResults());
+    }
+
+    public function getCurrentPageResultsReturnType(): array
+    {
+        return [
+            [['foo', 'bar'], 2],
+            [['foo', 'bar'], 1],
+            [[], null],
+        ];
     }
 }


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

We're using `ProxyQuery::execute()` method as if it alway return an array|Traversable.
Indeed, we're sometimes using `TraversableToCollection::transform()` on it.
So I think we can update the phpdoc. Same for `ModelManager::executeQuery()`.

I also used `TraversableToCollection` in the `SimplePager`.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Restrict return type of `ProxyQuery::execute()` method to `array<object>|(\Traversable<object>&\Countable)`
```