### PR TITLE
RFC: Remove CRUDController::getRequest method

### DIFF
--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -480,7 +480,7 @@ class CRUDControllerTest extends TestCase
     {
         $this->assertInstanceOf(
             Response::class,
-            $this->controller->renderWithExtraParams('@FooAdmin/foo.html.twig', [], null)
+            $this->controller->renderWithExtraParams($this->request, '@FooAdmin/foo.html.twig', [], null)
         );
         $this->assertSame($this->admin, $this->parameters['admin']);
         $this->assertSame('@SonataAdmin/standard_layout.html.twig', $this->parameters['base_template']);
@@ -491,7 +491,7 @@ class CRUDControllerTest extends TestCase
     {
         $response = new Response();
         $response->headers->set('X-foo', 'bar');
-        $responseResult = $this->controller->renderWithExtraParams('@FooAdmin/foo.html.twig', [], $response);
+        $responseResult = $this->controller->renderWithExtraParams($this->request, '@FooAdmin/foo.html.twig', [], $response);
 
         $this->assertSame($response, $responseResult);
         $this->assertSame('bar', $responseResult->headers->get('X-foo'));
@@ -505,6 +505,7 @@ class CRUDControllerTest extends TestCase
         $this->assertInstanceOf(
             Response::class,
             $this->controller->renderWithExtraParams(
+                $this->request,
                 '@FooAdmin/foo.html.twig',
                 ['foo' => 'bar'],
                 null
@@ -522,6 +523,7 @@ class CRUDControllerTest extends TestCase
         $this->assertInstanceOf(
             Response::class,
             $this->controller->renderWithExtraParams(
+                $this->request,
                 '@FooAdmin/foo.html.twig',
                 ['foo' => 'bar'],
                 null
@@ -853,7 +855,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo($route))
             ->willReturn(true);
 
-        $response = $this->protectedTestedMethods['redirectTo']->invoke($this->controller, $object, $this->request);
+        $response = $this->protectedTestedMethods['redirectTo']->invoke($this->controller, $this->request, $object);
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame($expected, $response->getTargetUrl());
     }
@@ -876,7 +878,7 @@ class CRUDControllerTest extends TestCase
             ->with($this->equalTo('edit'), $object)
             ->willReturn(false);
 
-        $response = $this->protectedTestedMethods['redirectTo']->invoke($this->controller, $object, $this->request);
+        $response = $this->protectedTestedMethods['redirectTo']->invoke($this->controller, $this->request, $object);
         $this->assertInstanceOf(RedirectResponse::class, $response);
         $this->assertSame('list', $response->getTargetUrl());
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

As discussed here https://github.com/sonata-project/SonataAdminBundle/pull/7228#discussion_r642943408 we could remove the `getRequest` method in favor of passing the request as an argument of the method which require it.

I added the `request` as first argument to all the method in order to have some consistency.

Related to this consistency, the only one method with `request` as second argument is the `batchActions`.
We're doing `$this->$finalAction($query, $forwardedRequest);`. Should we swap the argument ?

## Changelog


<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- `renderWithExtraParams()`, `isXmlHttpRequest()`, `getBaseTemplate()`, `redirectTo()`, `isPreviewApproved()`, `isInPreviewMode()`, `isPreviewDeclined()`, `validateCsrfToken()` signatures. They now require to pass the request as first argument.

### Removed
- `CRUDController::getRequest()` method
```