### PR TITLE
Easier way to override button

### DIFF
--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -97,45 +97,62 @@
                         {% if objectId|default(admin.id(object)) is not null %}
                             <button type="submit" class="btn btn-success" name="btn_update"><i class="fa fa-save" aria-hidden="true"></i> {{ 'btn_update'|trans({}, 'SonataAdminBundle') }}</button>
                             {% if admin.hasRoute('delete') and admin.hasAccess('delete', object) %}
-                                {{ 'delete_or'|trans({}, 'SonataAdminBundle') }}
-                                <a class="btn btn-danger" href="{{ admin.generateObjectUrl('delete', object) }}">
-                                    <i class="fa fa-minus-circle" aria-hidden="true"></i> {{ 'link_delete'|trans({}, 'SonataAdminBundle') }}
-                                </a>
+                                {% block btn_delete %}
+                                    {{ 'delete_or'|trans({}, 'SonataAdminBundle') }}
+                                    <a class="btn btn-danger" href="{{ admin.generateObjectUrl('delete', object) }}">
+                                        <i class="fa fa-minus-circle" aria-hidden="true"></i> {{ 'link_delete'|trans({}, 'SonataAdminBundle') }}
+                                    </a>
+                                {% endblock %}
                             {% endif %}
                         {% else %}
-                            <button type="submit" class="btn btn-success" name="btn_create"><i class="fa fa-plus-circle" aria-hidden="true"></i> {{ 'btn_create'|trans({}, 'SonataAdminBundle') }}</button>
+                            {% block btn_create %}
+                                <button type="submit" class="btn btn-success" name="btn_create"><i class="fa fa-plus-circle" aria-hidden="true"></i> {{ 'btn_create'|trans({}, 'SonataAdminBundle') }}</button>
+                            {% endblock %}
                         {% endif %}
                     {% else %}
                         {% if admin.supportsPreviewMode %}
-                            <button class="btn btn-info persist-preview" name="btn_preview" type="submit">
-                                <i class="fa fa-eye" aria-hidden="true"></i>
-                                {{ 'btn_preview'|trans({}, 'SonataAdminBundle') }}
-                            </button>
+                            {% block btn_preview %}
+                                <button class="btn btn-info persist-preview" name="btn_preview" type="submit">
+                                    <i class="fa fa-eye" aria-hidden="true"></i>
+                                    {{ 'btn_preview'|trans({}, 'SonataAdminBundle') }}
+                                </button>
+                            {% endblock %}
                         {% endif %}
                         {# NEXT_MAJOR: remove default filter #}
                         {% if objectId|default(admin.id(object)) is not null %}
-                            <button type="submit" class="btn btn-success" name="btn_update_and_edit"><i class="fa fa-save" aria-hidden="true"></i> {{ 'btn_update_and_edit_again'|trans({}, 'SonataAdminBundle') }}</button>
+                            {% block btn_update_and_edit %}
+                                <button type="submit" class="btn btn-success" name="btn_update_and_edit"><i class="fa fa-save" aria-hidden="true"></i> {{ 'btn_update_and_edit_again'|trans({}, 'SonataAdminBundle') }}</button>
+                            {% endblock %}
 
                             {% if admin.hasRoute('list') and admin.hasAccess('list') %}
-                                <button type="submit" class="btn btn-success" name="btn_update_and_list"><i class="fa fa-save"></i> <i class="fa fa-list" aria-hidden="true"></i> {{ 'btn_update_and_return_to_list'|trans({}, 'SonataAdminBundle') }}</button>
+                                {% block btn_update_and_list %}
+                                    <button type="submit" class="btn btn-success" name="btn_update_and_list"><i class="fa fa-save"></i> <i class="fa fa-list" aria-hidden="true"></i> {{ 'btn_update_and_return_to_list'|trans({}, 'SonataAdminBundle') }}</button>
+                                {% endblock %}
                             {% endif %}
 
                             {% if admin.hasRoute('delete') and admin.hasAccess('delete', object) %}
-                                {{ 'delete_or'|trans({}, 'SonataAdminBundle') }}
-                                <a class="btn btn-danger" href="{{ admin.generateObjectUrl('delete', object) }}"><i class="fa fa-minus-circle" aria-hidden="true"></i> {{ 'link_delete'|trans({}, 'SonataAdminBundle') }}</a>
+                                {{ block('btn_delete') }}
                             {% endif %}
 
                             {% if admin.isAclEnabled() and admin.hasRoute('acl') and admin.hasAccess('acl', object) %}
-                                <a class="btn btn-info" href="{{ admin.generateObjectUrl('acl', object) }}"><i class="fa fa-users" aria-hidden="true"></i> {{ 'link_edit_acl'|trans({}, 'SonataAdminBundle') }}</a>
+                                {% block btn_acl %}
+                                    <a class="btn btn-info" href="{{ admin.generateObjectUrl('acl', object) }}"><i class="fa fa-users" aria-hidden="true"></i> {{ 'link_edit_acl'|trans({}, 'SonataAdminBundle') }}</a>
+                                {% endblock %}
                             {% endif %}
                         {% else %}
                             {% if admin.hasroute('edit') and admin.hasAccess('edit') %}
-                                <button class="btn btn-success" type="submit" name="btn_create_and_edit"><i class="fa fa-save" aria-hidden="true"></i> {{ 'btn_create_and_edit_again'|trans({}, 'SonataAdminBundle') }}</button>
+                                {% block btn_create_and_edit %}
+                                    <button class="btn btn-success" type="submit" name="btn_create_and_edit"><i class="fa fa-save" aria-hidden="true"></i> {{ 'btn_create_and_edit_again'|trans({}, 'SonataAdminBundle') }}</button>
+                                {% endblock %}
                             {% endif %}
                             {% if admin.hasroute('list') and admin.hasAccess('list') %}
-                                <button type="submit" class="btn btn-success" name="btn_create_and_list"><i class="fa fa-save"></i> <i class="fa fa-list" aria-hidden="true"></i> {{ 'btn_create_and_return_to_list'|trans({}, 'SonataAdminBundle') }}</button>
+                                {% block btn_create_and_list %}
+                                    <button type="submit" class="btn btn-success" name="btn_create_and_list"><i class="fa fa-save"></i> <i class="fa fa-list" aria-hidden="true"></i> {{ 'btn_create_and_return_to_list'|trans({}, 'SonataAdminBundle') }}</button>
+                                {% endblock %}
                             {% endif %}
-                            <button class="btn btn-success" type="submit" name="btn_create_and_create"><i class="fa fa-plus-circle" aria-hidden="true"></i> {{ 'btn_create_and_create_a_new_one'|trans({}, 'SonataAdminBundle') }}</button>
+                            {% block btn_create_and_create %}
+                                <button class="btn btn-success" type="submit" name="btn_create_and_create"><i class="fa fa-plus-circle" aria-hidden="true"></i> {{ 'btn_create_and_create_a_new_one'|trans({}, 'SonataAdminBundle') }}</button>
+                            {% endblock %}
                         {% endif %}
                     {% endif %}
                 {% endblock %}


### PR DESCRIPTION
## Subject

I am targeting this branch, because BC.

When you want to override a button label, or changing some design, you currently have to override the whole form actions, and copy paste all the logic.

With these new blocks, you can now override only one button without taking care bout the logic behind.
WDYT ?

## Changelog
<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- New `block` twig in order to override the button display by the admin in the base_edit_form.
```