### PR TITLE
Do not throw error on invalidArgument

### DIFF
--- a/src/ArgumentResolver/AdminValueResolver.php
+++ b/src/ArgumentResolver/AdminValueResolver.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\ArgumentResolver;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Exception\AdminCodeNotFoundException;
 use Sonata\AdminBundle\Request\AdminFetcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
@@ -40,7 +39,7 @@ final class AdminValueResolver implements ArgumentValueResolverInterface
 
         try {
             $admin = $this->adminFetcher->get($request);
-        } catch (AdminCodeNotFoundException $exception) {
+        } catch (\InvalidArgumentException $exception) {
             return false;
         }
 

--- a/src/Request/AdminFetcherInterface.php
+++ b/src/Request/AdminFetcherInterface.php
@@ -14,9 +14,14 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Request;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Exception\AdminCodeNotFoundException;
 use Symfony\Component\HttpFoundation\Request;
 
 interface AdminFetcherInterface
 {
+    /**
+     * @throws \InvalidArgumentException  if the admin code is not found in the request
+     * @throws AdminCodeNotFoundException if no admin was found for the admin code provided
+     */
     public function get(Request $request): AdminInterface;
 }

--- a/tests/ArgumentResolver/AdminValueResolverTest.php
+++ b/tests/ArgumentResolver/AdminValueResolverTest.php
@@ -69,6 +69,12 @@ final class AdminValueResolverTest extends TestCase
             new ArgumentMetadata('_sonata_admin', __CLASS__, false, false, null),
         ];
 
+        yield 'Admin code must be passed' => [
+            false,
+            Request::create('/'),
+            new ArgumentMetadata('_sonata_admin', PostAdmin::class, false, false, null),
+        ];
+
         $request = Request::create('/');
         $request->attributes->set('_sonata_admin', 'non_existing');
 


### PR DESCRIPTION
## Subject

I am targeting this branch, because bugFix.

When the admin fetcher has no sonata_code it throws an exception so does the valueResolver.
The value resolver should catch everything instead.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Do not throw error when trying to inject an admin as a service in an action.
```