### PR TITLE
[RFC] Allow to pass id of parent admin in the admin code when accessing to a child admin

### DIFF
--- a/src/Action/AppendFormFieldElementAction.php
+++ b/src/Action/AppendFormFieldElementAction.php
@@ -56,7 +56,7 @@ final class AppendFormFieldElementAction
         $objectId = $request->get('objectId');
         $uniqid = $request->get('uniqid');
 
-        $admin = $this->pool->getInstance($code);
+        $admin = $this->pool->getAdminByAdminCode($code);
         $admin->setRequest($request);
 
         if ($uniqid) {

--- a/src/Action/RetrieveFormFieldElementAction.php
+++ b/src/Action/RetrieveFormFieldElementAction.php
@@ -55,7 +55,7 @@ final class RetrieveFormFieldElementAction
         $objectId = $request->get('objectId');
         $uniqid = $request->get('uniqid');
 
-        $admin = $this->pool->getInstance($code);
+        $admin = $this->pool->getAdminByAdminCode($code);
         $admin->setRequest($request);
 
         if ($uniqid) {

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2489,7 +2489,7 @@ EOT;
         $this->baseCodeRoute = $baseCodeRoute;
     }
 
-    public function getBaseCodeRoute()
+    public function getBaseCodeRoute($withId = false)
     {
         // NEXT_MAJOR: Uncomment the following lines.
         // if ($this->isChild()) {
@@ -2503,7 +2503,12 @@ EOT;
             $parentCode = $this->getParent()->getCode();
 
             if ($this->getParent()->isChild()) {
-                $parentCode = $this->getParent()->getBaseCodeRoute();
+                $parentCode = $this->getParent()->getBaseCodeRoute($withId);
+            }
+
+            if ($withId && $this->getParent()->hasSubject()) {
+                $id = $this->getParent()->id($this->getParent()->getSubject());
+                $parentCode = sprintf('%s(%s)', $parentCode, $id);
             }
 
             return sprintf('%s|%s', $parentCode, $this->getCode());

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -445,9 +445,27 @@ class Pool
 
         $codes = explode('|', $adminCode);
         $code = trim(array_shift($codes));
+
+        if (preg_match('/^(.*)\((.*)\)$/', $code, $matches)) {
+            $code = $matches[1];
+            $id = $matches[2];
+        } else {
+            $id = null;
+        }
+
         $admin = $this->getInstance($code);
+        if (isset($id)) {
+            $admin->setSubject($admin->getObject($id));
+        }
 
         foreach ($codes as $code) {
+            if (preg_match('/^(.*)\((.*)\)$/', $code, $matches)) {
+                $code = $matches[1];
+                $id = $matches[2];
+            } else {
+                $id = null;
+            }
+
             if (!\in_array($code, $this->adminServiceIds, true)) {
                 @trigger_error(sprintf(
                     'Passing an invalid admin code as argument 1 for %s() is deprecated since'
@@ -478,6 +496,9 @@ class Pool
             }
 
             $admin = $admin->getChild($code);
+            if (isset($id)) {
+                $admin->setSubject($admin->getObject($id));
+            }
         }
 
         return $admin;

--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -319,7 +319,7 @@ This code manages the many-to-[one|many] association field popup
                                 'subclass':  sonata_admin.admin.hasActiveSubClass() ? sonata_admin.admin.getActiveSubclassCode() : null,
                                 'objectId':  sonata_admin.admin.root.id(sonata_admin.admin.root.subject),
                                 'uniqid':    sonata_admin.admin.root.uniqid,
-                                'code':      sonata_admin.admin.root.code
+                                'code':      sonata_admin.admin.root.getBaseCodeRoute(true)
                             }) }}',
                             data: {_xml_http_request: true },
                             dataType: 'html',

--- a/src/Resources/views/CRUD/Association/edit_one_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_script.html.twig
@@ -33,7 +33,7 @@ This code manages the one-to-many association field popup
         // the ajax post
         jQuery(form).ajaxSubmit({
             url: '{{ path('sonata_admin_append_form_element', {
-                'code':      sonata_admin.admin.root.code,
+                'code':      sonata_admin.admin.root.getBaseCodeRoute(true),
                 'elementId': id,
                 'objectId':  sonata_admin.admin.root.id(sonata_admin.admin.root.subject),
                 'uniqid':    sonata_admin.admin.root.uniqid,


### PR DESCRIPTION
## Subject

Closes #7185.

In the AppendFormFieldElementAction we're passing a `code` used to create an instance of an admin.
When this admin is a childAdmin, there is no information about this.
Neither the parent code is passed, neither the id of the parent object.

The method `getCode` is returning the code of an admin: `myAdminCode`
But the method `getBaseRouteCode` is returning the full code: `myParentAdminCode|myAdminCode`.

I tried to add a parameter to `getBaseRouteCode` in in order to add the id of the subject: `myParentAdminCode(42)|myAdminCode`. 
Maybe another method is better (and may help to be BC) ? How would you call it ?

Then, in the Pool, is the code has the following syntax `foo(xxx)`, I split the code in two.
`foo` is the real code, and `xxx` will be the id of the subject I have to set.

This will forbid custom code `foo(bar)`. Do you prefer another syntax ?
For 3.x I could try/catch to make `getInstance` with `foo(bar)` and in the catch doing my regex manipulation.

@sonata-project/contributors 

## Changelog

TODO

```markdown
### Added

### Changed

### Deprecated

### Removed

### Fixed

### Security
```