### PR TITLE
Allow null mappingType

### DIFF
--- a/src/FieldDescription/BaseFieldDescription.php
+++ b/src/FieldDescription/BaseFieldDescription.php
@@ -79,7 +79,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
     protected $type;
 
     /**
-     * @var string|int the original mapping type
+     * @var string|int|null the original mapping type
      */
     protected $mappingType;
 

--- a/src/FieldDescription/FieldDescriptionInterface.php
+++ b/src/FieldDescription/FieldDescriptionInterface.php
@@ -340,7 +340,7 @@ interface FieldDescriptionInterface
     /**
      * Returns the mapping type.
      *
-     * @return int|string
+     * @return int|string|null
      */
     public function getMappingType();
 


### PR DESCRIPTION
## Subject

The mapping type is not set in the constructor so it can be nullable.
Also the mapping type is only used if the field is linked to an entity so it can be null.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `FieldDescriptionInterface::getMappingType()` return type
```