### PR TITLE
Stop using response_item_callback param 3 as reference

### DIFF
--- a/docs/reference/form_types.rst
+++ b/docs/reference/form_types.rst
@@ -321,8 +321,11 @@ The available options are:
     $formMapper
         ->add('category', ModelAutocompleteType::class, [
             'property' => 'title',
-            'response_item_callback' => function ($admin, $entity, &$item) {
+            'response_item_callback' => function (AdminInterface $admin, object $entity, array $item): array {
                 $item['type'] = $entity->getType();
+
+                return $item;
+
             },
         ])
     ;

--- a/docs/reference/form_types.rst
+++ b/docs/reference/form_types.rst
@@ -325,7 +325,6 @@ The available options are:
                 $item['type'] = $entity->getType();
 
                 return $item;
-
             },
         ])
     ;

--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -225,7 +225,7 @@ final class RetrieveAutocompleteItemsAction
             ];
 
             if (\is_callable($responseItemCallback)) {
-                \call_user_func($responseItemCallback, $admin, $model, $item);
+                $item = \call_user_func($responseItemCallback, $admin, $model, $item);
             }
 
             $items[] = $item;

--- a/tests/Action/RetrieveAutocompleteItemsActionTest.php
+++ b/tests/Action/RetrieveAutocompleteItemsActionTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Action\GetShortObjectDescriptionAction;
 use Sonata\AdminBundle\Action\RetrieveAutocompleteItemsAction;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Datagrid\PagerInterface;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
@@ -201,7 +202,7 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('application/json', $response->headers->get('Content-Type'));
-        $this->assertSame('{"status":"OK","more":false,"items":[{"id":123,"label":"FOO"}]}', $response->getContent());
+        $this->assertSame('{"status":"OK","more":false,"items":[{"id":123,"label":"FOO","foo":"bar"}]}', $response->getContent());
     }
 
     public function testRetrieveAutocompleteItemsComplexProperty(): void
@@ -332,7 +333,11 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
             ['items_per_page', null, 10],
             ['req_param_name_page_number', null, DatagridInterface::PAGE],
             ['target_admin_access_action', null, 'list'],
-            ['response_item_callback', null, null],
+            ['response_item_callback', null, static function (AdminInterface $admin, object $model, array $item): array {
+                $item['foo'] = 'bar';
+
+                return $item;
+            }],
         ]);
     }
 }


### PR DESCRIPTION
## Subject

I am targeting this branch, because it's a BC-break but since it can't work like this, we can consider this as a bugfix.

Closes #7298.

## Changelog
```markdown
### Changed
- `response_item_callback` callback signature.

### Fixed
- `response_item_callback` option of ModelAutocompleteFilter.
```