### PR TITLE
Add defined check for translation_domain property

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_one_to_many_inline_tabs.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many_inline_tabs.html.twig
@@ -20,7 +20,7 @@ file that was distributed with this source code.
                                 data-toggle="tab"
                             >
                                 <i class="icon-exclamation-sign has-errors hide"></i>
-                                {% if form_group.translation_domain is same as(false) %}
+                                {% if form_group.translation_domain is defined and form_group.translation_domain is same as(false) %}
                                     {{ form_group.label }}
                                 {% else %}
                                     {{ form_group.label|trans({}, form_group.translation_domain ?? associationAdmin.translationDomain) }}

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -43,7 +43,7 @@
                                     <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (tab_query_index == loop.index) %} class="active"{% endif %}>
                                         <a href="#{{ _tab_name }}" class="changer-tab" aria-controls="{{ _tab_name }}" data-toggle="tab">
                                             <i class="fa fa-exclamation-circle has-errors hide" aria-hidden="true"></i>
-                                            {% if form_tab.translation_domain is same as(false) %}
+                                            {% if form_tab.translation_domain is defined and form_tab.translation_domain is same as(false) %}
                                                 {{ form_tab.label }}
                                             {% else %}
                                                 {{ form_tab.label|trans({}, form_tab.translation_domain ?? admin.translationDomain) }}
@@ -62,7 +62,7 @@
                                         <div class="box-body  container-fluid">
                                             <div class="sonata-ba-collapsed-fields">
                                                 {% if form_tab.description != false %}
-                                                    {% if form_tab.translation_domain is same as(false) %}
+                                                    {% if form_tab.translation_domain is defined and form_tab.translation_domain is same as(false) %}
                                                         <p>{{ form_tab.description|raw }}</p>
                                                     {% else %}
                                                         <p>{{ form_tab.description|trans({}, form_tab.translation_domain ?? admin.translationDomain)|raw }}</p>

--- a/src/Resources/views/CRUD/base_edit_form_macro.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form_macro.html.twig
@@ -8,7 +8,7 @@
             <div class="{{ form_group.box_class }}">
                 <div class="box-header">
                     <h4 class="box-title">
-                        {% if form_group.translation_domain is same as(false) %}
+                        {% if form_group.translation_domain is defined and form_group.translation_domain is same as(false) %}
                             {{ form_group.label }}
                         {% else %}
                             {{ form_group.label|trans({}, form_group.translation_domain ?? admin.translationDomain) }}
@@ -18,7 +18,7 @@
                 <div class="box-body">
                     <div class="sonata-ba-collapsed-fields">
                         {% if form_group.description %}
-                            {% if form_group.translation_domain is same as(false) %}
+                            {% if form_group.translation_domain is defined and form_group.translation_domain is same as(false) %}
                                 <p>{{ form_group.description|raw }}</p>
                             {% else %}
                                 <p>{{ form_group.description|trans({}, form_group.translation_domain ?? admin.translationDomain)|raw }}</p>
@@ -29,7 +29,7 @@
                             {{ form_row(form[field_name]) }}
                         {% else %}
                             {% if form_group.empty_message != false %}
-                                {% if form_group.empty_message_translation_domain is same as(false) %}
+                                {% if form_group.empty_message_translation_domain is defined and form_group.empty_message_translation_domain is same as(false) %}
                                     <em>{{ form_group.empty_message }}</em>
                                 {% else %}
                                     <em>{{ form_group.empty_message|trans({}, form_group.empty_message_translation_domain ?? admin.translationDomain) }}</em>

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -190,7 +190,7 @@ file that was distributed with this source code.
                                             <select name="action" style="width: auto; height: auto" class="form-control">
                                                 {% for action, options in batchactions %}
                                                     <option value="{{ action }}">
-                                                        {% if options.translation_domain is same as(false) %}
+                                                        {% if options.translation_domain is defined and options.translation_domain is same as(false) %}
                                                             {{ options.label }}
                                                         {% else %}
                                                             {{ options.label|trans({}, options.translation_domain ?? admin.translationDomain) }}

--- a/src/Resources/views/CRUD/base_show.html.twig
+++ b/src/Resources/views/CRUD/base_show.html.twig
@@ -48,7 +48,7 @@ file that was distributed with this source code.
                         {% set _tab_name = tab_prefix ~ '_' ~ loop.index %}
                         <li{% if (not app.request.query.has('_tab') and loop.index == 1) or (tab_query_index == loop.index) %} class="active"{% endif %}>
                             <a href="#{{ _tab_name }}" class="changer-tab" aria-controls="{{ _tab_name }}" data-toggle="tab">
-                                {% if show_tab.translation_domain is same as(false) %}
+                                {% if show_tab.translation_domain is defined and show_tab.translation_domain is same as(false) %}
                                     {{ show_tab.label }}
                                 {% else %}
                                     {{ show_tab.label|trans({}, show_tab.translation_domain ?? admin.translationDomain) }}
@@ -100,7 +100,7 @@ file that was distributed with this source code.
                         <div class="box-header">
                             <h4 class="box-title">
                                 {% block show_title %}
-                                    {% if show_group.translation_domain is same as(false) %}
+                                    {% if show_group.translation_domain is defined and show_group.translation_domain is same as(false) %}
                                         {{ show_group.label }}
                                     {% else %}
                                         {{ show_group.label|trans({}, show_group.translation_domain ?? admin.translationDomain) }}

--- a/src/Resources/views/CRUD/base_show_macro.html.twig
+++ b/src/Resources/views/CRUD/base_show_macro.html.twig
@@ -15,7 +15,7 @@
                 <div class="box-header">
                     <h4 class="box-title">
                         {% block show_title %}
-                            {% if show_group.translation_domain is same as(false) %}
+                            {% if show_group.translation_domain is defined and show_group.translation_domain is same as(false) %}
                                 {{ show_group.label }}
                             {% else %}
                                 {{ show_group.label|trans({}, show_group.translation_domain ?? admin.translationDomain) }}

--- a/src/Resources/views/CRUD/dashboard__action.html.twig
+++ b/src/Resources/views/CRUD/dashboard__action.html.twig
@@ -1,6 +1,6 @@
 <a class="btn btn-link btn-flat" href="{{ action.url }}">
     {{ action.icon|parse_icon }}
-    {% if action.translation_domain is same as(false) %}
+    {% if action.translation_domain is defined and action.translation_domain is same as(false) %}
         {{ action.label }}
     {% else %}
         {{ action.label|trans({}, action.translation_domain|default('SonataAdminBundle')) }}

--- a/src/Resources/views/CRUD/dashboard__action_create.html.twig
+++ b/src/Resources/views/CRUD/dashboard__action_create.html.twig
@@ -1,7 +1,7 @@
 {% if admin.subClasses is empty %}
     <a class="btn btn-link btn-flat" href="{{ action.url }}">
         {{ action.icon|parse_icon }}
-        {% if action.translation_domain is same as(false) %}
+        {% if action.translation_domain is defined and action.translation_domain is same as(false) %}
             {{ action.label }}
         {% else %}
             {{ action.label|trans({}, action.translation_domain|default('SonataAdminBundle')) }}
@@ -10,7 +10,7 @@
 {% else %}
     <a class="btn btn-link btn-flat dropdown-toggle" data-toggle="dropdown" href="#">
         {{ action.icon|parse_icon }}
-        {% if action.translation_domain is same as(false) %}
+        {% if action.translation_domain is defined and action.translation_domain is same as(false) %}
             {{ action.label }}
         {% else %}
             {{ action.label|trans({}, action.translation_domain|default('SonataAdminBundle')) }}
@@ -21,7 +21,7 @@
         {% for subclass in admin.subclasses|keys %}
             <li>
                 <a href="{{ admin.generateUrl('create', {'subclass': subclass}) }}">
-                    {% if action.translation_domain is same as(false) %}
+                    {% if action.translation_domain is defined and action.translation_domain is same as(false) %}
                         {{ subclass }}
                     {% else %}
                         {{ subclass|trans({}, action.translation_domain|default('SonataAdminBundle')) }}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I added the `is defined` check every time it's not a getter, (and we have a `??` check in the next line).

Close #7324
Close #7318

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Accessing on non existent array keys `translation_domain`
```