### PR TITLE
Drop support for phpcr

### DIFF
--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -302,8 +302,7 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
             'route_generator' => 'sonata.admin.route.default_generator',
             'security_handler' => 'sonata.admin.security.handler',
             'menu_factory' => 'knp_menu.factory',
-            'route_builder' => 'sonata.admin.route.path_info'.
-                (('doctrine_phpcr' === $managerType) ? '_slashes' : ''),
+            'route_builder' => 'sonata.admin.route.path_info',
             'label_translator_strategy' => 'sonata.admin.label.strategy.native',
         ];
 

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -196,12 +196,6 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
         );
 
         $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
-            'sonata_article_admin',
-            'setRouteBuilder',
-            ['sonata.admin.route.path_info_slashes']
-        );
-
-        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'sonata_news_admin',
             'setFormTheme',
             [[]]
@@ -686,7 +680,7 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
             ->setPublic(true)
             ->setClass(CustomAdmin::class)
             ->setArguments(['', ArticleEntity::class, 'sonata.admin.controller.crud'])
-            ->addTag('sonata.admin', ['group' => 'sonata_group_one', 'label' => '1 Entry', 'manager_type' => 'doctrine_phpcr'])
+            ->addTag('sonata.admin', ['group' => 'sonata_group_one', 'label' => '1 Entry', 'manager_type' => 'doctrine_mongodb'])
             ->addMethodCall('setFormTheme', [['custom_form_theme.twig']])
             ->addMethodCall('setFilterTheme', [['custom_filter_theme.twig']]);
         $this->container


### PR DESCRIPTION
The Phpcr bundle is not abandonned.
There is no Sonata-4 compatibility.

IMHO we shouldn't add code for a specific persistence-bundle.
It should be the persistence bundle to adapt his code instead.