### PR TITLE
Fix for no focus on Select2 or CKEditor in modal dialog

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_modal.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_modal.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-<div class="modal fade" id="field_dialog_{{ id }}" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+<div class="modal fade" id="field_dialog_{{ id }}" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
     <div class="modal-dialog modal-lg">
         <div class="modal-content">
             <div class="modal-header">

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -69,6 +69,7 @@ file that was distributed with this source code.
                 dropdownAutoWidth: {{ dropdown_auto_width ? 'true' : 'false' }},
                 containerCssClass: '{{ container_css_class ~ ' form-control' }}',
                 dropdownCssClass: '{{ dropdown_css_class }}',
+                dropdownParent: autocompleteInput.parents('.modal').length > 0 ? autocompleteInput.parents('.modal') : $(document.body),
                 ajax: {
                     url:  '{{ url ?: path(route.name, route.parameters|default([])) }}',
                     dataType: 'json',

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -623,7 +623,7 @@ file that was distributed with this source code.
 
         {{ form_help(form) }}
 
-        <div class="modal fade" id="field_dialog_{{ id }}" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
+        <div class="modal fade" id="field_dialog_{{ id }}" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">
             <div class="modal-dialog modal-lg">
                 <div class="modal-content">
                     <div class="modal-header">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #7222

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Focus on Select2 or CKEditor in modal dialog 

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
