### PR TITLE
fix issue 7268 by checking Symfony form type inheritance

### DIFF
--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -2877,7 +2877,8 @@ class AdminTest extends TestCase
     {
         $this->expectNotToPerformAssertions();
 
-        $formFactory = new FormFactory(new FormRegistry([], new ResolvedFormTypeFactory()));
+        $registry = new FormRegistry([], new ResolvedFormTypeFactory());
+        $formFactory = new FormFactory($registry);
         $modelManager = $this->createStub(ModelManagerInterface::class);
         $modelManager
             ->method('getDefaultSortValues')
@@ -2888,7 +2889,7 @@ class AdminTest extends TestCase
 
         $admin->setModelManager($modelManager);
 
-        $admin->setFormContractor(new FormContractor($formFactory));
+        $admin->setFormContractor(new FormContractor($formFactory, $registry));
 
         $admin->setShowBuilder(new ShowBuilder());
 

--- a/tests/App/config/services.yml
+++ b/tests/App/config/services.yml
@@ -16,6 +16,7 @@ services:
         class: Sonata\AdminBundle\Tests\App\Builder\FormContractor
         arguments:
             - '@form.factory'
+            - '@form.registry'
 
     sonata.admin.builder.test_show:
         class: Sonata\AdminBundle\Tests\App\Builder\ShowBuilder

--- a/tests/Builder/AbstractFormContractorTest.php
+++ b/tests/Builder/AbstractFormContractorTest.php
@@ -58,12 +58,12 @@ final class AbstractFormContractorTest extends TestCase
             ->getMockForAbstractClass();
 
         $this->formFactory = $this->createMock(FormFactoryInterface::class);
-        $formRegistry = $this->createMock(FormRegistryInterface::class);
+        $formRegistry = $this->createStub(FormRegistryInterface::class);
         $formRegistry->method('getType')->willReturnCallback(function (string $type) {
-            $resolvedType = $this->createMock(ResolvedFormTypeInterface::class);
+            $resolvedType = $this->createStub(ResolvedFormTypeInterface::class);
             if ('MyCustomType' === $type) {
-                $parentType = $this->createMock(ResolvedFormTypeInterface::class);
-                $parentType->method('getInnerType')->willReturn(new ModelType($this->createMock(PropertyAccessor::class)));
+                $parentType = $this->createStub(ResolvedFormTypeInterface::class);
+                $parentType->method('getInnerType')->willReturn(new ModelType($this->createStub(PropertyAccessor::class)));
                 $resolvedType->method('getParent')->willReturn($parentType);
             }
 

--- a/tests/Builder/AbstractFormContractorTest.php
+++ b/tests/Builder/AbstractFormContractorTest.php
@@ -27,6 +27,9 @@ use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\Form\Type\CollectionType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\Form\FormRegistryInterface;
+use Symfony\Component\Form\ResolvedFormTypeInterface;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
 
 final class AbstractFormContractorTest extends TestCase
 {
@@ -55,8 +58,19 @@ final class AbstractFormContractorTest extends TestCase
             ->getMockForAbstractClass();
 
         $this->formFactory = $this->createMock(FormFactoryInterface::class);
+        $formRegistry = $this->createMock(FormRegistryInterface::class);
+        $formRegistry->method('getType')->willReturnCallback(function (string $type) {
+            $resolvedType = $this->createMock(ResolvedFormTypeInterface::class);
+            if ('MyCustomType' === $type) {
+                $parentType = $this->createMock(ResolvedFormTypeInterface::class);
+                $parentType->method('getInnerType')->willReturn(new ModelType($this->createMock(PropertyAccessor::class)));
+                $resolvedType->method('getParent')->willReturn($parentType);
+            }
 
-        $this->formContractor = new class($this->formFactory) extends AbstractFormContractor {
+            return $resolvedType;
+        });
+
+        $this->formContractor = new class($this->formFactory, $formRegistry) extends AbstractFormContractor {
             protected function hasAssociation(FieldDescriptionInterface $fieldDescription): bool
             {
                 return $fieldDescription->describesAssociation();
@@ -98,6 +112,7 @@ final class AbstractFormContractorTest extends TestCase
             ModelListType::class,
             ModelHiddenType::class,
             ModelAutocompleteType::class,
+            'MyCustomType',
         ];
         $adminTypes = [
             AdminType::class,
@@ -127,7 +142,7 @@ final class AbstractFormContractorTest extends TestCase
         }
 
         // collection type
-        foreach ($collectionTypes as $index => $formType) {
+        foreach ($collectionTypes as $formType) {
             $options = $this->formContractor->getDefaultOptions($formType, $this->fieldDescription, [
                 'by_reference' => false,
             ]);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

This fixes issue https://github.com/sonata-project/SonataAdminBundle/issues/7268 by resolving parent form types 

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataAdminBundle/issues/7268

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Deprecated
- not passing argument 2 of `Symfony\Component\Form\FormRegistryInterface` to `AbstractFormContractor::__construct`

### Fixed
- default options are added correctly to form types that use the Symfony way of extending Sonata's default types
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] fix the service definitions on the persistence bundles 
-->
