### PR TITLE
Do not lose _route_params

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -326,7 +326,8 @@ This code manages the many-to-[one|many] association field popup
                                 sonata_admin.admin.root.hasRequest()
                                 ? sonata_admin.admin.root.request.attributes.get('_route_params', {})
                                 : {}
-                            )) }}',
+                            ) + app.request.query.all
+                            ) }}',
                             data: {_xml_http_request: true },
                             dataType: 'html',
                             type: 'POST',
@@ -537,7 +538,8 @@ This code manages the many-to-[one|many] association field popup
                     associationadmin.hasRequest()
                     ? associationadmin.request.attributes.get('_route_params', {})
                     : {}
-                ))}}'.replace('OBJECT_ID', objectId),
+                ) + app.request.query.all
+                )}}'.replace('OBJECT_ID', objectId),
                 dataType: 'html',
                 success: function(html) {
                     jQuery('#field_widget_{{ id }}').html(html);

--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -326,7 +326,7 @@ This code manages the many-to-[one|many] association field popup
                                 sonata_admin.admin.root.hasRequest()
                                 ? sonata_admin.admin.root.request.attributes.get('_route_params', {})
                                 : {}
-                            ) + app.request.query.all
+                            ) + app.request.query.all|default({})
                             ) }}',
                             data: {_xml_http_request: true },
                             dataType: 'html',
@@ -538,7 +538,7 @@ This code manages the many-to-[one|many] association field popup
                     associationadmin.hasRequest()
                     ? associationadmin.request.attributes.get('_route_params', {})
                     : {}
-                ) + app.request.query.all
+                ) + app.request.query.all|default({})
                 )}}'.replace('OBJECT_ID', objectId),
                 dataType: 'html',
                 success: function(html) {

--- a/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
@@ -31,7 +31,7 @@ file that was distributed with this source code.
                         sonata_admin.field_description.associationadmin.hasRequest()
                         ? sonata_admin.field_description.associationadmin.request.attributes.get('_route_params', {})
                         : {}
-                    ) + app.request.query.all
+                    ) + app.request.query.all|default({})
                     )) }}
                 {% elseif sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder') %}
                     <span class="inner-field-short-description">

--- a/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
@@ -31,7 +31,8 @@ file that was distributed with this source code.
                         sonata_admin.field_description.associationadmin.hasRequest()
                         ? sonata_admin.field_description.associationadmin.request.attributes.get('_route_params', {})
                         : {}
-                    ))) }}
+                    ) + app.request.query.all
+                    )) }}
                 {% elseif sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder') %}
                     <span class="inner-field-short-description">
                         {{ sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder')|trans({}, 'SonataAdminBundle') }}

--- a/src/Resources/views/CRUD/Association/edit_one_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_script.html.twig
@@ -44,7 +44,7 @@ This code manages the one-to-many association field popup
                 sonata_admin.admin.root.hasRequest()
                 ? sonata_admin.admin.root.request.attributes.get('_route_params', {})
                 : {}
-            ) + app.request.query.all
+            ) + app.request.query.all|default({})
             ) }}',
             type: "POST",
             dataType: 'html',

--- a/src/Resources/views/CRUD/Association/edit_one_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_script.html.twig
@@ -39,13 +39,13 @@ This code manages the one-to-many association field popup
                 'elementId': id,
                 'objectId': sonata_admin.admin.root.id(sonata_admin.admin.root.subject),
                 'uniqid': sonata_admin.admin.root.uniqid,
-                'subclass': app.request.query.get('subclass'),
             } + sonata_admin.field_description.getOption('link_parameters', {})
             + (
                 sonata_admin.admin.root.hasRequest()
                 ? sonata_admin.admin.root.request.attributes.get('_route_params', {})
                 : {}
-            )) }}',
+            ) + app.request.query.all
+            ) }}',
             type: "POST",
             dataType: 'html',
             data: { _xml_http_request: true },

--- a/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
@@ -31,7 +31,7 @@ file that was distributed with this source code.
                         sonata_admin.field_description.associationadmin.hasRequest()
                         ? sonata_admin.field_description.associationadmin.request.attributes.get('_route_params', {})
                         : {}
-                    ) + app.request.query.all
+                    ) + app.request.query.all|default({})
                     )) }}
                 {% elseif sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder') %}
                     <span class="inner-field-short-description">

--- a/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
@@ -31,7 +31,8 @@ file that was distributed with this source code.
                         sonata_admin.field_description.associationadmin.hasRequest()
                         ? sonata_admin.field_description.associationadmin.request.attributes.get('_route_params', {})
                         : {}
-                    ))) }}
+                    ) + app.request.query.all
+                    )) }}
                 {% elseif sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder') %}
                     <span class="inner-field-short-description">
                         {{ sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder')|trans({}, 'SonataAdminBundle') }}

--- a/src/Resources/views/CRUD/base_list_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_field.html.twig
@@ -55,6 +55,7 @@ file that was distributed with this source code.
                     'code': admin.code(object)
                 } + (admin.hasRequest() ? admin.request.attributes.get('_route_params', {}) : {})
                 + admin.getPersistentParameters()
+                + app.request.query.all
             ) %}
 
             {% if field_description.type == constant('Sonata\\AdminBundle\\Admin\\FieldDescriptionInterface::TYPE_DATE') and value is not empty %}

--- a/src/Resources/views/CRUD/base_list_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_field.html.twig
@@ -55,7 +55,7 @@ file that was distributed with this source code.
                     'code': admin.code(object)
                 } + (admin.hasRequest() ? admin.request.attributes.get('_route_params', {}) : {})
                 + admin.getPersistentParameters()
-                + app.request.query.all
+                + app.request.query.all|default({})
             ) %}
 
             {% if field_description.type == constant('Sonata\\AdminBundle\\Admin\\FieldDescriptionInterface::TYPE_DATE') and value is not empty %}

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -607,7 +607,7 @@ file that was distributed with this source code.
                     sonata_admin.field_description.associationadmin.hasRequest()
                     ? sonata_admin.field_description.associationadmin.request.attributes.get('_route_params', {})
                     : {}
-                ) + app.request.query.all
+                ) + app.request.query.all|default({})
                 )) }}
             {% elseif sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder') %}
                 <span class="inner-field-short-description">

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -607,7 +607,8 @@ file that was distributed with this source code.
                     sonata_admin.field_description.associationadmin.hasRequest()
                     ? sonata_admin.field_description.associationadmin.request.attributes.get('_route_params', {})
                     : {}
-                ))) }}
+                ) + app.request.query.all
+                )) }}
             {% elseif sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder') %}
                 <span class="inner-field-short-description">
                     {{ sonata_admin.field_description.option('placeholder', 'short_object_description_placeholder')|trans({}, 'SonataAdminBundle') }}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because bugfix.

This is an attempt to fix https://github.com/sonata-project/SonataAdminBundle/issues/7185

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- childId are not lost anymore when using multiple times the appendFormFieldAction and similar actions.
```