### PR TITLE
Improve signature of method using securityInformation

### DIFF
--- a/src/Security/Handler/AclSecurityHandler.php
+++ b/src/Security/Handler/AclSecurityHandler.php
@@ -154,7 +154,7 @@ final class AclSecurityHandler implements AclSecurityHandlerInterface
         $securityIdentity = UserSecurityIdentity::fromAccount($user);
 
         $this->addObjectOwner($acl, $securityIdentity);
-        $this->addObjectClassAces($acl, $this->buildSecurityInformation($admin));
+        $this->addObjectClassAces($acl, $admin);
         $this->updateAcl($acl);
     }
 
@@ -199,11 +199,11 @@ final class AclSecurityHandler implements AclSecurityHandlerInterface
         }
     }
 
-    public function addObjectClassAces(MutableAclInterface $acl, array $roleInformation = []): void
+    public function addObjectClassAces(MutableAclInterface $acl, AdminInterface $admin): void
     {
         $builder = new $this->maskBuilderClass();
 
-        foreach ($roleInformation as $role => $permissions) {
+        foreach ($this->buildSecurityInformation($admin) as $role => $permissions) {
             $aceIndex = $this->findClassAceIndexByRole($acl, $role);
             $hasRole = false;
 

--- a/src/Security/Handler/AclSecurityHandlerInterface.php
+++ b/src/Security/Handler/AclSecurityHandlerInterface.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Security\Handler;
 
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 use Symfony\Component\Security\Acl\Model\MutableAclInterface;
 use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
@@ -76,9 +77,9 @@ interface AclSecurityHandlerInterface extends SecurityHandlerInterface
     /**
      * Add the object class ACE's to the object ACL.
      *
-     * @param array<string, string[]> $roleInformation
+     * @param AdminInterface<object> $admin
      */
-    public function addObjectClassAces(MutableAclInterface $acl, array $roleInformation = []): void;
+    public function addObjectClassAces(MutableAclInterface $acl, AdminInterface $admin): void;
 
     /**
      * Create an object ACL.

--- a/src/Util/AdminAclManipulator.php
+++ b/src/Util/AdminAclManipulator.php
@@ -58,7 +58,7 @@ final class AdminAclManipulator implements AdminAclManipulatorInterface
 
         // create admin ACL
         $output->writeln(sprintf(' > install ACL for %s', $admin->getCode()));
-        $configResult = $this->addAdminClassAces($output, $acl, $securityHandler, $securityHandler->buildSecurityInformation($admin));
+        $configResult = $this->addAdminClassAces($output, $acl, $securityHandler, $admin);
 
         if ($configResult) {
             $securityHandler->updateAcl($acl);
@@ -72,12 +72,12 @@ final class AdminAclManipulator implements AdminAclManipulatorInterface
         OutputInterface $output,
         MutableAclInterface $acl,
         AclSecurityHandlerInterface $securityHandler,
-        array $roleInformation = []
+        AdminInterface $admin
     ): bool {
         if (\count($securityHandler->getAdminPermissions()) > 0) {
             $builder = new $this->maskBuilderClass();
 
-            foreach ($roleInformation as $role => $permissions) {
+            foreach ($securityHandler->buildSecurityInformation($admin) as $role => $permissions) {
                 $aceIndex = $securityHandler->findClassAceIndexByRole($acl, $role);
                 $roleAdminPermissions = [];
 

--- a/src/Util/AdminAclManipulatorInterface.php
+++ b/src/Util/AdminAclManipulatorInterface.php
@@ -33,7 +33,7 @@ interface AdminAclManipulatorInterface
     /**
      * Add the class ACE's to the admin ACL.
      *
-     * @param array<string, string[]> $roleInformation
+     * @param AdminInterface<object> $admin
      *
      * @return bool TRUE if admin class ACEs are added, FALSE if not
      */
@@ -41,6 +41,6 @@ interface AdminAclManipulatorInterface
         OutputInterface $output,
         MutableAclInterface $acl,
         AclSecurityHandlerInterface $securityHandler,
-        array $roleInformation = []
+        AdminInterface $admin
     ): bool;
 }

--- a/src/Util/ObjectAclManipulator.php
+++ b/src/Util/ObjectAclManipulator.php
@@ -69,7 +69,7 @@ abstract class ObjectAclManipulator implements ObjectAclManipulatorInterface
                 $securityHandler->addObjectOwner($acl, $securityIdentity);
             }
 
-            $securityHandler->addObjectClassAces($acl, $securityHandler->buildSecurityInformation($admin));
+            $securityHandler->addObjectClassAces($acl, $admin);
 
             try {
                 $securityHandler->updateAcl($acl);

--- a/tests/Util/ObjectAclManipulatorTest.php
+++ b/tests/Util/ObjectAclManipulatorTest.php
@@ -91,8 +91,7 @@ final class ObjectAclManipulatorTest extends TestCase
         $securityHandler->expects(self::once())->method('findObjectAcls')->with($this->oids)->willReturn($acls);
         $securityHandler->expects(self::once())->method('createAcl')->with(self::isInstanceOf(ObjectIdentityInterface::class))->willReturn($acl);
         $securityHandler->expects(self::atLeastOnce())->method('addObjectOwner')->with($acl, self::isInstanceOf(UserSecurityIdentity::class));
-        $securityHandler->expects(self::atLeastOnce())->method('buildSecurityInformation')->with($this->admin)->willReturn([]);
-        $securityHandler->expects(self::atLeastOnce())->method('addObjectClassAces')->with($acl, []);
+        $securityHandler->expects(self::atLeastOnce())->method('addObjectClassAces')->with($acl, $this->admin);
         $securityHandler->expects(self::atLeastOnce())->method('updateAcl')->with($acl)->willThrowException(new \Exception('test exception'));
         $this->output->method('writeln')->with(self::logicalAnd(
             self::stringContains('ignoring'),


### PR DESCRIPTION
## Subject

I take a look at https://github.com/sonata-project/SonataAdminBundle/issues/4925, and saw that multiple method were passing both the securityHandler and the `securityInformation` from this securityHander. This seems wrong to me
- The method could have the need to access to the Admin (don't know if it will be needed for the bugFix, but if it does and we discover it after the stable release, the BC-break won't be possible).
- Those method could been call with a securityHandler and securityInformation from another securityHandler ; which makes no sens.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- `AclSecurityHandlerInterface::addObjectClassAces()` signature
- `AclSecurityHandler::addObjectClassAces()` signature
- `AdminAclManipulator::addAdminClassAces()` signature
- `AdminAclManipulatorInterface::addAdminClassAces()` signature
```
