### PR TITLE
Fix "show_empty_boxes" option in the documentation

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -247,5 +247,5 @@ Full Configuration Options
             filter_persister: sonata.admin.filter_persister.session
             show_mosaic_button: true
             global_search:
-                show_empty_boxes: show
+                empty_boxes: show
                 case_sensitive: true


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

Fix option `show_empty_boxes` to `empty_boxes` under **global_search**