### PR TITLE
Bug - Removed do-not-use alias for exporter service

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -163,7 +163,7 @@ class CRUDController implements ContainerAwareInterface
             'form' => $formView,
             'datagrid' => $datagrid,
             'csrf_token' => $this->getCsrfToken('sonata.batch'),
-            'export_formats' => $this->has('sonata.admin.admin_exporter') ?
+            'export_formats' => $this->has('sonata.admin.admin_exporter.do-not-use') ?
                 $this->get('sonata.admin.admin_exporter.do-not-use')->getAvailableFormats($this->admin) :
                 $this->admin->getExportFormats(),
         ]);
@@ -940,7 +940,7 @@ class CRUDController implements ContainerAwareInterface
         $format = $request->get('format');
 
         // NEXT_MAJOR: remove the check
-        if (!$this->has('sonata.admin.admin_exporter')) {
+        if (!$this->has('sonata.admin.admin_exporter.do-not-use')) {
             @trigger_error(
                 'Not registering the exporter bundle is deprecated since version 3.14. You must register it to be able to use the export action in 4.0.',
                 \E_USER_DEPRECATED
@@ -959,7 +959,7 @@ class CRUDController implements ContainerAwareInterface
             $adminExporter = $this->get('sonata.admin.admin_exporter.do-not-use');
             $allowedExportFormats = $adminExporter->getAvailableFormats($this->admin);
             $filename = $adminExporter->getExportFilename($this->admin, $format);
-            $exporter = $this->get('sonata.exporter.exporter.do-not-use');
+            $exporter = $this->get('sonata.exporter.exporter');
         }
 
         if (!\in_array($format, $allowedExportFormats, true)) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Remove `do-not-use` alias for exporter service

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it's failing in 3.x version.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #7134.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Remove `do-not-use` alias for exporter service.

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
