### PR TITLE
Only use one array for the option of DatagridMapper

### DIFF
--- a/tests/Datagrid/DatagridMapperTest.php
+++ b/tests/Datagrid/DatagridMapperTest.php
@@ -301,14 +301,14 @@ class DatagridMapperTest extends TestCase
 
         $this->assertTrue($this->datagridMapper->has('bar'));
 
-        $this->datagridMapper->add('quux', 'bar', [], ['role' => 'ROLE_QUX']);
+        $this->datagridMapper->add('quux', 'bar', ['role' => 'ROLE_QUX']);
 
         $this->assertTrue($this->datagridMapper->has('bar'));
         $this->assertFalse($this->datagridMapper->has('quux'));
 
         $this->datagridMapper
-            ->add('foobar', 'bar', [], ['role' => self::DEFAULT_GRANTED_ROLE])
-            ->add('foo', 'bar', [], ['role' => 'ROLE_QUX'])
+            ->add('foobar', 'bar', ['role' => self::DEFAULT_GRANTED_ROLE])
+            ->add('foo', 'bar', ['role' => 'ROLE_QUX'])
             ->add('baz', 'bar');
 
         $this->assertTrue($this->datagridMapper->has('foobar'));


### PR DESCRIPTION
## Subject

When working on https://github.com/sonata-project/SonataAdminBundle/pull/7257, I discovered we have $filterOptions and $fieldDescriptions which does pretty the same things for the DatagridMapper. They are merged half the time, the filterOptions is passed to a field description (which is weird because we could expect the passed one is the fieldDescriptionOptions), ...

I think we can merge the two options.

I am targeting this branch, because I just added a deprecation.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Passing more than 3 arguments to `DatagridMapper::add()` method.
```