### PR TITLE
Avoid missing translation on batch confirmation

### DIFF
--- a/src/Form/Type/Filter/FilterDataType.php
+++ b/src/Form/Type/Filter/FilterDataType.php
@@ -26,8 +26,14 @@ final class FilterDataType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
-            ->add('type', $options['operator_type'], $options['operator_options'] + ['required' => false])
-            ->add('value', $options['field_type'], $options['field_options'] + ['required' => false]);
+            ->add('type', $options['operator_type'], $options['operator_options'] + [
+                'label' => false,
+                'required' => false,
+            ])
+            ->add('value', $options['field_type'], $options['field_options'] + [
+                'label' => false,
+                'required' => false,
+            ]);
 
         $builder
             ->addModelTransformer(new FilterDataTransformer());

--- a/src/Resources/views/CRUD/batch_confirmation.html.twig
+++ b/src/Resources/views/CRUD/batch_confirmation.html.twig
@@ -48,7 +48,9 @@ file that was distributed with this source code.
                         {{ form_rest(form) }}
                     </div>
 
-                    <button type="submit" class="btn btn-danger">{{ 'btn_execute_batch_action'|trans({}, 'SonataAdminBundle') }}</button>
+                    <button type="submit" class="btn btn-danger">
+                        {{ 'btn_execute_batch_action'|trans({}, 'SonataAdminBundle') }}
+                    </button>
 
                     {% if admin.hasRoute('list') and admin.hasAccess('list') %}
                         {{ 'delete_or'|trans({}, 'SonataAdminBundle') }}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because bug fix.

When we render FilterDataType in the datagrid we only use form_widget, so the label is not needed.
When we render it in the batch confirmation page we render everything in display none, so the label are translated.
This PR solve this.

This solve half of the issue #4069, I don't know if we want to do more for this issue.
In order to use `HiddenType` in the batch confirmation we need to change
```
foreach ($this->getFilters() as $filter) {
    [$type, $options] = $filter->getRenderSettings();

    $this->formBuilder->add($filter->getFormName(), $type, $options);
}
```
to
```
foreach ($this->getFilters() as $filter) {
    $this->formBuilder->add($filter->getFormName(), HiddenType::class);
}
```

This means we need a different method to get the Form, and to get an HiddenForm.
Do we want to add a method to the datagridInterface just for this ?

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Missing translation on batch confirmation page.
```