### PR TITLE
Introduce HISTORY role

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -259,3 +259,9 @@ protected function configureListFields(ListMapper $listMapper)
 }
 ```
 but the best is to use the constant `ListMapper::NAME_ACTIONS`.
+
+## History actions
+
+Instead of relying on the `ROLE_MYADMIN_EDIT` role, a new `ROLE_MYADMIN_HISTORY`
+role was introduced to get access to the history actions. If you use the
+revisions be sure to add this role to your users.

--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -61,6 +61,7 @@ Full Configuration Options
                     # Defaults:
                     - VIEW
                     - EDIT
+                    - HISTORY
                     - DELETE
                     - UNDELETE
                     - OPERATOR

--- a/docs/reference/security.rst
+++ b/docs/reference/security.rst
@@ -90,7 +90,7 @@ Using ACL:
                 # acl security information
                 information:
                     GUEST:    [VIEW, LIST]
-                    STAFF:    [EDIT, LIST, CREATE]
+                    STAFF:    [EDIT, HISTORY, LIST, CREATE]
                     EDITOR:   [OPERATOR, EXPORT]
                     ADMIN:    [MASTER]
 
@@ -99,7 +99,7 @@ Using ACL:
                 admin_permissions: [CREATE, LIST, DELETE, UNDELETE, EXPORT, OPERATOR, MASTER]
 
                 # permission related to the objects
-                object_permissions: [VIEW, EDIT, DELETE, UNDELETE, OPERATOR, MASTER, OWNER]
+                object_permissions: [VIEW, EDIT, HISTORY, DELETE, UNDELETE, OPERATOR, MASTER, OWNER]
 
 Later, we will explain how to set up ACL with the ``FriendsOfSymfony/UserBundle``.
 
@@ -126,6 +126,7 @@ LIST         view the list of objects
 VIEW         view the detail of one object
 CREATE       create a new object
 EDIT         update an existing object
+HISTORY      access to the history of edition of an object
 DELETE       delete an existing object
 EXPORT       (for the native Sonata export links)
 **ALL**      **grants LIST, VIEW, CREATE, EDIT, DELETE and EXPORT**

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2206,9 +2206,9 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         $access = array_merge([
             'acl' => AdminPermissionMap::PERMISSION_MASTER,
             'export' => AdminPermissionMap::PERMISSION_EXPORT,
-            'historyCompareRevisions' => AdminPermissionMap::PERMISSION_EDIT,
-            'historyViewRevision' => AdminPermissionMap::PERMISSION_EDIT,
-            'history' => AdminPermissionMap::PERMISSION_EDIT,
+            'historyCompareRevisions' => AdminPermissionMap::PERMISSION_HISTORY,
+            'historyViewRevision' => AdminPermissionMap::PERMISSION_HISTORY,
+            'history' => AdminPermissionMap::PERMISSION_HISTORY,
             'edit' => AdminPermissionMap::PERMISSION_EDIT,
             'show' => AdminPermissionMap::PERMISSION_VIEW,
             'create' => AdminPermissionMap::PERMISSION_CREATE,

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -138,13 +138,6 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
     protected $searchResultActions = ['edit', 'show'];
 
     /**
-     * The Access mapping.
-     *
-     * @var array<string, string|string[]> [action1 => requiredRole1, action2 => [requiredRole2, requiredRole3]]
-     */
-    protected $accessMapping = [];
-
-    /**
      * The list FieldDescription constructed from the configureListField method.
      *
      * @var array<string, FieldDescriptionInterface>
@@ -1731,11 +1724,6 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $this->getRequest()->getSession()->get(sprintf('%s.list_mode', $this->getCode()), 'list');
     }
 
-    final public function getAccessMapping(): array
-    {
-        return $this->accessMapping;
-    }
-
     final public function checkAccess(string $action, ?object $object = null): void
     {
         $access = $this->getAccess();
@@ -2222,6 +2210,14 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         }
 
         return $access;
+    }
+
+    /**
+     * @return array<string, string|string[]> [action1 => requiredRole1, action2 => [requiredRole2, requiredRole3]]
+     */
+    protected function getAccessMapping(): array
+    {
+        return [];
     }
 
     /**

--- a/src/Admin/AccessRegistryInterface.php
+++ b/src/Admin/AccessRegistryInterface.php
@@ -23,13 +23,6 @@ namespace Sonata\AdminBundle\Admin;
 interface AccessRegistryInterface
 {
     /**
-     * Return the controller access mapping.
-     *
-     * @return array<string, string[]|string>
-     */
-    public function getAccessMapping(): array;
-
-    /**
      * Hook to handle access authorization.
      *
      * @phpstan-param T|null $object

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -88,6 +88,7 @@ final class Configuration implements ConfigurationInterface
                             ->defaultValue([
                                 AdminPermissionMap::PERMISSION_VIEW,
                                 AdminPermissionMap::PERMISSION_EDIT,
+                                AdminPermissionMap::PERMISSION_HISTORY,
                                 AdminPermissionMap::PERMISSION_DELETE,
                                 AdminPermissionMap::PERMISSION_UNDELETE,
                                 AdminPermissionMap::PERMISSION_OPERATOR,

--- a/src/Security/Acl/Permission/AdminPermissionMap.php
+++ b/src/Security/Acl/Permission/AdminPermissionMap.php
@@ -26,6 +26,7 @@ final class AdminPermissionMap implements PermissionMapInterface
 {
     public const PERMISSION_VIEW = 'VIEW';
     public const PERMISSION_EDIT = 'EDIT';
+    public const PERMISSION_HISTORY = 'HISTORY';
     public const PERMISSION_CREATE = 'CREATE';
     public const PERMISSION_DELETE = 'DELETE';
     public const PERMISSION_UNDELETE = 'UNDELETE';
@@ -53,6 +54,13 @@ final class AdminPermissionMap implements PermissionMapInterface
 
         self::PERMISSION_EDIT => [
             MaskBuilder::MASK_EDIT,
+            MaskBuilder::MASK_OPERATOR,
+            MaskBuilder::MASK_MASTER,
+            MaskBuilder::MASK_OWNER,
+        ],
+
+        self::PERMISSION_HISTORY => [
+            MaskBuilder::MASK_HISTORY,
             MaskBuilder::MASK_OPERATOR,
             MaskBuilder::MASK_MASTER,
             MaskBuilder::MASK_OWNER,

--- a/src/Security/Acl/Permission/MaskBuilder.php
+++ b/src/Security/Acl/Permission/MaskBuilder.php
@@ -18,12 +18,16 @@ use Symfony\Component\Security\Acl\Permission\MaskBuilder as BaseMaskBuilder;
 /**
  * {@inheritdoc}
  * - LIST: the SID is allowed to view a list of the domain objects / fields.
+ * - EXPORT: the SID is allowed to export the list of the domain objects / fields.
+ * - HISTORY: the SID is allowed to see the history of edition of a domain objects / fields.
  */
 final class MaskBuilder extends BaseMaskBuilder
 {
     public const MASK_LIST = 4096;       // 1 << 12
-    public const MASK_EXPORT = 8192;       // 1 << 13
+    public const MASK_EXPORT = 8192;     // 1 << 13
+    public const MASK_HISTORY = 16384;   // 1 << 14
 
     public const CODE_LIST = 'L';
     public const CODE_EXPORT = 'E';
+    public const CODE_HISTORY = 'H';
 }

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -255,7 +255,6 @@ final class CRUDControllerTest extends TestCase
         ]);
 
         $this->admin->method('getIdParameter')->willReturn('id');
-        $this->admin->method('getAccessMapping')->willReturn([]);
         $this->admin->method('getCode')->willReturn('foo.admin');
         $this->admin->method('hasTemplateRegistry')->willReturn(true);
         $this->admin->method('getTemplateRegistry')->willReturn($this->templateRegistry);

--- a/tests/Security/Acl/Permission/AdminPermissionMapTest.php
+++ b/tests/Security/Acl/Permission/AdminPermissionMapTest.php
@@ -62,6 +62,7 @@ final class AdminPermissionMapTest extends TestCase
         return [
             [true, AdminPermissionMap::PERMISSION_VIEW],
             [true, AdminPermissionMap::PERMISSION_EDIT],
+            [true, AdminPermissionMap::PERMISSION_HISTORY],
             [true, AdminPermissionMap::PERMISSION_CREATE],
             [true, AdminPermissionMap::PERMISSION_DELETE],
             [true, AdminPermissionMap::PERMISSION_UNDELETE],

--- a/tests/Util/AdminObjectAclDataTest.php
+++ b/tests/Util/AdminObjectAclDataTest.php
@@ -15,11 +15,11 @@ namespace Sonata\AdminBundle\Tests\Util;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Security\Acl\Permission\MaskBuilder;
 use Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface;
 use Sonata\AdminBundle\Util\AdminObjectAclData;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Security\Acl\Domain\Acl;
-use Symfony\Component\Security\Acl\Permission\MaskBuilder;
 
 /**
  * @author Kévin Dunglas <kevin@les-tilleuls.coop>
@@ -223,7 +223,7 @@ final class AdminObjectAclDataTest extends TestCase
 
         $securityHandler
             ->method('getObjectPermissions')
-            ->willReturn(['VIEW', 'EDIT', 'DELETE', 'UNDELETE', 'OPERATOR', 'MASTER', 'OWNER']);
+            ->willReturn(['VIEW', 'EDIT', 'HISTORY', 'DELETE', 'UNDELETE', 'OPERATOR', 'MASTER', 'OWNER']);
 
         $securityHandler
             ->method('buildSecurityInformation')


### PR DESCRIPTION
## Subject

I am targeting this branch, because there is no real BC way to do it.
It will be a BC-break only for revisions users (with EntityAuditBundle).

Closes #7444.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- New role `ROLE_MYADMIN_HISTORY` to access to the history actions

### Changed
- `AbstractAdmin::getAccessMapping` visibility

### Removed
- Access to the history actions with the role `ROLE_MYADMIN_EDIT` 
- `AdminInterface::getAccessMapping` method
```