### PR TITLE
add "setFormTheme" and "setFilterTheme" calls + change "initialize" priority

### DIFF
--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -386,8 +386,12 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
             $definition->addMethodCall('setSecurityInformation', ['%sonata.admin.configuration.security.information%']);
         }
 
-        $definition->addMethodCall('setFormTheme', [$overwriteAdminConfiguration['templates']['form'] ?? []]);
-        $definition->addMethodCall('setFilterTheme', [$overwriteAdminConfiguration['templates']['filter'] ?? []]);
+        if (!$definition->hasMethodCall('setFormTheme')) {
+            $definition->addMethodCall('setFormTheme', [$overwriteAdminConfiguration['templates']['form'] ?? []]);
+        }
+        if (!$definition->hasMethodCall('setFilterTheme')) {
+            $definition->addMethodCall('setFilterTheme', [$overwriteAdminConfiguration['templates']['filter'] ?? []]);
+        }
 
         return $definition;
     }

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -338,7 +338,7 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
             $method = $this->generateSetterMethodName($attr);
 
-            if (isset($overwriteAdminConfiguration[$attr]) || !$definition->hasMethodCall($method)) {
+            if (!$definition->hasMethodCall($method)) {
                 $args = [new Reference($overwriteAdminConfiguration[$attr] ?? $addServiceId)];
                 if ('translator' === $attr) {
                     $args[] = false;

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -386,7 +386,8 @@ class AddDependencyCallsCompilerPass implements CompilerPassInterface
             $definition->addMethodCall('setSecurityInformation', ['%sonata.admin.configuration.security.information%']);
         }
 
-        $definition->addMethodCall('initialize');
+        $definition->addMethodCall('setFormTheme', [$overwriteAdminConfiguration['templates']['form'] ?? []]);
+        $definition->addMethodCall('setFilterTheme', [$overwriteAdminConfiguration['templates']['filter'] ?? []]);
 
         return $definition;
     }

--- a/src/DependencyInjection/Compiler/AdminAddInitializeCallCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AdminAddInitializeCallCompilerPass.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * this compiler pass is registered with low priority to make sure it runs after all the other passes
+ * as we want the "initialize()" calls to come after all the other calls.
+ *
+ * @internal
+ */
+final class AdminAddInitializeCallCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $admins = $container->findTaggedServiceIds('sonata.admin');
+        foreach (array_keys($admins) as $id) {
+            $container->getDefinition($id)->addMethodCall('initialize');
+        }
+    }
+}

--- a/src/SonataAdminBundle.php
+++ b/src/SonataAdminBundle.php
@@ -17,6 +17,7 @@ use Mopa\Bundle\BootstrapBundle\Form\Type\TabType;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddAuditReadersCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddFilterTypeCompilerPass;
+use Sonata\AdminBundle\DependencyInjection\Compiler\AdminAddInitializeCallCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AdminMakerCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AdminSearchCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AliasDeprecatedPublicServicesCompilerPass;
@@ -63,6 +64,7 @@ class SonataAdminBundle extends Bundle
         $container->addCompilerPass(new AdminMakerCompilerPass());
         $container->addCompilerPass(new AddAuditReadersCompilerPass());
         $container->addCompilerPass(new AliasDeprecatedPublicServicesCompilerPass(), PassConfig::TYPE_AFTER_REMOVING);
+        $container->addCompilerPass(new AdminAddInitializeCallCompilerPass(), PassConfig::TYPE_BEFORE_REMOVING, -100);
 
         $this->registerFormMapping();
     }

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -202,15 +202,27 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
         );
 
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
-            'sonata_article_admin',
+            'sonata_news_admin',
             'setFormTheme',
             [[]]
         );
 
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
-            'sonata_article_admin',
+            'sonata_news_admin',
             'setFilterTheme',
             [[]]
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata_article_admin',
+            'setFormTheme',
+            [['custom_form_theme.twig']]
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata_article_admin',
+            'setFilterTheme',
+            [['custom_filter_theme.twig']]
         );
 
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
@@ -626,6 +638,12 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
                         'view' => ['user_block' => 'foo.twig.html'],
                     ],
                 ],
+                'sonata_article_admin' => [
+                    'templates' => [
+                        'form' => ['some_form_template.twig'],
+                        'filter' => ['some_filter_template.twig'],
+                    ],
+                ],
             ],
         ];
     }
@@ -662,7 +680,9 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
             ->setPublic(true)
             ->setClass(MockAdmin::class)
             ->setArguments(['', Article::class, CRUDController::class])
-            ->addTag('sonata.admin', ['group' => 'sonata_group_one', 'label' => '1 Entry', 'manager_type' => 'doctrine_phpcr']);
+            ->addTag('sonata.admin', ['group' => 'sonata_group_one', 'label' => '1 Entry', 'manager_type' => 'doctrine_phpcr'])
+            ->addMethodCall('setFormTheme', [['custom_form_theme.twig']])
+            ->addMethodCall('setFilterTheme', [['custom_filter_theme.twig']]);
         $this->container
             ->register('sonata_report_admin')
             ->setPublic(true)

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -200,6 +200,30 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
             'setRouteBuilder',
             ['sonata.admin.route.path_info_slashes']
         );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata_article_admin',
+            'setFormTheme',
+            [[]]
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata_article_admin',
+            'setFilterTheme',
+            [[]]
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata_post_admin',
+            'setFormTheme',
+            [['some_form_template.twig']]
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata_post_admin',
+            'setFilterTheme',
+            [['some_filter_template.twig']]
+        );
     }
 
     public function testProcessSortAdmins(): void
@@ -591,6 +615,8 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
                 'sonata_post_admin' => [
                     'templates' => [
                         'view' => ['user_block' => 'foobar.twig.html'],
+                        'form' => ['some_form_template.twig'],
+                        'filter' => ['some_filter_template.twig'],
                     ],
                 ],
                 'sonata_news_admin' => [

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -27,6 +27,7 @@ use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveEnvPlaceholdersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @author Tiago Garcia
@@ -211,6 +212,12 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
             'sonata_news_admin',
             'setFilterTheme',
             [[]]
+        );
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata_news_admin',
+            'setModelManager',
+            [new Reference('my.model.manager')]
         );
 
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
@@ -668,7 +675,8 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
             ->setPublic(true)
             ->setClass(MockAdmin::class)
             ->setArguments(['', News::class, CRUDController::class])
-            ->addTag('sonata.admin', ['group' => 'sonata_group_two', 'label' => '5 Entry', 'manager_type' => 'orm']);
+            ->addTag('sonata.admin', ['group' => 'sonata_group_two', 'label' => '5 Entry', 'manager_type' => 'orm'])
+            ->addMethodCall('setModelManager', [new Reference('my.model.manager')]);
         $this->container
             ->register('sonata_post_admin')
             ->setClass(MockAdmin::class)

--- a/tests/DependencyInjection/Compiler/AdminAddInitializeCallCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AdminAddInitializeCallCompilerPassTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\DependencyInjection\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\DependencyInjection\Compiler\AdminAddInitializeCallCompilerPass;
+use Sonata\AdminBundle\Tests\App\Admin\FooAdmin;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class AdminAddInitializeCallCompilerPassTest extends TestCase
+{
+    public function testProcess(): void
+    {
+        $builder = new ContainerBuilder();
+        $builder->register('foo', FooAdmin::class)
+            ->addTag('sonata.admin');
+
+        (new AdminAddInitializeCallCompilerPass())->process($builder);
+
+        $this->assertSame([['initialize', []]], $builder->getDefinition('foo')->getMethodCalls());
+    }
+}

--- a/tests/SonataAdminBundleTest.php
+++ b/tests/SonataAdminBundleTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddAuditReadersCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddFilterTypeCompilerPass;
+use Sonata\AdminBundle\DependencyInjection\Compiler\AdminAddInitializeCallCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AdminMakerCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AdminSearchCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AliasDeprecatedPublicServicesCompilerPass;
@@ -37,7 +38,7 @@ class SonataAdminBundleTest extends TestCase
     {
         $containerBuilder = $this->createMock(ContainerBuilder::class);
 
-        $containerBuilder->expects($this->exactly(11))
+        $containerBuilder->expects($this->exactly(12))
             ->method('addCompilerPass')
             ->withConsecutive(
                 [new AddDependencyCallsCompilerPass()],
@@ -51,6 +52,7 @@ class SonataAdminBundleTest extends TestCase
                 [new AdminMakerCompilerPass()],
                 [new AddAuditReadersCompilerPass()],
                 [new AliasDeprecatedPublicServicesCompilerPass()],
+                [new AdminAddInitializeCallCompilerPass()],
             );
 
         $bundle = new SonataAdminBundle();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its BC and part of fixing https://github.com/sonata-project/SonataAdminBundle/issues/7104

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `AdminInterface::initialize()` is the last method called
- `admin_services.templates.form` is correctly set
- `admin_services.templates.filter` is correctly set
- default service setter calls on `AdminInterface` are only added if there are no calls defined yet

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
