### PR TITLE
Fix static analysis

### DIFF
--- a/src/FieldDescription/FieldDescriptionInterface.php
+++ b/src/FieldDescription/FieldDescriptionInterface.php
@@ -19,7 +19,7 @@ use Sonata\AdminBundle\Exception\NoValueException;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
- * @phpstan-type FieldDescriptionOptions = array{
+ * @psalm-type FieldDescriptionOptions = array{
  *  accessor?: string|callable|\Symfony\Component\PropertyAccess\PropertyPathInterface,
  *  associated_property?: string|callable|\Symfony\Component\PropertyAccess\PropertyPathInterface,
  *  label?: string|false|null,
@@ -33,6 +33,7 @@ use Sonata\AdminBundle\Exception\NoValueException;
  *  type?: string,
  *  virtual_field?: bool
  * }&array<string, mixed>
+ * @phpstan-type FieldDescriptionOptions = array<string, mixed>
  */
 interface FieldDescriptionInterface
 {

--- a/tests/Menu/Provider/GroupMenuProviderTest.php
+++ b/tests/Menu/Provider/GroupMenuProviderTest.php
@@ -118,10 +118,12 @@ final class GroupMenuProviderTest extends TestCase
         self::assertCount(1, $children);
         self::assertArrayHasKey('foo_admin_label', $children);
         self::assertArrayNotHasKey('route_label', $children);
-        self::assertInstanceOf(MenuItem::class, $menu['foo_admin_label']);
-        self::assertSame('foo_admin_label', $menu['foo_admin_label']->getLabel());
 
-        $extras = $menu['foo_admin_label']->getExtras();
+        $item = $menu['foo_admin_label'];
+        self::assertInstanceOf(MenuItem::class, $item);
+        self::assertSame('foo_admin_label', $item->getLabel());
+
+        $extras = $item->getExtras();
         self::assertArrayHasKey('label_catalogue', $extras);
         self::assertSame($extras['label_catalogue'], 'SonataAdminBundle');
     }
@@ -244,10 +246,12 @@ final class GroupMenuProviderTest extends TestCase
         self::assertCount(3, $children);
         self::assertArrayHasKey('foo_admin_label', $children);
         self::assertArrayHasKey('route_label', $children);
-        self::assertInstanceOf(MenuItem::class, $menu['foo_admin_label']);
-        self::assertSame('foo_admin_label', $menu['foo_admin_label']->getLabel());
 
-        $extras = $menu['foo_admin_label']->getExtras();
+        $item = $menu['foo_admin_label'];
+        self::assertInstanceOf(MenuItem::class, $item);
+        self::assertSame('foo_admin_label', $item->getLabel());
+
+        $extras = $item->getExtras();
         self::assertArrayHasKey('label_catalogue', $extras);
         self::assertSame('SonataAdminBundle', $extras['label_catalogue']);
 


### PR DESCRIPTION
phpstan doesn't support `array{foo: bar}&array<string, mixed>`