### PR TITLE
Fix countResult of SimplePager

### DIFF
--- a/src/Datagrid/SimplePager.php
+++ b/src/Datagrid/SimplePager.php
@@ -87,12 +87,7 @@ class SimplePager extends Pager
 
     public function countResults(): int
     {
-        $n = ($this->getLastPage() - 1) * $this->getMaxPerPage();
-        if ($this->getLastPage() === $this->getPage()) {
-            return $n + $this->thresholdCount;
-        }
-
-        return $n;
+        return ($this->getPage() - 1) * $this->getMaxPerPage() + $this->thresholdCount;
     }
 
     public function getCurrentPageResults(): iterable


### PR DESCRIPTION
## Subject

The recent change I made broke the pagination of the SimplePager.
This is because the SimplePager is now using a check `countResults > maxPerPage`.
But the `SimplePager::countResults` was returning the the maxPerPage so the pagination wasn't triggered.

Previously, this was the behavior.
Let's say you wanted to display 25 results per page and you have 30 in database.
The simple pager look for 26 results.
It then display
> page 1/?: at least 25 results.
And page 2,
> page 2/?: at least 30 results.

I change this behavior to 
> page 1/?: at least 26 results.
> page 2/?: at least 30 results.

This fix the pagination, and give a more precise information about the result number.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix SimplePager pagination
```