### PR TITLE
Make getPreviousFilter non nullable to be consistent

### DIFF
--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -217,8 +217,13 @@ abstract class Filter implements FilterInterface, ChainableFilterInterface
         $this->previousFilter = $filter;
     }
 
-    final public function getPreviousFilter(): ?FilterInterface
+    final public function getPreviousFilter(): FilterInterface
     {
+        if (!$this->hasPreviousFilter()) {
+            throw new \LogicException(sprintf('Filter "%s" has no previous filter.', $this->getName()));
+        }
+        \assert(null !== $this->previousFilter);
+
         return $this->previousFilter;
     }
 

--- a/src/Search/ChainableFilterInterface.php
+++ b/src/Search/ChainableFilterInterface.php
@@ -22,7 +22,7 @@ interface ChainableFilterInterface
 {
     public function setPreviousFilter(FilterInterface $filter): void;
 
-    public function getPreviousFilter(): ?FilterInterface;
+    public function getPreviousFilter(): FilterInterface;
 
     public function hasPreviousFilter(): bool;
 }


### PR DESCRIPTION
This is consistent with all the getter with hasser of the admin.

And solve static analysis issue from https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1483