### PR TITLE
#7230 Quick fix

### DIFF
--- a/src/Resources/views/Pager/base_results.html.twig
+++ b/src/Resources/views/Pager/base_results.html.twig
@@ -25,6 +25,7 @@ file that was distributed with this source code.
     <select class="per-page small form-control" id="{{ admin.uniqid }}_per_page" style="width: auto">
         {% for per_page in admin.getperpageoptions %}
             <option {% if per_page == admin.datagrid.pager.maxperpage %}selected="selected"{% endif %} value="{{ admin.generateUrl(action, {'filter': admin.datagrid.values|merge({
+                (constant('Sonata\\AdminBundle\\Datagrid\\DatagridInterface::SORT_BY')): admin.datagrid.values[constant('Sonata\\AdminBundle\\Datagrid\\DatagridInterface::SORT_BY')].name,
                 (constant('Sonata\\AdminBundle\\Datagrid\\DatagridInterface::PAGE')): 1,
                 (constant('Sonata\\AdminBundle\\Datagrid\\DatagridInterface::PER_PAGE')): per_page})
             }) }}">


### PR DESCRIPTION
## Subject
Quick fix to fix issue #7230, adding the value of the filter directly to the array and don't use the object

I am targeting this branch, because is my current branch.

Closes #7230.

## Changelog

```markdown
### Fixed
- `Max_per_page` drowpdown propagate correctly the `sort_by` filter value
```
