### PR TITLE
[Doc] Fix minor RST syntax issue

### DIFF
--- a/docs/reference/security.rst
+++ b/docs/reference/security.rst
@@ -144,9 +144,9 @@ The role name will be based on the name of your admin service.
 ========================   ======================================================
 Service name               Role name
 ========================   ======================================================
-app.admin.foo              ROLE_APP_ADMIN_FOO_{PERMISSION}
-my.blog.admin.foo_bar      ROLE_MY_BLOG_ADMIN_FOO_BAR_{PERMISSION}
-App\\Admin\\FooAdmin       ROLE_APP\\ADMIN\\FOOADMIN_{PERMISSION}
+app.admin.foo              ``ROLE_APP_ADMIN_FOO_{PERMISSION}``
+my.blog.admin.foo_bar      ``ROLE_MY_BLOG_ADMIN_FOO_BAR_{PERMISSION}``
+App\\Admin\\FooAdmin       ``ROLE_APP\\ADMIN\\FOOADMIN_{PERMISSION}``
 ========================   ======================================================
 
 .. note::


### PR DESCRIPTION
## Subject

Fix some minor issues related to RST syntax.

### Fixed

These errors showed when building Sonata docs. It's because RST is very strict with links/references, which use the `_` (e.g. `ROLE_APP_ADMIN_FOO_{PERMISSION}` is considered like a link `ROLE_APP_ADMIN_FOO_` followed by some text `{PERMISSION}`)

```
/!\ Found invalid reference "ROLE_APP_ADMIN_FOO" in file "reference/security"
/!\ Found invalid reference "ROLE_MY_BLOG_ADMIN_FOO_BAR" in file "reference/security"
```