### PR TITLE
Add `default` parameter to getPersistentParameter

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1495,11 +1495,11 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $parameters;
     }
 
-    final public function getPersistentParameter(string $name)
+    final public function getPersistentParameter(string $name, $default = null)
     {
         $parameters = $this->getPersistentParameters();
 
-        return $parameters[$name] ?? null;
+        return $parameters[$name] ?? $default;
     }
 
     final public function setCurrentChild(bool $currentChild): void

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -418,9 +418,11 @@ interface AdminInterface extends TaggedAdminInterface, AccessRegistryInterface, 
     public function getPersistentParameters(): array;
 
     /**
+     * @param mixed $default
+     *
      * @return mixed
      */
-    public function getPersistentParameter(string $name);
+    public function getPersistentParameter(string $name, $default = null);
 
     /**
      * Set the current child status.

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1376,11 +1376,20 @@ final class AdminTest extends TestCase
         $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
 
         $extension = $this->createMock(AdminExtensionInterface::class);
-        $extension->expects(self::once())->method('configurePersistentParameters')->willReturn($expected);
+        $extension->method('configurePersistentParameters')->willReturn($expected);
 
         $admin->addExtension($extension);
 
         self::assertSame($expected, $admin->getPersistentParameters());
+        self::assertSame('foobar', $admin->getPersistentParameter('context'));
+    }
+
+    public function testGetPersistentParameterDefaultValue(): void
+    {
+        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+
+        self::assertNull($admin->getPersistentParameter('foo'));
+        self::assertSame('bar', $admin->getPersistentParameter('foo', 'bar'));
     }
 
     public function testGetNewInstanceForChildAdminWithParentValue(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because BC-break.

This way the signature is more similar to the request.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added second parameter to `AdminInterface::getPersistentParameter()`
```