### PR TITLE
Remove Countable from execute return type

### DIFF
--- a/src/Datagrid/ProxyQueryInterface.php
+++ b/src/Datagrid/ProxyQueryInterface.php
@@ -29,7 +29,7 @@ interface ProxyQueryInterface
     public function __call($name, $args);
 
     /**
-     * @return array<object>|(\Traversable<object>&\Countable)
+     * @return array<object>|\Traversable<object>
      */
     public function execute();
 

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -332,9 +332,9 @@ interface ModelManagerInterface extends DatagridManagerInterface
     /**
      * @param object $query
      *
-     * @return array<object>|(\Traversable<object>&\Countable)
+     * @return array<object>|\Traversable<object>
      *
-     * @phpstan-return array<T>|(\Traversable<T>&\Countable)
+     * @phpstan-return array<T>|\Traversable<T>
      */
     public function executeQuery($query);
 


### PR DESCRIPTION
## Subject

Patch

If I understand correctly https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/585, the `execute` return type is not Countable. (cc @franmomu)

In the SonataAdmin we don't call count directly since we're using `TraversableToCollection`.

## Changelog

```markdown
### Fixed
- `ProxyQuery::execute()` return type ; it doesn't require to be a Countable.
```