### PR TITLE
Add a default value to export_format variable

### DIFF
--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -202,7 +202,7 @@ file that was distributed with this source code.
                                 </div>
 
                                 <div class="pull-right">
-                                    {% if admin.hasRoute('export') and admin.hasAccess('export') and export_formats|length %}
+                                    {% if admin.hasRoute('export') and admin.hasAccess('export') and export_formats|default([])|length %}
                                         <div class="btn-group">
                                             <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
                                                 <i class="fas fa-share-square" aria-hidden="true"></i>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

When using the latest master branch in association with the SonataMediaBundle we face an error when trying to reach the media list page. Actually it seems related to the removal of the export_format initialization done in PR #5928.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because the removal has been done in master branch.
