### PR TITLE
Remove deprecations with Symfony 5.3

### DIFF
--- a/src/Menu/Matcher/Voter/AdminVoter.php
+++ b/src/Menu/Matcher/Voter/AdminVoter.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Menu\Matcher\Voter;
 use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\Voter\VoterInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -39,7 +40,8 @@ final class AdminVoter implements VoterInterface
     {
         $admin = $item->getExtra('admin');
 
-        $request = $this->requestStack->getMasterRequest();
+        // TODO: Use $this->requestStack->getMainRequest() when dropping support of Symfony < 5.3
+        $request = $this->getMainRequest();
 
         if ($admin instanceof AdminInterface
             && $admin->hasRoute('list') && $admin->hasAccess('list')
@@ -64,5 +66,17 @@ final class AdminVoter implements VoterInterface
         }
 
         return null;
+    }
+
+    /**
+     * TODO: Remove it when dropping support of Symfony < 5.3.
+     */
+    private function getMainRequest(): ?Request
+    {
+        if (method_exists($this->requestStack, 'getMainRequest')) {
+            return $this->requestStack->getMainRequest();   // symfony 5.3+
+        }
+
+        return $this->requestStack->getMasterRequest();
     }
 }

--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -139,7 +139,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         ->set('sonata.admin.filter_persister.session', SessionFilterPersister::class)
             ->args([
-                new ReferenceConfigurator('session'),
+                new ReferenceConfigurator('request_stack'),
             ])
 
         ->alias(FilterPersisterInterface::class, 'sonata.admin.filter_persister.session')

--- a/tests/Filter/Persister/SessionFilterPersisterTest.php
+++ b/tests/Filter/Persister/SessionFilterPersisterTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Filter\Persister\SessionFilterPersister;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class SessionFilterPersisterTest extends TestCase
@@ -86,6 +88,11 @@ class SessionFilterPersisterTest extends TestCase
 
     private function createPersister(): SessionFilterPersister
     {
-        return new SessionFilterPersister($this->session);
+        $request = new Request();
+        $request->setSession($this->session);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        return new SessionFilterPersister($requestStack);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

`session` service has been deprecated in favor of fetching the session from the `request_stack` and `RequestStack::getMasterRequest` in favor of getMainRequest.

Ref: https://github.com/symfony/symfony/blob/5.4/UPGRADE-5.3.md#frameworkbundle and https://github.com/symfony/symfony/blob/5.4/UPGRADE-5.3.md#httpkernel

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because is where support of symfony 5 is.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Changed argument 1 of `SessionFilterPersister::__construct()` from `SessionInterface` to `RequestStack`
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
