### PR TITLE
Updated documentation for select 2

### DIFF
--- a/docs/cookbook/recipe_select2.rst
+++ b/docs/cookbook/recipe_select2.rst
@@ -72,3 +72,26 @@ to enable ``allowClear`` or ``data-sonata-select2-allow-clear = "false"`` to dis
 .. note::
 
     You have to use false as string! ``"false"``!
+
+Minimum results for search
+--------------------------
+
+To control the minimum amount of results that are required before the select is searchable you can set the data attribute ``data-sonata-select2-minimumResultsForSearch``. This controls select2's ``minimumResultsForSearch`` parameter:
+
+
+    use Sonata\AdminBundle\Form\Type\ModelType;
+
+    protected function configureFormFields(FormMapper $formMapper): void
+    {
+        $formMapper
+            ->add('category', ModelType::class, [
+                'attr' => [
+                    'data-sonata-select2-minimumResultsForSearch' => '10',
+                ]
+            ])
+        ;
+    }
+
+.. note::
+
+    By default ``minimumResultsForSearch`` will be set to ``10``

--- a/docs/cookbook/recipe_select2.rst
+++ b/docs/cookbook/recipe_select2.rst
@@ -76,7 +76,7 @@ to enable ``allowClear`` or ``data-sonata-select2-allow-clear = "false"`` to dis
 Minimum results for search
 --------------------------
 
-To control the minimum amount of results that are required before the select is searchable you can set the data attribute ``data-sonata-select2-minimumResultsForSearch``. This controls select2's ``minimumResultsForSearch`` parameter:
+To control the minimum amount of results that are required before the select is searchable you can set the data attribute ``data-sonata-select2-minimumResultsForSearch``. This controls select2's ``minimumResultsForSearch`` parameter::
 
 
     use Sonata\AdminBundle\Form\Type\ModelType;


### PR DESCRIPTION
## Updated documentation for select 2

I added documentation on how the user can control the minimum amount of results required before a select input turns into a searchable select input.

I am targeting this branch, because the documentation for the select2 integration was lacking.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #7260.