### PR TITLE
Respect false as translation domain

### DIFF
--- a/src/Resources/views/Block/block_admin_preview.html.twig
+++ b/src/Resources/views/Block/block_admin_preview.html.twig
@@ -46,7 +46,11 @@ file that was distributed with this source code.
                                                 {% if field_description.option('label_icon') %}
                                                     <i class="sonata-ba-list-field-header-label-icon {{ field_description.option('label_icon') }}" aria-hidden="true"></i>
                                                 {% endif %}
-                                                {{ field_description.label|trans({}, field_description.translationDomain) }}
+                                                {% if field_description.translationDomain is same as(false) %}
+                                                    {{ field_description.label }}
+                                                {% else %}
+                                                    {{ field_description.label|trans({}, field_description.translationDomain) }}
+                                                {% endif %}
                                             </th>
                                         {% endfilter %}
                                     {% endif %}

--- a/src/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -11,8 +11,7 @@
                         {% if form_group.translation_domain is same as(false) %}
                             {{ form_group.label }}
                         {% else %}
-                            {% set translationDomain = form_group.translation_domain|default(admin.translationDomain) %}
-                            {{ form_group.label|trans({}, translationDomain) }}
+                            {{ form_group.label|trans({}, form_group.translation_domain|default(admin.translationDomain)) }}
                         {% endif %}
                     </h4>
                 </div>
@@ -22,8 +21,7 @@
                             {% if form_group.translation_domain is same as(false) %}
                                 <p>{{ show_group.description|raw }}</p>
                             {% else %}
-                                {% set translationDomain = form_group.translation_domain|default(admin.translationDomain) %}
-                                {{ form_group.description|trans({}, translationDomain)|raw }}
+                                {{ form_group.description|trans({}, form_group.translation_domain|default(admin.translationDomain))|raw }}
                             {% endif %}
                         {% endif %}
 
@@ -34,8 +32,7 @@
                                 {% if form_group.translation_domain is same as(false) %}
                                     <em>{{ form_group.empty_message|trans({}, form_group.empty_message_translation_domain) }}</em>
                                 {% else %}
-                                    {% set translationDomain = form_group.empty_message_translation_domain|default(admin.translationDomain) %}
-                                    <em>{{ form_group.empty_message|trans({}, translationDomain) }}</em>
+                                    <em>{{ form_group.empty_message|trans({}, form_group.empty_message_translation_domain|default(admin.translationDomain)) }}</em>
                                 {% endif %}
                             {% endif %}
                         {% endfor %}

--- a/src/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -29,8 +29,8 @@
                             {{ form_row(form[field_name]) }}
                         {% else %}
                             {% if form_group.empty_message != false %}
-                                {% if form_group.translation_domain is same as(false) %}
-                                    <em>{{ form_group.empty_message|trans({}, form_group.empty_message_translation_domain) }}</em>
+                                {% if form_group.empty_message_translation_domain is same as(false) %}
+                                    <em>{{ form_group.empty_message }}</em>
                                 {% else %}
                                     <em>{{ form_group.empty_message|trans({}, form_group.empty_message_translation_domain|default(admin.translationDomain)) }}</em>
                                 {% endif %}

--- a/src/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -8,20 +8,35 @@
             <div class="{{ form_group.box_class }}">
                 <div class="box-header">
                     <h4 class="box-title">
-                        {{ form_group.label|trans({}, form_group.translation_domain ?: admin.translationDomain) }}
+                        {% if form_group.translation_domain is same as(false) %}
+                            {{ form_group.label }}
+                        {% else %}
+                            {% set translationDomain = form_group.translation_domain|default(admin.translationDomain) %}
+                            {{ form_group.label|trans({}, translationDomain) }}
+                        {% endif %}
                     </h4>
                 </div>
                 <div class="box-body">
                     <div class="sonata-ba-collapsed-fields">
                         {% if form_group.description %}
-                            <p>{{ form_group.description|trans({}, form_group.translation_domain ?: admin.translationDomain)|raw }}</p>
+                            {% if form_group.translation_domain is same as(false) %}
+                                <p>{{ show_group.description|raw }}</p>
+                            {% else %}
+                                {% set translationDomain = form_group.translation_domain|default(admin.translationDomain) %}
+                                {{ form_group.description|trans({}, translationDomain)|raw }}
+                            {% endif %}
                         {% endif %}
 
                         {% for field_name in form_group.fields|filter(field_name => form[field_name] is defined) %}
                             {{ form_row(form[field_name]) }}
                         {% else %}
                             {% if form_group.empty_message != false %}
-                                <em>{{ form_group.empty_message|trans({}, form_group.empty_message_translation_domain) }}</em>
+                                {% if form_group.translation_domain is same as(false) %}
+                                    <em>{{ form_group.empty_message|trans({}, form_group.empty_message_translation_domain) }}</em>
+                                {% else %}
+                                    {% set translationDomain = form_group.empty_message_translation_domain|default(admin.translationDomain) %}
+                                    <em>{{ form_group.empty_message|trans({}, translationDomain) }}</em>
+                                {% endif %}
                             {% endif %}
                         {% endfor %}
                     </div>

--- a/src/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -19,9 +19,9 @@
                     <div class="sonata-ba-collapsed-fields">
                         {% if form_group.description %}
                             {% if form_group.translation_domain is same as(false) %}
-                                <p>{{ show_group.description|raw }}</p>
+                                <p>{{ form_group.description|raw }}</p>
                             {% else %}
-                                {{ form_group.description|trans({}, form_group.translation_domain|default(admin.translationDomain))|raw }}
+                                <p>{{ form_group.description|trans({}, form_group.translation_domain|default(admin.translationDomain))|raw }}</p>
                             {% endif %}
                         {% endif %}
 

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -83,7 +83,11 @@ file that was distributed with this source code.
                                                         <i class="sonata-ba-list-field-header-label-icon {{ field_description.getOption('label_icon') }}" aria-hidden="true"></i>
                                                     {% endif %}
                                                     {% if field_description.label is not same as(false) %}
-                                                        {{ field_description.label|trans({}, field_description.translationDomain) }}
+                                                        {% if field_description.translationDomain is same as(false) %}
+                                                            {{ field_description.label }}
+                                                        {% else %}
+                                                            {{ field_description.label|trans({}, field_description.translationDomain) }}
+                                                        {% endif %}
                                                     {% endif %}
                                                     {% if sortable %}</a>{% endif %}
                                                 </th>

--- a/src/Resources/views/CRUD/base_list_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_field.html.twig
@@ -73,7 +73,11 @@ file that was distributed with this source code.
                   data-type="{{ x_editable_type }}"
                   data-value="{{ data_value }}"
                   {% if field_description.label is not same as(false) %}
-                    data-title="{{ field_description.label|trans({}, field_description.translationDomain) }}"
+                      {% if field_description.translationDomain is same as(false) %}
+                          data-title="{{ field_description.label }}"
+                      {% else %}
+                          data-title="{{ field_description.label|trans({}, field_description.translationDomain) }}"
+                      {% endif %}
                   {% endif %}
                   {% if field_description.type == constant('Sonata\\AdminBundle\\Admin\\FieldDescriptionInterface::TYPE_DATE') %}
                     data-format="yyyy-mm-dd"

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -96,7 +96,12 @@ file that was distributed with this source code.
                         <div class="box-header">
                             <h4 class="box-title">
                                 {% block show_title %}
-                                    {{ show_group.label|trans({}, show_group.translation_domain|default(admin.translationDomain)) }}
+                                    {% if show_group.translation_domain is same as(false) %}
+                                        {{ show_group.label }}
+                                    {% else %}
+                                        {% set translationDomain = show_group.translation_domain|default(admin.translationDomain) %}
+                                        {{ show_group.label|trans({}, translationDomain) }}
+                                    {% endif %}
                                 {% endblock %}
                             </h4>
                         </div>

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -99,8 +99,7 @@ file that was distributed with this source code.
                                     {% if show_group.translation_domain is same as(false) %}
                                         {{ show_group.label }}
                                     {% else %}
-                                        {% set translationDomain = show_group.translation_domain|default(admin.translationDomain) %}
-                                        {{ show_group.label|trans({}, translationDomain) }}
+                                        {{ show_group.label|trans({}, show_group.translation_domain|default(admin.translationDomain)) }}
                                     {% endif %}
                                 {% endblock %}
                             </h4>

--- a/src/Resources/views/CRUD/base_show_field.html.twig
+++ b/src/Resources/views/CRUD/base_show_field.html.twig
@@ -13,7 +13,11 @@ file that was distributed with this source code.
     {%- block name -%}
         {% apply spaceless %}
             {% if field_description.label is not same as(false) %}
-                {{ field_description.label|trans({}, field_description.translationDomain ?: admin.translationDomain) }}
+                {% if field_description.translationDomain is same as(false) %}
+                    {{ field_description.label }}
+                {% else %}
+                    {{ field_description.label|trans({}, field_description.translationDomain) }}
+                {% endif %}
             {% endif %}
         {% endapply %}
     {%- endblock -%}

--- a/src/Resources/views/CRUD/base_show_macro.html.twig
+++ b/src/Resources/views/CRUD/base_show_macro.html.twig
@@ -18,8 +18,7 @@
                             {% if show_group.translation_domain is same as(false) %}
                                 {{ show_group.label }}
                             {% else %}
-                                {% set translationDomain = show_group.translation_domain|default(admin.translationDomain) %}
-                                {{ show_group.label|trans({}, translationDomain) }}
+                                {{ show_group.label|trans({}, show_group.translation_domain|default(admin.translationDomain)) }}
                             {% endif %}
                         {% endblock %}
                     </h4>

--- a/src/Resources/views/CRUD/base_show_macro.html.twig
+++ b/src/Resources/views/CRUD/base_show_macro.html.twig
@@ -15,7 +15,12 @@
                 <div class="box-header">
                     <h4 class="box-title">
                         {% block show_title %}
-                            {{ show_group.label|trans({}, show_group.translation_domain ?: admin.translationDomain) }}
+                            {% if show_group.translation_domain is same as(false) %}
+                                {{ show_group.label }}
+                            {% else %}
+                                {% set translationDomain = show_group.translation_domain|default(admin.translationDomain) %}
+                                {{ show_group.label|trans({}, translationDomain) }}
+                            {% endif %}
                         {% endblock %}
                     </h4>
                 </div>


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Do not try to translate fieldDescription label when false is provided as translation domain.
```