### PR TITLE
Fail fast if using ACL and the service security.acl.provider is missing

### DIFF
--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -137,6 +137,13 @@ final class SonataAdminExtension extends Extension
 
                 break;
             case 'sonata.admin.security.handler.acl':
+                if (!$container->has('security.acl.provider')) {
+                    throw new \RuntimeException(
+                        'The "security.acl.provider" service is needed to use ACL as security handler.'
+                        .' You MUST install and enable the "symfony/acl-bundle" bundle.'
+                    );
+                }
+
                 if (0 === \count($config['security']['information'])) {
                     $config['security']['information'] = [
                         'GUEST' => ['VIEW', 'LIST'],


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Closes #7097

## Changelog

```markdown
### Changed
- Fail fast when using ACL as security handler without security.acl.provider service
```