### PR TITLE
Restrict visibility of some AbstractAdmin property and rename uniqid to uniqId

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -231,14 +231,12 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
     private $currentChild = false;
 
     /**
-     * NEXT_MAJOR: Rename $uniqId.
-     *
      * The uniqId is used to avoid clashing with 2 admin related to the code
      * ie: a Block linked to a Block.
      *
      * @var string|null
      */
-    private $uniqid;
+    private $uniqId;
 
     /**
      * The current request object.
@@ -1467,18 +1465,18 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return \count($this->children) > 0;
     }
 
-    final public function setUniqid(string $uniqId): void
+    final public function setUniqId(string $uniqId): void
     {
-        $this->uniqid = $uniqId;
+        $this->uniqId = $uniqId;
     }
 
-    final public function getUniqid(): string
+    final public function getUniqId(): string
     {
-        if (!$this->uniqid) {
-            $this->uniqid = sprintf('s%s', uniqid());
+        if (!$this->uniqId) {
+            $this->uniqId = sprintf('s%s', uniqid());
         }
 
-        return $this->uniqid;
+        return $this->uniqId;
     }
 
     final public function getClassnameLabel(): string

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -100,41 +100,6 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
     private const DEFAULT_LIST_PER_PAGE_OPTIONS = [10, 25, 50, 100, 250];
 
     /**
-     * The list FieldDescription constructed from the configureListField method.
-     *
-     * @var array<string, FieldDescriptionInterface>
-     */
-    protected $listFieldDescriptions = [];
-
-    /**
-     * The show FieldDescription constructed from the configureShowFields method.
-     *
-     * @var FieldDescriptionInterface[]
-     */
-    protected $showFieldDescriptions = [];
-
-    /**
-     * The list FieldDescription constructed from the configureFormField method.
-     *
-     * @var FieldDescriptionInterface[]
-     */
-    protected $formFieldDescriptions = [];
-
-    /**
-     * The filter FieldDescription constructed from the configureFilterField method.
-     *
-     * @var FieldDescriptionInterface[]
-     */
-    protected $filterFieldDescriptions = [];
-
-    /**
-     * The maximum number of page numbers to display in the list.
-     *
-     * @var int
-     */
-    protected $maxPageLinks = 25;
-
-    /**
      * The base route name used to generate the routing information.
      *
      * @var string|null
@@ -156,102 +121,6 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
     protected $classnameLabel;
 
     /**
-     * The translation domain to be used to translate messages.
-     *
-     * @var string
-     */
-    protected $translationDomain = 'messages';
-
-    /**
-     * Array of routes related to this admin.
-     *
-     * @var RouteCollectionInterface|null
-     */
-    protected $routes;
-
-    /**
-     * The subject only set in edit/update/create mode.
-     *
-     * @var object|null
-     *
-     * @phpstan-var T|null
-     */
-    protected $subject;
-
-    /**
-     * Define a Collection of child admin, ie /admin/order/{id}/order-element/{childId}.
-     *
-     * @var array<string, AdminInterface>
-     */
-    protected $children = [];
-
-    /**
-     * Reference the parent admin.
-     *
-     * @var AdminInterface|null
-     */
-    protected $parent;
-
-    /**
-     * Reference the parent FieldDescription related to this admin
-     * only set for FieldDescription which is associated to an Sub Admin instance.
-     *
-     * @var FieldDescriptionInterface|null
-     */
-    protected $parentFieldDescription;
-
-    /**
-     * If true then the current admin is part of the nested admin set (from the url).
-     *
-     * @var bool
-     */
-    protected $currentChild = false;
-
-    /**
-     * NEXT_MAJOR: Rename $uniqId.
-     *
-     * The uniqId is used to avoid clashing with 2 admin related to the code
-     * ie: a Block linked to a Block.
-     *
-     * @var string|null
-     */
-    protected $uniqid;
-
-    /**
-     * The current request object.
-     *
-     * @var Request|null
-     */
-    protected $request;
-
-    /**
-     * The datagrid instance.
-     *
-     * @var DatagridInterface|null
-     */
-    protected $datagrid;
-
-    /**
-     * @var ItemInterface|null
-     */
-    protected $menu;
-
-    /**
-     * @var string[]
-     */
-    protected $formTheme = [];
-
-    /**
-     * @var string[]
-     */
-    protected $filterTheme = [];
-
-    /**
-     * @var AdminExtensionInterface[]
-     */
-    protected $extensions = [];
-
-    /**
      * Setting to true will enable preview mode for
      * the entity and show a preview button in the
      * edit/create forms.
@@ -259,11 +128,6 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
      * @var bool
      */
     protected $supportsPreviewMode = false;
-
-    /**
-     * @var array<string, bool>
-     */
-    protected $cacheIsGranted = [];
 
     /**
      * Action list for the search result.
@@ -278,6 +142,142 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
      * @var array<string, string|string[]> [action1 => requiredRole1, action2 => [requiredRole2, requiredRole3]]
      */
     protected $accessMapping = [];
+
+    /**
+     * The list FieldDescription constructed from the configureListField method.
+     *
+     * @var array<string, FieldDescriptionInterface>
+     */
+    private $listFieldDescriptions = [];
+
+    /**
+     * The show FieldDescription constructed from the configureShowFields method.
+     *
+     * @var FieldDescriptionInterface[]
+     */
+    private $showFieldDescriptions = [];
+
+    /**
+     * The list FieldDescription constructed from the configureFormField method.
+     *
+     * @var FieldDescriptionInterface[]
+     */
+    private $formFieldDescriptions = [];
+
+    /**
+     * The filter FieldDescription constructed from the configureFilterField method.
+     *
+     * @var FieldDescriptionInterface[]
+     */
+    private $filterFieldDescriptions = [];
+
+    /**
+     * The maximum number of page numbers to display in the list.
+     *
+     * @var int
+     */
+    private $maxPageLinks = 25;
+
+    /**
+     * The translation domain to be used to translate messages.
+     *
+     * @var string
+     */
+    private $translationDomain = 'messages';
+
+    /**
+     * Array of routes related to this admin.
+     *
+     * @var RouteCollectionInterface|null
+     */
+    private $routes;
+
+    /**
+     * The subject only set in edit/update/create mode.
+     *
+     * @var object|null
+     *
+     * @phpstan-var T|null
+     */
+    private $subject;
+
+    /**
+     * Define a Collection of child admin, ie /admin/order/{id}/order-element/{childId}.
+     *
+     * @var array<string, AdminInterface>
+     */
+    private $children = [];
+
+    /**
+     * Reference the parent admin.
+     *
+     * @var AdminInterface|null
+     */
+    private $parent;
+
+    /**
+     * Reference the parent FieldDescription related to this admin
+     * only set for FieldDescription which is associated to an Sub Admin instance.
+     *
+     * @var FieldDescriptionInterface|null
+     */
+    private $parentFieldDescription;
+
+    /**
+     * If true then the current admin is part of the nested admin set (from the url).
+     *
+     * @var bool
+     */
+    private $currentChild = false;
+
+    /**
+     * NEXT_MAJOR: Rename $uniqId.
+     *
+     * The uniqId is used to avoid clashing with 2 admin related to the code
+     * ie: a Block linked to a Block.
+     *
+     * @var string|null
+     */
+    private $uniqid;
+
+    /**
+     * The current request object.
+     *
+     * @var Request|null
+     */
+    private $request;
+
+    /**
+     * The datagrid instance.
+     *
+     * @var DatagridInterface|null
+     */
+    private $datagrid;
+
+    /**
+     * @var ItemInterface|null
+     */
+    private $menu;
+
+    /**
+     * @var string[]
+     */
+    private $formTheme = [];
+
+    /**
+     * @var string[]
+     */
+    private $filterTheme = [];
+
+    /**
+     * @var AdminExtensionInterface[]
+     */
+    private $extensions = [];
+
+    /**
+     * @var array<string, bool>
+     */
+    private $cacheIsGranted = [];
 
     /**
      * @var array<string, string>

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -190,9 +190,9 @@ interface AdminInterface extends TaggedAdminInterface, AccessRegistryInterface, 
      */
     public function getNewInstance(): object;
 
-    public function setUniqid(string $uniqId): void;
+    public function setUniqId(string $uniqId): void;
 
-    public function getUniqid(): string;
+    public function getUniqId(): string;
 
     public function getClassnameLabel(): string;
 

--- a/src/Admin/Extension/LockExtension.php
+++ b/src/Admin/Extension/LockExtension.php
@@ -65,7 +65,7 @@ final class LockExtension extends AbstractAdminExtension
 
     public function preUpdate(AdminInterface $admin, object $object): void
     {
-        if (!$admin->hasRequest() || !$data = $admin->getRequest()->get($admin->getUniqid())) {
+        if (!$admin->hasRequest() || !$data = $admin->getRequest()->get($admin->getUniqId())) {
             return;
         }
 

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -306,10 +306,10 @@ class AdminTest extends TestCase
     public function testConfigure(): void
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'Application\Sonata\NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
-        $this->assertNotNull($admin->getUniqid());
+        $this->assertNotNull($admin->getUniqId());
 
         $admin->initialize();
-        $this->assertNotNull($admin->getUniqid());
+        $this->assertNotNull($admin->getUniqId());
         $this->assertSame('Post', $admin->getClassnameLabel());
 
         $admin = new CommentAdmin('sonata.post.admin.comment', 'Application\Sonata\NewsBundle\Entity\Comment', 'Sonata\NewsBundle\Controller\CommentAdminController');
@@ -588,17 +588,17 @@ class AdminTest extends TestCase
     }
 
     /**
-     * @covers \Sonata\AdminBundle\Admin\AbstractAdmin::setUniqid
-     * @covers \Sonata\AdminBundle\Admin\AbstractAdmin::getUniqid
+     * @covers \Sonata\AdminBundle\Admin\AbstractAdmin::setUniqId
+     * @covers \Sonata\AdminBundle\Admin\AbstractAdmin::getUniqId
      */
-    public function testSetUniqid(): void
+    public function testSetUniqId(): void
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
 
-        $uniqid = uniqid();
-        $admin->setUniqid($uniqid);
+        $uniqId = uniqid();
+        $admin->setUniqId($uniqId);
 
-        $this->assertSame($uniqid, $admin->getUniqid());
+        $this->assertSame($uniqId, $admin->getUniqId());
     }
 
     public function testToString(): void

--- a/tests/Admin/Extension/LockExtensionTest.php
+++ b/tests/Admin/Extension/LockExtensionTest.php
@@ -172,37 +172,37 @@ class LockExtensionTest extends TestCase
 
     public function testPreUpdateIfRequestDoesNotHaveLockVersion(): void
     {
-        $uniqid = 'admin123';
-        $this->configureAdmin($this->modelManager, $uniqid, $this->request);
+        $uniqId = 'admin123';
+        $this->configureAdmin($this->modelManager, $uniqId, $this->request);
 
         $this->modelManager->expects($this->never())->method('lock');
 
-        $this->request->request->set($uniqid, ['something']);
+        $this->request->request->set($uniqId, ['something']);
         $this->lockExtension->preUpdate($this->admin, $this->object);
     }
 
     public function testPreUpdateIfModelManagerIsNotImplementingLockerInterface(): void
     {
-        $uniqid = 'admin123';
+        $uniqId = 'admin123';
         $this->configureAdmin(
             $this->createStub(ModelManagerInterface::class),
-            $uniqid,
+            $uniqId,
             $this->request
         );
         $this->modelManager->expects($this->never())->method('lock');
 
-        $this->request->request->set($uniqid, ['_lock_version' => 1]);
+        $this->request->request->set($uniqId, ['_lock_version' => 1]);
         $this->lockExtension->preUpdate($this->admin, $this->object);
     }
 
     public function testPreUpdateIfObjectIsVersioned(): void
     {
-        $uniqid = 'admin123';
-        $this->configureAdmin($this->modelManager, $uniqid, $this->request);
+        $uniqId = 'admin123';
+        $this->configureAdmin($this->modelManager, $uniqId, $this->request);
 
         $this->modelManager->expects($this->once())->method('lock')->with($this->object, 1);
 
-        $this->request->request->set($uniqid, ['_lock_version' => 1]);
+        $this->request->request->set($uniqId, ['_lock_version' => 1]);
         $this->lockExtension->preUpdate($this->admin, $this->object);
     }
 
@@ -237,10 +237,10 @@ class LockExtensionTest extends TestCase
 
     private function configureAdmin(
         ModelManagerInterface $modelManager,
-        string $uniqid = '',
+        string $uniqId = '',
         ?Request $request = null
     ): void {
-        $this->admin->method('getUniqid')->willReturn($uniqid);
+        $this->admin->method('getUniqId')->willReturn($uniqId);
         $this->admin->method('getModelManager')->willReturn($modelManager);
 
         $this->admin->method('hasRequest')->willReturn(null !== $request);

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -392,9 +392,9 @@ class CRUDControllerTest extends TestCase
         $uniqueId = '';
 
         $this->admin->expects($this->once())
-            ->method('setUniqid')
-            ->willReturnCallback(static function (string $uniqid) use (&$uniqueId): void {
-                $uniqueId = $uniqid;
+            ->method('setUniqId')
+            ->willReturnCallback(static function (string $uniqId) use (&$uniqueId): void {
+                $uniqueId = $uniqId;
             });
 
         $this->request->query->set('uniqid', '123456');
@@ -408,9 +408,9 @@ class CRUDControllerTest extends TestCase
         $uniqueId = '';
 
         $this->admin->expects($this->once())
-            ->method('setUniqid')
-            ->willReturnCallback(static function (string $uniqid) use (&$uniqueId): void {
-                $uniqueId = $uniqid;
+            ->method('setUniqId')
+            ->willReturnCallback(static function (string $uniqId) use (&$uniqueId): void {
+                $uniqueId = $uniqId;
             });
 
         $this->admin->expects($this->once())

--- a/tests/Request/AdminFetcherTest.php
+++ b/tests/Request/AdminFetcherTest.php
@@ -63,7 +63,7 @@ final class AdminFetcherTest extends TestCase
         $this->adminFetcher->get($request);
     }
 
-    public function testSetsUniqidToAdmin(): void
+    public function testSetsUniqIdToAdmin(): void
     {
         $request = new Request();
         $request->attributes->set('_sonata_admin', 'sonata.admin.post');
@@ -72,7 +72,7 @@ final class AdminFetcherTest extends TestCase
 
         $this->admin
             ->expects($this->once())
-            ->method('setUniqid')
+            ->method('setUniqId')
             ->with($uniqueId);
 
         $this->adminFetcher->get($request);

--- a/tests/Route/DefaultRouteGeneratorTest.php
+++ b/tests/Route/DefaultRouteGeneratorTest.php
@@ -76,7 +76,7 @@ class DefaultRouteGeneratorTest extends TestCase
         $admin->method('getBaseCodeRoute')->willReturn('base.Code.Foo');
         $admin->expects($this->once())->method('hasParentFieldDescription')->willReturn(false);
         $admin->expects($this->once())->method('hasRequest')->willReturn(true);
-        $admin->method('getUniqid')->willReturn('foo_uniqueid');
+        $admin->method('getUniqId')->willReturn('foo_uniqueid');
         $admin->expects($this->once())->method('getPersistentParameters')->willReturn(['abc' => 'a123', 'efg' => 'e456']);
         $admin->method('getRoutes')->willReturn($collection);
         $admin->method('getExtensions')->willReturn([]);
@@ -170,7 +170,7 @@ class DefaultRouteGeneratorTest extends TestCase
         $admin->method('getIdParameter')->willReturn('id');
         $admin->method('hasParentFieldDescription')->willReturn(false);
         $admin->method('hasRequest')->willReturn(true);
-        $admin->method('getUniqid')->willReturn('foo_uniqueid');
+        $admin->method('getUniqId')->willReturn('foo_uniqueid');
         $admin->method('getPersistentParameters')->willReturn(['abc' => 'a123', 'efg' => 'e456']);
         $admin->method('getRoutes')->willReturn($childCollection);
         $admin->method('getExtensions')->willReturn([]);
@@ -261,7 +261,7 @@ class DefaultRouteGeneratorTest extends TestCase
         // embeded admin (not nested ...)
         $admin->expects($this->once())->method('hasParentFieldDescription')->willReturn(true);
         $admin->expects($this->once())->method('hasRequest')->willReturn(true);
-        $admin->expects($this->any())->method('getUniqid')->willReturn('foo_uniqueid');
+        $admin->expects($this->any())->method('getUniqId')->willReturn('foo_uniqueid');
         $admin->expects($this->once())->method('getPersistentParameters')->willReturn(['abc' => 'a123', 'efg' => 'e456']);
         $admin->method('getExtensions')->willReturn([]);
         $admin->method('getRoutes')->willReturn($collection);
@@ -289,7 +289,7 @@ class DefaultRouteGeneratorTest extends TestCase
         $fieldDescription->expects($this->once())->method('getOption')->willReturn([]);
 
         $parentAdmin = $this->getMockForAbstractClass(AdminInterface::class);
-        $parentAdmin->method('getUniqid')->willReturn('parent_foo_uniqueid');
+        $parentAdmin->method('getUniqId')->willReturn('parent_foo_uniqueid');
         $parentAdmin->method('getCode')->willReturn('parent_foo_code');
         $parentAdmin->method('getExtensions')->willReturn([]);
 
@@ -339,7 +339,7 @@ class DefaultRouteGeneratorTest extends TestCase
         $admin->method('getIdParameter')->willReturn('id');
         $admin->method('hasParentFieldDescription')->willReturn(false);
         $admin->method('hasRequest')->willReturn(true);
-        $admin->method('getUniqid')->willReturn('foo_uniqueid');
+        $admin->method('getUniqId')->willReturn('foo_uniqueid');
         $admin->method('getPersistentParameters')->willReturn(['abc' => 'a123', 'efg' => 'e456']);
         $admin->method('getRoutes')->willReturn($childCollection);
         $admin->method('getExtensions')->willReturn([]);
@@ -374,7 +374,7 @@ class DefaultRouteGeneratorTest extends TestCase
         $standaloneAdmin->method('getBaseCodeRoute')->willReturn('base.Code.Child');
         $standaloneAdmin->expects($this->once())->method('hasParentFieldDescription')->willReturn(false);
         $standaloneAdmin->expects($this->once())->method('hasRequest')->willReturn(true);
-        $standaloneAdmin->method('getUniqid')->willReturn('foo_uniqueid');
+        $standaloneAdmin->method('getUniqId')->willReturn('foo_uniqueid');
         $standaloneAdmin->expects($this->once())->method('getPersistentParameters')->willReturn(['abc' => 'a123', 'efg' => 'e456']);
         $standaloneAdmin->method('getRoutes')->willReturn($standaloneCollection);
         $standaloneAdmin->method('getExtensions')->willReturn([]);


### PR DESCRIPTION
## Subject

I let as protected all the property without setter.
The property I changed has a setter (which is final), so we should promote the setter instead.

Also, we were mixing `$uniqId` and `$uniqid`. In the last psalm patch I used `uniqId` so I follow the changes here.
I think the method call are not case sensitive so it's not a BC break.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- All the protected property of the AsbtractAdmin with a specific setter are now private.
```