### PR TITLE
[RFC] Propagate group translation domain to field description

### DIFF
--- a/src/FieldDescription/BaseFieldDescription.php
+++ b/src/FieldDescription/BaseFieldDescription.php
@@ -782,7 +782,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
      */
     public function getTranslationDomain()
     {
-        return $this->getOption('translation_domain') ?: $this->getAdmin()->getTranslationDomain();
+        return $this->getOption('translation_domain') ?? $this->getAdmin()->getTranslationDomain();
     }
 
     /**

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -118,8 +118,8 @@ class FormMapper extends BaseGroupedMapper
             $fieldDescriptionOptions['type'] = $type;
         }
 
-        if ($group['translation_domain'] && !isset($fieldDescriptionOptions['translation_domain'])) {
-            $fieldDescriptionOptions['translation_domain'] = $group['translation_domain'];
+        if (!isset($fieldDescriptionOptions['translation_domain'])) {
+            $fieldDescriptionOptions['translation_domain'] = $group['translation_domain'] ?? null;
         }
 
         // NEXT_MAJOR: Remove the check and use `createFieldDescription`.

--- a/src/Mapper/BaseGroupedMapper.php
+++ b/src/Mapper/BaseGroupedMapper.php
@@ -425,7 +425,10 @@ abstract class BaseGroupedMapper extends BaseMapper implements MapperInterface
             $label = $this->getAdmin()->getLabel();
 
             if (null === $label) {
-                $this->with('default', ['auto_created' => true]);
+                $this->with('default', [
+                    'auto_created' => true,
+                    'translation_domain' => null,
+                ]);
             } else {
                 $this->with($label, [
                     'auto_created' => true,

--- a/tests/FieldDescription/BaseFieldDescriptionTest.php
+++ b/tests/FieldDescription/BaseFieldDescriptionTest.php
@@ -354,8 +354,7 @@ class BaseFieldDescriptionTest extends TestCase
         $description->setAdmin($admin);
 
         $admin->expects($this->never())
-            ->method('getTranslationDomain')
-            ->willReturn('AdminDomain');
+            ->method('getTranslationDomain');
 
         $this->assertFalse($description->getTranslationDomain());
     }

--- a/tests/FieldDescription/BaseFieldDescriptionTest.php
+++ b/tests/FieldDescription/BaseFieldDescriptionTest.php
@@ -346,6 +346,20 @@ class BaseFieldDescriptionTest extends TestCase
         $this->assertSame('ExtensionDomain', $description->getTranslationDomain());
     }
 
+    public function testGetTranslationDomainWithFalse(): void
+    {
+        $description = new FieldDescription('name', ['translation_domain' => false]);
+
+        $admin = $this->createMock(AdminInterface::class);
+        $description->setAdmin($admin);
+
+        $admin->expects($this->never())
+            ->method('getTranslationDomain')
+            ->willReturn('AdminDomain');
+
+        $this->assertFalse($description->getTranslationDomain());
+    }
+
     /**
      * @group legacy
      */

--- a/tests/Form/FormMapperTest.php
+++ b/tests/Form/FormMapperTest.php
@@ -235,6 +235,56 @@ class FormMapperTest extends TestCase
         ]], $this->admin->getFormGroups());
     }
 
+    public function testWithFieldsCascadeTranslationDomainFalse(): void
+    {
+        $this->contractor->expects($this->once())
+            ->method('getDefaultOptions')
+            ->willReturn([]);
+
+        $this->formMapper->with('foobar', [
+            'translation_domain' => false,
+        ])
+            ->add('foo', 'bar')
+            ->end();
+
+        $fieldDescription = $this->admin->getFormFieldDescription('foo');
+        $this->assertSame('foo', $fieldDescription->getName());
+        $this->assertSame('bar', $fieldDescription->getType());
+        $this->assertFalse($fieldDescription->getTranslationDomain());
+
+        $this->assertTrue($this->formMapper->has('foo'));
+
+        $this->assertSame(['default' => [
+            'collapsed' => false,
+            'class' => false,
+            'description' => false,
+            'label' => 'default',
+            'translation_domain' => false,
+            'name' => 'default',
+            'box_class' => 'box box-primary',
+            'empty_message' => 'message_form_group_empty',
+            'empty_message_translation_domain' => 'SonataAdminBundle',
+            'auto_created' => true,
+            'groups' => ['foobar'],
+            'tab' => true,
+        ]], $this->admin->getFormTabs());
+
+        $this->assertSame(['foobar' => [
+            'collapsed' => false,
+            'class' => false,
+            'description' => false,
+            'label' => 'foobar',
+            'translation_domain' => false,
+            'name' => 'foobar',
+            'box_class' => 'box box-primary',
+            'empty_message' => 'message_form_group_empty',
+            'empty_message_translation_domain' => 'SonataAdminBundle',
+            'fields' => [
+                'foo' => 'foo',
+            ],
+        ]], $this->admin->getFormGroups());
+    }
+
     /**
      * @doesNotPerformAssertions
      */


### PR DESCRIPTION
## Subject

Two things here:
- When using the group `default`, I added the `translation_domain` in order to avoid error when accessing `$group['translation_domain']`. @jordisala1991 got this error recently.
- I also added `?? null`.
- Previously the check was "If the field description has no translation domain, but the group has one, use it, but if the group has `false` just use the default translation domain". I wonder why we propagate the group `translation_domain` but not the false value, so I considered to propagate in both situation.

With the following code
```
->with('foo', ['translation_domain' => 'foo'])
->add('bar')
```
bar will use the `foo` translation_domain.

With the following code
```
->with('foo', ['translation_domain' => false])
->add('bar')
```
Do you think `bar` should use the default `translation_domain` or `false` ?

I am targeting this branch, because can be considered as a bug fix.
If you agree with this change but consider it's more a BC-break than a bugfix, I can update the PR to add a `NEXT_MAJOR` comment instead.

I'll update the changelog after your answer @sonata-project/contributors 

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Correctly propagate the group translation domain to field description even if it's `false`.
- Field description stop to use the admin translation domain if the value was set to `false`.
```