### PR TITLE
Allow sortable option as string

### DIFF
--- a/src/FieldDescription/FieldDescriptionInterface.php
+++ b/src/FieldDescription/FieldDescriptionInterface.php
@@ -27,7 +27,7 @@ use Sonata\AdminBundle\Exception\NoValueException;
  *  role?: string|string[],
  *  sort_field_mapping?: array<string, mixed>,
  *  sort_parent_association_mappings?: array<array<string, mixed>>,
- *  sortable?: bool,
+ *  sortable?: string|bool,
  *  template?: string,
  *  translation_domain?: string,
  *  type?: string,


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

It is used as `string` for specify the field name for example in:

https://github.com/sonata-project/SonataAdminBundle/blob/33d99daf74d3fdeb760dbec60e16856b34fd3ef3/src/Datagrid/Datagrid.php#L386

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed type of `sortable` option in `FieldDescriptionOptions`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
