### PR TITLE
Support custom role with RoleSecurityHandler

### DIFF
--- a/src/Security/Handler/RoleSecurityHandler.php
+++ b/src/Security/Handler/RoleSecurityHandler.php
@@ -57,8 +57,14 @@ class RoleSecurityHandler implements SecurityHandlerInterface
             $attributes = [$attributes];
         }
 
+        $useAll = false;
         foreach ($attributes as $pos => $attribute) {
-            $attributes[$pos] = sprintf($this->getBaseRole($admin), $attribute);
+            // If the attribute is not already a ROLE_ we generate the related role.
+            if (0 !== strpos($attribute, 'ROLE_')) {
+                $attributes[$pos] = sprintf($this->getBaseRole($admin), $attribute);
+                // All the admin related role are available when you have the `_ALL` role.
+                $useAll = true;
+            }
         }
 
         $allRole = sprintf($this->getBaseRole($admin), 'ALL');
@@ -66,7 +72,7 @@ class RoleSecurityHandler implements SecurityHandlerInterface
         try {
             return $this->isAnyGranted($this->superAdminRoles)
                 || $this->isAnyGranted($attributes, $object)
-                || $this->isAnyGranted([$allRole], $object);
+                || $useAll && $this->isAnyGranted([$allRole], $object);
         } catch (AuthenticationCredentialsNotFoundException $e) {
             return false;
         }

--- a/tests/Security/Handler/RoleSecurityHandlerTest.php
+++ b/tests/Security/Handler/RoleSecurityHandlerTest.php
@@ -85,6 +85,7 @@ class RoleSecurityHandlerTest extends TestCase
                     case 'ROLE_IRONMAN':
                     case 'ROLE_FOO_BAR_ABC':
                     case 'ROLE_FOO_BAR_BAZ_ALL':
+                    case 'ROLE_CUSTOM':
                         return true;
                     case 'ROLE_AUTH_EXCEPTION':
                         throw new AuthenticationCredentialsNotFoundException();
@@ -161,6 +162,11 @@ class RoleSecurityHandlerTest extends TestCase
             [false, [], 'foo.bar.baz.xyz', 'BAZ', new \stdClass()],
             [false, [], 'foo.bar.baz.xyz', ['BAZ'], new \stdClass()],
             [false, ['ROLE_AUTH_EXCEPTION'], 'foo.bar.baz.xyz', ['BAZ'], new \stdClass()],
+
+            //role
+            [false, [], 'foo.bar', ['CUSTOM']],
+            [true, [], 'foo.bar', ['ROLE_CUSTOM']],
+            [false, [], 'foo.bar', ['ROLE_ANOTHER_CUSTOM']],
 
             // ALL role
             [true, [], 'foo.bar.baz', 'LIST'],


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Closes #5992
I am targeting this branch, because BC.

Prior to this, when using isGranted with something like `ROLE_USER` it was transformed to `ROLE_FOOADMIN_ROLE_USER`, which feel really unnatural and buggy.

Now,
- if we pass the full role, no prefix is added
- if we pass a string not starting by `ROLE`, the prefix is added.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added support for non admin prefixed `ROLE_*` roles by the RoleSecurityHandler.
```