### PR TITLE
Allow admin extension to configure admin at initialize time

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -581,6 +581,13 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         $this->baseCodeRoute = $this->getCode();
 
         $this->configure();
+
+        foreach ($this->getExtensions() as $extension) {
+            // NEXT_MAJOR: remove method_exists check
+            if (method_exists($extension, 'configure')) {
+                $extension->configure($this);
+            }
+        }
     }
 
     /**
@@ -588,12 +595,6 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
      */
     public function configure()
     {
-        foreach ($this->getExtensions() as $extension) {
-            // NEXT_MAJOR: remove method_exists check
-            if (method_exists($extension, 'configure')) {
-                $extension->configure($this);
-            }
-        }
     }
 
     public function update($object)

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -588,6 +588,12 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
      */
     public function configure()
     {
+        foreach ($this->getExtensions() as $extension) {
+            // NEXT_MAJOR: remove method_exists check
+            if (method_exists($extension, 'configure')) {
+                $extension->configure($this);
+            }
+        }
     }
 
     public function update($object)

--- a/src/Admin/AbstractAdminExtension.php
+++ b/src/Admin/AbstractAdminExtension.php
@@ -113,6 +113,13 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
     /**
      * @phpstan-param AdminInterface<T> $admin
      */
+    public function configure(AdminInterface $admin): void
+    {
+    }
+
+    /**
+     * @phpstan-param AdminInterface<T> $admin
+     */
     public function configureBatchActions(AdminInterface $admin, array $actions)
     {
         return $actions;

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -167,6 +167,13 @@ interface AdminExtensionInterface
     public function getPersistentParameters(AdminInterface $admin);
 
     /**
+     * Get a chance to configure admin before used.
+     *
+     * @phpstan-param AdminInterface<T> $admin
+     */
+//    public function configure(AdminInterface $admin): void;
+
+    /**
      * Get a chance to add persistent parameters.
      *
      * @param array<string, mixed> $parameters

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -26,6 +26,7 @@ use Sonata\Form\Validator\ErrorElement;
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
  * @method array getAccessMapping(AdminInterface $admin)
+ * @method array configure(AdminInterface $admin)
  * @method array configureBatchActions(AdminInterface $admin, array $actions)
  * @method array configureExportFields(AdminInterface $admin, array $fields)
  * @method array configureActionButtons(AdminInterface $admin, array $list, string $action, object $object)

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -26,7 +26,7 @@ use Sonata\Form\Validator\ErrorElement;
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
  * @method array getAccessMapping(AdminInterface $admin)
- * @method array configure(AdminInterface $admin)
+ * @method void  configure(AdminInterface $admin)
  * @method array configureBatchActions(AdminInterface $admin, array $actions)
  * @method array configureExportFields(AdminInterface $admin, array $fields)
  * @method array configureActionButtons(AdminInterface $admin, array $list, string $action, object $object)


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Allow admin to be configured by extensions at initialize time.

I am targeting this branch, because code is backwards compatible.

Closes #6890.

## Changelog

```markdown
### Added
- Added `AdminExtensionInterface::configure` method
- Added `AbstractAdminExtension::configure` method with no content

### Changed
- Changed `AbstractAdmin::initialize` and call `AdminExtensionInterface::configure` on each extension
```

## To do

- [ ] Update the documentation;

