### PR TITLE
Replace usages of `$` with `jQuery` in `Admin.js`

### DIFF
--- a/src/Resources/public/Admin.js
+++ b/src/Resources/public/Admin.js
@@ -50,7 +50,7 @@ var Admin = {
       }
     },
     read_config: function() {
-      var data = $('[data-sonata-admin]').data('sonata-admin');
+      var data = jQuery('[data-sonata-admin]').data('sonata-admin');
 
       this.config = data.config;
       this.translations = data.translations;
@@ -152,7 +152,7 @@ var Admin = {
               })
               // See https://github.com/fronteed/iCheck/issues/244
               .on('ifToggled', function (e) {
-                  $(e.target).trigger('change');
+                  jQuery(e.target).trigger('change');
               });
 
             // In case some checkboxes were already checked (for instance after moving back in the browser's session history), update iCheck checkboxes.
@@ -335,12 +335,12 @@ var Admin = {
             }
 
             var defaults = Admin.convert_query_string_to_object(
-                $.param({'filter': JSON.parse(this.dataset.defaultValues)})
+                jQuery.param({'filter': JSON.parse(this.dataset.defaultValues)})
             );
 
             // Keep only changed values
             $form.find('[name*=filter]').each(function (i, field) {
-                if (JSON.stringify(defaults[field.name] || '') === JSON.stringify($(field).val())) {
+                if (JSON.stringify(defaults[field.name] || '') === JSON.stringify(jQuery(field).val())) {
                     field.removeAttribute('name');
                 }
             });


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Replace usages of `$` with `jQuery` in `Admin.js`.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes respect BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Conflicts with other libraries using the `$` variable.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
