### PR TITLE
Fix display of history_revision_timestamp

### DIFF
--- a/src/Resources/views/CRUD/history_revision_timestamp.html.twig
+++ b/src/Resources/views/CRUD/history_revision_timestamp.html.twig
@@ -11,6 +11,4 @@ file that was distributed with this source code.
 
 {%- include '@SonataAdmin/CRUD/display_datetime.html.twig' with {
     value: revision.timestamp,
-    format: field_description.option('format'),
-    timezone: field_description.option('timezone'),
 } only -%}


### PR DESCRIPTION
## Subject

Patch

Closes #7217.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Display of `history_revision_timestamp.html.twig`
```