### PR TITLE
[RFC] Add FilterData

### DIFF
--- a/src/Filter/Model/FilterData.php
+++ b/src/Filter/Model/FilterData.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Filter\Model;
+
+/**
+ * @psalm-immutable
+ */
+final class FilterData
+{
+    /**
+     * @var ?int
+     */
+    private $type;
+
+    /**
+     * @var mixed
+     */
+    private $value;
+
+    /**
+     * @var bool
+     */
+    private $hasValue;
+
+    private function __construct()
+    {
+        $this->hasValue = false;
+    }
+
+    /**
+     * @psalm-pure
+     *
+     * @phpstan-param array{type?: int|numeric-string|null, value?: mixed} $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $filterData = new self();
+
+        if (isset($data['type'])) {
+            if (!\is_int($data['type']) && (!\is_string($data['type']) || !is_numeric($data['type']))) {
+                throw new \InvalidArgumentException(sprintf(
+                    'The "type" parameter MUST be of type "integer" or "null", %s given.',
+                    \is_object($data['type']) ? 'instance of "'.\get_class($data['type']).'"' : '"'.\gettype($data['type']).'"'
+                ));
+            }
+
+            $filterData->type = (int) $data['type'];
+        }
+
+        if (\array_key_exists('value', $data)) {
+            $filterData->value = $data['value'];
+            $filterData->hasValue = true;
+        }
+
+        return $filterData;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        if (!$this->hasValue) {
+            throw new \LogicException('The FilterData object does not have a value.');
+        }
+
+        return $this->value;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function changeValue($value): self
+    {
+        return self::fromArray([
+            'type' => $this->getType(),
+            'value' => $value,
+        ]);
+    }
+
+    public function getType(): ?int
+    {
+        return $this->type;
+    }
+
+    public function isType(int $type): bool
+    {
+        return $this->type === $type;
+    }
+
+    public function hasValue(): bool
+    {
+        return $this->hasValue;
+    }
+}

--- a/tests/Filter/Model/FilterDataTest.php
+++ b/tests/Filter/Model/FilterDataTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Filter\Model;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Filter\Model\FilterData;
+
+final class FilterDataTest extends TestCase
+{
+    /**
+     * @dataProvider getInvalidTypes
+     *
+     * @param mixed $type
+     */
+    public function testTypeMustBeNumericOrNull($type): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
+            'The "type" parameter MUST be of type "integer" or "null", %s given.',
+            \is_object($type) ? 'instance of "'.\get_class($type).'"' : '"'.\gettype($type).'"'
+        ));
+
+        FilterData::fromArray(['type' => $type]);
+    }
+
+    /**
+     * @return iterable<array<mixed>>
+     */
+    public function getInvalidTypes(): iterable
+    {
+        yield ['string'];
+        yield [new \stdClass()];
+        yield [[]];
+        yield [42.0];
+    }
+
+    public function testEmptyArray(): void
+    {
+        $filterData = FilterData::fromArray([]);
+        $this->assertFalse($filterData->hasValue());
+        $this->assertNull($filterData->getType());
+    }
+
+    public function testHasValue(): void
+    {
+        $this->assertFalse(FilterData::fromArray([])->hasValue());
+        $this->assertTrue(FilterData::fromArray(['value' => ''])->hasValue());
+        $this->assertTrue(FilterData::fromArray(['value' => null])->hasValue());
+    }
+
+    /**
+     * @dataProvider getTypes
+     *
+     * @param int|string|null $type
+     */
+    public function testGetType(?int $expected, $type): void
+    {
+        $this->assertSame($expected, FilterData::fromArray(['type' => $type])->getType());
+    }
+
+    /**
+     * @return iterable<array<string|int|null>>
+     */
+    public function getTypes(): iterable
+    {
+        yield 'nullable' => [null, null];
+        yield 'int' => [3, 3];
+        yield 'numeric string' => [3, '3'];
+    }
+
+    /**
+     * @dataProvider getValues
+     *
+     * @param mixed $value
+     */
+    public function testGetValue($value): void
+    {
+        $this->assertSame($value, FilterData::fromArray(['value' => $value])->getValue());
+    }
+
+    /**
+     * @return iterable<array<mixed>>
+     */
+    public function getValues(): iterable
+    {
+        yield [null];
+        yield [new \stdClass()];
+        yield [3];
+        yield ['3'];
+    }
+
+    public function testSetValue(): void
+    {
+        $filterData = FilterData::fromArray(['type' => 1, 'value' => 'value']);
+        $newFilterData = $filterData->changeValue('new_value');
+
+        $this->assertSame(1, $newFilterData->getType());
+        $this->assertSame('new_value', $newFilterData->getValue());
+    }
+
+    public function testGetValueThrowsExceptionIfValueNotPresent(): void
+    {
+        $filterData = FilterData::fromArray([]);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('The FilterData object does not have a value.');
+
+        $filterData->getValue();
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Ref: https://github.com/sonata-project/SonataAdminBundle/pull/7022#issuecomment-826994705

Adding this VO introduced in next major version allows us to add forward compatibility for callback filter functions.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `FilterData` to use it for forward compatibility with `4.0`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
