### PR TITLE
Stop trying to foreach on ArrayAccess

### DIFF
--- a/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
+++ b/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
@@ -131,11 +131,11 @@ class ModelToIdPropertyTransformer implements DataTransformerInterface
     }
 
     /**
-     * @param object|object[]|null $value
+     * @param object|array<object>|\Traversable<object>|null $value
      *
      * @return mixed[]
      *
-     * @phpstan-param T|T[]|null $value
+     * @phpstan-param T|array<T>|\Traversable<T>|null $value
      */
     public function transform($value)
     {
@@ -145,8 +145,8 @@ class ModelToIdPropertyTransformer implements DataTransformerInterface
             return $result;
         }
 
+        $isArray = \is_array($value);
         if ($this->multiple) {
-            $isArray = \is_array($value);
             if (!$isArray && substr(\get_class($value), -1 * \strlen($this->className)) === $this->className) {
                 throw new \InvalidArgumentException(
                     'A multiple selection must be passed a collection not a single value.'
@@ -154,7 +154,7 @@ class ModelToIdPropertyTransformer implements DataTransformerInterface
                     .' is set for many-to-many or one-to-many relations.'
                 );
             }
-            if ($isArray || ($value instanceof \ArrayAccess)) {
+            if ($isArray || ($value instanceof \Traversable)) {
                 $collection = $value;
             } else {
                 throw new \InvalidArgumentException(
@@ -166,7 +166,7 @@ class ModelToIdPropertyTransformer implements DataTransformerInterface
         } else {
             if (substr(\get_class($value), -1 * \strlen($this->className)) === $this->className) {
                 $collection = [$value];
-            } elseif ($value instanceof \ArrayAccess) {
+            } elseif ($isArray || $value instanceof \Traversable) {
                 throw new \InvalidArgumentException(
                     'A single selection must be passed a single value not a collection.'
                     .' Make sure that form option "multiple=false" is set for many-to-one relation and "multiple=true"'


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Backport of https://github.com/sonata-project/SonataAdminBundle/pull/7119/commits/f5b96041ff10f1d008f72e86824f3eb9dd6f042b

I am targeting this branch, because bugfix.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Calling foreach on `ArrayAccess` in ModelToIdPropertyTransformer
```