### PR TITLE
Use adminFetcher in Actions

### DIFF
--- a/src/Action/AppendFormFieldElementAction.php
+++ b/src/Action/AppendFormFieldElementAction.php
@@ -87,7 +87,7 @@ final class AppendFormFieldElementAction
                 \E_USER_DEPRECATED
             );
 
-            $request->request->set('_sonata_admin', $request->get('code'));
+            $request->query->set('_sonata_admin', $request->get('code'));
         }
 
         try {

--- a/src/Action/AppendFormFieldElementAction.php
+++ b/src/Action/AppendFormFieldElementAction.php
@@ -83,8 +83,9 @@ final class AppendFormFieldElementAction
         if (null === $request->get('_sonata_admin')) {
             @trigger_error(
                 'Not passing "_sonata_admin" value in the request is deprecated since sonata-project/admin-bundle 3.x'
-                .' and will throw %s exception in 4.0.'
-            , \E_USER_DEPRECATED);
+                .' and will throw %s exception in 4.0.',
+                \E_USER_DEPRECATED
+            );
 
             $request->request->set('_sonata_admin', $request->get('code'));
         }

--- a/src/Action/AppendFormFieldElementAction.php
+++ b/src/Action/AppendFormFieldElementAction.php
@@ -56,7 +56,7 @@ final class AppendFormFieldElementAction
         } elseif ($poolOrAdminFetcher instanceof Pool) {
             @trigger_error(sprintf(
                 'Passing other type than %s in argument 2 to %s() is deprecated since sonata-project/admin-bundle 3.x'
-                .' and will throw %s exception in 4.0.',
+                .' and will throw %s error in 4.0.',
                 AdminFetcherInterface::class,
                 __METHOD__,
                 \TypeError::class
@@ -82,8 +82,8 @@ final class AppendFormFieldElementAction
         // NEXT_MAJOR: Remove this BC-layer.
         if (null === $request->get('_sonata_admin')) {
             @trigger_error(
-                'Not passing "_sonata_admin" value in the request is deprecated since sonata-project/admin-bundle 3.x'
-                .' and will throw %s exception in 4.0.',
+                'Not passing the "_sonata_admin" parameter in the request is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will throw an exception in 4.0.',
                 \E_USER_DEPRECATED
             );
 
@@ -94,7 +94,7 @@ final class AppendFormFieldElementAction
             $admin = $this->adminFetcher->get($request);
         } catch (\InvalidArgumentException $e) {
             throw new NotFoundHttpException(sprintf(
-                'Could not find admin for code "%s"',
+                'Could not find admin for code "%s".',
                 $request->get('_sonata_admin')
             ));
         }

--- a/src/Action/GetShortObjectDescriptionAction.php
+++ b/src/Action/GetShortObjectDescriptionAction.php
@@ -75,8 +75,9 @@ final class GetShortObjectDescriptionAction
         if (null === $request->get('_sonata_admin')) {
             @trigger_error(
                 'Not passing "_sonata_admin" value in the request is deprecated since sonata-project/admin-bundle 3.x'
-                .' and will throw %s exception in 4.0.'
-                , \E_USER_DEPRECATED);
+                .' and will throw %s exception in 4.0.',
+                \E_USER_DEPRECATED
+            );
 
             $request->request->set('_sonata_admin', $request->get('code'));
         }
@@ -89,8 +90,6 @@ final class GetShortObjectDescriptionAction
                 $request->get('_sonata_admin')
             ));
         }
-
-        $admin->setRequest($request);
 
         $objectId = $request->get('objectId');
         $object = $admin->getObject($objectId);

--- a/src/Action/GetShortObjectDescriptionAction.php
+++ b/src/Action/GetShortObjectDescriptionAction.php
@@ -48,7 +48,7 @@ final class GetShortObjectDescriptionAction
         } elseif ($poolOrAdminFetcher instanceof Pool) {
             @trigger_error(sprintf(
                 'Passing other type than %s in argument 2 to %s() is deprecated since sonata-project/admin-bundle 3.x'
-                .' and will throw %s exception in 4.0.',
+                .' and will throw %s error in 4.0.',
                 AdminFetcherInterface::class,
                 __METHOD__,
                 \TypeError::class
@@ -74,8 +74,8 @@ final class GetShortObjectDescriptionAction
         // NEXT_MAJOR: Remove this BC-layer.
         if (null === $request->get('_sonata_admin')) {
             @trigger_error(
-                'Not passing "_sonata_admin" value in the request is deprecated since sonata-project/admin-bundle 3.x'
-                .' and will throw %s exception in 4.0.',
+                'Not passing the "_sonata_admin" parameter in the request is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will throw an exception in 4.0.',
                 \E_USER_DEPRECATED
             );
 
@@ -86,7 +86,7 @@ final class GetShortObjectDescriptionAction
             $admin = $this->adminFetcher->get($request);
         } catch (\InvalidArgumentException $e) {
             throw new NotFoundHttpException(sprintf(
-                'Could not find admin for code "%s"',
+                'Could not find admin for code "%s".',
                 $request->get('_sonata_admin')
             ));
         }

--- a/src/Action/GetShortObjectDescriptionAction.php
+++ b/src/Action/GetShortObjectDescriptionAction.php
@@ -79,7 +79,7 @@ final class GetShortObjectDescriptionAction
                 \E_USER_DEPRECATED
             );
 
-            $request->request->set('_sonata_admin', $request->get('code'));
+            $request->query->set('_sonata_admin', $request->get('code'));
         }
 
         try {

--- a/src/Action/GetShortObjectDescriptionAction.php
+++ b/src/Action/GetShortObjectDescriptionAction.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Action;
 
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Request\AdminFetcher;
+use Sonata\AdminBundle\Request\AdminFetcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -23,19 +25,45 @@ use Twig\Environment;
 final class GetShortObjectDescriptionAction
 {
     /**
-     * @var Pool
+     * @var AdminFetcherInterface
      */
-    private $pool;
+    private $adminFetcher;
 
     /**
      * @var Environment
      */
     private $twig;
 
-    public function __construct(Environment $twig, Pool $pool)
+    /**
+     * NEXT_MAJOR: Restrict second param to AdminFetcherInterface.
+     *
+     * @param Pool|AdminFetcherInterface $poolOrAdminFetcher
+     */
+    public function __construct(Environment $twig, $poolOrAdminFetcher)
     {
-        $this->pool = $pool;
         $this->twig = $twig;
+
+        if ($poolOrAdminFetcher instanceof AdminFetcherInterface) {
+            $this->adminFetcher = $poolOrAdminFetcher;
+        } elseif ($poolOrAdminFetcher instanceof Pool) {
+            @trigger_error(sprintf(
+                'Passing other type than %s in argument 2 to %s() is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will throw %s exception in 4.0.',
+                AdminFetcherInterface::class,
+                __METHOD__,
+                \TypeError::class
+            ), \E_USER_DEPRECATED);
+
+            $this->adminFetcher = new AdminFetcher($poolOrAdminFetcher);
+        } else {
+            throw new \TypeError(sprintf(
+                'Argument 2 passed to "%s()" must be either an instance of %s or %s, %s given.',
+                __METHOD__,
+                Pool::class,
+                AdminFetcherInterface::class,
+                \is_object($poolOrAdminFetcher) ? 'instance of "'.\get_class($poolOrAdminFetcher).'"' : '"'.\gettype($poolOrAdminFetcher).'"'
+            ));
+        }
     }
 
     /**
@@ -43,23 +71,28 @@ final class GetShortObjectDescriptionAction
      */
     public function __invoke(Request $request): Response
     {
-        $code = $request->get('code');
-        $objectId = $request->get('objectId');
-        $uniqid = $request->get('uniqid');
-        $linkParameters = $request->get('linkParameters', []);
+        // NEXT_MAJOR: Remove this BC-layer.
+        if (null === $request->get('_sonata_admin')) {
+            @trigger_error(
+                'Not passing "_sonata_admin" value in the request is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will throw %s exception in 4.0.'
+                , \E_USER_DEPRECATED);
+
+            $request->request->set('_sonata_admin', $request->get('code'));
+        }
 
         try {
-            $admin = $this->pool->getInstance($code);
+            $admin = $this->adminFetcher->get($request);
         } catch (\InvalidArgumentException $e) {
-            throw new NotFoundHttpException(sprintf('Could not find admin for code "%s"', $code));
+            throw new NotFoundHttpException(sprintf(
+                'Could not find admin for code "%s"',
+                $request->get('_sonata_admin')
+            ));
         }
 
         $admin->setRequest($request);
 
-        if ($uniqid) {
-            $admin->setUniqid($uniqid);
-        }
-
+        $objectId = $request->get('objectId');
         $object = $admin->getObject($objectId);
 
         if (!$object) {
@@ -89,7 +122,7 @@ final class GetShortObjectDescriptionAction
                 'admin' => $admin,
                 'description' => $admin->toString($object),
                 'object' => $object,
-                'link_parameters' => $linkParameters,
+                'link_parameters' => $request->get('linkParameters', []),
             ]));
         }
 

--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -75,8 +75,9 @@ final class RetrieveAutocompleteItemsAction
         if (null === $request->get('_sonata_admin')) {
             @trigger_error(
                 'Not passing "_sonata_admin" value in the request is deprecated since sonata-project/admin-bundle 3.x'
-                .' and will throw %s exception in 4.0.'
-                , \E_USER_DEPRECATED);
+                .' and will throw %s exception in 4.0.',
+                \E_USER_DEPRECATED
+            );
 
             $request->request->set('_sonata_admin', $request->get('admin_code'));
         }

--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -79,7 +79,7 @@ final class RetrieveAutocompleteItemsAction
                 \E_USER_DEPRECATED
             );
 
-            $request->request->set('_sonata_admin', $request->get('admin_code'));
+            $request->query->set('_sonata_admin', $request->get('admin_code'));
         }
 
         try {

--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -45,7 +45,7 @@ final class RetrieveAutocompleteItemsAction
         } elseif ($poolOrAdminFetcher instanceof Pool) {
             @trigger_error(sprintf(
                 'Passing other type than %s in argument 2 to %s() is deprecated since sonata-project/admin-bundle 3.x'
-                .' and will throw %s exception in 4.0.',
+                .' and will throw %s error in 4.0.',
                 AdminFetcherInterface::class,
                 __METHOD__,
                 \TypeError::class
@@ -74,8 +74,8 @@ final class RetrieveAutocompleteItemsAction
         // NEXT_MAJOR: Remove this BC-layer.
         if (null === $request->get('_sonata_admin')) {
             @trigger_error(
-                'Not passing "_sonata_admin" value in the request is deprecated since sonata-project/admin-bundle 3.x'
-                .' and will throw %s exception in 4.0.',
+                'Not passing the "_sonata_admin" parameter in the request is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will throw an exception in 4.0.',
                 \E_USER_DEPRECATED
             );
 
@@ -86,7 +86,7 @@ final class RetrieveAutocompleteItemsAction
             $admin = $this->adminFetcher->get($request);
         } catch (\InvalidArgumentException $e) {
             throw new NotFoundHttpException(sprintf(
-                'Could not find admin for code "%s"',
+                'Could not find admin for code "%s".',
                 $request->get('_sonata_admin')
             ));
         }

--- a/src/Action/RetrieveFormFieldElementAction.php
+++ b/src/Action/RetrieveFormFieldElementAction.php
@@ -82,8 +82,9 @@ final class RetrieveFormFieldElementAction
         if (null === $request->get('_sonata_admin')) {
             @trigger_error(
                 'Not passing "_sonata_admin" value in the request is deprecated since sonata-project/admin-bundle 3.x'
-                .' and will throw %s exception in 4.0.'
-                , \E_USER_DEPRECATED);
+                .' and will throw %s exception in 4.0.',
+                \E_USER_DEPRECATED
+            );
 
             $request->request->set('_sonata_admin', $request->get('code'));
         }

--- a/src/Action/RetrieveFormFieldElementAction.php
+++ b/src/Action/RetrieveFormFieldElementAction.php
@@ -55,7 +55,7 @@ final class RetrieveFormFieldElementAction
         } elseif ($poolOrAdminFetcher instanceof Pool) {
             @trigger_error(sprintf(
                 'Passing other type than %s in argument 2 to %s() is deprecated since sonata-project/admin-bundle 3.x'
-                .' and will throw %s exception in 4.0.',
+                .' and will throw %s error in 4.0.',
                 AdminFetcherInterface::class,
                 __METHOD__,
                 \TypeError::class
@@ -81,8 +81,8 @@ final class RetrieveFormFieldElementAction
         // NEXT_MAJOR: Remove this BC-layer.
         if (null === $request->get('_sonata_admin')) {
             @trigger_error(
-                'Not passing "_sonata_admin" value in the request is deprecated since sonata-project/admin-bundle 3.x'
-                .' and will throw %s exception in 4.0.',
+                'Not passing the "_sonata_admin" parameter in the request is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will throw an exception in 4.0.',
                 \E_USER_DEPRECATED
             );
 
@@ -93,7 +93,7 @@ final class RetrieveFormFieldElementAction
             $admin = $this->adminFetcher->get($request);
         } catch (\InvalidArgumentException $e) {
             throw new NotFoundHttpException(sprintf(
-                'Could not find admin for code "%s"',
+                'Could not find admin for code "%s".',
                 $request->get('_sonata_admin')
             ));
         }

--- a/src/Action/RetrieveFormFieldElementAction.php
+++ b/src/Action/RetrieveFormFieldElementAction.php
@@ -86,7 +86,7 @@ final class RetrieveFormFieldElementAction
                 \E_USER_DEPRECATED
             );
 
-            $request->request->set('_sonata_admin', $request->get('code'));
+            $request->query->set('_sonata_admin', $request->get('code'));
         }
 
         try {

--- a/src/Action/RetrieveFormFieldElementAction.php
+++ b/src/Action/RetrieveFormFieldElementAction.php
@@ -15,6 +15,8 @@ namespace Sonata\AdminBundle\Action;
 
 use Sonata\AdminBundle\Admin\AdminHelper;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\Request\AdminFetcher;
+use Sonata\AdminBundle\Request\AdminFetcherInterface;
 use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -24,9 +26,9 @@ use Twig\Environment;
 final class RetrieveFormFieldElementAction
 {
     /**
-     * @var Pool
+     * @var AdminFetcherInterface
      */
-    private $pool;
+    private $adminFetcher;
 
     /**
      * @var AdminHelper
@@ -38,11 +40,37 @@ final class RetrieveFormFieldElementAction
      */
     private $twig;
 
-    public function __construct(Environment $twig, Pool $pool, AdminHelper $helper)
+    /**
+     * NEXT_MAJOR: Restrict second param to AdminFetcherInterface.
+     *
+     * @param Pool|AdminFetcherInterface $poolOrAdminFetcher
+     */
+    public function __construct(Environment $twig, $poolOrAdminFetcher, AdminHelper $helper)
     {
-        $this->pool = $pool;
         $this->helper = $helper;
         $this->twig = $twig;
+
+        if ($poolOrAdminFetcher instanceof AdminFetcherInterface) {
+            $this->adminFetcher = $poolOrAdminFetcher;
+        } elseif ($poolOrAdminFetcher instanceof Pool) {
+            @trigger_error(sprintf(
+                'Passing other type than %s in argument 2 to %s() is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will throw %s exception in 4.0.',
+                AdminFetcherInterface::class,
+                __METHOD__,
+                \TypeError::class
+            ), \E_USER_DEPRECATED);
+
+            $this->adminFetcher = new AdminFetcher($poolOrAdminFetcher);
+        } else {
+            throw new \TypeError(sprintf(
+                'Argument 2 passed to "%s()" must be either an instance of %s or %s, %s given.',
+                __METHOD__,
+                Pool::class,
+                AdminFetcherInterface::class,
+                \is_object($poolOrAdminFetcher) ? 'instance of "'.\get_class($poolOrAdminFetcher).'"' : '"'.\gettype($poolOrAdminFetcher).'"'
+            ));
+        }
     }
 
     /**
@@ -50,18 +78,26 @@ final class RetrieveFormFieldElementAction
      */
     public function __invoke(Request $request): Response
     {
-        $code = $request->get('code');
-        $elementId = $request->get('elementId');
-        $objectId = $request->get('objectId');
-        $uniqid = $request->get('uniqid');
+        // NEXT_MAJOR: Remove this BC-layer.
+        if (null === $request->get('_sonata_admin')) {
+            @trigger_error(
+                'Not passing "_sonata_admin" value in the request is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will throw %s exception in 4.0.'
+                , \E_USER_DEPRECATED);
 
-        $admin = $this->pool->getInstance($code);
-        $admin->setRequest($request);
-
-        if ($uniqid) {
-            $admin->setUniqid($uniqid);
+            $request->request->set('_sonata_admin', $request->get('code'));
         }
 
+        try {
+            $admin = $this->adminFetcher->get($request);
+        } catch (\InvalidArgumentException $e) {
+            throw new NotFoundHttpException(sprintf(
+                'Could not find admin for code "%s"',
+                $request->get('_sonata_admin')
+            ));
+        }
+
+        $objectId = $request->get('objectId');
         if ($objectId) {
             $subject = $admin->getObject($objectId);
             if (!$subject) {
@@ -83,6 +119,7 @@ final class RetrieveFormFieldElementAction
         $form->setData($subject);
         $form->handleRequest($request);
 
+        $elementId = $request->get('elementId');
         $view = $this->helper->getChildFormView($form->createView(), $elementId);
 
         // render the widget

--- a/src/Action/SetObjectFieldValueAction.php
+++ b/src/Action/SetObjectFieldValueAction.php
@@ -78,7 +78,7 @@ final class SetObjectFieldValueAction
         } elseif ($poolOrAdminFetcher instanceof Pool) {
             @trigger_error(sprintf(
                 'Passing other type than %s in argument 2 to %s() is deprecated since sonata-project/admin-bundle 3.x'
-                .' and will throw %s exception in 4.0.',
+                .' and will throw %s error in 4.0.',
                 AdminFetcherInterface::class,
                 __METHOD__,
                 \TypeError::class
@@ -145,8 +145,8 @@ final class SetObjectFieldValueAction
         // NEXT_MAJOR: Remove this BC-layer.
         if (null === $request->get('_sonata_admin')) {
             @trigger_error(
-                'Not passing "_sonata_admin" value in the request is deprecated since sonata-project/admin-bundle 3.x'
-                .' and will throw %s exception in 4.0.',
+                'Not passing the "_sonata_admin" parameter in the request is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will throw an exception in 4.0.',
                 \E_USER_DEPRECATED
             );
 
@@ -157,7 +157,7 @@ final class SetObjectFieldValueAction
             $admin = $this->adminFetcher->get($request);
         } catch (\InvalidArgumentException $e) {
             throw new NotFoundHttpException(sprintf(
-                'Could not find admin for code "%s"',
+                'Could not find admin for code "%s".',
                 $request->get('_sonata_admin')
             ));
         }

--- a/src/Action/SetObjectFieldValueAction.php
+++ b/src/Action/SetObjectFieldValueAction.php
@@ -17,12 +17,16 @@ use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 use Sonata\AdminBundle\Form\DataTransformerResolver;
 use Sonata\AdminBundle\Form\DataTransformerResolverInterface;
+use Sonata\AdminBundle\Request\AdminFetcher;
+use Sonata\AdminBundle\Request\AdminFetcherInterface;
 use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -31,9 +35,9 @@ use Twig\Environment;
 final class SetObjectFieldValueAction
 {
     /**
-     * @var Pool
+     * @var AdminFetcherInterface
      */
-    private $pool;
+    private $adminFetcher;
 
     /**
      * @var Environment
@@ -58,16 +62,40 @@ final class SetObjectFieldValueAction
     /**
      * NEXT_MAJOR: Make all arguments mandatory.
      *
+     * @param Pool|AdminFetcherInterface   $poolOrAdminFetcher
      * @param ValidatorInterface           $validator
      * @param DataTransformerResolver|null $resolver
      */
     public function __construct(
         Environment $twig,
-        Pool $pool,
+        $poolOrAdminFetcher,
         $validator,
         $resolver = null,
         ?PropertyAccessorInterface $propertyAccessor = null
     ) {
+        // NEXT_MAJOR: Move AdminFetcherInterface check to method signature
+        if ($poolOrAdminFetcher instanceof AdminFetcherInterface) {
+            $this->adminFetcher = $poolOrAdminFetcher;
+        } elseif ($poolOrAdminFetcher instanceof Pool) {
+            @trigger_error(sprintf(
+                'Passing other type than %s in argument 2 to %s() is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will throw %s exception in 4.0.',
+                AdminFetcherInterface::class,
+                __METHOD__,
+                \TypeError::class
+            ), \E_USER_DEPRECATED);
+
+            $this->adminFetcher = new AdminFetcher($poolOrAdminFetcher);
+        } else {
+            throw new \TypeError(sprintf(
+                'Argument 2 passed to "%s()" must be either an instance of %s or %s, %s given.',
+                __METHOD__,
+                Pool::class,
+                AdminFetcherInterface::class,
+                \is_object($poolOrAdminFetcher) ? 'instance of "'.\get_class($poolOrAdminFetcher).'"' : '"'.\gettype($poolOrAdminFetcher).'"'
+            ));
+        }
+
         // NEXT_MAJOR: Move ValidatorInterface check to method signature
         if (!($validator instanceof ValidatorInterface)) {
             throw new \InvalidArgumentException(sprintf(
@@ -97,10 +125,13 @@ final class SetObjectFieldValueAction
                 PropertyAccessorInterface::class
             ), \E_USER_DEPRECATED);
 
-            $propertyAccessor = $pool->getPropertyAccessor();
+            if ($poolOrAdminFetcher instanceof Pool) {
+                $propertyAccessor = $poolOrAdminFetcher->getPropertyAccessor();
+            } else {
+                $propertyAccessor = PropertyAccess::createPropertyAccessor();
+            }
         }
 
-        $this->pool = $pool;
         $this->twig = $twig;
         $this->validator = $validator;
         $this->resolver = $resolver;
@@ -112,14 +143,29 @@ final class SetObjectFieldValueAction
      */
     public function __invoke(Request $request): JsonResponse
     {
+        // NEXT_MAJOR: Remove this BC-layer.
+        if (null === $request->get('_sonata_admin')) {
+            @trigger_error(
+                'Not passing "_sonata_admin" value in the request is deprecated since sonata-project/admin-bundle 3.x'
+                .' and will throw %s exception in 4.0.'
+                , \E_USER_DEPRECATED);
+
+            $request->request->set('_sonata_admin', $request->get('code'));
+        }
+
+        try {
+            $admin = $this->adminFetcher->get($request);
+        } catch (\InvalidArgumentException $e) {
+            throw new NotFoundHttpException(sprintf(
+                'Could not find admin for code "%s"',
+                $request->get('_sonata_admin')
+            ));
+        }
+
         $field = $request->get('field');
-        $code = $request->get('code');
         $objectId = $request->get('objectId');
         $value = $originalValue = $request->get('value');
         $context = $request->get('context');
-
-        $admin = $this->pool->getInstance($code);
-        $admin->setRequest($request);
 
         // alter should be done by using a post method
         if (!$request->isXmlHttpRequest()) {

--- a/src/Action/SetObjectFieldValueAction.php
+++ b/src/Action/SetObjectFieldValueAction.php
@@ -26,7 +26,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
-use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
@@ -147,8 +146,9 @@ final class SetObjectFieldValueAction
         if (null === $request->get('_sonata_admin')) {
             @trigger_error(
                 'Not passing "_sonata_admin" value in the request is deprecated since sonata-project/admin-bundle 3.x'
-                .' and will throw %s exception in 4.0.'
-                , \E_USER_DEPRECATED);
+                .' and will throw %s exception in 4.0.',
+                \E_USER_DEPRECATED
+            );
 
             $request->request->set('_sonata_admin', $request->get('code'));
         }

--- a/src/Action/SetObjectFieldValueAction.php
+++ b/src/Action/SetObjectFieldValueAction.php
@@ -150,7 +150,7 @@ final class SetObjectFieldValueAction
                 \E_USER_DEPRECATED
             );
 
-            $request->request->set('_sonata_admin', $request->get('code'));
+            $request->query->set('_sonata_admin', $request->get('code'));
         }
 
         try {

--- a/src/Resources/config/actions.php
+++ b/src/Resources/config/actions.php
@@ -65,7 +65,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->public()
             ->args([
                 new ReferenceConfigurator('twig'),
-                new ReferenceConfigurator('sonata.admin.pool'),
+                new ReferenceConfigurator('sonata.admin.request.fetcher'),
                 new ReferenceConfigurator('sonata.admin.helper'),
             ])
 
@@ -73,7 +73,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->public()
             ->args([
                 new ReferenceConfigurator('twig'),
-                new ReferenceConfigurator('sonata.admin.pool'),
+                new ReferenceConfigurator('sonata.admin.request.fetcher'),
                 new ReferenceConfigurator('sonata.admin.helper'),
             ])
 
@@ -81,14 +81,14 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->public()
             ->args([
                 new ReferenceConfigurator('twig'),
-                new ReferenceConfigurator('sonata.admin.pool'),
+                new ReferenceConfigurator('sonata.admin.request.fetcher'),
             ])
 
         ->set('sonata.admin.action.set_object_field_value', SetObjectFieldValueAction::class)
             ->public()
             ->args([
                 new ReferenceConfigurator('twig'),
-                new ReferenceConfigurator('sonata.admin.pool'),
+                new ReferenceConfigurator('sonata.admin.request.fetcher'),
                 new ReferenceConfigurator('validator'),
                 new ReferenceConfigurator('sonata.admin.form.data_transformer_resolver'),
                 new ReferenceConfigurator('property_accessor'),
@@ -97,6 +97,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set('sonata.admin.action.retrieve_autocomplete_items', RetrieveAutocompleteItemsAction::class)
             ->public()
             ->args([
-                new ReferenceConfigurator('sonata.admin.pool'),
+                new ReferenceConfigurator('sonata.admin.request.fetcher'),
             ]);
 };

--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -524,12 +524,13 @@ This code manages the many-to-[one|many] association field popup
                 type: 'GET',
                 {# NEXT_MAJOR: Remove the 'code' parameter #}
                 url: '{{ path('sonata_admin_short_object_information', {
-                    '_sonata_admin': associationadmin.baseCodeRoute,
-                    'objectId': 'OBJECT_ID',
-                    'uniqid': associationadmin.uniqid,
-                    'code': associationadmin.code,
-                    'linkParameters': sonata_admin.field_description.option('link_parameters', {})
-                })}}'.replace('OBJECT_ID', objectId),
+                        '_sonata_admin': associationadmin.baseCodeRoute,
+                        'objectId': 'OBJECT_ID',
+                        'uniqid': associationadmin.uniqid,
+                        'code': associationadmin.code,
+                        'linkParameters': sonata_admin.field_description.option('link_parameters', {})
+                    } + admin.request.attributes.get('_route_params', {})
+                )}}'.replace('OBJECT_ID', objectId),
                 dataType: 'html',
                 success: function(html) {
                     jQuery('#field_widget_{{ id }}').html(html);

--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -322,7 +322,11 @@ This code manages the many-to-[one|many] association field popup
                                 'objectId': sonata_admin.admin.root.id(sonata_admin.admin.root.subject),
                                 'uniqid': sonata_admin.admin.root.uniqid,
                                 'code': sonata_admin.admin.root.code
-                            }) }}',
+                            } + (
+                                sonata_admin.admin.root.hasRequest()
+                                ? sonata_admin.admin.root.request.attributes.get('_route_params', {})
+                                : {}
+                            ) }}',
                             data: {_xml_http_request: true },
                             dataType: 'html',
                             type: 'POST',
@@ -529,7 +533,11 @@ This code manages the many-to-[one|many] association field popup
                         'uniqid': associationadmin.uniqid,
                         'code': associationadmin.code,
                         'linkParameters': sonata_admin.field_description.option('link_parameters', {})
-                    } + (admin.hasRequest() ? admin.request.attributes.get('_route_params', {}) : {})
+                    } + (
+                        associationadmin.hasRequest()
+                        ? associationadmin.request.attributes.get('_route_params', {})
+                        : {}
+                    )
                 )}}'.replace('OBJECT_ID', objectId),
                 dataType: 'html',
                 success: function(html) {

--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -529,7 +529,7 @@ This code manages the many-to-[one|many] association field popup
                         'uniqid': associationadmin.uniqid,
                         'code': associationadmin.code,
                         'linkParameters': sonata_admin.field_description.option('link_parameters', {})
-                    } + admin.request.attributes.get('_route_params', {})
+                    } + (admin.hasRequest() ? admin.request.attributes.get('_route_params', {}) : {})
                 )}}'.replace('OBJECT_ID', objectId),
                 dataType: 'html',
                 success: function(html) {

--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -314,12 +314,14 @@ This code manages the many-to-[one|many] association field popup
 
                         // reload the form element
                         jQuery('#field_widget_{{ id }}').closest('form').ajaxSubmit({
+                            // NEXT_MAJOR: Remove the 'code' parameter
                             url: '{{ path('sonata_admin_retrieve_form_element', {
+                                '_sonata_admin' : sonata_admin.admin.root.baseCodeRoute
                                 'elementId': id,
-                                'subclass':  sonata_admin.admin.hasActiveSubClass() ? sonata_admin.admin.getActiveSubclassCode() : null,
-                                'objectId':  sonata_admin.admin.root.id(sonata_admin.admin.root.subject),
-                                'uniqid':    sonata_admin.admin.root.uniqid,
-                                'code':      sonata_admin.admin.root.code
+                                'subclass': sonata_admin.admin.hasActiveSubClass() ? sonata_admin.admin.getActiveSubclassCode() : null,
+                                'objectId': sonata_admin.admin.root.id(sonata_admin.admin.root.subject),
+                                'uniqid': sonata_admin.admin.root.uniqid,
+                                'code': sonata_admin.admin.root.code
                             }) }}',
                             data: {_xml_http_request: true },
                             dataType: 'html',
@@ -520,7 +522,9 @@ This code manages the many-to-[one|many] association field popup
             jQuery('#field_widget_{{ id }}').html("<span><img src=\"{{ asset('bundles/sonataadmin/ajax-loader.gif') }}\" style=\"vertical-align: middle; margin-right: 10px\"/>{{ 'loading_information'|trans([], 'SonataAdminBundle') }}</span>");
             jQuery.ajax({
                 type: 'GET',
+                {# NEXT_MAJOR: Remove the 'code' parameter #}
                 url: '{{ path('sonata_admin_short_object_information', {
+                    '_sonata_admin': associationadmin.baseCodeRoute,
                     'objectId': 'OBJECT_ID',
                     'uniqid': associationadmin.uniqid,
                     'code': associationadmin.code,

--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -316,7 +316,7 @@ This code manages the many-to-[one|many] association field popup
                         jQuery('#field_widget_{{ id }}').closest('form').ajaxSubmit({
                             // NEXT_MAJOR: Remove the 'code' parameter
                             url: '{{ path('sonata_admin_retrieve_form_element', {
-                                '_sonata_admin' : sonata_admin.admin.root.baseCodeRoute
+                                '_sonata_admin': sonata_admin.admin.root.baseCodeRoute
                                 'elementId': id,
                                 'subclass': sonata_admin.admin.hasActiveSubClass() ? sonata_admin.admin.getActiveSubclassCode() : null,
                                 'objectId': sonata_admin.admin.root.id(sonata_admin.admin.root.subject),

--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -527,18 +527,17 @@ This code manages the many-to-[one|many] association field popup
             jQuery.ajax({
                 type: 'GET',
                 {# NEXT_MAJOR: Remove the 'code' parameter #}
-                url: '{{ path('sonata_admin_short_object_information', {
-                        '_sonata_admin': associationadmin.baseCodeRoute,
-                        'objectId': 'OBJECT_ID',
-                        'uniqid': associationadmin.uniqid,
-                        'code': associationadmin.code,
-                        'linkParameters': sonata_admin.field_description.option('link_parameters', {})
-                    } + (
-                        associationadmin.hasRequest()
-                        ? associationadmin.request.attributes.get('_route_params', {})
-                        : {}
-                    )
-                )}}'.replace('OBJECT_ID', objectId),
+                url: '{{ path('sonata_admin_short_object_information',{
+                    '_sonata_admin': associationadmin.baseCodeRoute,
+                    'objectId': 'OBJECT_ID',
+                    'uniqid': associationadmin.uniqid,
+                    'code': associationadmin.code,
+                    'linkParameters': sonata_admin.field_description.option('link_parameters', {})
+                } + (
+                    associationadmin.hasRequest()
+                    ? associationadmin.request.attributes.get('_route_params', {})
+                    : {}
+                ))}}'.replace('OBJECT_ID', objectId),
                 dataType: 'html',
                 success: function(html) {
                     jQuery('#field_widget_{{ id }}').html(html);

--- a/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
@@ -27,8 +27,11 @@ file that was distributed with this source code.
                         'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
                         'uniqid': sonata_admin.field_description.associationadmin.uniqid,
                         'linkParameters': sonata_admin.field_description.option('link_parameters', {})
-                    } + sonata_admin.field_description.associationadmin.request.attributes.get('_route_params', {})
-                    )) }}
+                    } + (
+                        sonata_admin.field_description.associationadmin.hasRequest()
+                        ? sonata_admin.field_description.associationadmin.request.attributes.get('_route_params', {})
+                        : {}
+                    ))) }}
                 {% elseif sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder') %}
                     <span class="inner-field-short-description">
                         {{ sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder')|trans({}, 'SonataAdminBundle') }}

--- a/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
@@ -20,10 +20,12 @@ file that was distributed with this source code.
         {% if sonata_admin.edit == 'list' %}
             <span id="field_widget_{{ id }}" class="field-short-description">
                 {% if sonata_admin.value and sonata_admin.field_description.associationadmin.id(sonata_admin.value) is not null %}
+                    {# NEXT_MAJOR: Remove the 'code' parameter #}
                     {{ render(path('sonata_admin_short_object_information', {
-                        'code':     sonata_admin.field_description.associationadmin.code,
+                        'sonata_admin': sonata_admin.field_description.associationadmin.baseCodeRoute,
+                        'code': sonata_admin.field_description.associationadmin.code,
                         'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
-                        'uniqid':   sonata_admin.field_description.associationadmin.uniqid,
+                        'uniqid': sonata_admin.field_description.associationadmin.uniqid,
                         'linkParameters': sonata_admin.field_description.option('link_parameters', {})
                     })) }}
                 {% elseif sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder') %}

--- a/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
@@ -22,7 +22,7 @@ file that was distributed with this source code.
                 {% if sonata_admin.value and sonata_admin.field_description.associationadmin.id(sonata_admin.value) is not null %}
                     {# NEXT_MAJOR: Remove the 'code' parameter #}
                     {{ render(path('sonata_admin_short_object_information', {
-                        'sonata_admin': sonata_admin.field_description.associationadmin.baseCodeRoute,
+                        '_sonata_admin': sonata_admin.field_description.associationadmin.baseCodeRoute,
                         'code': sonata_admin.field_description.associationadmin.code,
                         'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
                         'uniqid': sonata_admin.field_description.associationadmin.uniqid,

--- a/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
@@ -27,7 +27,8 @@ file that was distributed with this source code.
                         'objectId': sonata_admin.field_description.associationadmin.id(sonata_admin.value),
                         'uniqid': sonata_admin.field_description.associationadmin.uniqid,
                         'linkParameters': sonata_admin.field_description.option('link_parameters', {})
-                    })) }}
+                    } + sonata_admin.field_description.associationadmin.request.attributes.get('_route_params', {})
+                    )) }}
                 {% elseif sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder') %}
                     <span class="inner-field-short-description">
                         {{ sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder')|trans({}, 'SonataAdminBundle') }}

--- a/src/Resources/views/CRUD/Association/edit_one_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_script.html.twig
@@ -32,11 +32,13 @@ This code manages the one-to-many association field popup
 
         // the ajax post
         jQuery(form).ajaxSubmit({
+            // NEXT_MAJOR: Remove the 'code' parameter
             url: '{{ path('sonata_admin_append_form_element', {
-                'code':      sonata_admin.admin.root.code,
+                'code': sonata_admin.admin.root.code,
+                '_sonata_admin': sonata_admin.admin.root.baseCodeRoute,
                 'elementId': id,
-                'objectId':  sonata_admin.admin.root.id(sonata_admin.admin.root.subject),
-                'uniqid':    sonata_admin.admin.root.uniqid,
+                'objectId': sonata_admin.admin.root.id(sonata_admin.admin.root.subject),
+                'uniqid': sonata_admin.admin.root.uniqid,
                 'subclass': app.request.query.get('subclass'),
             } + sonata_admin.field_description.getOption('link_parameters', {})) }}',
             type: "POST",

--- a/src/Resources/views/CRUD/Association/edit_one_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_script.html.twig
@@ -41,8 +41,11 @@ This code manages the one-to-many association field popup
                 'uniqid': sonata_admin.admin.root.uniqid,
                 'subclass': app.request.query.get('subclass'),
             } + sonata_admin.field_description.getOption('link_parameters', {})
-            + sonata_admin.admin.root.request.attributes.get('_route_params', {})
-            ) }}',
+            + (
+                sonata_admin.admin.root.hasRequest()
+                ? sonata_admin.admin.root.request.attributes.get('_route_params', {})
+                : {}
+            )) }}',
             type: "POST",
             dataType: 'html',
             data: { _xml_http_request: true },

--- a/src/Resources/views/CRUD/Association/edit_one_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_script.html.twig
@@ -40,7 +40,9 @@ This code manages the one-to-many association field popup
                 'objectId': sonata_admin.admin.root.id(sonata_admin.admin.root.subject),
                 'uniqid': sonata_admin.admin.root.uniqid,
                 'subclass': app.request.query.get('subclass'),
-            } + sonata_admin.field_description.getOption('link_parameters', {})) }}',
+            } + sonata_admin.field_description.getOption('link_parameters', {})
+            + sonata_admin.admin.root.request.attributes.get('_route_params', {})
+            ) }}',
             type: "POST",
             dataType: 'html',
             data: { _xml_http_request: true },

--- a/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
@@ -28,8 +28,8 @@ file that was distributed with this source code.
                         'uniqid': sonata_admin.field_description.associationadmin.uniqid,
                         'linkParameters': sonata_admin.field_description.option('link_parameters', {})
                     } + (
-                        sonata_admin.admin.root.hasRequest()
-                        ? sonata_admin.admin.root.request.attributes.get('_route_params', {})
+                        sonata_admin.field_description.associationadmin.hasRequest()
+                        ? sonata_admin.field_description.associationadmin.request.attributes.get('_route_params', {})
                         : {}
                     ))) }}
                 {% elseif sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder') %}

--- a/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
@@ -20,10 +20,12 @@ file that was distributed with this source code.
         {% if sonata_admin.edit == 'list' %}
             <span id="field_widget_{{ id }}" class="field-short-description">
                 {% if sonata_admin.value and sonata_admin.field_description.associationadmin.urlSafeIdentifier(sonata_admin.value) is not null %}
+                    {# NEXT_MAJOR: Remove the 'code' parameter #}
                     {{ render(path('sonata_admin_short_object_information', {
-                        'code':     sonata_admin.field_description.associationadmin.code,
+                        '_sonata_admin': sonata_admin.field_description.associationadmin.baseCodeRoute,
+                        'code': sonata_admin.field_description.associationadmin.code,
                         'objectId': sonata_admin.field_description.associationadmin.urlSafeIdentifier(sonata_admin.value),
-                        'uniqid':   sonata_admin.field_description.associationadmin.uniqid,
+                        'uniqid': sonata_admin.field_description.associationadmin.uniqid,
                         'linkParameters': sonata_admin.field_description.option('link_parameters', {})
                     })) }}
                 {% elseif sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder') %}

--- a/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
@@ -27,8 +27,11 @@ file that was distributed with this source code.
                         'objectId': sonata_admin.field_description.associationadmin.urlSafeIdentifier(sonata_admin.value),
                         'uniqid': sonata_admin.field_description.associationadmin.uniqid,
                         'linkParameters': sonata_admin.field_description.option('link_parameters', {})
-                    } + sonata_admin.admin.root.request.attributes.get('_route_params', {})
-                    )) }}
+                    } + (
+                        sonata_admin.admin.root.hasRequest()
+                        ? sonata_admin.admin.root.request.attributes.get('_route_params', {})
+                        : {}
+                    ))) }}
                 {% elseif sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder') %}
                     <span class="inner-field-short-description">
                         {{ sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder')|trans({}, 'SonataAdminBundle') }}

--- a/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
@@ -27,7 +27,8 @@ file that was distributed with this source code.
                         'objectId': sonata_admin.field_description.associationadmin.urlSafeIdentifier(sonata_admin.value),
                         'uniqid': sonata_admin.field_description.associationadmin.uniqid,
                         'linkParameters': sonata_admin.field_description.option('link_parameters', {})
-                    })) }}
+                    } + sonata_admin.admin.root.request.attributes.get('_route_params', {})
+                    )) }}
                 {% elseif sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder') %}
                     <span class="inner-field-short-description">
                         {{ sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder')|trans({}, 'SonataAdminBundle') }}

--- a/src/Resources/views/CRUD/base_list_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_field.html.twig
@@ -53,7 +53,7 @@ file that was distributed with this source code.
                     'field': field_description.name,
                     'objectId': admin.urlSafeIdentifier(object),
                     'code': admin.code(object)
-                } + admin.request.attributes.get('_route_params', {})
+                } + (admin.hasRequest() ? admin.request.attributes.get('_route_params', {}) : {})
                 + admin.getPersistentParameters()
             ) %}
 

--- a/src/Resources/views/CRUD/base_list_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_field.html.twig
@@ -44,9 +44,11 @@ file that was distributed with this source code.
         {% endif %}
 
         {% if is_editable and x_editable_type %}
+            {# NEXT_MAJOR: Remove the 'code' parameter #}
             {% set url = path(
                 'sonata_admin_set_object_field_value',
                 admin.getPersistentParameters|default([])|merge({
+                    '_sonata_admin': admin.baseCodeRoute,
                     'context': 'list',
                     'field': field_description.name,
                     'objectId': admin.urlSafeIdentifier(object),

--- a/src/Resources/views/CRUD/base_list_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_field.html.twig
@@ -47,13 +47,14 @@ file that was distributed with this source code.
             {# NEXT_MAJOR: Remove the 'code' parameter #}
             {% set url = path(
                 'sonata_admin_set_object_field_value',
-                admin.getPersistentParameters|default([])|merge({
+                {
                     '_sonata_admin': admin.baseCodeRoute,
                     'context': 'list',
                     'field': field_description.name,
                     'objectId': admin.urlSafeIdentifier(object),
                     'code': admin.code(object)
-                })
+                } + admin.request.attributes.get('_route_params', {})
+                + admin.getPersistentParameters()
             ) %}
 
             {% if field_description.type == constant('Sonata\\AdminBundle\\Admin\\FieldDescriptionInterface::TYPE_DATE') and value is not empty %}

--- a/src/Resources/views/Core/search.html.twig
+++ b/src/Resources/views/Core/search.html.twig
@@ -36,7 +36,7 @@ file that was distributed with this source code.
                             'page': 0,
                             'per_page': 10,
                             'icon': group.icon
-                        }) }}
+                        } + admin.request.attributes.get('_route_params', {})) }}
                     {% endif %}
                 {% endfor %}
             {% endif %}

--- a/src/Resources/views/Core/search.html.twig
+++ b/src/Resources/views/Core/search.html.twig
@@ -26,11 +26,13 @@ file that was distributed with this source code.
                 {% for admin in group.items %}
                     {% set count = count + 1 %}
                     {% if admin.hasRoute('create') and admin.hasAccess('create') or admin.hasRoute('list') and admin.hasAccess('list') %}
+                        {# NEXT_MAJOR: Remove the admin_code param. #}
                         {{ sonata_block_render({
                             'type': 'sonata.admin.block.search_result'
                         }, {
                             'query': query,
                             'admin_code': admin.code,
+                            '_sonata_admin': admin.baseCodeRoute,
                             'page': 0,
                             'per_page': 10,
                             'icon': group.icon

--- a/src/Resources/views/Core/search.html.twig
+++ b/src/Resources/views/Core/search.html.twig
@@ -26,18 +26,15 @@ file that was distributed with this source code.
                 {% for admin in group.items %}
                     {% set count = count + 1 %}
                     {% if admin.hasRoute('create') and admin.hasAccess('create') or admin.hasRoute('list') and admin.hasAccess('list') %}
-                        {# NEXT_MAJOR: Remove the admin_code param. #}
                         {{ sonata_block_render({
                             'type': 'sonata.admin.block.search_result'
                         }, {
                             'query': query,
                             'admin_code': admin.code,
-                            '_sonata_admin': admin.baseCodeRoute,
                             'page': 0,
                             'per_page': 10,
                             'icon': group.icon
-                        } + (admin.hasRequest() ? admin.request.attributes.get('_route_params', {}) : {})
-                        ) }}
+                        }) }}
                     {% endif %}
                 {% endfor %}
             {% endif %}

--- a/src/Resources/views/Core/search.html.twig
+++ b/src/Resources/views/Core/search.html.twig
@@ -36,7 +36,8 @@ file that was distributed with this source code.
                             'page': 0,
                             'per_page': 10,
                             'icon': group.icon
-                        } + admin.request.attributes.get('_route_params', {})) }}
+                        } + (admin.hasRequest() ? admin.request.attributes.get('_route_params', {}) : {})
+                        ) }}
                     {% endif %}
                 {% endfor %}
             {% endif %}

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -111,9 +111,13 @@ file that was distributed with this source code.
                                 // admin
                                 {% if sonata_admin.admin is not null %}
                                     'uniqid': '{{ sonata_admin.admin.uniqid }}',
+                                    // NEXT_MAJOR: Remove the admin_code param.
                                     'admin_code': '{{ sonata_admin.admin.code|e('js') }}',
+                                    '_sonata_admin': '{{ sonata_admin.admin.baseCodeRoute|e('js') }}',
                                 {% elseif admin_code %}
-                                    'admin_code':  '{{ admin_code|e('js') }}',
+                                    // NEXT_MAJOR: Remove the admin_code param.
+                                    'admin_code': '{{ admin_code|e('js') }}',
+                                    '_sonata_admin': '{{ admin_code|e('js') }}',
                                 {% endif %}
 
                                  // subclass

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -596,7 +596,9 @@ file that was distributed with this source code.
     <div id="field_container_{{ id }}" class="field-container">
         <span id="field_widget_{{ id }}" class="field-short-description">
             {% if sonata_admin.value and sonata_admin.field_description.associationadmin.urlSafeIdentifier(sonata_admin.value) is not null %}
+                {# NEXT_MAJOR: Remove the 'code' parameter #}
                 {{ render(path('sonata_admin_short_object_information', {
+                    '_sonata_admin': sonata_admin.field_description.associationadmin,
                     'code': sonata_admin.field_description.associationadmin.code,
                     'objectId': sonata_admin.field_description.associationadmin.urlSafeIdentifier(sonata_admin.value),
                     'uniqid': sonata_admin.field_description.associationadmin.uniqid,

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -603,8 +603,11 @@ file that was distributed with this source code.
                     'objectId': sonata_admin.field_description.associationadmin.urlSafeIdentifier(sonata_admin.value),
                     'uniqid': sonata_admin.field_description.associationadmin.uniqid,
                     'linkParameters': sonata_admin.field_description.option('link_parameters', {})
-                } + sonata_admin.field_description.associationadmin.request.attributes.get('_route_params', {})
-                )) }}
+                } + (
+                    sonata_admin.field_description.associationadmin.hasRequest()
+                    ? sonata_admin.field_description.associationadmin.request.attributes.get('_route_params', {})
+                    : {}
+                ))) }}
             {% elseif sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder') %}
                 <span class="inner-field-short-description">
                     {{ sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder')|trans({}, 'SonataAdminBundle') }}

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -598,12 +598,13 @@ file that was distributed with this source code.
             {% if sonata_admin.value and sonata_admin.field_description.associationadmin.urlSafeIdentifier(sonata_admin.value) is not null %}
                 {# NEXT_MAJOR: Remove the 'code' parameter #}
                 {{ render(path('sonata_admin_short_object_information', {
-                    '_sonata_admin': sonata_admin.field_description.associationadmin,
+                    '_sonata_admin': sonata_admin.field_description.associationadmin.baseCodeRoute,
                     'code': sonata_admin.field_description.associationadmin.code,
                     'objectId': sonata_admin.field_description.associationadmin.urlSafeIdentifier(sonata_admin.value),
                     'uniqid': sonata_admin.field_description.associationadmin.uniqid,
                     'linkParameters': sonata_admin.field_description.option('link_parameters', {})
-                })) }}
+                } + sonata_admin.field_description.associationadmin.request.attributes.get('_route_params', {})
+                )) }}
             {% elseif sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder') %}
                 <span class="inner-field-short-description">
                     {{ sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder')|trans({}, 'SonataAdminBundle') }}

--- a/tests/Action/AppendFormFieldElementActionTest.php
+++ b/tests/Action/AppendFormFieldElementActionTest.php
@@ -13,15 +13,15 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\Action;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Action\AppendFormFieldElementAction;
 use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminHelper;
-use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
-use Symfony\Component\DependencyInjection\Container;
+use Sonata\AdminBundle\Request\AdminFetcherInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
@@ -32,9 +32,9 @@ use Twig\Environment;
 final class AppendFormFieldElementActionTest extends TestCase
 {
     /**
-     * @var Pool
+     * @var MockObject&AdminFetcherInterface
      */
-    private $pool;
+    private $adminFetcher;
 
     /**
      * @var Environment
@@ -60,14 +60,12 @@ final class AppendFormFieldElementActionTest extends TestCase
     {
         $this->twig = $this->createStub(Environment::class);
         $this->admin = $this->createMock(AbstractAdmin::class);
-        $this->admin->expects($this->once())->method('setRequest');
-        $container = new Container();
-        $container->set('sonata.post.admin', $this->admin);
-        $this->pool = new Pool($container, ['sonata.post.admin']);
+        $this->adminFetcher = $this->createMock(AdminFetcherInterface::class);
+        $this->adminFetcher->method('get')->willReturn($this->admin);
         $this->helper = $this->createStub(AdminHelper::class);
         $this->action = new AppendFormFieldElementAction(
             $this->twig,
-            $this->pool,
+            $this->adminFetcher,
             $this->helper
         );
     }
@@ -76,7 +74,7 @@ final class AppendFormFieldElementActionTest extends TestCase
     {
         $object = new \stdClass();
         $request = new Request([
-            'code' => 'sonata.post.admin',
+            '_sonata_admin' => 'sonata.post.admin',
             'objectId' => 42,
             'field' => 'enabled',
             'value' => 1,

--- a/tests/Action/AppendFormFieldElementActionTest.php
+++ b/tests/Action/AppendFormFieldElementActionTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\Action;
 
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Action\AppendFormFieldElementAction;
 use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
@@ -32,7 +32,7 @@ use Twig\Environment;
 final class AppendFormFieldElementActionTest extends TestCase
 {
     /**
-     * @var MockObject&AdminFetcherInterface
+     * @var Stub&AdminFetcherInterface
      */
     private $adminFetcher;
 
@@ -60,7 +60,7 @@ final class AppendFormFieldElementActionTest extends TestCase
     {
         $this->twig = $this->createStub(Environment::class);
         $this->admin = $this->createMock(AbstractAdmin::class);
-        $this->adminFetcher = $this->createMock(AdminFetcherInterface::class);
+        $this->adminFetcher = $this->createStub(AdminFetcherInterface::class);
         $this->adminFetcher->method('get')->willReturn($this->admin);
         $this->helper = $this->createStub(AdminHelper::class);
         $this->action = new AppendFormFieldElementAction(

--- a/tests/Action/GetShortObjectDescriptionActionTest.php
+++ b/tests/Action/GetShortObjectDescriptionActionTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\Action;
 
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
@@ -28,7 +28,7 @@ use Twig\Loader\ArrayLoader;
 final class GetShortObjectDescriptionActionTest extends TestCase
 {
     /**
-     * @var MockObject&AdminFetcherInterface
+     * @var Stub&AdminFetcherInterface
      */
     private $adminFetcher;
 
@@ -51,7 +51,7 @@ final class GetShortObjectDescriptionActionTest extends TestCase
     {
         $this->twig = new Environment(new ArrayLoader(['template' => 'renderedTemplate']));
         $this->admin = $this->createMock(AbstractAdmin::class);
-        $this->adminFetcher = $this->createMock(AdminFetcherInterface::class);
+        $this->adminFetcher = $this->createStub(AdminFetcherInterface::class);
         $this->action = new GetShortObjectDescriptionAction(
             $this->twig,
             $this->adminFetcher

--- a/tests/Action/RetrieveAutocompleteItemsActionTest.php
+++ b/tests/Action/RetrieveAutocompleteItemsActionTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Action;
 
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
 use Sonata\AdminBundle\Action\RetrieveAutocompleteItemsAction;
@@ -33,7 +34,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 final class RetrieveAutocompleteItemsActionTest extends TestCase
 {
     /**
-     * @var AdminFetcherInterface
+     * @var Stub&AdminFetcherInterface
      */
     private $adminFetcher;
 
@@ -50,7 +51,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
     protected function setUp(): void
     {
         $this->admin = $this->createMock(AbstractAdmin::class);
-        $this->adminFetcher = $this->createMock(AdminFetcherInterface::class);
+        $this->adminFetcher = $this->createStub(AdminFetcherInterface::class);
         $this->adminFetcher->method('get')->willReturn($this->admin);
         $this->action = new RetrieveAutocompleteItemsAction($this->adminFetcher);
     }

--- a/tests/Action/RetrieveAutocompleteItemsActionTest.php
+++ b/tests/Action/RetrieveAutocompleteItemsActionTest.php
@@ -18,13 +18,12 @@ use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
 use Sonata\AdminBundle\Action\RetrieveAutocompleteItemsAction;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
-use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Datagrid\PagerInterface;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 use Sonata\AdminBundle\Object\MetadataInterface;
+use Sonata\AdminBundle\Request\AdminFetcherInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Filter\FooFilter;
-use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormConfigInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -34,9 +33,9 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 final class RetrieveAutocompleteItemsActionTest extends TestCase
 {
     /**
-     * @var Pool
+     * @var AdminFetcherInterface
      */
-    private $pool;
+    private $adminFetcher;
 
     /**
      * @var GetShortObjectDescriptionAction
@@ -51,17 +50,15 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
     protected function setUp(): void
     {
         $this->admin = $this->createMock(AbstractAdmin::class);
-        $this->admin->expects($this->once())->method('setRequest');
-        $container = new Container();
-        $container->set('foo.admin', $this->admin);
-        $this->pool = new Pool($container, ['foo.admin']);
-        $this->action = new RetrieveAutocompleteItemsAction($this->pool);
+        $this->adminFetcher = $this->createMock(AdminFetcherInterface::class);
+        $this->adminFetcher->method('get')->willReturn($this->admin);
+        $this->action = new RetrieveAutocompleteItemsAction($this->adminFetcher);
     }
 
     public function testRetrieveAutocompleteItemsActionNotGranted(): void
     {
         $request = new Request([
-            'admin_code' => 'foo.admin',
+            '_sonata_admin' => 'foo.admin',
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_GET, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
         $this->admin->method('hasAccess')->willReturnMap([
@@ -78,7 +75,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
     {
         $object = new \stdClass();
         $request = new Request([
-            'admin_code' => 'foo.admin',
+            '_sonata_admin' => 'foo.admin',
             'field' => 'barField',
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_GET, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
 
@@ -108,7 +105,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
     {
         $object = new \stdClass();
         $request = new Request([
-            'admin_code' => 'foo.admin',
+            '_sonata_admin' => 'foo.admin',
             'field' => 'barField',
             'q' => 'so',
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_GET, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
@@ -141,7 +138,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
     public function testRetrieveAutocompleteItems(): void
     {
         $request = new Request([
-            'admin_code' => 'foo.admin',
+            '_sonata_admin' => 'foo.admin',
             'field' => 'barField',
             'q' => 'sonata',
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_GET, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
@@ -170,7 +167,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
     public function testRetrieveAutocompleteItemsComplexPropertyArray(): void
     {
         $request = new Request([
-            'admin_code' => 'foo.admin',
+            '_sonata_admin' => 'foo.admin',
             'field' => 'barField',
             'q' => 'sonata',
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_GET, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);
@@ -209,7 +206,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
     public function testRetrieveAutocompleteItemsComplexProperty(): void
     {
         $request = new Request([
-            'admin_code' => 'foo.admin',
+            '_sonata_admin' => 'foo.admin',
             'field' => 'barField',
             'q' => 'sonata',
         ], [], [], [], [], ['REQUEST_METHOD' => Request::METHOD_GET, 'HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest']);

--- a/tests/Action/RetrieveFormFieldElementActionTest.php
+++ b/tests/Action/RetrieveFormFieldElementActionTest.php
@@ -18,9 +18,8 @@ use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
 use Sonata\AdminBundle\Action\RetrieveFormFieldElementAction;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminHelper;
-use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
-use Symfony\Component\DependencyInjection\Container;
+use Sonata\AdminBundle\Request\AdminFetcherInterface;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormRenderer;
@@ -32,9 +31,9 @@ use Twig\Environment;
 final class RetrieveFormFieldElementActionTest extends TestCase
 {
     /**
-     * @var Pool
+     * @var AdminFetcherInterface
      */
-    private $pool;
+    private $adminFetcher;
 
     /**
      * @var GetShortObjectDescriptionAction
@@ -60,14 +59,12 @@ final class RetrieveFormFieldElementActionTest extends TestCase
     {
         $this->twig = $this->createStub(Environment::class);
         $this->admin = $this->createMock(AbstractAdmin::class);
-        $this->admin->expects($this->once())->method('setRequest');
-        $container = new Container();
-        $container->set('sonata.post.admin', $this->admin);
-        $this->pool = new Pool($container, ['sonata.post.admin']);
+        $this->adminFetcher = $this->createMock(AdminFetcherInterface::class);
+        $this->adminFetcher->method('get')->willReturn($this->admin);
         $this->helper = $this->createStub(AdminHelper::class);
         $this->action = new RetrieveFormFieldElementAction(
             $this->twig,
-            $this->pool,
+            $this->adminFetcher,
             $this->helper
         );
     }
@@ -76,7 +73,7 @@ final class RetrieveFormFieldElementActionTest extends TestCase
     {
         $object = new \stdClass();
         $request = new Request([
-            'code' => 'sonata.post.admin',
+            '_sonata_admin' => 'sonata.post.admin',
             'objectId' => 42,
             'field' => 'enabled',
             'value' => 1,

--- a/tests/Action/RetrieveFormFieldElementActionTest.php
+++ b/tests/Action/RetrieveFormFieldElementActionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\Action;
 
+use PHPUnit\Framework\MockObject\Stub\Stub;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
 use Sonata\AdminBundle\Action\RetrieveFormFieldElementAction;
@@ -31,7 +32,7 @@ use Twig\Environment;
 final class RetrieveFormFieldElementActionTest extends TestCase
 {
     /**
-     * @var AdminFetcherInterface
+     * @var Stub&AdminFetcherInterface
      */
     private $adminFetcher;
 
@@ -59,7 +60,7 @@ final class RetrieveFormFieldElementActionTest extends TestCase
     {
         $this->twig = $this->createStub(Environment::class);
         $this->admin = $this->createMock(AbstractAdmin::class);
-        $this->adminFetcher = $this->createMock(AdminFetcherInterface::class);
+        $this->adminFetcher = $this->createStub(AdminFetcherInterface::class);
         $this->adminFetcher->method('get')->willReturn($this->admin);
         $this->helper = $this->createStub(AdminHelper::class);
         $this->action = new RetrieveFormFieldElementAction(

--- a/tests/Action/SetObjectFieldValueActionTest.php
+++ b/tests/Action/SetObjectFieldValueActionTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\Action;
 
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Action\SetObjectFieldValueAction;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
@@ -39,7 +40,7 @@ use Twig\Loader\ArrayLoader;
 final class SetObjectFieldValueActionTest extends TestCase
 {
     /**
-     * @var AdminFetcherInterface
+     * @var Stub&AdminFetcherInterface
      */
     private $adminFetcher;
 
@@ -85,7 +86,7 @@ final class SetObjectFieldValueActionTest extends TestCase
             'field_template' => 'renderedTemplate',
         ]));
         $this->admin = $this->createMock(AbstractAdmin::class);
-        $this->adminFetcher = $this->createMock(AdminFetcherInterface::class);
+        $this->adminFetcher = $this->createStub(AdminFetcherInterface::class);
         $this->adminFetcher->method('get')->willReturn($this->admin);
         $this->validator = $this->createStub(ValidatorInterface::class);
         $this->modelManager = $this->createStub(ModelManagerInterface::class);

--- a/tests/Controller/HelperControllerTest.php
+++ b/tests/Controller/HelperControllerTest.php
@@ -100,7 +100,7 @@ class HelperControllerTest extends TestCase
         $this->admin = $this->createMock(AbstractAdmin::class);
         $this->resolver = new DataTransformerResolver();
 
-        $this->pool->method('getInstance')->willReturn($this->admin);
+        $this->pool->method('getAdminByAdminCode')->willReturn($this->admin);
 
         $this->controller = new HelperController(
             $this->twig,
@@ -121,7 +121,7 @@ class HelperControllerTest extends TestCase
             'uniqid' => 'asdasd123',
             ]);
 
-        $this->pool->method('getInstance')->with($code)->willThrowException(new \InvalidArgumentException());
+        $this->pool->method('getAdminByAdminCode')->with($code)->willThrowException(new \InvalidArgumentException());
 
         $this->expectException(NotFoundHttpException::class);
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Follow #7188

Closes #7185.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Passing a `code` value in the request of AppendFormFieldElementAction, GetShortObjectDescriptionAction, RetrieveAutocompleteItemsAction, RetrieveFormFieldElementAction and SetObjectFieldValueAction. Pass `_sonata_admin` instead.
- Passing a `Pool` argument to the constructor of AppendFormFieldElementAction, GetShortObjectDescriptionAction, RetrieveAutocompleteItemsAction, RetrieveFormFieldElementAction and SetObjectFieldValueAction. Pass an AdminFetcher instead.

### Fixed
- AppendFormFieldElementAction, GetShortObjectDescriptionAction, RetrieveAutocompleteItemsAction, RetrieveFormFieldElementAction and SetObjectFieldValueAction now set the childAdmin subjects to the childAdmin.
```