### PR TITLE
Make action button icons configurable

### DIFF
--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -703,13 +703,14 @@ Icons on action buttons
 ------------------
 
 You can choose if the action buttons on the list-page show an icon, text or both.
+
 .. code-block:: yaml
 
     # config/packages/sonata_admin.yaml
 
     sonata_admin:
         options:
-            // Choices are: text,icon or both (default)
+            # Choices are: text,icon or both (default)
             button_mode: icon
 
 Checkbox range selection

--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -699,6 +699,19 @@ You need to add option ``show_mosaic_button`` in your admin services:
         tags:
             - { name: sonata.admin, manager_type: orm, group: admin, label: News, show_mosaic_button: false }
 
+Icons on action buttons
+------------------
+
+You can choose if the action buttons on the list-page show an icon, text or both.
+.. code-block:: yaml
+
+    # config/packages/sonata_admin.yaml
+
+    sonata_admin:
+        options:
+            // Choices are: text,icon or both (default)
+            button_mode: icon
+
 Checkbox range selection
 ------------------------
 

--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -700,7 +700,7 @@ You need to add option ``show_mosaic_button`` in your admin services:
             - { name: sonata.admin, manager_type: orm, group: admin, label: News, show_mosaic_button: false }
 
 Icons on action buttons
-------------------
+-----------------------
 
 You can choose if the action buttons on the list-page show an icon, text or both.
 

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -90,6 +90,7 @@ Full Configuration Options
                 default_icon: '<i class="fa fa-folder"></i>'
                 dropdown_number_groups_per_colums:  2
                 title_mode: ~ # One of "single_text"; "single_image"; "both"
+                button_mode: 'both' # One of "text"; "icon"; "both"
 
                 # Enable locking when editing an object, if the corresponding object manager supports it.
                 lock_protection: false

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -162,7 +162,7 @@ CASESENSITIVE;
                             ->values([
                                 'both',
                                 'icon',
-                                'text'
+                                'text',
                                 ])
                         ->end()
                         ->booleanNode('use_select2')->defaultTrue()->end()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -157,6 +157,14 @@ CASESENSITIVE;
                                 'skin-yellow-light',
                             ])
                         ->end()
+                        ->enumNode('button_style')
+                            ->defaultValue('both')
+                            ->values([
+                                'both',
+                                'icon',
+                                'text'
+                                ])
+                        ->end()
                         ->booleanNode('use_select2')->defaultTrue()->end()
                         ->booleanNode('use_icheck')->defaultTrue()->end()
                         ->booleanNode('use_bootlint')->defaultFalse()->end()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -157,7 +157,7 @@ CASESENSITIVE;
                                 'skin-yellow-light',
                             ])
                         ->end()
-                        ->enumNode('button_style')
+                        ->enumNode('button_mode')
                             ->defaultValue('both')
                             ->values([
                                 'both',

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -134,7 +134,7 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         $container->setParameter('sonata.admin.configuration.default_group', $config['options']['default_group']);
         $container->setParameter('sonata.admin.configuration.default_label_catalogue', $config['options']['default_label_catalogue']);
         $container->setParameter('sonata.admin.configuration.default_icon', $config['options']['default_icon']);
-        $container->setParameter('sonata.admin.configuration.button_style', $config['options']['button_style']);
+        $container->setParameter('sonata.admin.configuration.button_mode', $config['options']['button_mode']);
         $container->setParameter('sonata.admin.configuration.breadcrumbs', $config['breadcrumbs']);
 
         // NEXT_MAJOR: Remove this block and uncomment the one below.

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -134,7 +134,6 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         $container->setParameter('sonata.admin.configuration.default_group', $config['options']['default_group']);
         $container->setParameter('sonata.admin.configuration.default_label_catalogue', $config['options']['default_label_catalogue']);
         $container->setParameter('sonata.admin.configuration.default_icon', $config['options']['default_icon']);
-        $container->setParameter('sonata.admin.configuration.button_mode', $config['options']['button_mode']);
         $container->setParameter('sonata.admin.configuration.breadcrumbs', $config['breadcrumbs']);
 
         // NEXT_MAJOR: Remove this block and uncomment the one below.

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -134,6 +134,7 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         $container->setParameter('sonata.admin.configuration.default_group', $config['options']['default_group']);
         $container->setParameter('sonata.admin.configuration.default_label_catalogue', $config['options']['default_label_catalogue']);
         $container->setParameter('sonata.admin.configuration.default_icon', $config['options']['default_icon']);
+        $container->setParameter('sonata.admin.configuration.button_style', $config['options']['button_style']);
         $container->setParameter('sonata.admin.configuration.breadcrumbs', $config['breadcrumbs']);
 
         // NEXT_MAJOR: Remove this block and uncomment the one below.

--- a/src/Resources/views/CRUD/list__action_delete.html.twig
+++ b/src/Resources/views/CRUD/list__action_delete.html.twig
@@ -10,16 +10,19 @@ file that was distributed with this source code.
 #}
 
 {% if admin.hasAccess('delete', object) and admin.hasRoute('delete') %}
-    {% set _button_style = sonata_config.getOption('button_style') %}
+    {% set _button_mode = sonata_config.getOption('button_mode') %}
     <a
         href="{{ admin.generateObjectUrl('delete', object, actions.link_parameters|default([])) }}"
         class="btn btn-sm btn-default delete_link"
         title="{{ 'action_delete'|trans({}, 'SonataAdminBundle') }}"
     >
-        {% if _button_style == 'both' or _button_style == 'icon' %}
+        {% if _button_mode == 'both' or _button_mode == 'icon' %}
             <i class="fa fa-times" aria-hidden="true"></i>
+            <span class="sr-only">
+                {{ 'action_delete'|trans({}, 'SonataAdminBundle') }}
+            </span>
         {% endif %}
-        {% if _button_style == 'both' or _button_style == 'text' %}
+        {% if _button_mode == 'both' or _button_mode == 'text' %}
             {{ 'action_delete'|trans({}, 'SonataAdminBundle') }}
         {% endif %}
     </a>

--- a/src/Resources/views/CRUD/list__action_delete.html.twig
+++ b/src/Resources/views/CRUD/list__action_delete.html.twig
@@ -16,13 +16,14 @@ file that was distributed with this source code.
         class="btn btn-sm btn-default delete_link"
         title="{{ 'action_delete'|trans({}, 'SonataAdminBundle') }}"
     >
-        {% if _button_mode == 'both' or _button_mode == 'icon' %}
+        {% if _button_mode != 'text' %}
             <i class="fa fa-times" aria-hidden="true"></i>
+        {% endif %}
+        {% if _button_mode == 'icon' %}
             <span class="sr-only">
                 {{ 'action_delete'|trans({}, 'SonataAdminBundle') }}
             </span>
-        {% endif %}
-        {% if _button_mode == 'both' or _button_mode == 'text' %}
+        {% else %}
             {{ 'action_delete'|trans({}, 'SonataAdminBundle') }}
         {% endif %}
     </a>

--- a/src/Resources/views/CRUD/list__action_delete.html.twig
+++ b/src/Resources/views/CRUD/list__action_delete.html.twig
@@ -10,12 +10,17 @@ file that was distributed with this source code.
 #}
 
 {% if admin.hasAccess('delete', object) and admin.hasRoute('delete') %}
+    {% set _button_style = sonata_config.getOption('button_style') %}
     <a
         href="{{ admin.generateObjectUrl('delete', object, actions.link_parameters|default([])) }}"
         class="btn btn-sm btn-default delete_link"
         title="{{ 'action_delete'|trans({}, 'SonataAdminBundle') }}"
     >
-        <i class="fa fa-times" aria-hidden="true"></i>
-        {{ 'action_delete'|trans({}, 'SonataAdminBundle') }}
+        {% if _button_style == 'both' or _button_style == 'icon' %}
+            <i class="fa fa-times" aria-hidden="true"></i>
+        {% endif %}
+        {% if _button_style == 'both' or _button_style == 'text' %}
+            {{ 'action_delete'|trans({}, 'SonataAdminBundle') }}
+        {% endif %}
     </a>
 {% endif %}

--- a/src/Resources/views/CRUD/list__action_edit.html.twig
+++ b/src/Resources/views/CRUD/list__action_edit.html.twig
@@ -10,12 +10,17 @@ file that was distributed with this source code.
 #}
 
 {% if admin.hasAccess('edit', object) and admin.hasRoute('edit') %}
+    {% set _button_style = sonata_config.getOption('button_style') %}
     <a
         href="{{ admin.generateObjectUrl('edit', object, actions.link_parameters|default([])) }}"
         class="btn btn-sm btn-default edit_link"
         title="{{ 'action_edit'|trans({}, 'SonataAdminBundle') }}"
     >
-        <i class="fa fa-pencil" aria-hidden="true"></i>
-        {{ 'action_edit'|trans({}, 'SonataAdminBundle') }}
+        {% if _button_style == 'both' or _button_style == 'icon' %}
+            <i class="fa fa-edit" aria-hidden="true"></i>
+        {% endif %}
+        {% if _button_style == 'both' or _button_style == 'text' %}
+            {{ 'link_action_edit'|trans({}, 'SonataAdminBundle') }}
+        {% endif %}
     </a>
 {% endif %}

--- a/src/Resources/views/CRUD/list__action_edit.html.twig
+++ b/src/Resources/views/CRUD/list__action_edit.html.twig
@@ -16,13 +16,14 @@ file that was distributed with this source code.
         class="btn btn-sm btn-default edit_link"
         title="{{ 'action_edit'|trans({}, 'SonataAdminBundle') }}"
     >
-        {% if _button_mode == 'both' or _button_mode == 'icon' %}
+        {% if _button_mode != 'text' %}
             <i class="fa fa-edit" aria-hidden="true"></i>
+        {% endif %}
+        {% if _button_mode == 'icon' %}
             <span class="sr-only">
                 {{ 'link_action_edit'|trans({}, 'SonataAdminBundle') }}
             </span>
-        {% endif %}
-        {% if _button_mode == 'both' or _button_mode == 'text' %}
+        {% else %}
             {{ 'link_action_edit'|trans({}, 'SonataAdminBundle') }}
         {% endif %}
     </a>

--- a/src/Resources/views/CRUD/list__action_edit.html.twig
+++ b/src/Resources/views/CRUD/list__action_edit.html.twig
@@ -10,16 +10,19 @@ file that was distributed with this source code.
 #}
 
 {% if admin.hasAccess('edit', object) and admin.hasRoute('edit') %}
-    {% set _button_style = sonata_config.getOption('button_style') %}
+    {% set _button_mode = sonata_config.getOption('button_mode') %}
     <a
         href="{{ admin.generateObjectUrl('edit', object, actions.link_parameters|default([])) }}"
         class="btn btn-sm btn-default edit_link"
         title="{{ 'action_edit'|trans({}, 'SonataAdminBundle') }}"
     >
-        {% if _button_style == 'both' or _button_style == 'icon' %}
+        {% if _button_mode == 'both' or _button_mode == 'icon' %}
             <i class="fa fa-edit" aria-hidden="true"></i>
+            <span class="sr-only">
+                {{ 'link_action_edit'|trans({}, 'SonataAdminBundle') }}
+            </span>
         {% endif %}
-        {% if _button_style == 'both' or _button_style == 'text' %}
+        {% if _button_mode == 'both' or _button_mode == 'text' %}
             {{ 'link_action_edit'|trans({}, 'SonataAdminBundle') }}
         {% endif %}
     </a>

--- a/src/Resources/views/CRUD/list__action_history.html.twig
+++ b/src/Resources/views/CRUD/list__action_history.html.twig
@@ -10,16 +10,19 @@ file that was distributed with this source code.
 #}
 
 {% if admin.hasAccess('history', object) and admin.hasRoute('history') %}
-    {% set _button_style = sonata_config.getOption('button_style') %}
+    {% set _button_mode = sonata_config.getOption('button_mode') %}
     <a
         href="{{ admin.generateObjectUrl('history', object, actions.link_parameters|default([])) }}"
         class="btn btn-sm btn-default view_link"
         title="{{ 'link_action_history'|trans({}, 'SonataAdminBundle') }}"
     >
-        {% if _button_style == 'both' or _button_style == 'icon' %}
+        {% if _button_mode == 'both' or _button_mode == 'icon' %}
             <i class="fa fa-history" aria-hidden="true"></i>
+            <span class="sr-only">
+                {{ 'link_action_history'|trans({}, 'SonataAdminBundle') }}
+            </span>
         {% endif %}
-        {% if _button_style == 'both' or _button_style == 'text' %}
+        {% if _button_mode == 'both' or _button_mode == 'text' %}
             {{ 'link_action_history'|trans({}, 'SonataAdminBundle') }}
         {% endif %}
     </a>

--- a/src/Resources/views/CRUD/list__action_history.html.twig
+++ b/src/Resources/views/CRUD/list__action_history.html.twig
@@ -16,13 +16,14 @@ file that was distributed with this source code.
         class="btn btn-sm btn-default view_link"
         title="{{ 'link_action_history'|trans({}, 'SonataAdminBundle') }}"
     >
-        {% if _button_mode == 'both' or _button_mode == 'icon' %}
+        {% if _button_mode != 'text' %}
             <i class="fa fa-history" aria-hidden="true"></i>
+        {% endif %}
+        {% if _button_mode == 'icon' %}
             <span class="sr-only">
                 {{ 'link_action_history'|trans({}, 'SonataAdminBundle') }}
             </span>
-        {% endif %}
-        {% if _button_mode == 'both' or _button_mode == 'text' %}
+        {% else %}
             {{ 'link_action_history'|trans({}, 'SonataAdminBundle') }}
         {% endif %}
     </a>

--- a/src/Resources/views/CRUD/list__action_history.html.twig
+++ b/src/Resources/views/CRUD/list__action_history.html.twig
@@ -10,12 +10,17 @@ file that was distributed with this source code.
 #}
 
 {% if admin.hasAccess('history', object) and admin.hasRoute('history') %}
+    {% set _button_style = sonata_config.getOption('button_style') %}
     <a
         href="{{ admin.generateObjectUrl('history', object, actions.link_parameters|default([])) }}"
         class="btn btn-sm btn-default view_link"
         title="{{ 'link_action_history'|trans({}, 'SonataAdminBundle') }}"
     >
-        <i class="fa fa-history" aria-hidden="true"></i>
-        {{ 'link_action_history'|trans({}, 'SonataAdminBundle') }}
+        {% if _button_style == 'both' or _button_style == 'icon' %}
+            <i class="fa fa-history" aria-hidden="true"></i>
+        {% endif %}
+        {% if _button_style == 'both' or _button_style == 'text' %}
+            {{ 'link_action_history'|trans({}, 'SonataAdminBundle') }}
+        {% endif %}
     </a>
 {% endif %}

--- a/src/Resources/views/CRUD/list__action_show.html.twig
+++ b/src/Resources/views/CRUD/list__action_show.html.twig
@@ -10,16 +10,19 @@ file that was distributed with this source code.
 #}
 
 {% if admin.hasAccess('show', object) and admin.hasRoute('show') %}
-    {% set _button_style = sonata_config.getOption('button_style') %}
+    {% set _button_mode = sonata_config.getOption('button_mode') %}
     <a
         href="{{ admin.generateObjectUrl('show', object, actions.link_parameters|default([])) }}"
         class="btn btn-sm btn-default view_link"
         title="{{ 'action_show'|trans({}, 'SonataAdminBundle') }}"
     >
-        {% if _button_style == 'both' or _button_style == 'icon' %}
+        {% if _button_mode == 'both' or _button_mode == 'icon' %}
             <i class="fa fa-eye" aria-hidden="true"></i>
+            <span class="sr-only">
+                {{ 'action_show'|trans({}, 'SonataAdminBundle') }}
+            </span>
         {% endif %}
-        {% if _button_style == 'both' or _button_style == 'text' %}
+        {% if _button_mode == 'both' or _button_mode == 'text' %}
             {{ 'action_show'|trans({}, 'SonataAdminBundle') }}
         {% endif %}
     </a>

--- a/src/Resources/views/CRUD/list__action_show.html.twig
+++ b/src/Resources/views/CRUD/list__action_show.html.twig
@@ -16,13 +16,14 @@ file that was distributed with this source code.
         class="btn btn-sm btn-default view_link"
         title="{{ 'action_show'|trans({}, 'SonataAdminBundle') }}"
     >
-        {% if _button_mode == 'both' or _button_mode == 'icon' %}
+        {% if _button_mode != 'text' %}
             <i class="fa fa-eye" aria-hidden="true"></i>
+        {% endif %}
+        {% if _button_mode == 'icon' %}
             <span class="sr-only">
                 {{ 'action_show'|trans({}, 'SonataAdminBundle') }}
             </span>
-        {% endif %}
-        {% if _button_mode == 'both' or _button_mode == 'text' %}
+        {% else %}
             {{ 'action_show'|trans({}, 'SonataAdminBundle') }}
         {% endif %}
     </a>

--- a/src/Resources/views/CRUD/list__action_show.html.twig
+++ b/src/Resources/views/CRUD/list__action_show.html.twig
@@ -10,12 +10,17 @@ file that was distributed with this source code.
 #}
 
 {% if admin.hasAccess('show', object) and admin.hasRoute('show') %}
+    {% set _button_style = sonata_config.getOption('button_style') %}
     <a
         href="{{ admin.generateObjectUrl('show', object, actions.link_parameters|default([])) }}"
         class="btn btn-sm btn-default view_link"
         title="{{ 'action_show'|trans({}, 'SonataAdminBundle') }}"
     >
-        <i class="fa fa-eye" aria-hidden="true"></i>
-        {{ 'action_show'|trans({}, 'SonataAdminBundle') }}
+        {% if _button_style == 'both' or _button_style == 'icon' %}
+            <i class="fa fa-eye" aria-hidden="true"></i>
+        {% endif %}
+        {% if _button_style == 'both' or _button_style == 'text' %}
+            {{ 'action_show'|trans({}, 'SonataAdminBundle') }}
+        {% endif %}
     </a>
 {% endif %}

--- a/src/SonataConfiguration.php
+++ b/src/SonataConfiguration.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle;
 
 /**
  * @phpstan-type SonataConfigurationOptions = array{
+ *  button_mode: 'both'|'icon'|'text'
  *  confirm_exit: bool,
  *  default_group: string,
  *  default_icon: string,

--- a/src/SonataConfiguration.php
+++ b/src/SonataConfiguration.php
@@ -15,7 +15,7 @@ namespace Sonata\AdminBundle;
 
 /**
  * @phpstan-type SonataConfigurationOptions = array{
- *  button_mode: 'both'|'icon'|'text'
+ *  button_mode: 'both'|'icon'|'text',
  *  confirm_exit: bool,
  *  default_group: string,
  *  default_icon: string,


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it is BC.

It make it possible to choose if icon will be shown on action buttons, in the list view.

This is my first pull request and first contribution to a project.
Any comments are welcome

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6970

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
Make action button icons configurable

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
