### PR TITLE
Deprecate the use of ParamConverter in favor of argument resolver

### DIFF
--- a/UPGRADE-3.x.md
+++ b/UPGRADE-3.x.md
@@ -1,6 +1,43 @@
 UPGRADE 3.x
 ===========
 
+UPGRADE FROM 3.x to 3.x
+=======================
+
+### Deprecated the use of ParamConverter to fetch an admin as parameter
+
+Using `@ParamConverter` annotation to fetch an admin service is deprecated and will not work in version 4.0. Instead,
+you MUST type-hint with the appropriate admin class.
+
+The `Sonata\AdminBundle\Request\ParamConverter\AdminParamConverter` class has been deprecated.
+
+Before:
+```php
+final class MyController
+{
+    /**
+     * @ParamConverter("admin", class="App\Admin\MyAdmin")
+     */
+    public function custom($admin): Response
+    {
+        return new Response();
+    }
+}
+```
+
+After:
+```php
+use App\Admin\MyAdmin;
+
+final class MyController
+{
+    public function custom(MyAdmin $admin): Response
+    {
+        return new Response();
+    }
+}
+```
+
 UPGRADE FROM 3.102 to 3.103
 ===========================
 

--- a/docs/cookbook/recipe_decouple_crud_controller.rst
+++ b/docs/cookbook/recipe_decouple_crud_controller.rst
@@ -6,10 +6,10 @@ Decouple from CRUDController
     The ability to inject an Admin to an action and ``AdminFetcherInterface`` service were introduced in 3.99.
 
 When creating custom actions, we can create our controllers without extending ``CRUDController``. What we usually need
-is to access the ``admin`` instance associated to the action, to do so we can use a param converter or
+is to access the ``admin`` instance associated to the action, to do so we can type-hint to the admin class or use
 the ``AdminFetcherInterface`` service.
 
-If you are using ``SensioFrameworkExtraBundle``, then you can add your Admin as parameter of the action::
+You can add your Admin as parameter of the action::
 
     // src/Controller/CarAdminController.php
 

--- a/src/ArgumentResolver/AdminValueResolver.php
+++ b/src/ArgumentResolver/AdminValueResolver.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\ArgumentResolver;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Exception\AdminCodeNotFoundException;
+use Sonata\AdminBundle\Request\AdminFetcherInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+
+final class AdminValueResolver implements ArgumentValueResolverInterface
+{
+    /**
+     * @var AdminFetcherInterface
+     */
+    private $adminFetcher;
+
+    public function __construct(AdminFetcherInterface $adminFetcher)
+    {
+        $this->adminFetcher = $adminFetcher;
+    }
+
+    public function supports(Request $request, ArgumentMetadata $argument): bool
+    {
+        if (!is_subclass_of($argument->getType(), AdminInterface::class)) {
+            return false;
+        }
+
+        try {
+            $admin = $this->adminFetcher->get($request);
+        } catch (AdminCodeNotFoundException $exception) {
+            return false;
+        }
+
+        return is_a($admin, $argument->getType());
+    }
+
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    {
+        yield $this->adminFetcher->get($request);
+    }
+}

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -84,6 +84,7 @@ class SonataAdminExtension extends Extension implements PrependExtensionInterfac
             $loader->load('exporter.php');
         }
 
+        // NEXT_MAJOR: Remove this block.
         if (isset($bundles['SensioFrameworkExtraBundle'])) {
             $loader->load('param_converter.php');
         }

--- a/src/Request/ParamConverter/AdminParamConverter.php
+++ b/src/Request/ParamConverter/AdminParamConverter.php
@@ -21,6 +21,11 @@ use Sonata\AdminBundle\Request\AdminFetcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
+/**
+ * @deprecated since sonata-project/admin-bundle 3.x.
+ *
+ * NEXT_MAJOR: Remove this class.
+ */
 final class AdminParamConverter implements ParamConverterInterface
 {
     /**

--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -16,6 +16,7 @@ use Sonata\AdminBundle\Admin\BreadcrumbsBuilder;
 use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
 use Sonata\AdminBundle\Admin\Extension\LockExtension;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\ArgumentResolver\AdminValueResolver;
 use Sonata\AdminBundle\Controller\HelperController;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AliasDeprecatedPublicServicesCompilerPass;
 use Sonata\AdminBundle\Event\AdminEventExtension;
@@ -394,5 +395,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ReferenceConfigurator('sonata.admin.pool'),
             ])
 
-        ->alias(AdminFetcherInterface::class, 'sonata.admin.request.fetcher');
+        ->alias(AdminFetcherInterface::class, 'sonata.admin.request.fetcher')
+
+        ->set('sonata.admin.argument_resolver.admin', AdminValueResolver::class)
+            ->args([
+                new ReferenceConfigurator('sonata.admin.request.fetcher'),
+            ])
+            ->tag('controller.argument_value_resolver');
 };

--- a/src/Resources/config/param_converter.php
+++ b/src/Resources/config/param_converter.php
@@ -15,6 +15,9 @@ use Sonata\AdminBundle\Request\ParamConverter\AdminParamConverter;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
 
+/*
+ * NEXT_MAJOR: Remove this file.
+ */
 return static function (ContainerConfigurator $containerConfigurator): void {
     // Use "service" function for creating references to services when dropping support for Symfony 4.4
     $containerConfigurator->services()

--- a/tests/App/Admin/AdminAsParameterAdmin.php
+++ b/tests/App/Admin/AdminAsParameterAdmin.php
@@ -17,19 +17,20 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Route\RouteCollection;
 use Sonata\AdminBundle\Tests\App\Controller\InvokableController;
 
-final class TestingParamConverterAdmin extends AbstractAdmin
+final class AdminAsParameterAdmin extends AbstractAdmin
 {
-    protected $baseRoutePattern = 'tests/app/testing-param-converter';
-    protected $baseRouteName = 'admin_testing_param_converter';
+    protected $baseRoutePattern = 'tests/app/admin-as-parameter';
+    protected $baseRouteName = 'admin_admin_as_parameter';
 
     protected function configureRoutes(RouteCollection $collection): void
     {
+        // NEXT_MAJOR: Remove this route
         $collection->add('withAnnotation', null, [
-            '_controller' => 'Sonata\AdminBundle\Tests\App\Controller\ParamConverterController::withAnnotation',
+            '_controller' => 'Sonata\AdminBundle\Tests\App\Controller\AdminAsParameterController::withAnnotation',
         ]);
 
-        $collection->add('withoutAnnotation', null, [
-            '_controller' => 'Sonata\AdminBundle\Tests\App\Controller\ParamConverterController::withoutAnnotation',
+        $collection->add('test', null, [
+            '_controller' => 'Sonata\AdminBundle\Tests\App\Controller\AdminAsParameterController::test',
         ]);
 
         $collection->add('invokable', null, [

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -43,6 +43,7 @@ final class AppKernel extends Kernel
     {
         $bundles = [
             new FrameworkBundle(),
+            // NEXT_MAJOR: Remove next line and "sensio/framework-extra-bundle" package from composer.json.
             new SensioFrameworkExtraBundle(),
             new TwigBundle(),
             new SecurityBundle(),

--- a/tests/App/Controller/AdminAsParameterController.php
+++ b/tests/App/Controller/AdminAsParameterController.php
@@ -14,26 +14,33 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\App\Controller;
 
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
-use Sonata\AdminBundle\Tests\App\Admin\TestingParamConverterAdmin;
+use Sonata\AdminBundle\Tests\App\Admin\AdminAsParameterAdmin;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-final class ParamConverterController
+final class AdminAsParameterController
 {
     /**
-     * @ParamConverter("admin", class="Sonata\AdminBundle\Tests\App\Admin\TestingParamConverterAdmin")
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @ParamConverter("admin", class="Sonata\AdminBundle\Tests\App\Admin\AdminAsParameterAdmin")
      */
     public function withAnnotation($admin): Response
     {
-        if (!$admin instanceof TestingParamConverterAdmin) {
+        if (!$admin instanceof AdminAsParameterAdmin) {
             throw new NotFoundHttpException();
         }
 
         return new Response();
     }
 
-    public function withoutAnnotation(TestingParamConverterAdmin $admin): Response
+    public function test(AdminAsParameterAdmin $admin): Response
     {
+        if ('test' !== $admin->getUniqid()) {
+            throw new BadRequestHttpException();
+        }
+
         return new Response();
     }
 }

--- a/tests/App/Controller/InvokableController.php
+++ b/tests/App/Controller/InvokableController.php
@@ -13,13 +13,18 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\App\Controller;
 
-use Sonata\AdminBundle\Tests\App\Admin\TestingParamConverterAdmin;
+use Sonata\AdminBundle\Tests\App\Admin\AdminAsParameterAdmin;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 
 final class InvokableController
 {
-    public function __invoke(TestingParamConverterAdmin $admin): Response
+    public function __invoke(AdminAsParameterAdmin $admin): Response
     {
+        if ('invokable' !== $admin->getUniqid()) {
+            throw new BadRequestHttpException();
+        }
+
         return new Response();
     }
 }

--- a/tests/App/config/services.yml
+++ b/tests/App/config/services.yml
@@ -51,7 +51,7 @@ services:
         tags:
             - {name: sonata.admin, manager_type: test, label: Foo}
 
-    Sonata\AdminBundle\Tests\App\Admin\TestingParamConverterAdmin:
+    Sonata\AdminBundle\Tests\App\Admin\AdminAsParameterAdmin:
         arguments: [~, Sonata\AdminBundle\Tests\App\Model\Foo, ~]
         tags:
             - {name: sonata.admin, manager_type: test}

--- a/tests/ArgumentResolver/AdminValueResolverTest.php
+++ b/tests/ArgumentResolver/AdminValueResolverTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\ArgumentResolver;
+
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\ArgumentResolver\AdminValueResolver;
+use Sonata\AdminBundle\Request\AdminFetcher;
+use Sonata\AdminBundle\Tests\Fixtures\Admin\CommentAdmin;
+use Sonata\AdminBundle\Tests\Fixtures\Admin\PostAdmin;
+use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Post;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+
+final class AdminValueResolverTest extends TestCase
+{
+    /**
+     * @var Stub&AdminInterface
+     */
+    private $admin;
+
+    /**
+     * @var AdminValueResolver
+     */
+    private $adminValueResolver;
+
+    protected function setUp(): void
+    {
+        $this->admin = new PostAdmin('sonata.admin.post', Post::class, '');
+
+        $container = new Container();
+        $container->set('sonata.admin.post', $this->admin);
+
+        $adminFetcher = new AdminFetcher(new Pool($container, ['sonata.admin.post']));
+
+        $this->adminValueResolver = new AdminValueResolver($adminFetcher);
+    }
+
+    /**
+     * @dataProvider supportDataProvider
+     */
+    public function testSupports(bool $expectedSupport, Request $request, ArgumentMetadata $argumentMetadata): void
+    {
+        $this->assertSame($expectedSupport, $this->adminValueResolver->supports($request, $argumentMetadata));
+    }
+
+    /**
+     * @psalm-return iterable<array{bool, Request, ArgumentMetadata}>
+     */
+    public function supportDataProvider(): iterable
+    {
+        yield 'Object must implement AdminInterface' => [
+            false,
+            new Request(),
+            new ArgumentMetadata('_sonata_admin', __CLASS__, false, false, null),
+        ];
+
+        $request = Request::create('/');
+        $request->attributes->set('_sonata_admin', 'non_existing');
+
+        yield 'Admin code must exist' => [
+            false,
+            $request,
+            new ArgumentMetadata('_sonata_admin', PostAdmin::class, false, false, null),
+        ];
+
+        $request = new Request();
+        $request->attributes->set('_sonata_admin', 'non_existing');
+
+        yield 'Admin fetched must be of the type specified in the action' => [
+            false,
+            $request,
+            new ArgumentMetadata('_sonata_admin', CommentAdmin::class, false, false, null),
+        ];
+
+        $request = new Request();
+        $request->attributes->set('_sonata_admin', 'sonata.admin.post');
+
+        yield 'Admin class is valid' => [
+            true,
+            $request,
+            new ArgumentMetadata('_sonata_admin', PostAdmin::class, false, false, null),
+        ];
+    }
+
+    public function testResolveAdmin(): void
+    {
+        $request = new Request();
+        $request->attributes->set('_sonata_admin', 'sonata.admin.post');
+
+        $argument = new ArgumentMetadata('_sonata_admin', PostAdmin::class, false, false, null);
+
+        $this->assertTrue($this->adminValueResolver->supports($request, $argument));
+        $this->assertSame([$this->admin], $this->iterableToArray($this->adminValueResolver->resolve($request, $argument)));
+    }
+
+    /**
+     * @param iterable<AdminInterface> $iterable
+     *
+     * @return AdminInterface[]
+     */
+    private function iterableToArray(iterable $iterable): array
+    {
+        $array = [];
+        array_push($array, ...$iterable);
+
+        return $array;
+    }
+}

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -133,6 +133,7 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
         );
     }
 
+    // Remove this test.
     public function testLoadsParamConverterServiceDefinitionWhenSensioFrameworkExtraBundleIsRegistered(): void
     {
         $this->container->setParameter('kernel.bundles', ['SensioFrameworkExtraBundle' => 'whatever']);

--- a/tests/Functional/Controller/AdminAsParameterControllerTest.php
+++ b/tests/Functional/Controller/AdminAsParameterControllerTest.php
@@ -18,7 +18,7 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-final class ParamConverterControllerTest extends WebTestCase
+final class AdminAsParameterControllerTest extends WebTestCase
 {
     /**
      * @dataProvider urlIsSuccessfulDataProvider
@@ -34,9 +34,10 @@ final class ParamConverterControllerTest extends WebTestCase
     public function urlIsSuccessfulDataProvider(): iterable
     {
         return [
-            ['/admin/tests/app/testing-param-converter/withAnnotation'],
-            ['/admin/tests/app/testing-param-converter/withoutAnnotation'],
-            ['/admin/tests/app/testing-param-converter/invokable'],
+            ['/admin/tests/app/admin-as-parameter/test?uniqid=test'],
+            ['/admin/tests/app/admin-as-parameter/invokable?uniqid=invokable'],
+            // NEXT_MAJOR: Remove next line.
+            ['/admin/tests/app/admin-as-parameter/withAnnotation'],
         ];
     }
 

--- a/tests/Request/ParamConverter/AdminParamConverterTest.php
+++ b/tests/Request/ParamConverter/AdminParamConverterTest.php
@@ -28,6 +28,9 @@ use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
+/**
+ * NEXT_MAJOR: Remove this class.
+ */
 final class AdminParamConverterTest extends TestCase
 {
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Instead of relying on `SensioFrameworkExtraBundle` `ParamConverter` feature, we can do the same thanks to value resolvers: https://symfony.com/doc/4.4/controller/argument_value_resolver.html and remove the dependency of that bundle.

This would only affect to people using `@ParamConverter` annotation, for those type-hinting with the admin classes should work as it was.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Deprecated using `@ParamConverter` annotation for injecting admin services
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
