### PR TITLE
Introduce parse_icon method.

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -4,6 +4,17 @@ UPGRADE 3.x
 UPGRADE FROM 3.x to 3.x
 =======================
 
+### 'icon' option
+
+We used multiple icon option with different format:
+- `<i class="fa fa-plus"></i>`
+- `fa fa-plus`
+- `fa-plus`
+- `plus`
+
+The last two format are now deprecated.  Since we've fixed the deprecation in the code,
+if you've overriden some template, be sure to always render the icons with the new `parse_icon` filter.
+
 ### `Sonata\AdminBundle\Form\FormMapper`
 
 Deprecated passing `collection` as argument 2 for `FormMapper::add()` method. You MUST pass

--- a/docs/cookbook/recipe_knp_menu.rst
+++ b/docs/cookbook/recipe_knp_menu.rst
@@ -115,7 +115,7 @@ The following configuration uses a menu provider to populate the menu group ``my
                 groups:
                     my_group:
                         provider:        'MyBundle:MyMenuProvider:getMyMenu'
-                        icon:            '<i class="fa fa-edit"></i>'
+                        icon:            'fa fa-edit' # html is also supported
 
 With KnpMenuBundle you can create a custom menu by using a builder class
 or by declaring it as a service. Please see the `Knp documentation`_ for
@@ -161,7 +161,7 @@ name ``sonata.admin.event.configure.menu.sidebar``::
                 'label' => 'Daily and monthly reports',
                 'route' => 'app_reports_index',
             ])->setExtras([
-                'icon' => '<i class="fa fa-bar-chart"></i>',
+                'icon' => 'fa fa-bar-chart', // html is also supported
             ]);
         }
     }
@@ -230,7 +230,7 @@ open and ignore open/close effects:
                     keep_open:       true
                     label:           sonata_media
                     label_catalogue: SonataMediaBundle
-                    icon:            '<i class="fa fa-image"></i>'
+                    icon:            'fa fa-image' # html is also supported
                     items:
                         - sonata.media.admin.media
                         - sonata.media.admin.gallery

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -87,7 +87,7 @@ Full Configuration Options
                 form_type: standard
                 default_group: default
                 default_label_catalogue: SonataAdminBundle
-                default_icon: '<i class="fa fa-folder"></i>'
+                default_icon: 'fa fa-folder'
                 dropdown_number_groups_per_colums:  2
                 title_mode: ~ # One of "single_text"; "single_image"; "both"
 

--- a/docs/reference/dashboard.rst
+++ b/docs/reference/dashboard.rst
@@ -318,7 +318,7 @@ counter is related to the filters from one admin
                         type:     sonata.admin.block.stats   # block id
                         settings:
                             code:  sonata.page.admin.page    # admin code - service id
-                            icon:  fa-magic                  # font awesome icon
+                            icon:  fa fa-magic               # font awesome icon
                             text:  app.page.stats            # static text or translation message
                             color: bg-yellow                 # colors: bg-green, bg-red and bg-aqua
                             filters:                         # filter values
@@ -366,7 +366,7 @@ A preview block can be used to display a brief of an admin list.
                         type:     sonata.admin.block.admin_preview # block id
                         settings:
                             code:  sonata.page.admin.page          # admin code - service id
-                            icon:  fa-magic                        # font awesome icon
+                            icon:  fa fa-magic                     # font awesome icon
                             limit: 10
                             text:  Latest Edited Pages
                             filters:                               # filter values

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -3210,7 +3210,7 @@ EOT;
                 'template' => $this->getTemplate('action_create'),
                 // 'template' => $this->getTemplateRegistry()->getTemplate('action_create'),
                 'url' => $this->generateUrl('create'),
-                'icon' => 'plus-circle',
+                'icon' => 'fa fa-plus-circle',
             ];
         }
 
@@ -3219,7 +3219,7 @@ EOT;
                 'label' => 'link_list',
                 'translation_domain' => 'SonataAdminBundle',
                 'url' => $this->generateUrl('list'),
-                'icon' => 'list',
+                'icon' => 'fa fa-list',
             ];
         }
 

--- a/src/Block/AdminSearchBlockService.php
+++ b/src/Block/AdminSearchBlockService.php
@@ -199,7 +199,7 @@ class AdminSearchBlockService extends AbstractBlockService
                 'query' => '',
                 'page' => 0,
                 'per_page' => 10,
-                'icon' => '<i class="fa fa-list"></i>',
+                'icon' => 'fa fa-list',
             ])
             ->setRequired('admin_code')
             ->setAllowedTypes('admin_code', ['string']);

--- a/src/Block/AdminStatsBlockService.php
+++ b/src/Block/AdminStatsBlockService.php
@@ -125,7 +125,7 @@ class AdminStatsBlockService extends AbstractBlockService
     public function configureSettings(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'icon' => 'fa-line-chart',
+            'icon' => 'fa fa-line-chart',
             'text' => 'Statistics',
             'translation_domain' => null,
             'color' => 'bg-aqua',

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -172,7 +172,7 @@ CASESENSITIVE;
                             ->info('Label Catalogue used for admin services if one isn\'t provided.')
                         ->end()
                         ->scalarNode('default_icon')
-                            ->defaultValue('<i class="fa fa-folder"></i>')
+                            ->defaultValue('fa fa-folder')
                             ->info('Icon used for admin services if one isn\'t provided.')
                         ->end()
                         ->integerNode('dropdown_number_groups_per_colums')->defaultValue(2)->end()

--- a/src/Resources/config/twig.php
+++ b/src/Resources/config/twig.php
@@ -15,6 +15,7 @@ use Sonata\AdminBundle\DependencyInjection\Compiler\AliasDeprecatedPublicService
 use Sonata\AdminBundle\Twig\Extension\BreadcrumbsExtension;
 use Sonata\AdminBundle\Twig\Extension\CanonicalizeExtension;
 use Sonata\AdminBundle\Twig\Extension\GroupExtension;
+use Sonata\AdminBundle\Twig\Extension\IconExtension;
 use Sonata\AdminBundle\Twig\Extension\PaginationExtension;
 use Sonata\AdminBundle\Twig\Extension\RenderElementExtension;
 use Sonata\AdminBundle\Twig\Extension\SecurityExtension;
@@ -65,10 +66,13 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ])
 
         ->set('sonata.admin.group.extension', GroupExtension::class)
-        ->tag('twig.extension')
-        ->args([
-            new ReferenceConfigurator('sonata.admin.pool'),
-        ])
+            ->tag('twig.extension')
+            ->args([
+                new ReferenceConfigurator('sonata.admin.pool'),
+            ])
+
+        ->set('sonata.admin.twig.icon_extension', IconExtension::class)
+            ->tag('twig.extension')
 
         // NEXT_MAJOR: Remove this service.
         ->set('sonata.pagination.twig.extension', PaginationExtension::class)

--- a/src/Resources/views/Block/block_admin_preview.html.twig
+++ b/src/Resources/views/Block/block_admin_preview.html.twig
@@ -21,7 +21,7 @@ file that was distributed with this source code.
         <div class="box-header with-border">
             {% set icon = settings.icon|default('') %}
             {% if icon %}
-                <i class="fa {{ icon|raw }}"></i>
+                {{ icon|parse_icon }}
             {% endif %}
             <h3 class="box-title">
                 <a href="#{{ inlineAnchor }}">
@@ -47,10 +47,12 @@ file that was distributed with this source code.
                                     {% if field_description.name == constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_SELECT') %}
                                         <th class="sonata-ba-list-field-header sonata-ba-list-field-header-select"></th>
                                     {% else %}
-                                        {% filter spaceless %}
+                                        {% apply spaceless %}
                                             <th class="sonata-ba-list-field-header-{{ field_description.type}} {% if field_description.option('header_class') is not null %} {{ field_description.option('header_class') }}{% endif %}"{% if field_description.option('header_style') is not null %} style="{{ field_description.option('header_style') }}"{% endif %}>
                                                 {% if field_description.option('label_icon') %}
-                                                    <i class="sonata-ba-list-field-header-label-icon {{ field_description.option('label_icon') }}" aria-hidden="true"></i>
+                                                    <span class="sonata-ba-list-field-header-label-icon">
+                                                        {{ field_description.option('label_icon')|parse_icon }}
+                                                    </span>
                                                 {% endif %}
                                                 {% if field_description.translationDomain is same as(false) %}
                                                     {{ field_description.label }}
@@ -58,7 +60,7 @@ file that was distributed with this source code.
                                                     {{ field_description.label|trans({}, field_description.translationDomain) }}
                                                 {% endif %}
                                             </th>
-                                        {% endfilter %}
+                                        {% endapply %}
                                     {% endif %}
                                 {% endfor %}
                             </tr>

--- a/src/Resources/views/Block/block_search_result.html.twig
+++ b/src/Resources/views/Block/block_search_result.html.twig
@@ -28,7 +28,7 @@ file that was distributed with this source code.
         <div class="box box-solid {{ visibility_class }}">
             <div class="box-header with-border {{ visibility_class }}">
                 {% set icon = settings.icon|default('') %}
-                {{ icon|raw }}
+                {{ icon|parse_icon }}
                 <h3 class="box-title">
                     {% if admin.label is not empty %}
                         {{ admin.label|trans({}, admin.translationdomain) }}

--- a/src/Resources/views/Block/block_stats.html.twig
+++ b/src/Resources/views/Block/block_stats.html.twig
@@ -29,7 +29,7 @@ file that was distributed with this source code.
             </p>
         </div>
         <div class="icon">
-            <i class="fa {{ settings.icon }}"></i>
+            {{ settings.icon|parse_icon }}
         </div>
         <a href="{{ admin.generateUrl('list', {filter: settings.filters}) }}" class="small-box-footer">
             {{ 'stats_view_more'|trans({}, 'SonataAdminBundle') }} <i class="fa fa-arrow-circle-right" aria-hidden="true"></i>

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -80,7 +80,9 @@ file that was distributed with this source code.
                                                 <th class="sonata-ba-list-field-header-{{ field_description.type }}{% if sortable %} sonata-ba-list-field-header-order-{{ sort_by|lower }} {{ sort_active_class }}{% endif %}{% if field_description.option('header_class') %} {{ field_description.option('header_class') }}{% endif %}"{% if field_description.option('header_style') %} style="{{ field_description.option('header_style') }}"{% endif %}>
                                                     {% if sortable %}<a href="{{ admin.generateUrl('list', sort_parameters|merge({_list_mode: admin.getListMode()})) }}">{% endif %}
                                                     {% if field_description.getOption('label_icon') %}
-                                                        <i class="sonata-ba-list-field-header-label-icon {{ field_description.getOption('label_icon') }}" aria-hidden="true"></i>
+                                                        <span class="sonata-ba-list-field-header-label-icon">
+                                                            {{ field_description.getOption('label_icon')|parse_icon }}
+                                                        </span>
                                                     {% endif %}
                                                     {% if field_description.label is not same as(false) %}
                                                         {% if field_description.translationDomain is same as(false) %}

--- a/src/Resources/views/CRUD/dashboard__action.html.twig
+++ b/src/Resources/views/CRUD/dashboard__action.html.twig
@@ -1,5 +1,5 @@
 <a class="btn btn-link btn-flat" href="{{ action.url }}">
-    <i class="fa fa-{{ action.icon }}" aria-hidden="true"></i>
+    {{ action.icon|parse_icon }}
     {% if action.translation_domain is same as(false) %}
         {{ action.label }}
     {% else %}

--- a/src/Resources/views/CRUD/dashboard__action_create.html.twig
+++ b/src/Resources/views/CRUD/dashboard__action_create.html.twig
@@ -1,6 +1,6 @@
 {% if admin.subClasses is empty %}
     <a class="btn btn-link btn-flat" href="{{ action.url }}">
-        <i class="fa fa-{{ action.icon }}" aria-hidden="true"></i>
+        {{ action.icon|parse_icon }}
         {% if action.translation_domain is same as(false) %}
             {{ action.label }}
         {% else %}
@@ -9,7 +9,7 @@
     </a>
 {% else %}
     <a class="btn btn-link btn-flat dropdown-toggle" data-toggle="dropdown" href="#">
-        <i class="fa fa-{{ action.icon }}" aria-hidden="true"></i>
+        {{ action.icon|parse_icon }}
         {% if action.translation_domain is same as(false) %}
             {{ action.label }}
         {% else %}

--- a/src/Resources/views/Core/add_block.html.twig
+++ b/src/Resources/views/Core/add_block.html.twig
@@ -30,7 +30,7 @@
                     <li role="presentation" class="divider"></li>
                 {% endif %}
                 <li role="presentation" class="dropdown-header">
-                    {{ group.icon|raw }}
+                    {{ group.icon|parse_icon }}
                     {{ group.label|trans({}, group.label_catalogue) }}
                 </li>
 

--- a/src/Resources/views/Core/tab_menu_template.html.twig
+++ b/src/Resources/views/Core/tab_menu_template.html.twig
@@ -86,7 +86,7 @@
     {% import "knp_menu.html.twig" as macros %}
     <a href="{{ item.uri }}"{{ macros.attributes(item.linkAttributes) }}>
         {% if item.attribute('icon') is not empty %}
-            <i class="{{ item.attribute('icon') }}"></i>
+            {{ item.attribute('icon')|parse_icon }}
         {% endif %}
         {{ block('label') }}
     </a>
@@ -96,7 +96,7 @@
     {% import "knp_menu.html.twig" as macros %}
     <span {{ macros.attributes(item.labelAttributes) }}>
         {% if item.attribute('icon') is not empty %}
-            <i class="{{ item.attribute('icon') }}"></i>
+            {{ item.attribute('icon')|parse_icon }}
         {% endif %}
         {{ block('label') }}
     </span>
@@ -111,7 +111,7 @@
     {%- set attributes = attributes|merge({'data-toggle': 'dropdown'}) %}
     <a href="#"{{ macros.attributes(attributes) }}>
         {% if item.attribute('icon') is not empty %}
-            <i class="{{ item.attribute('icon') }}"></i>
+            {{ item.attribute('icon')|parse_icon }}
         {% endif %}
         {{ block('label') }}
         <b class="caret"></b>

--- a/src/Resources/views/Menu/sonata_menu.html.twig
+++ b/src/Resources/views/Menu/sonata_menu.html.twig
@@ -38,7 +38,7 @@
         <a href="#">
             {%- set translation_domain = item.extra('label_catalogue', 'messages') -%}
             {%- set icon = item.extra('icon')|default('') -%}
-            {{ icon|raw }}
+            {{ icon|parse_icon }}
             {{ parent() }}
             {%- if item.extra('keep_open') is not defined or not item.extra('keep_open') -%}
                 <span class="pull-right-container"><i class="fa pull-right fa-angle-left"></i></span>
@@ -50,7 +50,7 @@
 {% block label %}
     {% apply spaceless %}
         {%- if is_link|default(false) -%}
-            {{ icon|default|raw }}
+            {{ icon|default('')|parse_icon }}
         {%- endif -%}
         {# We use method accessor instead of ".label" since `item` implements `ArrayAccess` and could have a property called "label". #}
         {%- set item_label = item.getLabel() -%}

--- a/src/Resources/views/Menu/sonata_menu.html.twig
+++ b/src/Resources/views/Menu/sonata_menu.html.twig
@@ -24,7 +24,7 @@
     {% apply spaceless %}
         {%- set translation_domain = item.extra('label_catalogue', 'messages') -%}
         {%- if item.extra('on_top') is defined and not item.extra('on_top') -%}
-            {%- set icon = item.extra('icon')|default(item.level > 1 ? '<i class="fa fa-angle-double-right" aria-hidden="true"></i>' : '') -%}
+            {%- set icon = item.extra('icon')|default(item.level > 1 ? 'fa fa-angle-double-right' : '') -%}
         {%- else -%}
             {%- set icon = item.extra('icon') -%}
         {%- endif -%}

--- a/src/Twig/Extension/IconExtension.php
+++ b/src/Twig/Extension/IconExtension.php
@@ -27,39 +27,41 @@ final class IconExtension extends AbstractExtension
 
     public function parseIcon(string $icon): string
     {
-        if ('' === $icon) {
-            return '';
+        if ('' === $icon || 0 === strpos($icon, '<')) {
+            return $icon;
         }
 
-        switch (substr($icon, 0, 3)) {
-            case '<i ':
-                return $icon;
-            // NEXT_MAJOR: remove this case
-            case 'fa-':
-                // only the icon name is used by dev: 'fa-plus'
-                @trigger_error(
-                    'The icon format "fa-icon" is deprecated since sonata-project/admin-bundle 3.x.'
-                    .' You should use the full name `fa fa-icon` instead.',
-                    \E_USER_DEPRECATED
-                );
+        // NEXT_MAJOR: remove this check.
+        if ('fa-' === substr($icon, 0, 3)) {
+            // only the icon name is used by dev: 'fa-plus'
+            @trigger_error(
+                'The icon format "fa-icon" is deprecated since sonata-project/admin-bundle 3.x.'
+                .' You should use the full name `fa fa-icon` instead.',
+                \E_USER_DEPRECATED
+            );
 
-                return sprintf('<i class="fa %s" aria-hidden="true"></i>', $icon);
-            // NEXT_MAJOR: change to fas to to support font-awesome v5
-            case 'fa ':
-                // full font-awesome is used by dev: 'fa fa-plus'
-                // for fa v5 fas prefix should be used.
-                return sprintf('<i class="%s" aria-hidden="true"></i>', $icon);
-            // NEXT_MAJOR: Uncomment the exception instead.
-            default:
-                // only icon name is used by dev: 'plus'
-                @trigger_error(
-                    'The icon format "icon" is deprecated since sonata-project/admin-bundle 3.x.'
-                    .' You should use the full name `fa fa-icon` instead.',
-                    \E_USER_DEPRECATED
-                );
-
-                return sprintf('<i class="fa fa-%s" aria-hidden="true"></i>', $icon);
-//                throw new \InvalidArgumentException(sprintf('The icon format "%s" is not supported.', $icon));
+            return sprintf('<i class="fa %s" aria-hidden="true"></i>', $icon);
         }
+
+        if (
+            0 !== strpos($icon, 'fa ')
+            && 0 !== strpos($icon, 'fas ')
+            && 0 !== strpos($icon, 'far ')
+            && 0 !== strpos($icon, 'fal ')
+            && 0 !== strpos($icon, 'fad ')
+        ) {
+            // NEXT_MAJOR: uncomment the exception.
+            @trigger_error(
+                'The icon format "icon" is deprecated since sonata-project/admin-bundle 3.x.'
+                .' You should use the full name `fa fa-icon` instead.',
+                \E_USER_DEPRECATED
+            );
+
+            return sprintf('<i class="fa fa-%s" aria-hidden="true"></i>', $icon);
+
+//            throw new \InvalidArgumentException(sprintf('The icon format "%s" is not supported.', $icon));
+        }
+
+        return sprintf('<i class="%s" aria-hidden="true"></i>', $icon);
     }
 }

--- a/src/Twig/Extension/IconExtension.php
+++ b/src/Twig/Extension/IconExtension.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Twig\Extension;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class IconExtension extends AbstractExtension
+{
+    public function getFilters(): array
+    {
+        return [
+            new TwigFilter('parse_icon', [$this, 'parseIcon'], ['is_safe' => ['html']]),
+        ];
+    }
+
+    public function parseIcon(string $icon): string
+    {
+        if ('' === $icon) {
+            return '';
+        }
+
+        switch (substr($icon, 0, 3)) {
+            case '<i ':
+                return $icon;
+            // NEXT_MAJOR: remove this case
+            case 'fa-':
+                // only the icon name is used by dev: 'fa-plus'
+                @trigger_error(
+                    'The icon format "fa-icon" is deprecated since sonata-project/admin-bundle 3.x.'
+                    .' You should use the full name `fa fa-icon` instead.',
+                    \E_USER_DEPRECATED
+                );
+
+                return sprintf('<i class="fa %s" aria-hidden="true"></i>', $icon);
+            // NEXT_MAJOR: change to fas to to support font-awesome v5
+            case 'fa ':
+                // full font-awesome is used by dev: 'fa fa-plus'
+                // for fa v5 fas prefix should be used.
+                return sprintf('<i class="%s" aria-hidden="true"></i>', $icon);
+            // NEXT_MAJOR: Uncomment the exception instead.
+            default:
+                // only icon name is used by dev: 'plus'
+                @trigger_error(
+                    'The icon format "icon" is deprecated since sonata-project/admin-bundle 3.x.'
+                    .' You should use the full name `fa fa-icon` instead.',
+                    \E_USER_DEPRECATED
+                );
+
+                return sprintf('<i class="fa fa-%s" aria-hidden="true"></i>', $icon);
+//                throw new \InvalidArgumentException(sprintf('The icon format "%s" is not supported.', $icon));
+        }
+    }
+}

--- a/src/Twig/Extension/IconExtension.php
+++ b/src/Twig/Extension/IconExtension.php
@@ -16,7 +16,7 @@ namespace Sonata\AdminBundle\Twig\Extension;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFilter;
 
-class IconExtension extends AbstractExtension
+final class IconExtension extends AbstractExtension
 {
     public function getFilters(): array
     {

--- a/tests/Block/AdminSearchBlockServiceTest.php
+++ b/tests/Block/AdminSearchBlockServiceTest.php
@@ -63,7 +63,7 @@ final class AdminSearchBlockServiceTest extends BlockServiceTestCase
             'query' => '',
             'page' => 0,
             'per_page' => 10,
-            'icon' => '<i class="fa fa-list"></i>',
+            'icon' => 'fa fa-list',
         ], $blockContext);
     }
 
@@ -88,7 +88,7 @@ final class AdminSearchBlockServiceTest extends BlockServiceTestCase
             'query' => '',
             'page' => 0,
             'per_page' => 10,
-            'icon' => '<i class="fa fa-list"></i>',
+            'icon' => 'fa fa-list',
         ], $blockContext);
     }
 

--- a/tests/Block/AdminStatsBlockServiceTest.php
+++ b/tests/Block/AdminStatsBlockServiceTest.php
@@ -45,7 +45,7 @@ class AdminStatsBlockServiceTest extends BlockServiceTestCase
         $blockContext = $this->getBlockContext($blockService);
 
         $this->assertSettings([
-            'icon' => 'fa-line-chart',
+            'icon' => 'fa fa-line-chart',
             'text' => 'Statistics',
             'translation_domain' => null,
             'color' => 'bg-aqua',

--- a/tests/Block/DeprecatedAdminSearchBlockServiceTest.php
+++ b/tests/Block/DeprecatedAdminSearchBlockServiceTest.php
@@ -66,7 +66,7 @@ class DeprecatedAdminSearchBlockServiceTest extends BlockServiceTestCase
             'query' => '',
             'page' => 0,
             'per_page' => 10,
-            'icon' => '<i class="fa fa-list"></i>',
+            'icon' => 'fa fa-list',
         ], $blockContext);
     }
 

--- a/tests/Block/DeprecatedAdminStatsBlockServiceTest.php
+++ b/tests/Block/DeprecatedAdminStatsBlockServiceTest.php
@@ -52,7 +52,7 @@ class DeprecatedAdminStatsBlockServiceTest extends BlockServiceTestCase
         $blockContext = $this->getBlockContext($blockService);
 
         $this->assertSettings([
-            'icon' => 'fa-line-chart',
+            'icon' => 'fa fa-line-chart',
             'text' => 'Statistics',
             'translation_domain' => null,
             'color' => 'bg-aqua',

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -37,7 +37,7 @@ class ConfigurationTest extends TestCase
         $this->assertSame('bundles/sonataadmin/default_mosaic_image.png', $config['options']['mosaic_background']);
         $this->assertSame('default', $config['options']['default_group']);
         $this->assertSame('SonataAdminBundle', $config['options']['default_label_catalogue']);
-        $this->assertSame('<i class="fa fa-folder"></i>', $config['options']['default_icon']);
+        $this->assertSame('fa fa-folder', $config['options']['default_icon']);
     }
 
     public function testBreadcrumbsChildRouteDefaultsToEdit(): void

--- a/tests/Menu/Integration/BaseMenuTest.php
+++ b/tests/Menu/Integration/BaseMenuTest.php
@@ -18,6 +18,7 @@ use Knp\Menu\Matcher\MatcherInterface;
 use Knp\Menu\Renderer\TwigRenderer;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Tests\Fixtures\StubFilesystemLoader;
+use Sonata\AdminBundle\Twig\Extension\IconExtension;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Bundle\FrameworkBundle\Tests\Templating\Helper\Fixtures\StubTranslator;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -54,6 +55,7 @@ abstract class BaseMenuTest extends TestCase
     protected function renderMenu(ItemInterface $item, array $options = [])
     {
         $this->environment->addExtension(new TranslationExtension($this->getTranslator()));
+        $this->environment->addExtension(new IconExtension());
         $this->renderer = new TwigRenderer(
             $this->environment,
             $this->getTemplate(),

--- a/tests/Twig/Extension/IconExtensionTest.php
+++ b/tests/Twig/Extension/IconExtensionTest.php
@@ -38,6 +38,10 @@ final class IconExtensionTest extends TestCase
             ['', ''],
             ['<i class="fa fa-cog" aria-hidden="true"></i>', '<i class="fa fa-cog" aria-hidden="true"></i>'],
             ['fa fa-cog', '<i class="fa fa-cog" aria-hidden="true"></i>'],
+            ['far fa-cog', '<i class="far fa-cog" aria-hidden="true"></i>'],
+            ['fas fa-cog', '<i class="fas fa-cog" aria-hidden="true"></i>'],
+            ['fal fa-cog', '<i class="fal fa-cog" aria-hidden="true"></i>'],
+            ['fad fa-cog', '<i class="fad fa-cog" aria-hidden="true"></i>'],
             // NEXT_MAJOR: Remove next 2 tests cases.
             ['fa-cog', '<i class="fa fa-cog" aria-hidden="true"></i>'],
             ['cog', '<i class="fa fa-cog" aria-hidden="true"></i>'],

--- a/tests/Twig/Extension/IconExtensionTest.php
+++ b/tests/Twig/Extension/IconExtensionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Twig\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Twig\Extension\IconExtension;
+
+final class IconExtensionTest extends TestCase
+{
+    /**
+     * NEXT_MAJOR: Remove the group legacy.
+     *
+     * @group legacy
+     *
+     * @dataProvider iconProvider
+     */
+    public function testParseIcon(string $icon, string $expected): void
+    {
+        $twigExtension = new IconExtension();
+
+        $this->assertSame($expected, $twigExtension->parseIcon($icon));
+    }
+
+    public function iconProvider(): iterable
+    {
+        return [
+            ['', ''],
+            ['<i class="fa fa-cog" aria-hidden="true"></i>', '<i class="fa fa-cog" aria-hidden="true"></i>'],
+            ['fa fa-cog', '<i class="fa fa-cog" aria-hidden="true"></i>'],
+            // NEXT_MAJOR: Remove next 2 tests cases.
+            ['fa-cog', '<i class="fa fa-cog" aria-hidden="true"></i>'],
+            ['cog', '<i class="fa fa-cog" aria-hidden="true"></i>'],
+        ];
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Closes #7137
Closes #7174

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added `IconExtension` twig extension.
- Added `parse_icon` filter.

### Deprecated
- Passing an `icon` option with the format `fa-plus` or `plus`, use the format `fa fa-plus` or pass directly the `<i>` html instead.
```