### PR TITLE
Typo "buildBreacrumbs" in UPGRADE-3.x.md

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1198,7 +1198,7 @@ The Twig extension method that fallback to a default template when the specified
 You can no longer rely on that and should always specify templates that exist.
 
 ## Deprecated AbstractAdmin methods
-- `buildBreacrumbs` is deprecated, and no replacement is given, it will become an internal method.
+- `buildBreadcrumbs` is deprecated, and no replacement is given, it will become an internal method.
 - `getBreadcrumbs` is deprecated in favor of the homonym method of the `sonata.admin.breadcrumbs_builder` service.
 - The breadcrumbs builder accessors are deprecated,
 the `sonata.admin.breadcrumbs_builder` service should be used directly instead.


### PR DESCRIPTION
## Just a typo in a .md file

Changing "buildBreacrumbs" for "buildBreadcrumbs" in UPGRADE-3.x.md

I am targeting 3.x branch, because it is the branch with this typo

Closes nothing

No changelog
