### PR TITLE
Autoinject all admin variables

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -973,6 +973,8 @@ class CRUDController extends AbstractController
      *
      * @param string               $view       The view name
      * @param array<string, mixed> $parameters An array of parameters to pass to the view
+     *
+     * @deprecated since sonata-project/admin-bundle version 4.x
      */
     final protected function renderWithExtraParams(string $view, array $parameters = [], ?Response $response = null): Response
     {
@@ -983,6 +985,8 @@ class CRUDController extends AbstractController
      * @param array<string, mixed> $parameters
      *
      * @return array<string, mixed>
+     *
+     * @deprecated since sonata-project/admin-bundle version 4.x
      */
     protected function addRenderExtraParams(array $parameters = []): array
     {

--- a/src/EventListener/AdminEventListener.php
+++ b/src/EventListener/AdminEventListener.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\EventListener;
+
+use Sonata\AdminBundle\Request\AdminFetcherInterface;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\KernelEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Twig\Environment;
+
+/**
+ * @author Christian Gripp <mail@core23.de>
+ */
+final class AdminEventListener implements EventSubscriberInterface
+{
+    /**
+     * @var Environment
+     */
+    private $twig;
+
+    /**
+     * @var AdminFetcherInterface
+     */
+    private $adminFetcher;
+
+    /**
+     * @var TemplateRegistryInterface
+     */
+    private $templateRegistry;
+
+    public function __construct(
+        Environment $twig,
+        AdminFetcherInterface $adminFetcher,
+        TemplateRegistryInterface $templateRegistry
+    ) {
+        $this->twig = $twig;
+        $this->adminFetcher = $adminFetcher;
+        $this->templateRegistry = $templateRegistry;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => [['onKernelRequest', -50]],
+        ];
+    }
+
+    public function onKernelRequest(KernelEvent $event): void
+    {
+        $request = $event->getRequest();
+
+        try {
+            $admin = $this->adminFetcher->get($request);
+        } catch (\InvalidArgumentException $exception) {
+            return;
+        }
+
+        $this->addVariable('admin', $admin);
+
+        if ($this->isXmlHttpRequest($request)) {
+            $baseTemplate = $this->templateRegistry->getTemplate('ajax');
+        } else {
+            $baseTemplate = $this->templateRegistry->getTemplate('layout');
+        }
+
+        $this->addVariable('base_template', $baseTemplate);
+    }
+
+    /**
+     * Returns true if the request is a XMLHttpRequest.
+     *
+     * @return bool True if the request is an XMLHttpRequest, false otherwise
+     */
+    private function isXmlHttpRequest(Request $request): bool
+    {
+        if ($request->isXmlHttpRequest()) {
+            return true;
+        }
+
+        return null !== $request->attributes->get('_xml_http_request');
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function addVariable(string $name, $value): void
+    {
+        try {
+            $this->twig->addGlobal($name, $value);
+        } catch (\LogicException $exception) {
+        }
+    }
+}

--- a/src/Resources/config/event_listener.php
+++ b/src/Resources/config/event_listener.php
@@ -11,13 +11,24 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
+use Sonata\AdminBundle\EventListener\AdminEventListener;
 use Sonata\AdminBundle\EventListener\ConfigureCRUDControllerListener;
+use Sonata\AdminBundle\Request\AdminFetcherInterface;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ReferenceConfigurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     // Use "service" function for creating references to services when dropping support for Symfony 4.4
     // Use "param" function for creating references to parameters when dropping support for Symfony 5.1
     $containerConfigurator->services()
+
+        ->set(AdminEventListener::class)
+            ->tag('kernel.event_subscriber', [])
+            ->args([
+                new ReferenceConfigurator('twig'),
+                new ReferenceConfigurator(AdminFetcherInterface::class),
+                new ReferenceConfigurator('sonata.admin.global_template_registry'),
+            ])
 
         ->set('sonata.admin.event_listener.configure_crud_controller', ConfigureCRUDControllerListener::class)
             ->tag('kernel.event_subscriber');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

With this PR it is not necessary to use the `CRUDController::renderWithExtraParams` to render a template in the admin context. All admin pages with a `_sonata_admin` parameter inside the route configuration can use the autoinjected twig variables for that admin page.

IMHO we can remove this method on the `master` branch after merging:
https://github.com/sonata-project/SonataAdminBundle/blob/4.x/src/Controller/CRUDController.php#L932

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 3.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/3.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this feature is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
-  Autoinject all admin variables using event listeners
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
