### PR TITLE
enhance list documentation for virtual fields

### DIFF
--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -764,14 +764,17 @@ query and displayed::
 
 Lastly, you can also define your list fields as ``virtual``.
 This way, Sonata's FieldDescription will always return a value of null, as documented here:
-https://symfony.com/doc/current/bundles/SonataAdminBundle/cookbook/recipe_virtual_field.html ::
+https://symfony.com/doc/current/bundles/SonataAdminBundle/cookbook/recipe_virtual_field.html
+
+Combine this with configuring a custom template and you'll have a list column fully customizable in what it eventually renders. ::
 
     // src/Admin/PostAdmin.php
 
     protected function configureListFields(ListMapper $listMapper)
     {
-        $listMapper->addIdentifier('thisPropertyDoesNotExist', null, [
-            'virtual_field' => true
+        $listMapper->add('thisPropertyDoesNotExist', null, [
+            'virtual_field' => true,
+            'template' => 'path/to/your/template.html.twig'
         ]);
     }
     

--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -761,5 +761,20 @@ query and displayed::
         $listMapper->addIdentifier('numberofcomments');
     }
 
+
+Lastly, you can also define your list fields as ``virtual``.
+This way, Sonata's FieldDescription will always return a value of null, as documented here:
+https://symfony.com/doc/current/bundles/SonataAdminBundle/cookbook/recipe_virtual_field.html ::
+
+    // src/Admin/PostAdmin.php
+
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        $listMapper->addIdentifier('thisPropertyDoesNotExist', null, [
+            'virtual_field' => true
+        ]);
+    }
+    
 .. _`SonataDoctrineORMAdminBundle Documentation`: https://sonata-project.org/bundles/doctrine-orm-admin/master/doc/reference/list_field_definition.html
 .. _`here`: https://github.com/sonata-project/form-extensions/tree/1.x/src/Type
+    


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Enhance list documentation for virtual fields

This PR enhances the list documentation for non-model fields.
Right now only two ways to handle those are covered, additional getters and added select expressions.
You can however also mark list fields as virtual, as documented here by Sonata itself:
https://symfony.com/doc/current/bundles/SonataAdminBundle/cookbook/recipe_virtual_field.html

It may seem like a pointless use case to always have a list field display null as a value, but it becomes quite important when overriding the template that facilitates the FieldDescription to render a value.
In one of my apps, I enhanced the template to execute an anonymous callback function on the object instead of just rendering the value of the FieldDescription's associated property. That's incredibly powerful if data has needs to be enhanced before displaying it, but cannot be done easily in the model or query itself.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because the validity of this approach applies for both 3.x and 4.x.
It's also not a change of code, but documentation only, so Sonata's functionality doesn't change at all.
