### PR TITLE
Make setParent consistent with addChild

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -168,6 +168,11 @@ parameters:
             count: 1
             path: src/Datagrid/Pager.php
 
+        -
+            message: "#^Method Sonata\\\\AdminBundle\\\\Admin\\\\AdminInterface\\<object\\>\\:\\:setParent\\(\\) invoked with 2 parameters, 1 required\\.$#"
+            count: 1
+            path: src/Admin/AbstractAdmin.php
+
 # Symfony related errors
         -
             # Symfony BC break policy

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -6,8 +6,9 @@
             <code>$this-&gt;parentAssociationMapping</code>
         </InvalidReturnStatement>
         <!--will be fixed in v4. Currently BC break. Remove string from union type of $this->parentAssociationMapping-->
-        <InvalidArrayOffset occurrences="1">
+        <InvalidArrayOffset occurrences="2">
             <code>$this-&gt;parentAssociationMapping[$code]</code>
+            <code>$this-&gt;parentAssociationMapping[$parent-&gt;getCode()]</code>
         </InvalidArrayOffset>
         <!--will be removed in v4. Currently BC break-->
         <InvalidPropertyAssignmentValue occurrences="1">

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -46,7 +46,6 @@ use Symfony\Component\HttpFoundation\Request;
  * @method string                          getBaseRoutePattern()
  * @method string                          getBaseRouteName()
  * @method ItemInterface                   getSideMenu(string $action, ?AdminInterface $childAdmin = null)
- * @method void                            addParentAssociationMapping(string $code, string $value)
  * @method string                          getClassnameLabel()
  * @method AdminInterface|null             getCurrentChildAdmin()
  * @method string|null                     getParentAssociationMapping()
@@ -457,9 +456,11 @@ interface AdminInterface extends TaggedAdminInterface, AccessRegistryInterface, 
     public function getParent();
 
     /**
+     * NEXT_MAJOR: Uncomment the `$parentAssociationMapping` argument.
+     *
      * @return void
      */
-    public function setParent(self $parent);
+    public function setParent(self $parent/*, string $parentAssociationMapping*/);
 
     /**
      * Returns true if the Admin class has an Parent Admin defined.
@@ -754,9 +755,6 @@ interface AdminInterface extends TaggedAdminInterface, AccessRegistryInterface, 
 
 //    NEXT_MAJOR: uncomment this method in 4.0
 //    public function getSideMenu(string $action, ?AdminInterface $childAdmin = null): \Knp\Menu\ItemInterface;
-
-//    NEXT_MAJOR: uncomment this method in 4.0
-//    public function addParentAssociationMapping(string $code, string $value): void;
 
 //    NEXT_MAJOR: uncomment this method in 4.0
 //    /**

--- a/tests/Fixtures/Admin/CommentAdmin.php
+++ b/tests/Fixtures/Admin/CommentAdmin.php
@@ -27,9 +27,4 @@ class CommentAdmin extends AbstractAdmin
     {
         $collection->remove('edit');
     }
-
-    public function setParentAssociationMapping($associationMapping): void
-    {
-        $this->parentAssociationMapping = $associationMapping;
-    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Closes https://github.com/sonata-project/SonataAdminBundle/pull/6007

I rebased and reacting to this comment: https://github.com/sonata-project/SonataAdminBundle/pull/6007#discussion_r560753114, I added an exception is we're calling `getParentAssociationMapping` for an admin without Parent. The check `isChild()` must be used.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `AbstractAdmin::addParentAssociationMapping()` method.
- Calling `AdminInterface::setParent()` without second argument.
- Calling `AdminInterface::getParentAssociationMapping()` for a non parent admin.
```