### PR TITLE
Correctly pass pagination parameters

### DIFF
--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -118,7 +118,7 @@ file that was distributed with this source code.
                                         {# NEXT_MAJOR: remove the attribute check and just use .countResults() #}
                                         {%- if (attribute(admin.datagrid.pager, 'countResults') is defined ? admin.datagrid.pager.countResults() : admin.datagrid.pager.getNbResults()) > 0 -%}
                                             <li>
-                                                <a href="{{ admin.generateUrl('list', {'filter': admin.datagrid.values|merge({(constant('Sonata\\AdminBundle\\Datagrid\\DatagridInterface::PAGE')): 1})}) }}">
+                                                <a href="{{ admin.generateUrl('list', admin.datagrid.getPaginationParameters(1)) }}">
                                                     {{- 'go_to_the_first_page'|trans({}, 'SonataAdminBundle') -}}
                                                 </a>
                                             </li>

--- a/src/Resources/views/Pager/base_results.html.twig
+++ b/src/Resources/views/Pager/base_results.html.twig
@@ -24,8 +24,7 @@ file that was distributed with this source code.
     <label class="control-label" for="{{ admin.uniqid }}_per_page">{% trans from 'SonataAdminBundle' %}label_per_page{% endtrans %}</label>
     <select class="per-page small form-control" id="{{ admin.uniqid }}_per_page" style="width: auto">
         {% for per_page in admin.getperpageoptions %}
-            <option {% if per_page == admin.datagrid.pager.maxperpage %}selected="selected"{% endif %} value="{{ admin.generateUrl(action, {'filter': admin.datagrid.values|merge({
-                (constant('Sonata\\AdminBundle\\Datagrid\\DatagridInterface::PAGE')): 1,
+            <option {% if per_page == admin.datagrid.pager.maxperpage %}selected="selected"{% endif %} value="{{ admin.generateUrl(action, {'filter': admin.datagrid.getPaginationParameters(1).filter|merge({
                 (constant('Sonata\\AdminBundle\\Datagrid\\DatagridInterface::PER_PAGE')): per_page})
             }) }}">
                 {{- per_page -}}

--- a/tests/App/Datagrid/Datagrid.php
+++ b/tests/App/Datagrid/Datagrid.php
@@ -116,11 +116,11 @@ final class Datagrid implements DatagridInterface
 
     public function getSortParameters(FieldDescriptionInterface $fieldDescription): array
     {
-        return [];
+        return ['filter' => []];
     }
 
     public function getPaginationParameters(int $page): array
     {
-        return [];
+        return ['filter' => []];
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Right fix of https://github.com/sonata-project/SonataAdminBundle/pull/7231 IMHO.

Closes #7231.
Closes #7230.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `Max_per_page` drowpdown propagate correctly the `sort_by` filter value
```