### PR TITLE
Deprecate passing `collection` to `FormMapper::add()`

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,14 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=======================
+
+### `Sonata\AdminBundle\Form\FormMapper`
+
+Deprecated passing `collection` as argument 2 for `FormMapper::add()` method. You MUST pass
+`Symfony\Component\Form\Extension\Core\Type\CollectionType` or `Sonata\AdminBundle\Form\Type\CollectionType` instead.
+
 UPGRADE FROM 3.97 to 3.98
 =========================
 

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -101,9 +101,20 @@ class FormMapper extends BaseGroupedMapper
             $fieldName = $this->sanitizeFieldName($fieldName);
         }
 
-        // change `collection` to `sonata_type_native_collection` form type to
-        // avoid BC break problems
+        // NEXT_MAJOR: Remove the check with "collection".
         if ('collection' === $type || SymfonyCollectionType::class === $type) {
+            // NEXT_MAJOR Remove this "if" block.
+            if ('collection' === $type) {
+                @trigger_error(sprintf(
+                    'Passing "collection" as argument 2 for "%s()" is deprecated since'
+                    .' sonata-project/admin-bundle 3.x and will not work in version 4.0.'
+                    .' You MUST pass "%s" or "%s" instead.',
+                    __METHOD__,
+                    SymfonyCollectionType::class,
+                    CollectionType::class
+                ), \E_USER_DEPRECATED);
+            }
+
             $type = CollectionType::class;
         }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This is old code from where we allowed to pass form names instead of FQCN.

We could maybe deprecate also [`CollectionType`](https://github.com/sonata-project/SonataAdminBundle/blob/343256a2d7e679038b1fa6da9aea110fd5927673/src/Form/Type/CollectionType.php) since it's just adding a block prefix and we could override in twig the one from Symfony and remove completely this "if".

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated passing `collection` as argument 2 of `FormMapper::add()` method
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
