### PR TITLE
Revert: Show matching filters in search results

### DIFF
--- a/src/Block/AdminSearchBlockService.php
+++ b/src/Block/AdminSearchBlockService.php
@@ -15,7 +15,6 @@ namespace Sonata\AdminBundle\Block;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
-use Sonata\AdminBundle\Filter\FilterInterface;
 use Sonata\AdminBundle\Search\SearchHandler;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractBlockService;
@@ -154,11 +153,9 @@ class AdminSearchBlockService extends AbstractBlockService
 
         $admin->checkAccess('list');
 
-        $term = $blockContext->getSetting('query');
-
         $pager = $this->searchHandler->search(
             $admin,
-            $term,
+            $blockContext->getSetting('query'),
             $blockContext->getSetting('page'),
             $blockContext->getSetting('per_page')
         );
@@ -169,18 +166,12 @@ class AdminSearchBlockService extends AbstractBlockService
             return $response->setContent('')->setStatusCode(204);
         }
 
-        $filters = array_filter($admin->getDatagrid()->getFilters(), static function (FilterInterface $filter): bool {
-            return $filter->isActive();
-        });
-
         return $this->renderPrivateResponse($admin->getTemplate('search_result_block'), [
             'block' => $blockContext->getBlock(),
             'settings' => $blockContext->getSettings(),
             // NEXT_MAJOR: Remove next line.
             'admin_pool' => $this->pool,
             'pager' => $pager,
-            'term' => $term,
-            'filters' => $filters,
             'admin' => $admin,
             'show_empty_boxes' => $this->emptyBoxesOption,
         ], $response);

--- a/src/Resources/public/css/layout.css
+++ b/src/Resources/public/css/layout.css
@@ -355,16 +355,6 @@ body.fixed .content-header .navbar.stuck {
     word-wrap: break-word;
 }
 
-.sonata-search-result-list.nav-stacked > li.item > span.matches {
-    position: relative;
-    display: block;
-    padding: 10px 15px;
-}
-
-.sonata-search-result-list.nav-stacked > li.item > span.matches > a.label {
-   margin: 0 1px;
-}
-
 .form-actions.stuck {
     position:fixed;
     bottom:0;

--- a/src/Resources/views/Block/block_search_result.html.twig
+++ b/src/Resources/views/Block/block_search_result.html.twig
@@ -52,35 +52,11 @@ file that was distributed with this source code.
             </div>
             {% if results_count > 0 %}
                 <div class="box-body no-padding">
-                    <ul class="nav nav-stacked sonata-search-result-list products-list">
+                    <ul class="nav nav-stacked sonata-search-result-list">
                         {% for result in current_page_results %}
                             {% set link = admin.getSearchResultLink(result) %}
                             {% if link %}
-                                <li class="item no-padding">
-                                    <a class="main pull-left" href="{{ link }}">{{ admin.toString(result) }}</a>
-                                    <span class="matches pull-right">
-                                        {% for name, filter in filters %}
-                                            {% set match = name|split('.')|reduce((carry, v) => carry ? attribute(carry, v) : null, result) %}
-
-                                            {#
-                                                Some model managers are not respecting the "sonata_admin.global_search.case_sensitive" configuration option.
-                                                If you see no matching filters for a search result, it is probably the reason. In that case,
-                                                you SHOULD consider using `false` as value for this option.
-                                            #}
-                                            {% if match and ((filter.option('case_sensitive') is not same as(false) and term in match)
-                                                or filter.option('case_sensitive') is same as(false) and term|lower in match|lower)
-                                            %}
-                                                <a class="label label-primary" href="{{ admin.generateUrl('list', {'filter': {(filter.formName): {'value': term}}}) }}">
-                                                    {% if filter.option('translation_domain') is same as(false) %}
-                                                        {{ filter.option('label') }}
-                                                    {% else %}
-                                                        {{ filter.option('label')|trans({}, filter.option('translation_domain', admin.translationDomain)) }}
-                                                    {% endif %}
-                                                </a>
-                                            {% endif %}
-                                        {% endfor %}
-                                    </span>
-                                </li>
+                                <li><a href="{{ link }}">{{ admin.toString(result) }}</a></li>
                             {% else %}
                                 <li><a>{{ admin.toString(result) }}</a></li>
                             {% endif %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This is a hotfix to make the search useable again if you have cascaded search filters.
```php
    protected function configureDatagridFilters(DatagridMapper $filter): void
    {
        $filter
            ->add('addresses.city')
        ;
    }
```

The following code needs some rework to make the feature useable again:

```twig
 {% set match = name|split('.')|reduce((carry, v) => carry ? attribute(carry, v) : null, result) %}
```


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because #7005 break the search result.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
 - Information about the matching filters in the search results, because it does not work for cascaded oneToMany filters.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
