### PR TITLE
Add deprecated annotation to AbstractAdmin validate() method

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -557,6 +557,8 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
 
     /**
      * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle 3.82, use configureFormOptions() to set $formOptions['constraints'] instead.
      */
     public function validate(ErrorElement $errorElement, $object)
     {


### PR DESCRIPTION
## Subject

I'd like to add a deprecated annotation to the `AbstractAdmin` `validate()` method. This method was already planned to be removed in 4.0, but the code/comments do not point the developer into  the right direction. Today was the second time I started a Google search to the correct way and ended up on outdated documentation pages and old/outdated GH issues and had to continue searching for the right solution. I know this very small change will help future me a lot 😄 

I am targeting this branch, because this is the branch where the `validate()` method was set to be removed.

## Changelog

```markdown
### Added
- Added deprecated annotation to AbstractAdmin validate() method.
```
