### PR TITLE
Allow configured action buttons

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1768,7 +1768,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
      */
     final public function getActionButtons(string $action, ?object $object = null): array
     {
-        $internalButtonList = $this->getInternalActionButtons($action, $object);
+        $internalButtonList = $this->getDefaultActionButtons($action, $object);
         $buttonList = $this->configureActionButtons($internalButtonList, $action, $object);
 
         foreach ($this->getExtensions() as $extension) {
@@ -2219,7 +2219,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
      *
      * @phpstan-param T|null $object
      */
-    private function getInternalActionButtons(string $action, ?object $object = null): array
+    private function getDefaultActionButtons(string $action, ?object $object = null): array
     {
         // nothing to do for non-internal actions
         if (!isset(self::INTERNAL_ACTIONS[$action])) {

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1766,92 +1766,9 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
      *
      * @phpstan-param T|null $object
      */
-    private function getInternalActionButtons(string $action, ?object $object = null): array
-    {
-        // nothing to do for non-internal actions
-        if (!isset(self::INTERNAL_ACTIONS[$action])) {
-            return [];
-        }
-
-        $buttonList = [];
-
-        $actionBit = self::INTERNAL_ACTIONS[$action];
-
-        if (0 !== (self::MASK_OF_ACTION_CREATE & $actionBit)
-            && $this->hasRoute('create')
-            && $this->hasAccess('create')
-        ) {
-            $buttonList['create'] = [
-                'template' => $this->getTemplateRegistry()->getTemplate('button_create'),
-            ];
-        }
-
-        $canAccessObject = 0 !== (self::MASK_OF_ACTIONS_USING_OBJECT & $actionBit)
-            && null !== $object
-            && null !== $this->id($object);
-
-        if ($canAccessObject
-            && 0 !== (self::MASK_OF_ACTION_EDIT & $actionBit)
-            && $this->hasRoute('edit')
-            && $this->hasAccess('edit', $object)
-        ) {
-            $buttonList['edit'] = [
-                'template' => $this->getTemplateRegistry()->getTemplate('button_edit'),
-            ];
-        }
-
-        if ($canAccessObject
-            && 0 !== (self::MASK_OF_ACTION_HISTORY & $actionBit)
-            && $this->hasRoute('history')
-            && $this->hasAccess('history', $object)
-        ) {
-            $buttonList['history'] = [
-                'template' => $this->getTemplateRegistry()->getTemplate('button_history'),
-            ];
-        }
-
-        if ($canAccessObject
-            && 0 !== (self::MASK_OF_ACTION_ACL & $actionBit)
-            && $this->isAclEnabled()
-            && $this->hasRoute('acl')
-            && $this->hasAccess('acl', $object)
-        ) {
-            $buttonList['acl'] = [
-                'template' => $this->getTemplateRegistry()->getTemplate('button_acl'),
-            ];
-        }
-
-        if ($canAccessObject
-            && 0 !== (self::MASK_OF_ACTION_SHOW & $actionBit)
-            && $this->hasRoute('show')
-            && $this->hasAccess('show', $object)
-            && \count($this->getShow()) > 0
-        ) {
-            $buttonList['show'] = [
-                'template' => $this->getTemplateRegistry()->getTemplate('button_show'),
-            ];
-        }
-
-        if (0 !== (self::MASK_OF_ACTION_LIST & $actionBit)
-            && $this->hasRoute('list')
-            && $this->hasAccess('list')
-        ) {
-            $buttonList['list'] = [
-                'template' => $this->getTemplateRegistry()->getTemplate('button_list'),
-            ];
-        }
-
-        return $buttonList;
-    }
-
-    /**
-     * @return array<string, array<string, mixed>>
-     *
-     * @phpstan-param T|null $object
-     */
     final public function getActionButtons(string $action, ?object $object = null): array
     {
-        $buttonList = $this->getInternalActionButtons($buttonList, $action, $object);
+        $buttonList = $this->getInternalActionButtons($action, $object);
         $buttonList = $this->configureActionButtons($buttonList, $action, $object);
 
         foreach ($this->getExtensions() as $extension) {
@@ -2295,6 +2212,89 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
                 ObjectManipulator::setObject($object, $parentObject, $this->getParentFieldDescription());
             }
         }
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     *
+     * @phpstan-param T|null $object
+     */
+    private function getInternalActionButtons(string $action, ?object $object = null): array
+    {
+        // nothing to do for non-internal actions
+        if (!isset(self::INTERNAL_ACTIONS[$action])) {
+            return [];
+        }
+
+        $buttonList = [];
+
+        $actionBit = self::INTERNAL_ACTIONS[$action];
+
+        if (0 !== (self::MASK_OF_ACTION_CREATE & $actionBit)
+            && $this->hasRoute('create')
+            && $this->hasAccess('create')
+        ) {
+            $buttonList['create'] = [
+                'template' => $this->getTemplateRegistry()->getTemplate('button_create'),
+            ];
+        }
+
+        $canAccessObject = 0 !== (self::MASK_OF_ACTIONS_USING_OBJECT & $actionBit)
+            && null !== $object
+            && null !== $this->id($object);
+
+        if ($canAccessObject
+            && 0 !== (self::MASK_OF_ACTION_EDIT & $actionBit)
+            && $this->hasRoute('edit')
+            && $this->hasAccess('edit', $object)
+        ) {
+            $buttonList['edit'] = [
+                'template' => $this->getTemplateRegistry()->getTemplate('button_edit'),
+            ];
+        }
+
+        if ($canAccessObject
+            && 0 !== (self::MASK_OF_ACTION_HISTORY & $actionBit)
+            && $this->hasRoute('history')
+            && $this->hasAccess('history', $object)
+        ) {
+            $buttonList['history'] = [
+                'template' => $this->getTemplateRegistry()->getTemplate('button_history'),
+            ];
+        }
+
+        if ($canAccessObject
+            && 0 !== (self::MASK_OF_ACTION_ACL & $actionBit)
+            && $this->isAclEnabled()
+            && $this->hasRoute('acl')
+            && $this->hasAccess('acl', $object)
+        ) {
+            $buttonList['acl'] = [
+                'template' => $this->getTemplateRegistry()->getTemplate('button_acl'),
+            ];
+        }
+
+        if ($canAccessObject
+            && 0 !== (self::MASK_OF_ACTION_SHOW & $actionBit)
+            && $this->hasRoute('show')
+            && $this->hasAccess('show', $object)
+            && \count($this->getShow()) > 0
+        ) {
+            $buttonList['show'] = [
+                'template' => $this->getTemplateRegistry()->getTemplate('button_show'),
+            ];
+        }
+
+        if (0 !== (self::MASK_OF_ACTION_LIST & $actionBit)
+            && $this->hasRoute('list')
+            && $this->hasAccess('list')
+        ) {
+            $buttonList['list'] = [
+                'template' => $this->getTemplateRegistry()->getTemplate('button_list'),
+            ];
+        }
+
+        return $buttonList;
     }
 
     /**

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1762,11 +1762,13 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
     }
 
     /**
+     * @param array<string, array<string, mixed>> $buttonList
+     *
      * @return array<string, array<string, mixed>>
      *
      * @phpstan-param T|null $object
      */
-    final public function getActionButtons(string $action, ?object $object = null): array
+    final private function getInternalActionButtons(array $buttonList, string $action, ?object $object = null): array
     {
         // nothing to do for non-internal actions
         if (!isset(self::INTERNAL_ACTIONS[$action])) {
@@ -1774,8 +1776,6 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         }
 
         $actionBit = self::INTERNAL_ACTIONS[$action];
-
-        $buttonList = [];
 
         if (0 !== (self::MASK_OF_ACTION_CREATE & $actionBit)
             && $this->hasRoute('create')
@@ -1841,6 +1841,18 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
             ];
         }
 
+        return $buttonList;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     *
+     * @phpstan-param T|null $object
+     */
+    final public function getActionButtons(string $action, ?object $object = null): array
+    {
+        $buttonList = [];
+        $buttonList = $this->getInternalActionButtons($buttonList, $action, $object);
         $buttonList = $this->configureActionButtons($buttonList, $action, $object);
 
         foreach ($this->getExtensions() as $extension) {

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1762,18 +1762,18 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
     }
 
     /**
-     * @param array<string, array<string, mixed>> $buttonList
-     *
      * @return array<string, array<string, mixed>>
      *
      * @phpstan-param T|null $object
      */
-    private function getInternalActionButtons(array $buttonList, string $action, ?object $object = null): array
+    private function getInternalActionButtons(string $action, ?object $object = null): array
     {
         // nothing to do for non-internal actions
         if (!isset(self::INTERNAL_ACTIONS[$action])) {
             return [];
         }
+
+        $buttonList = [];
 
         $actionBit = self::INTERNAL_ACTIONS[$action];
 
@@ -1851,7 +1851,6 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
      */
     final public function getActionButtons(string $action, ?object $object = null): array
     {
-        $buttonList = [];
         $buttonList = $this->getInternalActionButtons($buttonList, $action, $object);
         $buttonList = $this->configureActionButtons($buttonList, $action, $object);
 

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1768,8 +1768,8 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
      */
     final public function getActionButtons(string $action, ?object $object = null): array
     {
-        $buttonList = $this->getInternalActionButtons($action, $object);
-        $buttonList = $this->configureActionButtons($buttonList, $action, $object);
+        $internalButtonList = $this->getInternalActionButtons($action, $object);
+        $buttonList = $this->configureActionButtons($internalButtonList, $action, $object);
 
         foreach ($this->getExtensions() as $extension) {
             $buttonList = $extension->configureActionButtons($this, $buttonList, $action, $object);

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1768,8 +1768,8 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
      */
     final public function getActionButtons(string $action, ?object $object = null): array
     {
-        $internalButtonList = $this->getDefaultActionButtons($action, $object);
-        $buttonList = $this->configureActionButtons($internalButtonList, $action, $object);
+        $defaultButtonList = $this->getDefaultActionButtons($action, $object);
+        $buttonList = $this->configureActionButtons($defaultButtonList, $action, $object);
 
         foreach ($this->getExtensions() as $extension) {
             $buttonList = $extension->configureActionButtons($this, $buttonList, $action, $object);

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1768,7 +1768,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
      *
      * @phpstan-param T|null $object
      */
-    final private function getInternalActionButtons(array $buttonList, string $action, ?object $object = null): array
+    private function getInternalActionButtons(array $buttonList, string $action, ?object $object = null): array
     {
         // nothing to do for non-internal actions
         if (!isset(self::INTERNAL_ACTIONS[$action])) {


### PR DESCRIPTION
## Subject

This PR fixes an issue where `configureActionButtons` are not called in custom actions.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - master is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a bugfix.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Issue where `configureActionButtons()` is not being called in custom actions.
```