### PR TITLE
fix select2 placeholder html

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -229,7 +229,7 @@ file that was distributed with this source code.
                         {% endif %}
                     {% endif %}
                 </option>
-            {% elseif placeholder is defined and placeholder is not none and not use_select2 %}
+            {% elseif placeholder is defined and placeholder is not none %}
                 <option value=""{% if required and value is empty %} selected="selected"{% endif %}>{{ data_placeholder }}</option>
             {% endif %}
             {% if preferred_choices|length > 0 %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

I'm testing v4/master on one of my apps and I noticed that https://github.com/sonata-project/SonataAdminBundle/pull/7330 broke some select2 choice fields for me.

For example I have this field:

```php
->add('planDiscount', ChoiceType::class, [
    'label' => 'Discount',
    'choices' => [
        '10% (for two packages purchased)' => 10,
        '15% (for three packages purchased)' => 15,
    ],
    'required' => false,
    'placeholder' => 'no discount',
])
```
Without this fix the empty option is not available and on page load always the first value is selected although on the persisted model its an empty value. 

I tested it and for me it works fine now.

On page load with empty value on model:
![after1](https://user-images.githubusercontent.com/921145/126995133-fe7ac9a1-0765-4159-8809-591cd939d3ae.png)

On page load with 10% persisted on model:
![after](https://user-images.githubusercontent.com/921145/126995320-c9b701b1-b63e-48a2-a7c0-c701b8906da7.png)

ping @willemverspyck does this look good to you?

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its a bugfix for master that does not affect 3.x.

Related to https://github.com/sonata-project/SonataAdminBundle/pull/7330

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- fixed behavior of placeholder (empty value) for select2 choice fields
```