### PR TITLE
Avoid accidental removal of some frontend dependencies

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -12,6 +12,9 @@ import '../scss/app.scss';
 
 // Require jQuery normally
 import $ from 'jquery';
+
+// jQuery scrollTo is not directly used in SonataAdmin
+// but it is used on SonataPage, SonataArticle and SonataDashboard
 import 'jquery.scrollto';
 
 // Only using sortable widget from jQuery UI library
@@ -23,6 +26,9 @@ import 'moment';
 // Eonasdan Bootstrap DateTimePicker in its version 3 does not
 // provide the scss or plain css, it only provides the less version
 // of its source files, that's why it is not included it via npm.
+//
+// Eonasdan Bootstrap DateTimePicker is not directly used in SonataAdmin
+// but it is used on form-extensions package
 import '../vendor/bootstrap-datetimepicker.min';
 import 'jquery-form';
 
@@ -34,6 +40,8 @@ import 'x-editable/dist/bootstrap3-editable/js/bootstrap-editable';
 import 'select2/dist/js/select2.full';
 import 'admin-lte';
 import 'icheck';
+
+// jQuery SlimScroll is used in AdminLTE v2
 import 'jquery-slimscroll';
 
 // No Framework Waypoints version and sticky shortcut

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -33,6 +33,9 @@
 // Eonasdan Bootstrap DateTimePicker in its version 3 does not
 // provide the scss or plain css, it only provides the less version
 // of its source files, that's why it is not included it via npm.
+//
+// Eonasdan Bootstrap DateTimePicker is not directly used in SonataAdmin
+// but it is used on form-extensions package
 @import "../vendor/bootstrap-datetimepicker.min.css";
 
 // Only use sortable widget from jQuery UI library

--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
     "eslint-plugin-header": "^3.1",
     "eslint-plugin-import": "^2.22",
     "file-loader": "^6.0",
+    "postcss": "^8.2",
     "postcss-loader": "^5.2",
     "sass": "^1.32",
     "sass-loader": "^11.0",
     "stylelint": "^13.12",
-    "stylelint-config-standard": "^21.0",
+    "stylelint-config-standard": "^22.0",
     "stylelint-order": "^4.1",
     "stylelint-scss": "^3.19",
     "stylelint-webpack-plugin": "^2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5906,7 +5906,7 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postcss@^8.2.10:
+postcss@^8.2, postcss@^8.2.10:
   version "8.2.13"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.13.tgz#dbe043e26e3c068e45113b1ed6375d2d37e2129f"
   integrity sha512-FCE5xLH+hjbzRdpbRb1IMCvPv9yZx2QnDarBEYSN0N0HYk+TcXsEhwdFcFb+SRWOKzKGErhIEbBK2ogyLdTtfQ==
@@ -6895,17 +6895,17 @@ stylehacks@^4.0.0:
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
 
-stylelint-config-recommended@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-4.0.0.tgz#665a0034065e6704d5032ba51bf4efa37d328ef9"
-  integrity sha512-sgna89Ng+25Hr9kmmaIxpGWt2LStVm1xf1807PdcWasiPDaOTkOHRL61sINw0twky7QMzafCGToGDnHT/kTHtQ==
+stylelint-config-recommended@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-5.0.0.tgz#fb5653f495a60b4938f2ad3e77712d9e1039ae78"
+  integrity sha512-c8aubuARSu5A3vEHLBeOSJt1udOdS+1iue7BmJDTSXoCBmfEQmmWX+59vYIj3NQdJBY6a/QRv1ozVFpaB9jaqA==
 
-stylelint-config-standard@^21.0:
-  version "21.0.0"
-  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-21.0.0.tgz#4942cfa27301eb6702fa8fc46a44da35d1a5cfd7"
-  integrity sha512-Yf6mx5oYEbQQJxWuW7X3t1gcxqbUx52qC9SMS3saC2ruOVYEyqmr5zSW6k3wXflDjjFrPhar3kp68ugRopmlzg==
+stylelint-config-standard@^22.0:
+  version "22.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-standard/-/stylelint-config-standard-22.0.0.tgz#c860be9a13ebbc1b084456fa10527bf13a44addf"
+  integrity sha512-uQVNi87SHjqTm8+4NIP5NMAyY/arXrBgimaaT7skvRfE9u3JKXRK9KBkbr4pVmeciuCcs64kAdjlxfq6Rur7Hw==
   dependencies:
-    stylelint-config-recommended "^4.0.0"
+    stylelint-config-recommended "^5.0.0"
 
 stylelint-order@^4.1:
   version "4.1.0"


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is only applies to master.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Part of #7049 

I tried to remove jquery-slimScroll and jquery-scrollTo but found that they are used outside this bundle:

jquery-slimScroll is kind of used for admin-lte
jquery-scrollTo is used by other sonata bundles

I just added some explanations to the javascript, just in case someone tries to remove them. Ideally the dependencies should be placed where the usage is done, but for now this is better than nothing.

I also added postcss, it was a missing dependency