### PR TITLE
Improve reorder methods.

### DIFF
--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -221,7 +221,16 @@ class Datagrid implements DatagridInterface
 
     public function reorderFilters(array $keys)
     {
-        $this->filters = array_merge(array_flip($keys), $this->filters);
+        $orderedFilters = [];
+        foreach ($keys as $name) {
+            if (!$this->hasFilter($name)) {
+                throw new \InvalidArgumentException(sprintf('Filter "%s" does not exist.', $name));
+            }
+
+            $orderedFilters[$name] = $this->filters[$name];
+        }
+
+        $this->filters = $orderedFilters + $this->filters;
     }
 
     public function getValues()

--- a/src/FieldDescription/FieldDescriptionCollection.php
+++ b/src/FieldDescription/FieldDescriptionCollection.php
@@ -71,11 +71,11 @@ class FieldDescriptionCollection implements \ArrayAccess, \Countable
      */
     public function get($name)
     {
-        if ($this->has($name)) {
-            return $this->elements[$name];
+        if (!$this->has($name)) {
+            throw new \InvalidArgumentException(sprintf('Element "%s" does not exist.', $name));
         }
 
-        throw new \InvalidArgumentException(sprintf('Element "%s" does not exist.', $name));
+        return $this->elements[$name];
     }
 
     /**
@@ -83,9 +83,7 @@ class FieldDescriptionCollection implements \ArrayAccess, \Countable
      */
     public function remove($name)
     {
-        if ($this->has($name)) {
-            unset($this->elements[$name]);
-        }
+        unset($this->elements[$name]);
     }
 
     public function offsetExists($offset)
@@ -126,7 +124,16 @@ class FieldDescriptionCollection implements \ArrayAccess, \Countable
             array_unshift($keys, ListMapper::NAME_BATCH);
         }
 
-        $this->elements = array_merge(array_flip($keys), $this->elements);
+        $orderedElements = [];
+        foreach ($keys as $name) {
+            if (!$this->has($name)) {
+                throw new \InvalidArgumentException(sprintf('Element "%s" does not exist.', $name));
+            }
+
+            $orderedElements[$name] = $this->elements[$name];
+        }
+
+        $this->elements = $orderedElements + $this->elements;
     }
 }
 

--- a/tests/Datagrid/DatagridTest.php
+++ b/tests/Datagrid/DatagridTest.php
@@ -174,6 +174,23 @@ final class DatagridTest extends TestCase
         $this->assertSame(['bar', 'baz', 'foo'], array_keys($this->datagrid->getFilters()));
     }
 
+    public function testReorderWithInvalidFilter(): void
+    {
+        $filter1 = $this->createMock(FilterInterface::class);
+        $filter1->method('getName')->willReturn('foo');
+
+        $filter2 = $this->createMock(FilterInterface::class);
+        $filter2->method('getName')->willReturn('bar');
+
+        $this->datagrid->addFilter($filter1);
+        $this->datagrid->addFilter($filter2);
+
+        self::expectException(\InvalidArgumentException::class);
+        self::expectExceptionMessage('Filter "baz" does not exist.');
+
+        $this->datagrid->reorderFilters(['bar', 'baz', 'foo']);
+    }
+
     public function testGetValues(): void
     {
         $this->assertSame([], $this->datagrid->getValues());

--- a/tests/FieldDescription/FieldDescriptionCollectionTest.php
+++ b/tests/FieldDescription/FieldDescriptionCollectionTest.php
@@ -113,4 +113,23 @@ class FieldDescriptionCollectionTest extends TestCase
         $actualElements = array_keys($collection->getElements());
         $this->assertSame($newOrder, $actualElements, 'the order is wrong');
     }
+
+    public function testReorderWithInvalidName(): void
+    {
+        $collection = new FieldDescriptionCollection();
+
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
+        $fieldDescription->method('getName')->willReturn('title');
+        $collection->add($fieldDescription);
+
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
+        $fieldDescription->method('getName')->willReturn('position');
+        $collection->add($fieldDescription);
+
+        self::expectException(\InvalidArgumentException::class);
+        self::expectExceptionMessage('Element "foo" does not exist.');
+
+        $newOrder = ['foo', 'title'];
+        $collection->reorder($newOrder);
+    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because BC.

I consider as BC the exception added because the code were already failing somewhere if an extra key were added.
Also, if I already have three fields `foo`, `bar`, `baz` and I call reorder(['baz', 'bar']), the current behavior is setting `foo` last. Do you agree with this or should we throw an exception if all the keys are not passed ? @sonata-project/contributors 

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `FieldCollection::reorder()` and `Datagrid::reorderFilter()` methods.
```