### PR TITLE
Fix error message

### DIFF
--- a/src/FieldDescription/BaseFieldDescription.php
+++ b/src/FieldDescription/BaseFieldDescription.php
@@ -414,15 +414,15 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
             ));
         }
 
-        $propertyAccesor = PropertyAccess::createPropertyAccessorBuilder()
+        $propertyAccessor = PropertyAccess::createPropertyAccessorBuilder()
             ->enableMagicCall()
             ->getPropertyAccessor();
 
         try {
-            return $propertyAccesor->getValue($object, $accessor);
+            return $propertyAccessor->getValue($object, $accessor);
         } catch (ExceptionInterface $exception) {
             throw new NoValueException(
-                sprintf('Cannot access property "%s" in class "%s".', $this->getName(), \get_class($object)),
+                sprintf('Cannot access property "%s" in class "%s".', $this->getName(), $this->getAdmin()->getClass()),
                 (int) $exception->getCode(),
                 $exception
             );

--- a/tests/FieldDescription/BaseFieldDescriptionTest.php
+++ b/tests/FieldDescription/BaseFieldDescriptionTest.php
@@ -125,11 +125,12 @@ final class BaseFieldDescriptionTest extends TestCase
 
     public function testGetFieldValueNoValueException(): void
     {
-        $this->expectException(NoValueException::class);
-
+        $admin = $this->createStub(AdminInterface::class);
         $description = new FieldDescription('name');
+        $description->setAdmin($admin);
         $mock = $this->getMockBuilder(\stdClass::class)->addMethods(['getFoo'])->getMock();
 
+        $this->expectException(NoValueException::class);
         $this->callMethod($description, 'getFieldValue', [$mock, 'fake']);
     }
 


### PR DESCRIPTION
Pedantic.

When using the `foo.bar` field on the `BazAdmin`, the message is 
"Cannot access 'foo.bar' on `Bar`", instead of "Cannot access 'foo.bar' on `Baz`"
