### PR TITLE
Respect false translationd domain

### DIFF
--- a/src/Resources/views/Block/block_admin_preview.html.twig
+++ b/src/Resources/views/Block/block_admin_preview.html.twig
@@ -24,7 +24,13 @@ file that was distributed with this source code.
                 <i class="fa {{ icon|raw }}"></i>
             {% endif %}
             <h3 class="box-title">
-                <a href="#{{ inlineAnchor }}">{{ settings.text|trans({}, translation_domain) }}</a>
+                <a href="#{{ inlineAnchor }}">
+                    {% if translation_domain is same as(false) %}
+                        {{ settings.text }}
+                    {% else %}
+                        {{ settings.text|trans({}, translation_domain) }}
+                    {% endif %}
+                </a>
             </h3>
         </div>
         <div class="box-body {% if results_count > 0 %}table-responsive no-padding{% endif %}">

--- a/src/Resources/views/Block/block_search_result.html.twig
+++ b/src/Resources/views/Block/block_search_result.html.twig
@@ -71,7 +71,11 @@ file that was distributed with this source code.
                                                 or filter.option('case_sensitive') is same as(false) and term|lower in match|lower)
                                             %}
                                                 <a class="label label-primary" href="{{ admin.generateUrl('list', {'filter': {(filter.formName): {'value': term}}}) }}">
-                                                    {{ filter.option('label')|trans({}, filter.option('translation_domain', admin.translationDomain)) }}
+                                                    {% if filter.option('translation_domain') is same as(false) %}
+                                                        {{ filter.option('label') }}
+                                                    {% else %}
+                                                        {{ filter.option('label')|trans({}, filter.option('translation_domain', admin.translationDomain)) }}
+                                                    {% endif %}
                                                 </a>
                                             {% endif %}
                                         {% endfor %}

--- a/src/Resources/views/CRUD/Association/edit_one_to_many_inline_tabs.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many_inline_tabs.html.twig
@@ -23,8 +23,7 @@ file that was distributed with this source code.
                                 {% if form_group.translation_domain is same as(false) %}
                                     {{ form_group.label }}
                                 {% else %}
-                                    {% set translationDomain = form_group.translation_domain|default(associationAdmin.translationDomain) %}
-                                    {{ form_group.label|trans({}, translationDomain) }}
+                                    {{ form_group.label|trans({}, form_group.translation_domain ?? associationAdmin.translationDomain) }}
                                 {% endif %}
                             </a>
                         </li>

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -42,7 +42,12 @@
                                     {% set _tab_name = tab_prefix ~ '_' ~ loop.index %}
                                     <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (tab_query_index == loop.index) %} class="active"{% endif %}>
                                         <a href="#{{ _tab_name }}" class="changer-tab" aria-controls="{{ _tab_name }}" data-toggle="tab">
-                                            <i class="fa fa-exclamation-circle has-errors hide" aria-hidden="true"></i> {{ form_tab.label|trans({}, form_tab.translation_domain ?: admin.translationDomain) }}
+                                            <i class="fa fa-exclamation-circle has-errors hide" aria-hidden="true"></i>
+                                            {% if form_tab.translation_domain is same as(false) %}
+                                                {{ form_tab.label }}
+                                            {% else %}
+                                                {{ form_tab.label|trans({}, form_tab.translation_domain ?: admin.translationDomain) }}
+                                            {% endif %}
                                         </a>
                                     </li>
                                 {% endfor %}
@@ -57,9 +62,11 @@
                                         <div class="box-body  container-fluid">
                                             <div class="sonata-ba-collapsed-fields">
                                                 {% if form_tab.description != false %}
-                                                    <p>
-                                                        {{ form_tab.description|trans({}, form_tab.translation_domain ?: admin.translationDomain)|raw }}
-                                                    </p>
+                                                    {% if form_tab.translation_domain is same as(false) %}
+                                                        <p>{{ form_tab.description|raw }}</p>
+                                                    {% else %}
+                                                        <p>{{ form_tab.description|trans({}, form_tab.translation_domain ?? admin.translationDomain)|raw }}</p>
+                                                    {% endif %}
                                                 {% endif %}
 
                                                 {{ form_helper.render_groups(admin, form, form_tab['groups'], has_tab) }}

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -46,7 +46,7 @@
                                             {% if form_tab.translation_domain is same as(false) %}
                                                 {{ form_tab.label }}
                                             {% else %}
-                                                {{ form_tab.label|trans({}, form_tab.translation_domain ?: admin.translationDomain) }}
+                                                {{ form_tab.label|trans({}, form_tab.translation_domain ?? admin.translationDomain) }}
                                             {% endif %}
                                         </a>
                                     </li>

--- a/src/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -11,7 +11,7 @@
                         {% if form_group.translation_domain is same as(false) %}
                             {{ form_group.label }}
                         {% else %}
-                            {{ form_group.label|trans({}, form_group.translation_domain|default(admin.translationDomain)) }}
+                            {{ form_group.label|trans({}, form_group.translation_domain ?? admin.translationDomain) }}
                         {% endif %}
                     </h4>
                 </div>
@@ -21,7 +21,7 @@
                             {% if form_group.translation_domain is same as(false) %}
                                 <p>{{ form_group.description|raw }}</p>
                             {% else %}
-                                <p>{{ form_group.description|trans({}, form_group.translation_domain|default(admin.translationDomain))|raw }}</p>
+                                <p>{{ form_group.description|trans({}, form_group.translation_domain ?? admin.translationDomain)|raw }}</p>
                             {% endif %}
                         {% endif %}
 
@@ -32,7 +32,7 @@
                                 {% if form_group.empty_message_translation_domain is same as(false) %}
                                     <em>{{ form_group.empty_message }}</em>
                                 {% else %}
-                                    <em>{{ form_group.empty_message|trans({}, form_group.empty_message_translation_domain|default(admin.translationDomain)) }}</em>
+                                    <em>{{ form_group.empty_message|trans({}, form_group.empty_message_translation_domain ?? admin.translationDomain) }}</em>
                                 {% endif %}
                             {% endif %}
                         {% endfor %}

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -187,7 +187,14 @@ file that was distributed with this source code.
 
                                             <select name="action" style="width: auto; height: auto" class="form-control">
                                                 {% for action, options in batchactions %}
-                                                    <option value="{{ action }}">{{ options.label|trans({}, options.translation_domain|default(admin.translationDomain)) }}</option>
+                                                    <option value="{{ action }}">
+                                                        {% if options.translation_domain is same as(false) %}
+                                                            {{ options.label }}
+                                                        {% else %}
+                                                            {{ options.label|trans({}, options.translation_domain|default(admin.translationDomain)) }}
+                                                        {% endif %}
+                                                        {{ options.label|trans({}, options.translation_domain|default(admin.translationDomain)) }}
+                                                    </option>
                                                 {% endfor %}
                                             </select>
                                         {% endblock %}

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -191,9 +191,8 @@ file that was distributed with this source code.
                                                         {% if options.translation_domain is same as(false) %}
                                                             {{ options.label }}
                                                         {% else %}
-                                                            {{ options.label|trans({}, options.translation_domain|default(admin.translationDomain)) }}
+                                                            {{ options.label|trans({}, options.translation_domain ?? admin.translationDomain) }}
                                                         {% endif %}
-                                                        {{ options.label|trans({}, options.translation_domain|default(admin.translationDomain)) }}
                                                     </option>
                                                 {% endfor %}
                                             </select>
@@ -283,7 +282,11 @@ file that was distributed with this source code.
                             <a href="#" class="sonata-toggle-filter sonata-ba-action" filter-target="filter-{{ admin.uniqid }}-{{ filter.name }}" filter-container="filter-container-{{ admin.uniqid() }}">
                                 <i class="fa {{ filterDisplayed ? 'fa-check-square-o' : 'fa-square-o' }}"></i>
                                 {% if filter.label is not same as(false) %}
-                                    {{ filter.label|trans(filter.option('label_translation_parameters', {}), filter.translationDomain ?: admin.translationDomain) }}
+                                    {% if filter.translationDomain is same as(false) %}
+                                        {{ filter.label }}
+                                    {% else %}
+                                        {{ filter.label|trans(filter.option('label_translation_parameters', {}), filter.translationDomain ?? admin.translationDomain) }}
+                                    {% endif %}
                                 {% endif %}
                             </a>
                         </li>
@@ -321,7 +324,13 @@ file that was distributed with this source code.
                                     {% set filterCanBeDisplayed = filter.option('show_filter') is not same as(false) %}
                                     <div class="form-group {% block sonata_list_filter_group_class %}{% endblock %}" id="filter-{{ admin.uniqid }}-{{ filter.name }}" sonata-filter="{{ filterCanBeDisplayed ? 'true' : 'false' }}" style="display: {% if filterDisplayed %}block{% else %}none{% endif %}">
                                         {% if filter.label is not same as(false) %}
-                                            <label for="{{ form[filter.formName].children['value'].vars.id }}" class="col-sm-3 control-label">{{ filter.label|trans(filter.option('label_translation_parameters', {}), filter.translationDomain ?: admin.translationDomain) }}</label>
+                                            <label for="{{ form[filter.formName].children['value'].vars.id }}" class="col-sm-3 control-label">
+                                                {% if filter.translationDomain is same as(false) %}
+                                                    {{ filter.label }}
+                                                {% else %}
+                                                    {{ filter.label|trans(filter.option('label_translation_parameters', {}), filter.translationDomain ?? admin.translationDomain) }}
+                                                {% endif %}
+                                            </label>
                                         {% endif %}
                                         {% set attr = form[filter.formName].children['type'].vars.attr|default({}) %}
 

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -103,7 +103,7 @@ file that was distributed with this source code.
                                     {% if show_group.translation_domain is same as(false) %}
                                         {{ show_group.label }}
                                     {% else %}
-                                        {{ show_group.label|trans({}, show_group.translation_domain|default(admin.translationDomain)) }}
+                                        {{ show_group.label|trans({}, show_group.translation_domain ?? admin.translationDomain) }}
                                     {% endif %}
                                 {% endblock %}
                             </h4>

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -48,7 +48,11 @@ file that was distributed with this source code.
                         {% set _tab_name = tab_prefix ~ '_' ~ loop.index %}
                         <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (tab_query_index == loop.index) %} class="active"{% endif %}>
                             <a href="#{{ _tab_name }}" class="changer-tab" aria-controls="{{ _tab_name }}" data-toggle="tab">
-                                {{ show_tab.label|trans({}, show_tab.translation_domain ?: admin.translationDomain) }}
+                                {% if show_tab.translation_domain is same as(false) %}
+                                    {{ show_tab.label }}
+                                {% else %}
+                                    {{ show_tab.label|trans({}, show_tab.translation_domain ?? admin.translationDomain) }}
+                                {% endif %}
                             </a>
                         </li>
                     {% endfor %}

--- a/src/Resources/views/CRUD/base_show_macro.html.twig
+++ b/src/Resources/views/CRUD/base_show_macro.html.twig
@@ -18,7 +18,7 @@
                             {% if show_group.translation_domain is same as(false) %}
                                 {{ show_group.label }}
                             {% else %}
-                                {{ show_group.label|trans({}, show_group.translation_domain|default(admin.translationDomain)) }}
+                                {{ show_group.label|trans({}, show_group.translation_domain ?? admin.translationDomain) }}
                             {% endif %}
                         {% endblock %}
                     </h4>

--- a/src/Resources/views/CRUD/dashboard__action.html.twig
+++ b/src/Resources/views/CRUD/dashboard__action.html.twig
@@ -1,4 +1,8 @@
 <a class="btn btn-link btn-flat" href="{{ action.url }}">
     <i class="fa fa-{{ action.icon }}" aria-hidden="true"></i>
-    {{ action.label|trans({}, action.translation_domain|default('SonataAdminBundle')) }}
+    {% if action.translation_domain is same as(false) %}
+        {{ action.label }}
+    {% else %}
+        {{ action.label|trans({}, action.translation_domain|default('SonataAdminBundle')) }}
+    {% endif %}
 </a>

--- a/src/Resources/views/CRUD/dashboard__action_create.html.twig
+++ b/src/Resources/views/CRUD/dashboard__action_create.html.twig
@@ -1,18 +1,32 @@
 {% if admin.subClasses is empty %}
     <a class="btn btn-link btn-flat" href="{{ action.url }}">
         <i class="fa fa-{{ action.icon }}" aria-hidden="true"></i>
-        {{ action.label|trans({}, action.translation_domain|default('SonataAdminBundle')) }}
+        {% if action.translation_domain is same as(false) %}
+            {{ action.label }}
+        {% else %}
+            {{ action.label|trans({}, action.translation_domain|default('SonataAdminBundle')) }}
+        {% endif %}
     </a>
 {% else %}
     <a class="btn btn-link btn-flat dropdown-toggle" data-toggle="dropdown" href="#">
         <i class="fa fa-{{ action.icon }}" aria-hidden="true"></i>
-        {{ action.label|trans({}, action.translation_domain|default('SonataAdminBundle')) }}
+        {% if action.translation_domain is same as(false) %}
+            {{ action.label }}
+        {% else %}
+            {{ action.label|trans({}, action.translation_domain|default('SonataAdminBundle')) }}
+        {% endif %}
         <span class="caret"></span>
     </a>
     <ul class="dropdown-menu">
         {% for subclass in admin.subclasses|keys %}
             <li>
-                <a href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">{{ subclass|trans({}, action.translation_domain|default('SonataAdminBundle')) }}</a>
+                <a href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">
+                    {% if action.translation_domain is same as(false) %}
+                        {{ subclass }}
+                    {% else %}
+                        {{ subclass|trans({}, action.translation_domain|default('SonataAdminBundle')) }}
+                    {% endif %}
+                </a>
             </li>
         {% endfor %}
     </ul>

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -412,7 +412,7 @@ file that was distributed with this source code.
 
             {# NEXT_MAJOR: Remove this block #}
             {% if sonata_admin is defined and sonata_admin_enabled and sonata_admin.field_description.getHelp('sonata_deprecation_mute')|default(false) %}
-                <span class="help-block sonata-ba-field-help">{{ sonata_admin.field_description.help|trans(help_translation_parameters, sonata_admin.field_description.translationDomain ?: admin.translationDomain)|raw }}</span>
+                <span class="help-block sonata-ba-field-help">{{ sonata_admin.field_description.help|trans(help_translation_parameters, sonata_admin.field_description.translationDomain ?? admin.translationDomain)|raw }}</span>
             {% endif %}
 
             {{ form_help(form) }}


### PR DESCRIPTION
## Subject

Similar to https://github.com/sonata-project/SonataAdminBundle/pull/7271

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Respect `false` as translation_domain for tab and action buttons.
```