### PR TITLE
Use a SearchableFilterInterface instead of a global_search option.

### DIFF
--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -601,7 +601,6 @@ type of your condition(s)::
     **TODO**:
     * basic filter configuration and options
     * targeting submodel fields using dot-separated notation
-    * advanced filter options (global_search)
 
 Visual configuration
 --------------------
@@ -777,7 +776,7 @@ Combine this with configuring a custom template and you'll have a list column fu
             'template' => 'path/to/your/template.html.twig'
         ]);
     }
-    
+
 .. _`SonataDoctrineORMAdminBundle Documentation`: https://sonata-project.org/bundles/doctrine-orm-admin/master/doc/reference/list_field_definition.html
 .. _`here`: https://github.com/sonata-project/form-extensions/tree/1.x/src/Type
-    
+

--- a/docs/reference/search.rst
+++ b/docs/reference/search.rst
@@ -140,31 +140,3 @@ and it looks like this:
     :align: center
     :alt: Custom view
     :width: 700px
-
-Case sensitive/insensitive
---------------------------
-
-By default all searches are done case-sensitive.
-
-.. note::
-
-    This will support PostgreSQL out of the box, but unless you change the collation of MySQL, MSSQL or SQLite,
-    it will have no effect! They are case-insensitive by default.
-
-To search case-insensitive use the following option:
-
-.. code-block:: yaml
-
-    # config/packages/sonata_admin.yaml
-
-    sonata_admin:
-        global_search:
-            case_sensitive: false
-
-Using case-insensitivity might lead to performance issues. You can find some more information
-`here <https://use-the-index-luke.com/sql/where-clause/functions/case-insensitive-search>`_.
-
-Instead of searching **all** fields case-insensitive with PostgreSQL, you can use a dedicated
-`CITEXT type <https://www.postgresql.org/docs/9.1/citext.html>`_ via
-`opsway/doctrine-dbal-postgresql <https://github.com/opsway/doctrine-dbal-postgresql/blob/master/src/Doctrine/DBAL/Types/Citext.php>`_
-and keep the ``case-sensitive`` option with ``true``.

--- a/docs/reference/search.rst
+++ b/docs/reference/search.rst
@@ -2,9 +2,9 @@ Search
 ======
 
 The admin comes with a basic global search available in the upper navigation menu. The search iterates over
-admin classes and look for filter extending the ``Sonata\AdminBundle\Search\SearchableFilterInterface`` with
-the method ``isSearchEnabled`` returning true. If you are using the ``SonataDoctrineORMBundle``, the
-``Sonata\DoctrineORMAdminBundle\Filter\StringFilter`` is searchable and rely on a ``global_search`` option.
+admin classes and looks for filters implementing the ``Sonata\AdminBundle\Search\SearchableFilterInterface`` interface with
+the method ``isSearchEnabled()`` returning true. If you are using ``SonataDoctrineORMBundle``, the
+``Sonata\DoctrineORMAdminBundle\Filter\StringFilter`` filter is searchable and relies on a ``global_search`` option.
 
 Disabling the search by admin
 -----------------------------

--- a/docs/reference/search.rst
+++ b/docs/reference/search.rst
@@ -1,9 +1,10 @@
 Search
 ======
 
-The admin comes with a basic global search available in the upper navigation menu. The search iterates over admin classes
-and look for filter with the option ``global_search`` set to true. If you are using the ``SonataDoctrineORMBundle``
-any text filter will be set to ``true`` by default.
+The admin comes with a basic global search available in the upper navigation menu. The search iterates over
+admin classes and look for filter extending the ``Sonata\AdminBundle\Search\SearchableFilterInterface`` with
+the method ``isSearchable`` returning true. If you are using the ``SonataDoctrineORMBundle``, the
+``Sonata\DoctrineORMAdminBundle\Filter\StringFilter`` is searchable and rely on a ``global_search`` option.
 
 Disabling the search by admin
 -----------------------------

--- a/docs/reference/search.rst
+++ b/docs/reference/search.rst
@@ -3,7 +3,7 @@ Search
 
 The admin comes with a basic global search available in the upper navigation menu. The search iterates over
 admin classes and look for filter extending the ``Sonata\AdminBundle\Search\SearchableFilterInterface`` with
-the method ``isSearchable`` returning true. If you are using the ``SonataDoctrineORMBundle``, the
+the method ``isSearchEnabled`` returning true. If you are using the ``SonataDoctrineORMBundle``, the
 ``Sonata\DoctrineORMAdminBundle\Filter\StringFilter`` is searchable and rely on a ``global_search`` option.
 
 Disabling the search by admin

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -39,6 +39,7 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->getRootNode();
         \assert($rootNode instanceof ArrayNodeDefinition);
 
+        // NEXT_MAJOR: Remove this line.
         $caseSensitiveInfo = <<<'CASESENSITIVE'
 Whether the global search should behave case sensitive or not.
 Using case-insensitivity might lead to performance issues.
@@ -111,7 +112,9 @@ CASESENSITIVE;
                                 ->thenInvalid('Configuration value of "global_search.empty_boxes" must be one of show, fade or hide.')
                             ->end()
                         ->end()
+                        // NEXT_MAJOR: Remove this option.
                         ->booleanNode('case_sensitive')
+                            ->setDeprecated('The "%node%" option is deprecated since sonata-project/admin-bundle 3.x.')
                             ->defaultTrue()
                             ->info($caseSensitiveInfo)
                         ->end()

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -120,6 +120,7 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
         }
 
         $container->setParameter('sonata.admin.configuration.global_search.empty_boxes', $config['global_search']['empty_boxes']);
+        // NEXT_MAJOR: Remove this line.
         $container->setParameter('sonata.admin.configuration.global_search.case_sensitive', $config['global_search']['case_sensitive']);
         $container->setParameter('sonata.admin.configuration.templates', $config['templates']);
         $container->setParameter('sonata.admin.configuration.default_admin_services', $config['default_admin_services']);

--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -311,6 +311,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             // NEXT_MAJOR: Remove public and sonata.container.private tag.
             ->public()
             ->tag(AliasDeprecatedPublicServicesCompilerPass::PRIVATE_TAG_NAME, ['version' => '3.98'])
+            // NEXT_MAJOR: Remove the args.
             ->args([
                 '%sonata.admin.configuration.global_search.case_sensitive%',
             ])

--- a/src/Search/SearchHandler.php
+++ b/src/Search/SearchHandler.php
@@ -91,7 +91,7 @@ class SearchHandler
             // NEXT_MAJOR: Remove the $filter->getOption('global_search', false) part.
             if (
                 $filter->getOption('global_search', false)
-                || $filter instanceof SearchableFilterInterface && $filter->isSearchActive()
+                || $filter instanceof SearchableFilterInterface && $filter->isSearchEnabled()
             ) {
                 if (!$filter instanceof SearchableFilterInterface) {
                     @trigger_error(sprintf(

--- a/src/Search/SearchHandler.php
+++ b/src/Search/SearchHandler.php
@@ -88,7 +88,19 @@ class SearchHandler
             /** @var FilterInterface $filter */
             $formName = $filter->getFormName();
 
-            if ($filter->getOption('global_search', false)) {
+            // NEXT_MAJOR: Remove the $filter->getOption('global_search', false) part.
+            if (
+                $filter->getOption('global_search', false)
+                || $filter instanceof SearchableFilterInterface && $filter->isSearchActive()
+            ) {
+                if (!$filter instanceof SearchableFilterInterface) {
+                    @trigger_error(sprintf(
+                        'Passing `global_search` to a filter which not implement %s is deprecated'
+                        .' since sonata-project/admin-bundle 3.x and won\'t work in 4.0.',
+                        SearchableFilterInterface::class
+                    ), \E_USER_DEPRECATED);
+                }
+
                 $filter->setOption('case_sensitive', $this->caseSensitive);
                 $filter->setOption('or_group', $admin->getCode());
                 $filter->setCondition(FilterInterface::CONDITION_OR);

--- a/src/Search/SearchHandler.php
+++ b/src/Search/SearchHandler.php
@@ -95,7 +95,7 @@ class SearchHandler
             ) {
                 if (!$filter instanceof SearchableFilterInterface) {
                     @trigger_error(sprintf(
-                        'Passing the "global_search" option to a filter which not implements %s is deprecated'
+                        'Passing the "global_search" option to a filter which does not implement %s is deprecated'
                         .' since sonata-project/admin-bundle 3.x and won\'t work in 4.0.',
                         SearchableFilterInterface::class
                     ), \E_USER_DEPRECATED);

--- a/src/Search/SearchHandler.php
+++ b/src/Search/SearchHandler.php
@@ -41,7 +41,7 @@ class SearchHandler
     private $adminsSearchConfig = [];
 
     /**
-     * NEXT_MAJOR: Change signature to __construct(bool $caseSensitive) and remove pool property.
+     * NEXT_MAJOR: Remove the construct.
      *
      * @param Pool|bool $deprecatedPoolOrCaseSensitive
      * @param bool      $caseSensitive
@@ -101,6 +101,7 @@ class SearchHandler
                     ), \E_USER_DEPRECATED);
                 }
 
+                // NEXT_MAJOR: Remove this line.
                 $filter->setOption('case_sensitive', $this->caseSensitive);
                 $filter->setOption('or_group', $admin->getCode());
                 $filter->setCondition(FilterInterface::CONDITION_OR);

--- a/src/Search/SearchHandler.php
+++ b/src/Search/SearchHandler.php
@@ -95,7 +95,7 @@ class SearchHandler
             ) {
                 if (!$filter instanceof SearchableFilterInterface) {
                     @trigger_error(sprintf(
-                        'Passing `global_search` to a filter which not implement %s is deprecated'
+                        'Passing the "global_search" option to a filter which not implements %s is deprecated'
                         .' since sonata-project/admin-bundle 3.x and won\'t work in 4.0.',
                         SearchableFilterInterface::class
                     ), \E_USER_DEPRECATED);

--- a/src/Search/SearchableFilterInterface.php
+++ b/src/Search/SearchableFilterInterface.php
@@ -21,7 +21,7 @@ use Sonata\AdminBundle\Filter\FilterInterface;
 interface SearchableFilterInterface extends FilterInterface
 {
     /**
-     * Return true if the filter should be used in the SearchHandler.
+     * Return true if the filter should be used in the SearchHandler class.
      */
     public function isSearchEnabled(): bool;
 }

--- a/src/Search/SearchableFilterInterface.php
+++ b/src/Search/SearchableFilterInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Search;
+
+use Sonata\AdminBundle\Filter\FilterInterface;
+
+/**
+ * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ */
+interface SearchableFilterInterface extends FilterInterface
+{
+    /**
+     * Return true if the filter should be used in the SearchHandler.
+     */
+    public function isSearchActive(): bool;
+}

--- a/src/Search/SearchableFilterInterface.php
+++ b/src/Search/SearchableFilterInterface.php
@@ -23,5 +23,5 @@ interface SearchableFilterInterface extends FilterInterface
     /**
      * Return true if the filter should be used in the SearchHandler.
      */
-    public function isSearchActive(): bool;
+    public function isSearchEnabled(): bool;
 }

--- a/tests/Search/SearchHandlerTest.php
+++ b/tests/Search/SearchHandlerTest.php
@@ -44,7 +44,7 @@ class SearchHandlerTest extends TestCase
     public function testBuildPagerWithSearchableFilter(bool $caseSensitive): void
     {
         $filter = $this->createMock(SearchableFilterInterface::class);
-        $filter->expects($this->once())->method('isSearchActive')->willReturn(true);
+        $filter->expects($this->once())->method('isSearchEnabled')->willReturn(true);
 
         $pager = $this->createMock(PagerInterface::class);
         $pager->expects($this->once())->method('setPage');
@@ -87,7 +87,7 @@ class SearchHandlerTest extends TestCase
     public function testAdminSearch($expected, $filterCallsCount, ?bool $enabled, string $adminCode): void
     {
         $filter = $this->createMock(SearchableFilterInterface::class);
-        $filter->method('isSearchActive')->willReturn(true);
+        $filter->method('isSearchEnabled')->willReturn(true);
 
         $pager = $this->createMock(PagerInterface::class);
         $pager->expects($this->exactly($filterCallsCount))->method('setPage');
@@ -134,11 +134,11 @@ class SearchHandlerTest extends TestCase
     public function testBuildPagerWithDefaultFilters(): void
     {
         $defaultFilter = $this->createMock(SearchableFilterInterface::class);
-        $defaultFilter->expects($this->once())->method('isSearchActive')->willReturn(false);
+        $defaultFilter->expects($this->once())->method('isSearchEnabled')->willReturn(false);
         $defaultFilter->expects($this->once())->method('getFormName')->willReturn('filter1');
 
         $filter = $this->createMock(SearchableFilterInterface::class);
-        $filter->expects($this->once())->method('isSearchActive')->willReturn(true);
+        $filter->expects($this->once())->method('isSearchEnabled')->willReturn(true);
         $filter->expects($this->once())->method('getFormName')->willReturn('filter2');
 
         $pager = $this->createMock(PagerInterface::class);

--- a/tests/Search/SearchHandlerTest.php
+++ b/tests/Search/SearchHandlerTest.php
@@ -18,14 +18,14 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Datagrid\PagerInterface;
 use Sonata\AdminBundle\Filter\FilterInterface;
+use Sonata\AdminBundle\Search\SearchableFilterInterface;
 use Sonata\AdminBundle\Search\SearchHandler;
 
 class SearchHandlerTest extends TestCase
 {
-    public function testBuildPagerWithNoGlobalSearchField(): void
+    public function testBuildPagerWithNonSearchableFilter(): void
     {
         $filter = $this->createMock(FilterInterface::class);
-        $filter->expects($this->once())->method('getOption')->with('global_search')->willReturn(false);
         $filter->expects($this->never())->method('setOption');
 
         $datagrid = $this->createMock(DatagridInterface::class);
@@ -39,12 +39,12 @@ class SearchHandlerTest extends TestCase
     }
 
     /**
-     * @dataProvider buildPagerWithGlobalSearchFieldProvider
+     * @dataProvider buildPagerWithSearchableFilterProvider
      */
-    public function testBuildPagerWithGlobalSearchField(bool $caseSensitive): void
+    public function testBuildPagerWithSearchableFilter(bool $caseSensitive): void
     {
-        $filter = $this->createMock(FilterInterface::class);
-        $filter->expects($this->once())->method('getOption')->with('global_search')->willReturn(true);
+        $filter = $this->createMock(SearchableFilterInterface::class);
+        $filter->expects($this->once())->method('isSearchActive')->willReturn(true);
 
         $pager = $this->createMock(PagerInterface::class);
         $pager->expects($this->once())->method('setPage');
@@ -73,7 +73,7 @@ class SearchHandlerTest extends TestCase
         $this->assertInstanceOf(PagerInterface::class, $handler->search($admin, 'myservice'));
     }
 
-    public function buildPagerWithGlobalSearchFieldProvider(): array
+    public function buildPagerWithSearchableFilterProvider(): array
     {
         return [
             [true],
@@ -86,8 +86,8 @@ class SearchHandlerTest extends TestCase
      */
     public function testAdminSearch($expected, $filterCallsCount, ?bool $enabled, string $adminCode): void
     {
-        $filter = $this->createMock(FilterInterface::class);
-        $filter->expects($this->exactly($filterCallsCount))->method('getOption')->with('global_search')->willReturn(true);
+        $filter = $this->createMock(SearchableFilterInterface::class);
+        $filter->method('isSearchActive')->willReturn(true);
 
         $pager = $this->createMock(PagerInterface::class);
         $pager->expects($this->exactly($filterCallsCount))->method('setPage');
@@ -133,12 +133,12 @@ class SearchHandlerTest extends TestCase
 
     public function testBuildPagerWithDefaultFilters(): void
     {
-        $defaultFilter = $this->createMock(FilterInterface::class);
-        $defaultFilter->expects($this->once())->method('getOption')->with('global_search')->willReturn(false);
+        $defaultFilter = $this->createMock(SearchableFilterInterface::class);
+        $defaultFilter->expects($this->once())->method('isSearchActive')->willReturn(false);
         $defaultFilter->expects($this->once())->method('getFormName')->willReturn('filter1');
 
-        $filter = $this->createMock(FilterInterface::class);
-        $filter->expects($this->once())->method('getOption')->with('global_search')->willReturn(true);
+        $filter = $this->createMock(SearchableFilterInterface::class);
+        $filter->expects($this->once())->method('isSearchActive')->willReturn(true);
         $filter->expects($this->once())->method('getFormName')->willReturn('filter2');
 
         $pager = $this->createMock(PagerInterface::class);


### PR DESCRIPTION
## Subject

Related to https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1467

Introducing this interface could allow to configure directly in the filter if he should be used for the global search or not.

We need to discuss about the issue https://github.com/sonata-project/SonataAdminBundle/issues/7274 now ; since if wanted we might add a method to the interface in order to change the line 
```
$filter->setOption('case_sensitive', $this->caseSensitive); 
```
to 
```
$filter->setCaseSensitive($this->caseSensitive); 
```
This way we do not need to know the name of the case_sensitive option.

But I'm not sure we want to keep an half-working case_sensitive option, already renamed to force_case_insensitivity by @phansys in one persistence bundle (and I don't know if a case_sensitive option could be implemented in mongo @franmomu). WDYT @sonata-project/contributors ?

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- SearchableFilterInterface

### Deprecated
- Passing `global_search` option to a filter which does not implements `SearchableFilterInterface`.
- `sonata_admin.global_search.case_sensitive` configuration.
```