### PR TITLE
Fix for ModelAutocompleteType does not display the previously selected value when editing an entity

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,0 @@
-
-# Default ignored files
-/workspace.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+
+# Default ignored files
+/workspace.xml

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -266,7 +266,7 @@ file that was distributed with this source code.
             // Select2 v3 data populate.
             // NEXT_MAJOR: Remove while dropping v3 support.
             if (window.Select2 && (undefined==data.length || 0<data.length)) { // Leave placeholder if no data set
-                autocompleteInput.attr('data', data);
+                autocompleteInput.select2('data', data);
             }
 
             // remove unneeded autocomplete text input before form submit
@@ -308,10 +308,10 @@ file that was distributed with this source code.
                         {% endif %}
 
                         // append to Select2
-                        autocompleteInput.attr('data', data).append(data).trigger('change');
+                        autocompleteInput.append(data).trigger('change');
 
                         // manually trigger the `select2:select` event
-                        autocompleteInput.attr('data', data).trigger({
+                        autocompleteInput.trigger({
                             type: 'select2:select',
                             params: {
                                 data: data

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -308,10 +308,10 @@ file that was distributed with this source code.
                         {% endif %}
 
                         // append to Select2
-                        autocompleteInput.append(data).trigger('change');
+                        autocompleteInput.select2('data', data).append(data).trigger('change');
 
                         // manually trigger the `select2:select` event
-                        autocompleteInput.trigger({
+                        autocompleteInput.select2('data', data).trigger({
                             type: 'select2:select',
                             params: {
                                 data: data

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -308,9 +308,11 @@ file that was distributed with this source code.
                         {% endif %}
 
                         // append to Select2
+                        // NEXT_MAJOR: Remove ".select2('data', data)" while dropping v3 support
                         autocompleteInput.select2('data', data).append(data).trigger('change');
 
                         // manually trigger the `select2:select` event
+                        // NEXT_MAJOR: Remove ".select2('data', data)" while dropping v3 support
                         autocompleteInput.select2('data', data).trigger({
                             type: 'select2:select',
                             params: {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it's BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #7210 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
Reverted the changes of #7196, because they only work for Select2 version 4, that is used on the Master branche. Branche 3.x uses Select2 version 3.

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
