### PR TITLE
Fix phpdoc

### DIFF
--- a/src/Command/QuestionableCommand.php
+++ b/src/Command/QuestionableCommand.php
@@ -52,7 +52,7 @@ abstract class QuestionableCommand extends Command
      *
      * NEXT_MAJOR: Remove `$separator` argument
      *
-     * @return string
+     * @return bool
      */
     final protected function askConfirmation(
         InputInterface $input,


### PR DESCRIPTION
## Subject

When running phpstan-strict on master, I have an issue because we're using the `askConfirmation` return value as a boolean.
The phpdoc is saying string but I think it's a boolean instead.

Pedantic I would say.