### PR TITLE
Make DeleteAction compatible with POST action

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -187,7 +187,7 @@ class CRUDController extends AbstractController
             return $preResponse;
         }
 
-        if (Request::METHOD_DELETE === $request->getMethod()) {
+        if (in_array($request->getMethod(), [Request::METHOD_POST, Request::METHOD_DELETE], true)) {
             // check the csrf token
             $this->validateCsrfToken($request, 'sonata.delete');
 
@@ -1026,7 +1026,7 @@ class CRUDController extends AbstractController
             return new RedirectResponse($this->admin->generateUrl('create', $params));
         }
 
-        if ('DELETE' === $request->getMethod()) {
+        if (null !== $request->get('btn_delete')) {
             return $this->redirectToList();
         }
 

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -187,7 +187,7 @@ class CRUDController extends AbstractController
             return $preResponse;
         }
 
-        if (in_array($request->getMethod(), [Request::METHOD_POST, Request::METHOD_DELETE], true)) {
+        if (\in_array($request->getMethod(), [Request::METHOD_POST, Request::METHOD_DELETE], true)) {
             // check the csrf token
             $this->validateCsrfToken($request, 'sonata.delete');
 

--- a/src/Resources/views/CRUD/delete.html.twig
+++ b/src/Resources/views/CRUD/delete.html.twig
@@ -37,7 +37,7 @@ file that was distributed with this source code.
                     <input type="hidden" name="_method" value="DELETE">
                     <input type="hidden" name="_sonata_csrf_token" value="{{ csrf_token }}">
 
-                    <button type="submit" class="btn btn-danger"><i class="fas fa-trash-alt" aria-hidden="true"></i> {{ 'btn_delete'|trans({}, 'SonataAdminBundle') }}</button>
+                    <button type="submit" name=btn_delete class="btn btn-danger"><i class="fas fa-trash-alt" aria-hidden="true"></i> {{ 'btn_delete'|trans({}, 'SonataAdminBundle') }}</button>
                     {% if admin.hasRoute('edit') and admin.hasAccess('edit', object) %}
                         {{ 'delete_or'|trans({}, 'SonataAdminBundle') }}
 

--- a/src/Resources/views/CRUD/delete.html.twig
+++ b/src/Resources/views/CRUD/delete.html.twig
@@ -37,7 +37,7 @@ file that was distributed with this source code.
                     <input type="hidden" name="_method" value="DELETE">
                     <input type="hidden" name="_sonata_csrf_token" value="{{ csrf_token }}">
 
-                    <button type="submit" name=btn_delete class="btn btn-danger"><i class="fas fa-trash-alt" aria-hidden="true"></i> {{ 'btn_delete'|trans({}, 'SonataAdminBundle') }}</button>
+                    <button type="submit" name="btn_delete" class="btn btn-danger"><i class="fas fa-trash-alt" aria-hidden="true"></i> {{ 'btn_delete'|trans({}, 'SonataAdminBundle') }}</button>
                     {% if admin.hasRoute('edit') and admin.hasAccess('edit', object) %}
                         {{ 'delete_or'|trans({}, 'SonataAdminBundle') }}
 

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -1256,6 +1256,41 @@ final class CRUDControllerTest extends TestCase
     /**
      * @dataProvider getToStringValues
      */
+    public function testDeleteActionSuccess3(string $expectedToStringValue, string $toStringValue): void
+    {
+        $this->request->attributes->set($this->admin->getIdParameter(), 21);
+
+        $object = new \stdClass();
+
+        $this->admin->expects(self::atLeastOnce())
+            ->method('getObject')
+            ->willReturn($object);
+
+        $this->admin->expects(self::once())
+            ->method('checkAccess')
+            ->with(self::equalTo('delete'));
+
+        $this->admin->expects(self::once())
+            ->method('toString')
+            ->with(self::equalTo($object))
+            ->willReturn($toStringValue);
+
+        $this->expectTranslate('flash_delete_success', ['%name%' => $expectedToStringValue], 'SonataAdminBundle');
+
+        $this->request->setMethod(Request::METHOD_POST);
+
+        $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.delete');
+
+        $response = $this->controller->deleteAction($this->request);
+
+        self::assertInstanceOf(RedirectResponse::class, $response);
+        self::assertSame(['flash_delete_success'], $this->session->getFlashBag()->get('sonata_flash_success'));
+        self::assertSame('list', $response->getTargetUrl());
+    }
+
+    /**
+     * @dataProvider getToStringValues
+     */
     public function testDeleteActionSuccessNoCsrfTokenProvider(string $expectedToStringValue, string $toStringValue): void
     {
         $this->request->attributes->set($this->admin->getIdParameter(), 21);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

The `redirectTo` method rely on the name of the button, so I did the same for the deleteAction.
For the check on the request method, I added `POST` to support project without `http_override_method`.

Closes #7346.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Support for POST request to deleteAction.
```