### PR TITLE
Fix for missing icon when sortable field in CollectionType

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_one_to_many_sortable_script_table.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many_sortable_script_table.html.twig
@@ -21,7 +21,7 @@ file that was distributed with this source code.
         jQuery('div#field_container_{{ id }} tbody.sonata-ba-tbody td.sonata-ba-td-{{ id }}-{{ sonata_admin.field_description.option('sortable') }}').each(function(index, element) {
             // remove the sortable handler and put it back
             jQuery('span.sonata-ba-sortable-handler', element).remove();
-            jQuery(element).append('<span class="sonata-ba-sortable-handler ui-icon ui-icon-grip-solid-horizontal"></span>');
+            jQuery(element).append('<span class="sonata-ba-sortable-handler"><i class="fas fa-grip-lines"></i></span>');
             jQuery('input', element).hide();
         });
 

--- a/src/Resources/views/CRUD/Association/edit_one_to_many_sortable_script_tabs.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_many_sortable_script_tabs.html.twig
@@ -24,7 +24,7 @@ file that was distributed with this source code.
             var tabs = parent.find('> .nav-tabs');
             jQuery('.sonata-ba-sortable-handler', tabs).remove();
             $('<li class="sonata-ba-sortable-handler pull-right"></li>')
-                    .prepend('<span class="ui-icon ui-icon-grip-solid-horizontal"></span>')
+                    .prepend('<i class="fas fa-grip-lines"></i>')
                     .appendTo(tabs);
             jQuery('input', element).hide();
         });


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

No icon is visible in the sortable field when using CollectionType:

```
$form
    ->add('blocks', CollectionType::class, [], [
        'edit' => 'inline',
        'inline' => 'table',
        'sortable' => 'position',
    ]);
```

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this issue started in v4.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
Add Font Awesome icon instead of the jQuery UI icon
```

Before:
<img width="607" alt="Before" src="https://user-images.githubusercontent.com/13450371/130940632-6d1704ca-da70-4d5f-a593-bcdbc8bc5b91.png">

After:
<img width="475" alt="After" src="https://user-images.githubusercontent.com/13450371/130940723-fbe713b7-3d6e-4682-9566-dff49228001c.png">

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
