### PR TITLE
Deprecate mergeOptions and passing an object to `add` methods.

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -3338,22 +3338,16 @@ EOT;
         $mapper = new ListMapper($this->getListBuilder(), $this->list, $this);
 
         if (\count($this->getBatchActions()) > 0 && $this->hasRequest() && !$this->getRequest()->isXmlHttpRequest()) {
-            $fieldDescription = $this->createFieldDescription(
-                ListMapper::NAME_BATCH,
-                [
-                    'label' => 'batch',
-                    // NEXT_MAJOR: Remove this code.
-                    'code' => '_batch',
-                    'sortable' => false,
-                    'virtual_field' => true,
-                ]
-            );
-
-            // NEXT_MAJOR: Remove this line and use commented line below it instead
-            $fieldDescription->setTemplate($this->getTemplate('batch'));
-            // $fieldDescription->setTemplate($this->getTemplateRegistry()->getTemplate('batch'));
-
-            $mapper->add($fieldDescription, ListMapper::TYPE_BATCH);
+            $mapper->add(ListMapper::NAME_BATCH, ListMapper::TYPE_BATCH, [
+                'label' => 'batch',
+                // NEXT_MAJOR: Remove this code.
+                'code' => '_batch',
+                'sortable' => false,
+                'virtual_field' => true,
+                // NEXT_MAJOR: Remove this line and use commented line below it instead
+                'template' => $this->getTemplate('batch'),
+                // 'template' => $this->getTemplateRegistry()->getTemplate('batch'),
+            ]);
         }
 
         $this->configureListFields($mapper);
@@ -3363,22 +3357,16 @@ EOT;
         }
 
         if ($this->hasRequest() && $this->getRequest()->isXmlHttpRequest()) {
-            $fieldDescription = $this->createFieldDescription(
-                ListMapper::NAME_SELECT,
-                [
-                    'label' => false,
-                    // NEXT_MAJOR: Remove this code.
-                    'code' => '_select',
-                    'sortable' => false,
-                    'virtual_field' => false,
-                ]
-            );
-
-            // NEXT_MAJOR: Remove this line and use commented line below it instead
-            $fieldDescription->setTemplate($this->getTemplate('select'));
-            // $fieldDescription->setTemplate($this->getTemplateRegistry()->getTemplate('select'));
-
-            $mapper->add($fieldDescription, ListMapper::TYPE_SELECT);
+            $mapper->add(ListMapper::NAME_SELECT, ListMapper::TYPE_SELECT, [
+                'label' => false,
+                // NEXT_MAJOR: Remove this code.
+                'code' => '_select',
+                'sortable' => false,
+                'virtual_field' => false,
+                // NEXT_MAJOR: Remove this line and use commented line below it instead
+                'template' => $this->getTemplate('select'),
+                // 'template' => $this->getTemplateRegistry()->getTemplate('select'),
+            ]);
         }
     }
 

--- a/src/Datagrid/DatagridMapper.php
+++ b/src/Datagrid/DatagridMapper.php
@@ -63,7 +63,7 @@ class DatagridMapper extends BaseMapper implements MapperInterface
     }
 
     /**
-     * NEXT_MAJOR: Change signature for ($name, ?string $type = null, array $filterOptions = [], array $fieldDescriptionOptions = []).
+     * NEXT_MAJOR: Change signature for (string $name, ?string $type = null, array $filterOptions = [], array $fieldDescriptionOptions = []).
      *
      * @param FieldDescriptionInterface|string $name
      * @param string|null                      $type
@@ -117,7 +117,18 @@ class DatagridMapper extends BaseMapper implements MapperInterface
             $fieldDescriptionOptions = $deprecatedFieldDescriptionOptions;
         }
 
+        // NEXT_MAJOR: Only keep the elseif part.
         if ($name instanceof FieldDescriptionInterface) {
+            @trigger_error(
+                sprintf(
+                    'Passing a %s instance as first param of %s is deprecated since sonata-project/admin-bundle 3.x'
+                    .' and will throw an exception in 4.0. You should pass a string instead.',
+                    FieldDescriptionInterface::class,
+                    __METHOD__
+                ),
+                \E_USER_DEPRECATED
+            );
+
             $fieldDescription = $name;
             $fieldDescription->mergeOptions($filterOptions);
         } elseif (\is_string($name)) {

--- a/src/Datagrid/ListMapper.php
+++ b/src/Datagrid/ListMapper.php
@@ -97,6 +97,8 @@ class ListMapper extends BaseMapper implements MapperInterface
     }
 
     /**
+     * NEXT_MAJOR: Restrict the type of the $name parameter to string.
+     *
      * @param FieldDescriptionInterface|string $name
      * @param string|null                      $type
      *
@@ -156,7 +158,18 @@ class ListMapper extends BaseMapper implements MapperInterface
             // ));
         }
 
+        // NEXT_MAJOR: Only keep the elseif part.
         if ($name instanceof FieldDescriptionInterface) {
+            @trigger_error(
+                sprintf(
+                    'Passing a %s instance as first param of %s is deprecated since sonata-project/admin-bundle 3.x'
+                    .' and will throw an exception in 4.0. You should pass a string instead.',
+                    FieldDescriptionInterface::class,
+                    __METHOD__
+                ),
+                \E_USER_DEPRECATED
+            );
+
             $fieldDescription = $name;
             $fieldDescription->mergeOptions($fieldDescriptionOptions);
         } elseif (\is_string($name)) {

--- a/src/FieldDescription/BaseFieldDescription.php
+++ b/src/FieldDescription/BaseFieldDescription.php
@@ -644,7 +644,9 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
      */
     public function mergeOptions(array $options = [])
     {
-        $this->setOptions(array_merge_recursive($this->options, $options));
+        foreach ($options as $key => $option) {
+            $this->mergeOption($key, $option);
+        }
     }
 
     /**

--- a/src/FieldDescription/BaseFieldDescription.php
+++ b/src/FieldDescription/BaseFieldDescription.php
@@ -623,9 +623,6 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
         return null !== $this->admin;
     }
 
-    /**
-     * @final since sonata-project/admin-bundle 3.99.
-     */
     public function mergeOption($name, array $options = [])
     {
         if (!isset($this->options[$name])) {
@@ -640,13 +637,16 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
     }
 
     /**
-     * @final since sonata-project/admin-bundle 3.99.
+     * NEXT_MAJOR: Remove this method.
      */
     public function mergeOptions(array $options = [])
     {
-        foreach ($options as $key => $option) {
-            $this->mergeOption($key, $option);
-        }
+        @trigger_error(sprintf(
+            'The "%s()" method is deprecated since version 3.x and will be removed in 4.0.',
+            __METHOD__
+        ), \E_USER_DEPRECATED);
+
+        $this->setOptions(array_merge_recursive($this->options, $options));
     }
 
     /**

--- a/src/FieldDescription/FieldDescriptionInterface.php
+++ b/src/FieldDescription/FieldDescriptionInterface.php
@@ -322,6 +322,8 @@ interface FieldDescriptionInterface
     public function mergeOption($name, array $options = []);
 
     /**
+     * NEXT_MAJOR: Remove this method from the interface.
+     *
      * merge options values.
      */
     public function mergeOptions(array $options = []);

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -70,6 +70,8 @@ class FormMapper extends BaseGroupedMapper
     }
 
     /**
+     * NEXT_MAJOR: Restrict the type of the $name parameter to string.
+     *
      * @param FormBuilderInterface|string $name
      * @param string|null                 $type
      * @param array<string, mixed>        $options
@@ -87,7 +89,18 @@ class FormMapper extends BaseGroupedMapper
             return $this;
         }
 
+        // NEXT_MAJOR: Only keep the else part.
         if ($name instanceof FormBuilderInterface) {
+            @trigger_error(
+                sprintf(
+                    'Passing a %s instance as first param of %s is deprecated since sonata-project/admin-bundle 3.x'
+                    .' and will throw an exception in 4.0. You should pass a string instead.',
+                    FormBuilderInterface::class,
+                    __METHOD__
+                ),
+                \E_USER_DEPRECATED
+            );
+
             $fieldName = $name->getName();
         } else {
             $fieldName = $name;

--- a/src/Show/ShowMapper.php
+++ b/src/Show/ShowMapper.php
@@ -56,6 +56,8 @@ class ShowMapper extends BaseGroupedMapper
     }
 
     /**
+     * NEXT_MAJOR: Restrict the type of the $name parameter to string.
+     *
      * @param FieldDescriptionInterface|string $name
      * @param string|null                      $type
      * @param array<string, mixed>             $fieldDescriptionOptions
@@ -74,7 +76,18 @@ class ShowMapper extends BaseGroupedMapper
 
         $this->addFieldToCurrentGroup($fieldKey);
 
+        // NEXT_MAJOR: Keep only the elseif part.
         if ($name instanceof FieldDescriptionInterface) {
+            @trigger_error(
+                sprintf(
+                    'Passing a %s instance as first param of %s is deprecated since sonata-project/admin-bundle 3.x'
+                    .' and will throw an exception in 4.0. You should pass a string instead.',
+                    FieldDescriptionInterface::class,
+                    __METHOD__
+                ),
+                \E_USER_DEPRECATED
+            );
+
             $fieldDescription = $name;
             $fieldDescription->mergeOptions($fieldDescriptionOptions);
         } elseif (\is_string($name)) {

--- a/tests/Datagrid/DatagridMapperTest.php
+++ b/tests/Datagrid/DatagridMapperTest.php
@@ -87,7 +87,7 @@ class DatagridMapperTest extends TestCase
         $admin
             ->method('createFieldDescription')
             ->willReturnCallback(function (string $name, array $options = []): FieldDescriptionInterface {
-                $fieldDescription = $this->getFieldDescriptionMock($name);
+                $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class, [$name, []]);
                 $fieldDescription->setOptions($options);
 
                 return $fieldDescription;
@@ -115,9 +115,7 @@ class DatagridMapperTest extends TestCase
 
     public function testFluidInterface(): void
     {
-        $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
-
-        $this->assertSame($this->datagridMapper, $this->datagridMapper->add($fieldDescription, null, ['field_name' => 'fooFilterName']));
+        $this->assertSame($this->datagridMapper, $this->datagridMapper->add('fooName', null, ['field_name' => 'fooFilterName']));
         $this->assertSame($this->datagridMapper, $this->datagridMapper->remove('fooName'));
         $this->assertSame($this->datagridMapper, $this->datagridMapper->reorder([]));
     }
@@ -126,9 +124,10 @@ class DatagridMapperTest extends TestCase
     {
         $this->assertFalse($this->datagridMapper->has('fooName'));
 
-        $fieldDescription = $this->getFieldDescriptionMock('foo.name', 'fooLabel');
-
-        $this->datagridMapper->add($fieldDescription, null, ['field_name' => 'fooFilterName']);
+        $this->datagridMapper->add('foo.name', null, [
+            'field_name' => 'fooFilterName',
+            'label' => 'fooLabel',
+        ]);
 
         $filter = $this->datagridMapper->get('foo.name');
         $this->assertInstanceOf(FilterInterface::class, $filter);
@@ -141,10 +140,10 @@ class DatagridMapperTest extends TestCase
             'show_filter' => null,
             'advanced_filter' => true,
             'foo_default_option' => 'bar_default',
+            'field_name' => 'fooFilterName',
+            'label' => 'fooLabel',
             'placeholder' => 'short_object_description_placeholder',
             'link_parameters' => [],
-            'label' => 'fooLabel',
-            'field_name' => 'fooFilterName',
         ], $filter->getOptions());
     }
 
@@ -152,9 +151,8 @@ class DatagridMapperTest extends TestCase
     {
         $this->assertFalse($this->datagridMapper->has('fooName'));
 
-        $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
-
-        $this->datagridMapper->add($fieldDescription, 'foo_type', [
+        $this->datagridMapper->add('fooName', 'foo_type', [
+            'label' => 'fooLabel',
             'field_name' => 'fooFilterName',
             'field_type' => 'foo_field_type',
             'field_options' => ['foo_field_option' => 'baz'],
@@ -173,13 +171,13 @@ class DatagridMapperTest extends TestCase
             'show_filter' => null,
             'advanced_filter' => true,
             'foo_default_option' => 'bar_custom',
-            'placeholder' => 'short_object_description_placeholder',
-            'link_parameters' => [],
             'label' => 'fooLabel',
             'field_name' => 'fooFilterName',
             'field_type' => 'foo_field_type',
             'field_options' => ['foo_field_option' => 'baz'],
             'foo_filter_option' => 'foo_filter_option_value',
+            'placeholder' => 'short_object_description_placeholder',
+            'link_parameters' => [],
         ], $filter->getOptions());
     }
 
@@ -213,14 +211,11 @@ class DatagridMapperTest extends TestCase
     {
         $this->assertFalse($this->datagridMapper->has('fooName'));
 
-        $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
-
-        $this->datagridMapper->add($fieldDescription, null, ['field_name' => 'fooFilterName']);
+        $this->datagridMapper->add('fooName', null, ['field_name' => 'fooFilterName']);
         $this->assertTrue($this->datagridMapper->has('fooName'));
 
         $this->datagridMapper->remove('fooName');
         $this->assertFalse($this->datagridMapper->has('fooName'));
-        $this->assertSame('fooFilterName', $fieldDescription->getOption('field_name'));
     }
 
     public function testAddException(): void
@@ -257,26 +252,18 @@ class DatagridMapperTest extends TestCase
 
     public function testKeys(): void
     {
-        $fieldDescription1 = $this->getFieldDescriptionMock('fooName1', 'fooLabel1');
-        $fieldDescription2 = $this->getFieldDescriptionMock('fooName2', 'fooLabel2');
-
-        $this->datagridMapper->add($fieldDescription1, null, ['field_name' => 'fooFilterName1']);
-        $this->datagridMapper->add($fieldDescription2, null, ['field_name' => 'fooFilterName2']);
+        $this->datagridMapper->add('fooName1', null, ['field_name' => 'fooFilterName1']);
+        $this->datagridMapper->add('fooName2', null, ['field_name' => 'fooFilterName2']);
 
         $this->assertSame(['fooName1', 'fooName2'], $this->datagridMapper->keys());
     }
 
     public function testReorder(): void
     {
-        $fieldDescription1 = $this->getFieldDescriptionMock('fooName1', 'fooLabel1');
-        $fieldDescription2 = $this->getFieldDescriptionMock('fooName2', 'fooLabel2');
-        $fieldDescription3 = $this->getFieldDescriptionMock('fooName3', 'fooLabel3');
-        $fieldDescription4 = $this->getFieldDescriptionMock('fooName4', 'fooLabel4');
-
-        $this->datagridMapper->add($fieldDescription1, null, ['field_name' => 'fooFilterName1']);
-        $this->datagridMapper->add($fieldDescription2, null, ['field_name' => 'fooFilterName2']);
-        $this->datagridMapper->add($fieldDescription3, null, ['field_name' => 'fooFilterName3']);
-        $this->datagridMapper->add($fieldDescription4, null, ['field_name' => 'fooFilterName4']);
+        $this->datagridMapper->add('fooName1', null, ['field_name' => 'fooFilterName1']);
+        $this->datagridMapper->add('fooName2', null, ['field_name' => 'fooFilterName2']);
+        $this->datagridMapper->add('fooName3', null, ['field_name' => 'fooFilterName3']);
+        $this->datagridMapper->add('fooName4', null, ['field_name' => 'fooFilterName4']);
 
         $this->assertSame([
             'fooName1',
@@ -314,16 +301,5 @@ class DatagridMapperTest extends TestCase
         $this->assertTrue($this->datagridMapper->has('foobar'));
         $this->assertFalse($this->datagridMapper->has('foo'));
         $this->assertTrue($this->datagridMapper->has('baz'));
-    }
-
-    private function getFieldDescriptionMock(string $name, ?string $label = null): BaseFieldDescription
-    {
-        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class, [$name, []]);
-
-        if (null !== $label) {
-            $fieldDescription->setOption('label', $label);
-        }
-
-        return $fieldDescription;
     }
 }

--- a/tests/Datagrid/ListMapperTest.php
+++ b/tests/Datagrid/ListMapperTest.php
@@ -68,7 +68,7 @@ class ListMapperTest extends TestCase
         $this->admin
             ->method('createFieldDescription')
             ->willReturnCallback(function (string $name, array $options = []): FieldDescriptionInterface {
-                $fieldDescription = $this->getFieldDescriptionMock($name);
+                $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class, [$name, []]);
                 $fieldDescription->setOptions($options);
 
                 return $fieldDescription;
@@ -89,32 +89,19 @@ class ListMapperTest extends TestCase
         $this->listMapper = new ListMapper($listBuilder, $this->fieldDescriptionCollection, $this->admin);
     }
 
-    public function testFluidInterface(): void
-    {
-        $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
-
-        $this->assertSame($this->listMapper, $this->listMapper->add($fieldDescription));
-        $this->assertSame($this->listMapper, $this->listMapper->remove('fooName'));
-        $this->assertSame($this->listMapper, $this->listMapper->reorder([]));
-    }
-
     public function testGet(): void
     {
         $this->assertFalse($this->listMapper->has('fooName'));
 
-        $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
-
-        $this->listMapper->add($fieldDescription);
-        $this->assertSame($fieldDescription, $this->listMapper->get('fooName'));
+        $this->listMapper->add('fooName');
+        $this->assertInstanceOf(FieldDescriptionInterface::class, $this->listMapper->get('fooName'));
     }
 
     public function testAddIdentifier(): void
     {
         $this->assertFalse($this->listMapper->has('fooName'));
 
-        $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
-
-        $this->listMapper->addIdentifier($fieldDescription);
+        $this->listMapper->addIdentifier('fooName');
         $this->assertTrue($this->listMapper->has('fooName'));
 
         $fieldDescription = $this->listMapper->get('fooName');
@@ -239,9 +226,7 @@ class ListMapperTest extends TestCase
     {
         $this->assertFalse($this->listMapper->has('fooName'));
 
-        $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
-
-        $this->listMapper->add($fieldDescription);
+        $this->listMapper->add('fooName');
         $this->assertTrue($this->listMapper->has('fooName'));
 
         $this->listMapper->remove('fooName');
@@ -360,43 +345,34 @@ class ListMapperTest extends TestCase
 
     public function testKeys(): void
     {
-        $fieldDescription1 = $this->getFieldDescriptionMock('fooName1', 'fooLabel1');
-        $fieldDescription2 = $this->getFieldDescriptionMock('fooName2', 'fooLabel2');
-
-        $this->listMapper->add($fieldDescription1);
-        $this->listMapper->add($fieldDescription2);
+        $this->listMapper->add('fooName1');
+        $this->listMapper->add('fooName2');
 
         $this->assertSame(['fooName1', 'fooName2'], $this->listMapper->keys());
     }
 
     public function testReorder(): void
     {
-        $fieldDescription1 = $this->getFieldDescriptionMock('fooName1', 'fooLabel1');
-        $fieldDescription2 = $this->getFieldDescriptionMock('fooName2', 'fooLabel2');
-        $fieldDescription3 = $this->getFieldDescriptionMock('fooName3', 'fooLabel3');
-        $fieldDescription4 = $this->getFieldDescriptionMock('fooName4', 'fooLabel4');
-
-        $this->listMapper->add($fieldDescription1);
-        $this->listMapper->add($fieldDescription2);
-        $this->listMapper->add($fieldDescription3);
-        $this->listMapper->add($fieldDescription4);
+        $this->listMapper->add('fooName1');
+        $this->listMapper->add('fooName2');
+        $this->listMapper->add('fooName3');
+        $this->listMapper->add('fooName4');
 
         $this->assertSame([
-            'fooName1' => $fieldDescription1,
-            'fooName2' => $fieldDescription2,
-            'fooName3' => $fieldDescription3,
-            'fooName4' => $fieldDescription4,
-        ], $this->fieldDescriptionCollection->getElements());
+            'fooName1',
+            'fooName2',
+            'fooName3',
+            'fooName4',
+        ], array_keys($this->fieldDescriptionCollection->getElements()));
 
         $this->listMapper->reorder(['fooName3', 'fooName2', 'fooName1', 'fooName4']);
 
-        // print_r is used to compare order of items in associative arrays
-        $this->assertSame(print_r([
-            'fooName3' => $fieldDescription3,
-            'fooName2' => $fieldDescription2,
-            'fooName1' => $fieldDescription1,
-            'fooName4' => $fieldDescription4,
-        ], true), print_r($this->fieldDescriptionCollection->getElements(), true));
+        $this->assertSame([
+            'fooName3',
+            'fooName2',
+            'fooName1',
+            'fooName4',
+        ], array_keys($this->fieldDescriptionCollection->getElements()));
     }
 
     public function testAddOptionRole(): void
@@ -430,16 +406,5 @@ class ListMapperTest extends TestCase
             $field->isVirtual(),
             'Failed asserting that FieldDescription with name "'.$field->getName().'" is tagged with virtual flag.'
         );
-    }
-
-    private function getFieldDescriptionMock(string $name, ?string $label = null): BaseFieldDescription
-    {
-        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class, [$name, []]);
-
-        if (null !== $label) {
-            $fieldDescription->setOption('label', $label);
-        }
-
-        return $fieldDescription;
     }
 }

--- a/tests/FieldDescription/BaseFieldDescriptionTest.php
+++ b/tests/FieldDescription/BaseFieldDescriptionTest.php
@@ -75,8 +75,8 @@ class BaseFieldDescriptionTest extends TestCase
         $this->assertNull($description->getOption('bar'));
         $this->assertSame('bar', $description->getOption('foo'));
 
-        $description->mergeOptions(['settings' => ['value_1', 'value_2']]);
-        $description->mergeOptions(['settings' => ['value_1', 'value_3']]);
+        $description->mergeOption('settings', ['value_1', 'value_2']);
+        $description->mergeOption('settings', ['value_1', 'value_3']);
 
         $this->assertSame(['value_1', 'value_2', 'value_1', 'value_3'], $description->getOption('settings'));
 
@@ -106,15 +106,6 @@ class BaseFieldDescriptionTest extends TestCase
 
         $description->setOption('sortable', 'field_name');
         $this->assertTrue($description->isSortable());
-    }
-
-    public function testMergeOptions(): void
-    {
-        $description = new FieldDescription('name');
-        $description->setOption('foo', 'bar');
-
-        $description->mergeOptions(['foo' => 'baz']);
-        $this->assertSame('baz', $description->getOption('foo'));
     }
 
     /**

--- a/tests/FieldDescription/BaseFieldDescriptionTest.php
+++ b/tests/FieldDescription/BaseFieldDescriptionTest.php
@@ -108,6 +108,15 @@ class BaseFieldDescriptionTest extends TestCase
         $this->assertTrue($description->isSortable());
     }
 
+    public function testMergeOptions(): void
+    {
+        $description = new FieldDescription('name');
+        $description->setOption('foo', 'bar');
+
+        $description->mergeOptions(['foo' => 'baz']);
+        $this->assertSame('baz', $description->getOption('foo'));
+    }
+
     /**
      * NEXT_MAJOR: Remove this test.
      *

--- a/tests/Form/FormMapperTest.php
+++ b/tests/Form/FormMapperTest.php
@@ -396,6 +396,11 @@ class FormMapperTest extends TestCase
         $this->assertFalse($this->formMapper->has('fooName'));
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testAddAcceptFormBuilder(): void
     {
         $formBuilder = $this
@@ -427,6 +432,11 @@ class FormMapperTest extends TestCase
         $this->assertSame($this->formMapper->get('foo'), $formBuilder);
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testAddFormBuilderWithType(): void
     {
         $formBuilder = $this

--- a/tests/Show/ShowMapperTest.php
+++ b/tests/Show/ShowMapperTest.php
@@ -105,7 +105,7 @@ class ShowMapperTest extends TestCase
         $this->admin
             ->method('createFieldDescription')
             ->willReturnCallback(function (string $name, array $options = []): FieldDescriptionInterface {
-                $fieldDescription = $this->getFieldDescriptionMock($name);
+                $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class, [$name, []]);
                 $fieldDescription->setOptions($options);
 
                 return $fieldDescription;
@@ -142,23 +142,12 @@ class ShowMapperTest extends TestCase
         $this->showMapper = new ShowMapper($this->showBuilder, $this->fieldDescriptionCollection, $this->admin);
     }
 
-    public function testFluidInterface(): void
-    {
-        $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
-
-        $this->assertSame($this->showMapper, $this->showMapper->add($fieldDescription));
-        $this->assertSame($this->showMapper, $this->showMapper->remove('fooName'));
-        $this->assertSame($this->showMapper, $this->showMapper->reorder([]));
-    }
-
     public function testGet(): void
     {
         $this->assertFalse($this->showMapper->has('fooName'));
 
-        $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
-
-        $this->showMapper->add($fieldDescription);
-        $this->assertSame($fieldDescription, $this->showMapper->get('fooName'));
+        $this->showMapper->add('fooName');
+        $this->assertInstanceOf(FieldDescriptionInterface::class, $this->showMapper->get('fooName'));
     }
 
     public function testAdd(): void
@@ -374,9 +363,7 @@ class ShowMapperTest extends TestCase
     {
         $this->assertFalse($this->showMapper->has('fooName'));
 
-        $fieldDescription = $this->getFieldDescriptionMock('fooName', 'fooLabel');
-
-        $this->showMapper->add($fieldDescription);
+        $this->showMapper->add('fooName');
         $this->assertTrue($this->showMapper->has('fooName'));
 
         $this->showMapper->remove('fooName');
@@ -405,11 +392,8 @@ class ShowMapperTest extends TestCase
 
     public function testKeys(): void
     {
-        $fieldDescription1 = $this->getFieldDescriptionMock('fooName1', 'fooLabel1');
-        $fieldDescription2 = $this->getFieldDescriptionMock('fooName2', 'fooLabel2');
-
-        $this->showMapper->add($fieldDescription1);
-        $this->showMapper->add($fieldDescription2);
+        $this->showMapper->add('fooName1');
+        $this->showMapper->add('fooName2');
 
         $this->assertSame(['fooName1', 'fooName2'], $this->showMapper->keys());
     }
@@ -418,16 +402,11 @@ class ShowMapperTest extends TestCase
     {
         $this->assertSame([], $this->admin->getShowGroups());
 
-        $fieldDescription1 = $this->getFieldDescriptionMock('fooName1', 'fooLabel1');
-        $fieldDescription2 = $this->getFieldDescriptionMock('fooName2', 'fooLabel2');
-        $fieldDescription3 = $this->getFieldDescriptionMock('fooName3', 'fooLabel3');
-        $fieldDescription4 = $this->getFieldDescriptionMock('fooName4', 'fooLabel4');
-
         $this->showMapper->with('Group1');
-        $this->showMapper->add($fieldDescription1);
-        $this->showMapper->add($fieldDescription2);
-        $this->showMapper->add($fieldDescription3);
-        $this->showMapper->add($fieldDescription4);
+        $this->showMapper->add('fooName1');
+        $this->showMapper->add('fooName2');
+        $this->showMapper->add('fooName3');
+        $this->showMapper->add('fooName4');
 
         $this->assertSame([
             'Group1' => [
@@ -574,7 +553,7 @@ class ShowMapperTest extends TestCase
         $fieldDescriptionFactory
             ->method('create')
             ->willReturnCallback(function (string $class, string $name, array $options = []): FieldDescriptionInterface {
-                $fieldDescription = $this->getFieldDescriptionMock($name);
+                $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class, [$name, []]);
                 $fieldDescription->setOptions($options);
 
                 return $fieldDescription;
@@ -584,16 +563,5 @@ class ShowMapperTest extends TestCase
         $this->admin->setLabelTranslatorStrategy(new NoopLabelTranslatorStrategy());
 
         $this->admin->setShowBuilder(new ShowBuilder());
-    }
-
-    private function getFieldDescriptionMock(string $name, ?string $label = null): BaseFieldDescription
-    {
-        $fieldDescription = $this->getMockForAbstractClass(BaseFieldDescription::class, [$name, []]);
-
-        if (null !== $label) {
-            $fieldDescription->setOption('label', $label);
-        }
-
-        return $fieldDescription;
     }
 }


### PR DESCRIPTION
## Subject

I had an issue with psalm3 on master with the `mergeOptions` so I look at it.

We're using `array_merge_recursive` in the mergeOptions method.
I would say it's wrong because an option can become an array.

I am targeting this branch, because I would like to add a bug fix.

I was tented to change to `array_replace_recursive`.
But then the test
```
$description->mergeOptions(['settings' => ['value_1', 'value_2']]);
$description->mergeOptions(['settings' => ['value_1', 'value_3']]);

$this->assertSame(['value_1', 'value_2', 'value_1', 'value_3'], $description->getOption('settings'));

$description->mergeOption('settings', ['value_4']);
$this->assertSame(['value_1', 'value_2', 'value_1', 'value_3', 'value_4'], $description->getOption('settings'));
```
Is failing.

Then I looked at the `mergeOption`, this method is doing
```
        if (!isset($this->options[$name])) {
            $this->options[$name] = [];
        }

        if (!\is_array($this->options[$name])) {
            throw new \RuntimeException(sprintf('The key `%s` does not point to an array value', $name));
        }

        $this->options[$name] = array_merge($this->options[$name], $options);
```
So it seems that `mergeOption` should only be used for array.

So I thought, maybe the right implementation of `mergeOptions` is
```
        foreach ($options as $key => $option) {
            $this->mergeOption($key, $option);
        }
```
This way we're checking that it's always called with array options.

And then a lot of test are now failing, showing the issue.

In the Mapper::add method, we're generally doing
```
if ($name instanceof FieldDescriptionInterface) {
    $fieldDescription = $name;
    $fieldDescription->mergeOptions($filterOptions);
} elseif (\is_string($name)) {
     // do other thing
}
```
So we're calling the `mergeOptions` method with non-array option values ; which is wrong.

In our code the only usage of `add` method with a fieldDescription is
```
$fieldDescription = $this->createFieldDescription(
                ListMapper::NAME_BATCH,
                [
                    'label' => 'batch',
                    // NEXT_MAJOR: Remove this code.
                    'code' => '_batch',
                    'sortable' => false,
                    'virtual_field' => true,
                ]
            );

            // NEXT_MAJOR: Remove this line and use commented line below it instead
            $fieldDescription->setTemplate($this->getTemplate('batch'));
            // $fieldDescription->setTemplate($this->getTemplateRegistry()->getTemplate('batch'));

            $mapper->add($fieldDescription, ListMapper::TYPE_BATCH);
```
And same with `SELECT`.

Since we're never passing extra option to the `add` method, the issue was never caught.

Since we can update this code to 
```
$mapper->add(ListMapper::NAME_BATCH, ListMapper::TYPE_BATCH, [...]);
```

I would say that we can and we should deprecate passing a FieldDescription instance to `add` method.
This allow to stop using the non-fully-working mergeOptions method, and deprecate it.

## Changelog

```markdown
### Deprecated
- Passing a FieldDescriptionInterface as first argument of method `ListMapper::add`.
- Passing a FieldDescriptionInterface as first argument of method `ShowMapper::add`.
- Passing a FieldDescriptionInterface as first argument of method `DatagridMapper::add`.
- Passing a FormBuilderInterface as first argument of method `FormMapper::add`.
- `FieldDescriptionInterface::mergeOptions()`.
- `BaseFieldDescription::mergeOptions()`.
```