### PR TITLE
Add Revision class

### DIFF
--- a/src/Model/AuditReaderInterface.php
+++ b/src/Model/AuditReaderInterface.php
@@ -29,7 +29,7 @@ interface AuditReaderInterface
     public function find(string $className, $id, $revisionId): ?object;
 
     /**
-     * @return object[]
+     * @return Revision[]
      *
      * @phpstan-param class-string $className
      */
@@ -40,12 +40,12 @@ interface AuditReaderInterface
      *
      * @phpstan-param class-string $className
      */
-    public function findRevision(string $className, $revisionId): ?object;
+    public function findRevision(string $className, $revisionId): ?Revision;
 
     /**
      * @param int|string $id
      *
-     * @return object[]
+     * @return Revision[]
      *
      * @phpstan-param class-string $className
      */

--- a/src/Model/Revision.php
+++ b/src/Model/Revision.php
@@ -21,9 +21,9 @@ final class Revision
     private $id;
 
     /**
-     * @var \DateTime
+     * @var \DateTimeInterface
      */
-    private $timestamp;
+    private $dateTime;
 
     /**
      * @var string
@@ -33,11 +33,19 @@ final class Revision
     /**
      * @param int|string $id
      */
-    public function __construct($id, \DateTime $timestamp, string $username)
+    public function __construct($id, \DateTimeInterface $dateTime, string $username)
     {
         $this->id = $id;
-        $this->timestamp = $timestamp;
+        $this->dateTime = $dateTime;
         $this->username = $username;
+    }
+
+    /**
+     * @return int|string
+     */
+    public function getId()
+    {
+        return $this->id;
     }
 
     /**
@@ -48,9 +56,14 @@ final class Revision
         return $this->id;
     }
 
-    public function getTimestamp(): \DateTime
+    public function getDateTime(): \DateTimeInterface
     {
-        return $this->timestamp;
+        return $this->dateTime;
+    }
+
+    public function getTimestamp(): \DateTimeInterface
+    {
+        return $this->dateTime;
     }
 
     public function getUsername(): string

--- a/src/Model/Revision.php
+++ b/src/Model/Revision.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Model;
+
+final class Revision
+{
+    /**
+     * @var int|string
+     */
+    private $id;
+
+    /**
+     * @var \DateTime
+     */
+    private $timestamp;
+
+    /**
+     * @var string
+     */
+    private $username;
+
+    /**
+     * @param int|string $id
+     */
+    public function __construct($id, \DateTime $timestamp, string $username)
+    {
+        $this->id = $id;
+        $this->timestamp = $timestamp;
+        $this->username = $username;
+    }
+
+    /**
+     * @return int|string
+     */
+    public function getRev()
+    {
+        return $this->id;
+    }
+
+    public function getTimestamp(): \DateTime
+    {
+        return $this->timestamp;
+    }
+
+    public function getUsername(): string
+    {
+        return $this->username;
+    }
+}

--- a/tests/Fixtures/Model/AuditReader.php
+++ b/tests/Fixtures/Model/AuditReader.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Fixtures\Model;
 
 use Sonata\AdminBundle\Model\AuditReaderInterface;
+use Sonata\AdminBundle\Model\Revision;
 
 final class AuditReader implements AuditReaderInterface
 {
@@ -25,19 +26,19 @@ final class AuditReader implements AuditReaderInterface
     public function findRevisionHistory(string $className, int $limit = 20, int $offset = 0): array
     {
         return [
-            new \stdClass(),
+            new Revision(1, new \DateTime(), 'Jack'),
         ];
     }
 
-    public function findRevision(string $className, $revisionId): ?object
+    public function findRevision(string $className, $revisionId): ?Revision
     {
-        return new \stdClass();
+        return new Revision(1, new \DateTime(), 'Jack');
     }
 
     public function findRevisions(string $className, $id): array
     {
         return [
-            new \stdClass(),
+            new Revision(1, new \DateTime(), 'Jack'),
         ];
     }
 


### PR DESCRIPTION
## Subject

I am targeting this branch, because the return type from `findRevision` is the only BC-break and 
- not a lot of people will implement `AuditReaderInterface`, it's already implemented in DoctrineORMAdmin
- the return type still need to be added from 3.x to 4.x

We might improve the getter `getRev` to `getId`, but I keep it like that for now in order to make the upgrade easier.

Closes #6279.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- `Revision` class

### Changed
- `AuditReaderInterface::findRevision()` return type
```