### PR TITLE
Fix RetrieveAutocompleteItemsAction for multiple properties

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -133,6 +133,24 @@ parameters:
             path: src/Form/FormMapper.php
 
         -
+            # will be fixed in v4. Currently BC break
+            message: "#^Method Sonata\\\\BlockBundle\\\\Block\\\\Service\\\\AbstractBlockService\\:\\:__construct\\(\\) invoked with 2 parameters, 1 required\\.$#"
+            count: 1
+            path: src/Block/AdminListBlockService.php
+
+        -
+            # will be fixed in v4. Currently BC break
+            message: "#^Method Sonata\\\\BlockBundle\\\\Block\\\\Service\\\\AbstractBlockService\\:\\:__construct\\(\\) invoked with 2 parameters, 1 required\\.$#"
+            count: 1
+            path: src/Block/AdminSearchBlockService.php
+
+        -
+            # will be fixed in v4. Currently BC break
+            message: "#^Method Sonata\\\\BlockBundle\\\\Block\\\\Service\\\\AbstractBlockService\\:\\:__construct\\(\\) invoked with 2 parameters, 1 required\\.$#"
+            count: 1
+            path: src/Block/AdminStatsBlockService.php
+
+        -
             # will be fixed in v4. The file won't exist
             message: "#^Call to static method load\\(\\) on an unknown class Symfony\\\\Component\\\\ClassLoader\\\\ClassCollectionLoader\\.$#"
             count: 1

--- a/tests/Action/RetrieveAutocompleteItemsActionTest.php
+++ b/tests/Action/RetrieveAutocompleteItemsActionTest.php
@@ -23,6 +23,7 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Datagrid\PagerInterface;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
+use Sonata\AdminBundle\Filter\Filter;
 use Sonata\AdminBundle\Object\MetadataInterface;
 use Sonata\AdminBundle\Request\AdminFetcherInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Filter\FooFilter;
@@ -199,6 +200,11 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         );
 
         $response = ($this->action)($request);
+
+        self::assertSame(Filter::CONDITION_OR, $filter->getCondition());
+        self::assertNull($filter->getPreviousFilter());
+        self::assertSame(Filter::CONDITION_OR, $filter2->getCondition());
+        self::assertSame($filter, $filter2->getPreviousFilter());
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertSame('application/json', $response->headers->get('Content-Type'));


### PR DESCRIPTION
## Subject

Closes #7359.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `RetrieveAutocompleItemsAction` when used with an array of property
```