### PR TITLE
Unify icons

### DIFF
--- a/src/Resources/config/twig.php
+++ b/src/Resources/config/twig.php
@@ -15,6 +15,7 @@ use Sonata\AdminBundle\DependencyInjection\Compiler\AliasDeprecatedPublicService
 use Sonata\AdminBundle\Twig\Extension\BreadcrumbsExtension;
 use Sonata\AdminBundle\Twig\Extension\CanonicalizeExtension;
 use Sonata\AdminBundle\Twig\Extension\GroupExtension;
+use Sonata\AdminBundle\Twig\Extension\IconExtension;
 use Sonata\AdminBundle\Twig\Extension\PaginationExtension;
 use Sonata\AdminBundle\Twig\Extension\RenderElementExtension;
 use Sonata\AdminBundle\Twig\Extension\SecurityExtension;
@@ -65,10 +66,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ])
 
         ->set('sonata.admin.group.extension', GroupExtension::class)
-        ->tag('twig.extension')
-        ->args([
-            new ReferenceConfigurator('sonata.admin.pool'),
-        ])
+            ->tag('twig.extension')
+            ->args([
+                new ReferenceConfigurator('sonata.admin.pool'),
+            ])
+
+        ->set('sonata.icon.twig.extension', IconExtension::class)
+            ->tag('twig.extension')
 
         // NEXT_MAJOR: Remove this service.
         ->set('sonata.pagination.twig.extension', PaginationExtension::class)

--- a/src/Resources/views/Block/block_admin_preview.html.twig
+++ b/src/Resources/views/Block/block_admin_preview.html.twig
@@ -21,7 +21,7 @@ file that was distributed with this source code.
         <div class="box-header with-border">
             {% set icon = settings.icon|default('') %}
             {% if icon %}
-                <i class="fa {{ icon|raw }}"></i>
+                {{ icon|parse_icon|raw }}">
             {% endif %}
             <h3 class="box-title">
                 <a href="#{{ inlineAnchor }}">{{ settings.text|trans({}, translation_domain) }}</a>
@@ -41,14 +41,14 @@ file that was distributed with this source code.
                                     {% if field_description.name == constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_SELECT') %}
                                         <th class="sonata-ba-list-field-header sonata-ba-list-field-header-select"></th>
                                     {% else %}
-                                        {% filter spaceless %}
+                                        {% apply spaceless %}
                                             <th class="sonata-ba-list-field-header-{{ field_description.type}} {% if field_description.option('header_class') is not null %} {{ field_description.option('header_class') }}{% endif %}"{% if field_description.option('header_style') is not null %} style="{{ field_description.option('header_style') }}"{% endif %}>
                                                 {% if field_description.option('label_icon') %}
-                                                    <i class="sonata-ba-list-field-header-label-icon {{ field_description.option('label_icon') }}" aria-hidden="true"></i>
+                                                    <i class="sonata-ba-list-field-header-label-icon {{ field_description.option('label_icon')|parse_icon(true)|raw }}" aria-hidden="true"></i>
                                                 {% endif %}
                                                 {{ field_description.label|trans({}, field_description.translationDomain) }}
                                             </th>
-                                        {% endfilter %}
+                                        {% endapply %}
                                     {% endif %}
                                 {% endfor %}
                             </tr>

--- a/src/Resources/views/Block/block_search_result.html.twig
+++ b/src/Resources/views/Block/block_search_result.html.twig
@@ -28,7 +28,7 @@ file that was distributed with this source code.
         <div class="box box-solid {{ visibility_class }}">
             <div class="box-header with-border {{ visibility_class }}">
                 {% set icon = settings.icon|default('') %}
-                {{ icon|raw }}
+                {{ icon|parse_icon|raw }}
                 <h3 class="box-title">
                     {% if admin.label is not empty %}
                         {{ admin.label|trans({}, admin.translationdomain) }}

--- a/src/Resources/views/Block/block_stats.html.twig
+++ b/src/Resources/views/Block/block_stats.html.twig
@@ -29,7 +29,7 @@ file that was distributed with this source code.
             </p>
         </div>
         <div class="icon">
-            <i class="fa {{ settings.icon }}"></i>
+            {{ settings.icon|parse_icon|raw }}
         </div>
         <a href="{{ admin.generateUrl('list', {filter: settings.filters}) }}" class="small-box-footer">
             {{ 'stats_view_more'|trans({}, 'SonataAdminBundle') }} <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -80,7 +80,7 @@ file that was distributed with this source code.
                                                 <th class="sonata-ba-list-field-header-{{ field_description.type }}{% if sortable %} sonata-ba-list-field-header-order-{{ sort_by|lower }} {{ sort_active_class }}{% endif %}{% if field_description.option('header_class') %} {{ field_description.option('header_class') }}{% endif %}"{% if field_description.option('header_style') %} style="{{ field_description.option('header_style') }}"{% endif %}>
                                                     {% if sortable %}<a href="{{ admin.generateUrl('list', sort_parameters|merge({_list_mode: admin.getListMode()})) }}">{% endif %}
                                                     {% if field_description.getOption('label_icon') %}
-                                                        <i class="sonata-ba-list-field-header-label-icon {{ field_description.getOption('label_icon') }}" aria-hidden="true"></i>
+                                                        <i class="sonata-ba-list-field-header-label-icon {{ field_description.getOption('label_icon')|parse_icon(true)|raw }}" aria-hidden="true"></i>
                                                     {% endif %}
                                                     {% if field_description.label is not same as(false) %}
                                                         {{ field_description.label|trans({}, field_description.translationDomain) }}

--- a/src/Resources/views/CRUD/dashboard__action.html.twig
+++ b/src/Resources/views/CRUD/dashboard__action.html.twig
@@ -1,4 +1,4 @@
 <a class="btn btn-link btn-flat" href="{{ action.url }}">
-    <i class="fa fa-{{ action.icon }}" aria-hidden="true"></i>
+    <i class="{{ action.icon|parse_icon(true)|raw }}" aria-hidden="true"></i>
     {{ action.label|trans({}, action.translation_domain|default('SonataAdminBundle')) }}
 </a>

--- a/src/Resources/views/CRUD/dashboard__action_create.html.twig
+++ b/src/Resources/views/CRUD/dashboard__action_create.html.twig
@@ -1,11 +1,11 @@
 {% if admin.subClasses is empty %}
     <a class="btn btn-link btn-flat" href="{{ action.url }}">
-        <i class="fa fa-{{ action.icon }}" aria-hidden="true"></i>
+        <i class="{{ action.icon|parse_icon(true)|raw }}" aria-hidden="true"></i>
         {{ action.label|trans({}, action.translation_domain|default('SonataAdminBundle')) }}
     </a>
 {% else %}
     <a class="btn btn-link btn-flat dropdown-toggle" data-toggle="dropdown" href="#">
-        <i class="fa fa-{{ action.icon }}" aria-hidden="true"></i>
+        <i class="{{ action.icon|parse_icon(true)|raw }}" aria-hidden="true"></i>
         {{ action.label|trans({}, action.translation_domain|default('SonataAdminBundle')) }}
         <span class="caret"></span>
     </a>

--- a/src/Resources/views/Core/add_block.html.twig
+++ b/src/Resources/views/Core/add_block.html.twig
@@ -30,7 +30,7 @@
                     <li role="presentation" class="divider"></li>
                 {% endif %}
                 <li role="presentation" class="dropdown-header">
-                    {{ group.icon|raw }}
+                    {{ group.icon|parse_icon|raw }}
                     {{ group.label|trans({}, group.label_catalogue) }}
                 </li>
 

--- a/src/Resources/views/Core/tab_menu_template.html.twig
+++ b/src/Resources/views/Core/tab_menu_template.html.twig
@@ -86,7 +86,7 @@
     {% import "knp_menu.html.twig" as macros %}
     <a href="{{ item.uri }}"{{ macros.attributes(item.linkAttributes) }}>
         {% if item.attribute('icon') is not empty %}
-            <i class="{{ item.attribute('icon') }}"></i>
+            {{ item.attribute('icon')|parse_icon|raw }}
         {% endif %}
         {{ block('label') }}
     </a>
@@ -96,7 +96,7 @@
     {% import "knp_menu.html.twig" as macros %}
     <span {{ macros.attributes(item.labelAttributes) }}>
         {% if item.attribute('icon') is not empty %}
-            <i class="{{ item.attribute('icon') }}"></i>
+            {{ item.attribute('icon')|parse_icon|raw }}
         {% endif %}
         {{ block('label') }}
     </span>
@@ -111,7 +111,7 @@
     {%- set attributes = attributes|merge({'data-toggle': 'dropdown'}) %}
     <a href="#"{{ macros.attributes(attributes) }}>
         {% if item.attribute('icon') is not empty %}
-            <i class="{{ item.attribute('icon') }}"></i>
+            {{ item.attribute('icon')|parse_icon|raw }}
         {% endif %}
         {{ block('label') }}
         <b class="caret"></b>

--- a/src/Resources/views/Menu/sonata_menu.html.twig
+++ b/src/Resources/views/Menu/sonata_menu.html.twig
@@ -38,7 +38,7 @@
         <a href="#">
             {%- set translation_domain = item.extra('label_catalogue', 'messages') -%}
             {%- set icon = item.extra('icon')|default('') -%}
-            {{ icon|raw }}
+            {{ icon|parse_icon|raw }}
             {{ parent() }}
             {%- if item.extra('keep_open') is not defined or not item.extra('keep_open') -%}
                 <span class="pull-right-container"><i class="fa pull-right fa-angle-left"></i></span>

--- a/src/Resources/views/Menu/sonata_menu.html.twig
+++ b/src/Resources/views/Menu/sonata_menu.html.twig
@@ -50,7 +50,7 @@
 {% block label %}
     {% apply spaceless %}
         {%- if is_link|default(false) -%}
-            {{ icon|default|raw }}
+            {{ icon|default|parse_icon|raw }}
         {%- endif -%}
         {# We use method accessor instead of ".label" since `item` implements `ArrayAccess` and could have a property called "label". #}
         {%- set item_label = item.getLabel() -%}

--- a/src/Twig/Extension/IconExtension.php
+++ b/src/Twig/Extension/IconExtension.php
@@ -26,7 +26,7 @@ class IconExtension extends AbstractExtension
         );
     }
 
-    public function parseIcon($icon, bool $inline = false): string
+    public function parseIcon(string $icon, bool $inline = false): string
     {
         switch (substr($icon,0,3)) {
             case "<i ":
@@ -38,14 +38,21 @@ class IconExtension extends AbstractExtension
                     $iconHtml = $icon;
                 }
                 break;
+            // NEXT_MAJOR: remove this case
             case "fa-":
                 // only the icon name is used by dev: 'fa-plus'
+                @trigger_error(
+                    //'Using this format for icons is deprecated. Please use "<i class="fa fa-icon"></i>" or "fa fa-icon"',
+                    'The icon format "fa-icon" is deprecated since sonata-project/admin-bundle 3.XX. You should stop using it, as it will not be supported in 4.0.',
+                    \E_USER_DEPRECATED
+                );
                 if($inline) {
                     $iconHtml = "fa ".$icon;
                 } else {
                     $iconHtml = sprintf('<i class="fa %s"></i>', $icon);
                 }
                 break;
+            // NEXT_MAJOR: change to fas to to support font-awesome v5
             case "fa ":
                 // full font-awesome is used by dev: 'fa fa-plus'
                 // for fa v5 fas prefix should be used.
@@ -55,13 +62,24 @@ class IconExtension extends AbstractExtension
                     $iconHtml = sprintf('<i class="%s"></i>', $icon);
                 }
                 break;
+
             default:
                 // only icon name is used by dev: 'plus'
+                @trigger_error(
+                    'The icon format "icon" is deprecated since sonata-project/admin-bundle 3.XX. You should stop using it, as it will not be supported in 4.0.',
+                    \E_USER_DEPRECATED
+                );
                 if ($inline) {
                     $iconHtml = "fa fa-" . $icon;
                 } else {
                     $iconHtml = sprintf('<i class="fa fa-%s"></i>', $icon);
                 }
+                // NEXT_MAJOR: replace default case with next lines
+                //@trigger_error(
+                //    'The icon format is not longer supported. Please use "<i class="fas fa-icon"></i>" or "fas fa-icon"',
+                //    \E_USER_ERROR
+                //);
+            //
         }
 
         return $iconHtml;

--- a/src/Twig/Extension/IconExtension.php
+++ b/src/Twig/Extension/IconExtension.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class IconExtension extends AbstractExtension
+{
+
+    public function getFilters(): array
+    {
+        return array(
+            new TwigFilter('parse_icon', array($this, 'parseIcon')),
+        );
+    }
+
+    public function parseIcon($icon, bool $inline = false): string
+    {
+        switch (substr($icon,0,3)) {
+            case "<i ":
+                // full style is used by dev: '<i class="fa fa-plus"></i>'
+                if ($inline) {
+                    preg_match('/"([^"]+)"/', $icon, $output);
+                    $iconHtml = $output[1];
+                } else {
+                    $iconHtml = $icon;
+                }
+                break;
+            case "fa-":
+                // only the icon name is used by dev: 'fa-plus'
+                if($inline) {
+                    $iconHtml = "fa ".$icon;
+                } else {
+                    $iconHtml = sprintf('<i class="fa %s"></i>', $icon);
+                }
+                break;
+            case "fa ":
+                // full font-awesome is used by dev: 'fa fa-plus'
+                // for fa v5 fas prefix should be used.
+                if ($inline) {
+                    $iconHtml = $icon;
+                } else {
+                    $iconHtml = sprintf('<i class="%s"></i>', $icon);
+                }
+                break;
+            default:
+                // only icon name is used by dev: 'plus'
+                if ($inline) {
+                    $iconHtml = "fa fa-" . $icon;
+                } else {
+                    $iconHtml = sprintf('<i class="fa fa-%s"></i>', $icon);
+                }
+        }
+
+        return $iconHtml;
+    }
+}

--- a/tests/Twig/Extension/IconExtensionTest.php
+++ b/tests/Twig/Extension/IconExtensionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Twig\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
+use Sonata\AdminBundle\Twig\Extension\IconExtension;
+use Sonata\AdminBundle\Twig\Extension\XEditableExtension;
+use Symfony\Component\Translation\Translator;
+
+final class IconExtensionTest extends TestCase
+{
+    /**
+     * @dataProvider iconProvider
+     */
+    public function testGetXEditableChoicesIsIdempotent(string $icon, bool $inline, string $expected): void
+    {
+        $twigExtension = new IconExtension();
+
+        $this->assertSame($expected, $twigExtension->parseIcon($icon, $inline));
+    }
+
+    public function iconProvider(): iterable
+    {
+        //'icon' => '<i class="fa fa-cog"></i>',
+        //'icon' => 'fa fa-cog',
+        //'icon' => 'fa-cog',
+        //'icon' => 'cog',
+        return [
+            'html input' => ['<i class="fa fa-cog"></i>', false ,'<i class="fa fa-cog"></i>'],
+            'html input, inline' => ['<i class="fa fa-cog"></i>', true, 'fa fa-cog'],
+            'with prefix' => ['<i class="fa fa-cog"></i>', false, '<i class="fa fa-cog"></i>'],
+            'with prefix, inline' => ['<i class="fa fa-cog"></i>', true, 'fa fa-cog'],
+            // NEXT_MAJOR: Remove next 4 tests cases.
+            'icon-prefix only' => ['fa-cog', false, '<i class="fa fa-cog"></i>'],
+            'icon-prefix only, inline' =>[ 'fa-cog', true, 'fa fa-cog'],
+            'icon name' => ['cog', false, '<i class="fa fa-cog"></i>'],
+            'icon name, inline' =>[ 'cog', true, 'fa fa-cog'],
+        ];
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it is BC

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
It is a first draft of how to unify icons.
The idea is that all method of using icons are supported:
```
'icon' => '<i class="fa fa-cog"></i>',
'icon' => 'fa fa-cog',
'icon' => 'fa-cog',
'icon' => 'cog',
```

All uses on templates need to be rewritten. i don't know is there is another way for this.

Closes #7137.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added a twig extension to be able to use all icon methods.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

## To do
- [ ] Update the tests
- [ ] Modify all templates
- [ ] ....

