### PR TITLE
Fixed select2 ModelAutocompleteType

### DIFF
--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -262,7 +262,7 @@ file that was distributed with this source code.
             // Select2 v3 data populate.
             // NEXT_MAJOR: Remove while dropping v3 support.
             if (window.Select2 && (undefined==data.length || 0<data.length)) { // Leave placeholder if no data set
-                autocompleteInput.select2('data', data);
+                autocompleteInput.attr('data', data);
             }
 
             // remove unneeded autocomplete text input before form submit
@@ -304,15 +304,17 @@ file that was distributed with this source code.
                         {% endif %}
 
                         // append to Select2
-                        autocompleteInput.select2('data', data).append(data).trigger('change');
+                        autocompleteInput.attr('data', data).append(data).trigger('change');
 
                         // manually trigger the `select2:select` event
-                        autocompleteInput.select2('data', data).trigger({
+                        autocompleteInput.attr('data', data).trigger({
                             type: 'select2:select',
                             params: {
                                 data: data
                             }
                         });
+                        
+                        $('#{{ id }}_hidden_inputs_wrap input:hidden').val(data.value);
                       }
                   }
                 });


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
- Fixed error `Uncaught TypeError: autocompleteInput.select2(...).append is not a function` after adding a new item to **ModelAutocompleteType** fields.
- Fixed error on save, id was missing from the hidden input (value attribute).

Closes #4022.
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Changed .select2() to .attr()
- Set id in the value attribute of hidden input after save
```
