### PR TITLE
Fix collection type with nested field 

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1061,7 +1061,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
 
     final public function removeFieldFromFormGroup(string $key): void
     {
-        foreach ($this->formGroups as $name => $formGroup) {
+        foreach ($this->formGroups as $name => $_formGroup) {
             unset($this->formGroups[$name]['fields'][$key]);
 
             if ([] === $this->formGroups[$name]['fields']) {
@@ -1105,6 +1105,17 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
     final public function setShowGroups(array $showGroups): void
     {
         $this->showGroups = $showGroups;
+    }
+
+    final public function removeFieldFromShowGroup(string $key): void
+    {
+        foreach ($this->showGroups as $name => $_showGroup) {
+            unset($this->showGroups[$name]['fields'][$key]);
+
+            if ([] === $this->showGroups[$name]['fields']) {
+                unset($this->showGroups[$name]);
+            }
+        }
     }
 
     final public function reorderShowGroup(string $group, array $keys): void

--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -15,7 +15,7 @@ namespace Sonata\AdminBundle\Admin;
 
 use Doctrine\Common\Collections\Collection;
 use Sonata\AdminBundle\Exception\NoValueException;
-use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 use Sonata\AdminBundle\Manipulator\ObjectManipulator;
 use Sonata\AdminBundle\Util\FormBuilderIterator;
 use Sonata\AdminBundle\Util\FormViewIterator;
@@ -121,11 +121,12 @@ class AdminHelper
 
         if (
             null !== $childFormBuilder
-            && $admin->hasFormFieldDescription(FormMapper::unsanitizeFormBuilderName($childFormBuilder->getName()))
+            && $childFormBuilder->getOption('sonata_field_description') instanceof FieldDescriptionInterface
+            && $admin->hasFormFieldDescription($childFormBuilder->getOption('sonata_field_description')->getName())
         ) {
             // retrieve the FieldDescription
             $fieldDescription = $admin->getFormFieldDescription(
-                FormMapper::unsanitizeFormBuilderName($childFormBuilder->getName())
+                $childFormBuilder->getOption('sonata_field_description')->getName()
             );
 
             try {

--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Admin;
 
 use Doctrine\Common\Collections\Collection;
 use Sonata\AdminBundle\Exception\NoValueException;
+use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Manipulator\ObjectManipulator;
 use Sonata\AdminBundle\Util\FormBuilderIterator;
 use Sonata\AdminBundle\Util\FormViewIterator;
@@ -118,9 +119,14 @@ class AdminHelper
         $form->setData($subject);
         $form->handleRequest($admin->getRequest());
 
-        if (null !== $childFormBuilder && $admin->hasFormFieldDescription($childFormBuilder->getName())) {
+        if (
+            null !== $childFormBuilder
+            && $admin->hasFormFieldDescription(FormMapper::unsanitizeFormBuilderName($childFormBuilder->getName()))
+        ) {
             // retrieve the FieldDescription
-            $fieldDescription = $admin->getFormFieldDescription($childFormBuilder->getName());
+            $fieldDescription = $admin->getFormFieldDescription(
+                FormMapper::unsanitizeFormBuilderName($childFormBuilder->getName())
+            );
 
             try {
                 $value = $fieldDescription->getValue($form->getData());

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -298,6 +298,8 @@ interface AdminInterface extends TaggedAdminInterface, AccessRegistryInterface, 
      */
     public function setFormGroups(array $formGroups): void;
 
+    public function removeFieldFromFormGroup(string $key): void;
+
     /**
      * @param string[] $keys
      */
@@ -323,8 +325,6 @@ interface AdminInterface extends TaggedAdminInterface, AccessRegistryInterface, 
      */
     public function setShowTabs(array $showTabs): void;
 
-    public function removeFieldFromFormGroup(string $key): void;
-
     /**
      * Returns the show groups.
      *
@@ -338,6 +338,8 @@ interface AdminInterface extends TaggedAdminInterface, AccessRegistryInterface, 
      * @param array<string, mixed> $showGroups
      */
     public function setShowGroups(array $showGroups): void;
+
+    public function removeFieldFromShowGroup(string $key): void;
 
     /**
      * Reorder items in showGroup.

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -172,10 +172,11 @@ final class FormMapper extends BaseGroupedMapper implements BlockFormMapper
      */
     public function remove(string $key): self
     {
-        $key = $this->sanitizeFieldName($key);
         $this->getAdmin()->removeFormFieldDescription($key);
         $this->getAdmin()->removeFieldFromFormGroup($key);
-        $this->formBuilder->remove($key);
+
+        $sanitizedKey = $this->sanitizeFieldName($key);
+        $this->formBuilder->remove($sanitizedKey);
 
         return $this;
     }
@@ -192,6 +193,14 @@ final class FormMapper extends BaseGroupedMapper implements BlockFormMapper
     public function create(string $name, ?string $type = null, array $options = []): FormBuilderInterface
     {
         return $this->formBuilder->create($name, $type, $options);
+    }
+
+    /**
+     * Reverse transform of the `sanitizeFieldName` method.
+     */
+    public static function unsanitizeFormBuilderName(string $formBuilderName): string
+    {
+        return str_replace(['__', '..'], ['.', '__'], $formBuilderName);
     }
 
     protected function getGroups(): array
@@ -220,9 +229,8 @@ final class FormMapper extends BaseGroupedMapper implements BlockFormMapper
     }
 
     /**
-     * Symfony default form class sadly can't handle
-     * form element with dots in its name (when data
-     * get bound, the default dataMapper is a PropertyPathMapper).
+     * Symfony default form class can't handle form element with dots in its
+     * name (when data get bound, the default dataMapper is a PropertyPathMapper).
      * So use this trick to avoid any issue.
      */
     private function sanitizeFieldName(string $fieldName): string

--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -195,14 +195,6 @@ final class FormMapper extends BaseGroupedMapper implements BlockFormMapper
         return $this->formBuilder->create($name, $type, $options);
     }
 
-    /**
-     * Reverse transform of the `sanitizeFieldName` method.
-     */
-    public static function unsanitizeFormBuilderName(string $formBuilderName): string
-    {
-        return str_replace(['__', '..'], ['.', '__'], $formBuilderName);
-    }
-
     protected function getGroups(): array
     {
         return $this->getAdmin()->getFormGroups();

--- a/src/Show/ShowMapper.php
+++ b/src/Show/ShowMapper.php
@@ -125,6 +125,7 @@ final class ShowMapper extends BaseGroupedMapper
     public function remove(string $key): self
     {
         $this->getAdmin()->removeShowFieldDescription($key);
+        $this->getAdmin()->removeFieldFromShowGroup($key);
         $this->list->remove($key);
 
         return $this;

--- a/tests/Admin/AdminHelperTest.php
+++ b/tests/Admin/AdminHelperTest.php
@@ -152,6 +152,7 @@ final class AdminHelperTest extends TestCase
         ];
 
         $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
+        $fieldDescription->method('getName')->willReturn('bar');
         $fieldDescription->method('getAssociationAdmin')->willReturn($associationAdmin);
         $fieldDescription->method('getAssociationMapping')->willReturn($associationMapping);
         $fieldDescription->method('getParentAssociationMappings')->willReturn([]);
@@ -209,7 +210,9 @@ final class AdminHelperTest extends TestCase
         $formFactory = $this->createStub(FormFactoryInterface::class);
         $eventDispatcher = $this->createStub(EventDispatcherInterface::class);
         $formBuilder = new FormBuilder('test', \get_class($foo), $eventDispatcher, $formFactory);
-        $childFormBuilder = new FormBuilder('bar', \stdClass::class, $eventDispatcher, $formFactory);
+        $childFormBuilder = new FormBuilder('bar', \stdClass::class, $eventDispatcher, $formFactory, [
+            'sonata_field_description' => $fieldDescription,
+        ]);
         $childFormBuilder->setCompound(true);
         $childFormBuilder->setDataMapper($dataMapper);
         $subChildFormBuilder = new FormBuilder('baz', \stdClass::class, $eventDispatcher, $formFactory);

--- a/tests/Form/FormMapperTest.php
+++ b/tests/Form/FormMapperTest.php
@@ -500,6 +500,10 @@ final class FormMapperTest extends TestCase
 
         self::assertSame(['fo__o', 'ba____z'], $this->formMapper->keys());
 
+        // The original key can be recomputed.
+        self::assertSame('fo.o', FormMapper::unsanitizeFormBuilderName('fo__o'));
+        self::assertSame('ba__z', FormMapper::unsanitizeFormBuilderName('ba____z'));
+
         // FormFieldDescriptions have the original key.
         self::assertTrue($this->admin->hasFormFieldDescription('fo.o'));
         self::assertTrue($this->admin->hasFormFieldDescription('ba__z'));

--- a/tests/Form/FormMapperTest.php
+++ b/tests/Form/FormMapperTest.php
@@ -500,10 +500,6 @@ final class FormMapperTest extends TestCase
 
         self::assertSame(['fo__o', 'ba____z'], $this->formMapper->keys());
 
-        // The original key can be recomputed.
-        self::assertSame('fo.o', FormMapper::unsanitizeFormBuilderName('fo__o'));
-        self::assertSame('ba__z', FormMapper::unsanitizeFormBuilderName('ba____z'));
-
         // FormFieldDescriptions have the original key.
         self::assertTrue($this->admin->hasFormFieldDescription('fo.o'));
         self::assertTrue($this->admin->hasFormFieldDescription('ba__z'));


### PR DESCRIPTION
## Subject

I just encounter this bug, it was introduced in 4.x.

The Admin keep a reference of FieldDescriptions using the name as key for every Mapper, also the FormMapper since 4.x. 
In 3.x it was using the formBuilder field name, so the sanitize name. So now, when a field `foo.bar` is added
- The fieldDescription is named `foo.bar`
- The fieldDescription is added to the admin with the key `foo.bar`
- The formBuilder is added with the name `foo__bar`
- The group is added with a reference to both value.

But the AdminHelper, try to find the fieldDescription from the admin with the name of the formBuilder, which is not possible anymore. Since the formBuilder has an option `sonata_field_description`, it should be prefer instead, it avoid to compute back the name of the field description.

Also, for the same reason, the `remove` method from the FormMapper needed to be updated.
And I discovered that the `ShowMapper::remove` needed some fixes because the field wasn't remove from the showGroup.

I checked that the bug fix for https://github.com/sonata-project/SonataAdminBundle/pull/6778 still work with my changes.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- `AdminInterface::removeFieldFromShowGroup` method
- `AbstractAdmin::removeFieldFromShowGroup` method

### Fixed
- Fix `CollectionType` for nested fields.
- `ShowMapper::remove` method now correctly remove the field from the groups.
```