### PR TITLE
Fix some Symfony 5.4 deprecations

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1573,6 +1573,9 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $this->getCode();
     }
 
+    /**
+     * @return string
+     */
     public function getObjectIdentifier()
     {
         return $this->getCode();

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -126,8 +126,8 @@ class CRUDController extends AbstractController
 
         $template = $this->templateRegistry->getTemplate('list');
 
-        if ($this->has('sonata.admin.admin_exporter')) {
-            $exporter = $this->get('sonata.admin.admin_exporter');
+        if ($this->container->has('sonata.admin.admin_exporter')) {
+            $exporter = $this->container->get('sonata.admin.admin_exporter');
             \assert($exporter instanceof AdminExporter);
             $exportFormats = $exporter->getAvailableFormats($this->admin);
         }
@@ -643,7 +643,7 @@ class CRUDController extends AbstractController
 
         $this->admin->checkAccess('history', $object);
 
-        $manager = $this->get('sonata.admin.audit.manager');
+        $manager = $this->container->get('sonata.admin.audit.manager');
         \assert($manager instanceof AuditManagerInterface);
 
         if (!$manager->hasReader($this->admin->getClass())) {
@@ -684,7 +684,7 @@ class CRUDController extends AbstractController
 
         $this->admin->checkAccess('historyViewRevision', $object);
 
-        $manager = $this->get('sonata.admin.audit.manager');
+        $manager = $this->container->get('sonata.admin.audit.manager');
         \assert($manager instanceof AuditManagerInterface);
 
         if (!$manager->hasReader($this->admin->getClass())) {
@@ -734,7 +734,7 @@ class CRUDController extends AbstractController
         $id = $request->get($this->admin->getIdParameter());
         \assert(null !== $id);
 
-        $manager = $this->get('sonata.admin.audit.manager');
+        $manager = $this->container->get('sonata.admin.audit.manager');
         \assert($manager instanceof AuditManagerInterface);
 
         if (!$manager->hasReader($this->admin->getClass())) {
@@ -792,12 +792,12 @@ class CRUDController extends AbstractController
 
         $format = $request->get('format');
 
-        $adminExporter = $this->get('sonata.admin.admin_exporter');
+        $adminExporter = $this->container->get('sonata.admin.admin_exporter');
         \assert($adminExporter instanceof AdminExporter);
         $allowedExportFormats = $adminExporter->getAvailableFormats($this->admin);
         $filename = $adminExporter->getExportFilename($this->admin, $format);
 
-        $exporter = $this->get('sonata.exporter.exporter');
+        $exporter = $this->container->get('sonata.exporter.exporter');
         \assert($exporter instanceof Exporter);
 
         if (!\in_array($format, $allowedExportFormats, true)) {
@@ -841,7 +841,7 @@ class CRUDController extends AbstractController
         $aclUsers = $this->getAclUsers();
         $aclRoles = $this->getAclRoles();
 
-        $adminObjectAclManipulator = $this->get('sonata.admin.object.manipulator.acl.admin');
+        $adminObjectAclManipulator = $this->container->get('sonata.admin.object.manipulator.acl.admin');
         \assert($adminObjectAclManipulator instanceof AdminObjectAclManipulator);
 
         $adminObjectAclData = new AdminObjectAclData(
@@ -964,8 +964,8 @@ class CRUDController extends AbstractController
      */
     protected function getLogger(): LoggerInterface
     {
-        if ($this->has('logger')) {
-            $logger = $this->get('logger');
+        if ($this->container->has('logger')) {
+            $logger = $this->container->get('logger');
             \assert($logger instanceof LoggerInterface);
 
             return $logger;
@@ -981,7 +981,7 @@ class CRUDController extends AbstractController
      */
     protected function getBaseTemplate(): string
     {
-        $requestStack = $this->get('request_stack');
+        $requestStack = $this->container->get('request_stack');
         \assert($requestStack instanceof RequestStack);
         $request = $requestStack->getCurrentRequest();
         \assert(null !== $request);
@@ -1111,11 +1111,11 @@ class CRUDController extends AbstractController
      */
     protected function getAclUsers(): \Traversable
     {
-        if (!$this->has('sonata.admin.security.acl_user_manager')) {
+        if (!$this->container->has('sonata.admin.security.acl_user_manager')) {
             return new \ArrayIterator([]);
         }
 
-        $aclUserManager = $this->get('sonata.admin.security.acl_user_manager');
+        $aclUserManager = $this->container->get('sonata.admin.security.acl_user_manager');
         \assert($aclUserManager instanceof AdminAclUserManagerInterface);
         $aclUsers = $aclUserManager->findUsers();
 
@@ -1130,7 +1130,7 @@ class CRUDController extends AbstractController
         $aclRoles = [];
         $roleHierarchy = $this->getParameter('security.role_hierarchy.roles');
         \assert(\is_array($roleHierarchy));
-        $pool = $this->get('sonata.admin.pool');
+        $pool = $this->container->get('sonata.admin.pool');
         \assert($pool instanceof Pool);
 
         foreach ($pool->getAdminServiceIds() as $id) {
@@ -1164,12 +1164,12 @@ class CRUDController extends AbstractController
      */
     final protected function validateCsrfToken(Request $request, string $intention): void
     {
-        if (!$this->has('security.csrf.token_manager')) {
+        if (!$this->container->has('security.csrf.token_manager')) {
             return;
         }
 
         $token = $request->get('_sonata_csrf_token');
-        $tokenManager = $this->get('security.csrf.token_manager');
+        $tokenManager = $this->container->get('security.csrf.token_manager');
         \assert($tokenManager instanceof CsrfTokenManagerInterface);
 
         if (!$tokenManager->isTokenValid(new CsrfToken($intention, $token))) {
@@ -1190,11 +1190,11 @@ class CRUDController extends AbstractController
      */
     final protected function getCsrfToken(string $intention): ?string
     {
-        if (!$this->has('security.csrf.token_manager')) {
+        if (!$this->container->has('security.csrf.token_manager')) {
             return null;
         }
 
-        $tokenManager = $this->get('security.csrf.token_manager');
+        $tokenManager = $this->container->get('security.csrf.token_manager');
         \assert($tokenManager instanceof CsrfTokenManagerInterface);
 
         return $tokenManager->getToken($intention)->getValue();
@@ -1261,7 +1261,7 @@ class CRUDController extends AbstractController
     final protected function trans(string $id, array $parameters = [], ?string $domain = null, ?string $locale = null): string
     {
         $domain = $domain ?? $this->admin->getTranslationDomain();
-        $translator = $this->get('translator');
+        $translator = $this->container->get('translator');
         \assert($translator instanceof TranslatorInterface);
 
         return $translator->trans($id, $parameters, $domain, $locale);
@@ -1343,7 +1343,7 @@ class CRUDController extends AbstractController
      */
     final protected function setFormTheme(FormView $formView, ?array $theme = null): void
     {
-        $twig = $this->get('twig');
+        $twig = $this->container->get('twig');
         \assert($twig instanceof Environment);
         $formRenderer = $twig->getRuntime(FormRenderer::class);
         \assert($formRenderer instanceof FormRenderer);

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -40,9 +40,9 @@ final class AppKernel extends Kernel
         parent::__construct('test', false);
     }
 
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
-        $bundles = [
+        return [
             new FrameworkBundle(),
             new TwigBundle(),
             new SecurityBundle(),
@@ -53,8 +53,6 @@ final class AppKernel extends Kernel
             new SonataTwigBundle(),
             new SonataFormBundle(),
         ];
-
-        return $bundles;
     }
 
     public function getCacheDir(): string
@@ -67,7 +65,7 @@ final class AppKernel extends Kernel
         return sprintf('%slog', $this->getBaseDir());
     }
 
-    public function getProjectDir()
+    public function getProjectDir(): string
     {
         return __DIR__;
     }

--- a/tests/Fixtures/StubFilesystemLoader.php
+++ b/tests/Fixtures/StubFilesystemLoader.php
@@ -21,7 +21,7 @@ final class StubFilesystemLoader extends FilesystemLoader
      * @param string $name
      * @param bool   $throw
      */
-    protected function findTemplate($name, $throw = true)
+    protected function findTemplate($name, $throw = true): ?string
     {
         // strip away bundle name
         $parts = explode(':', $name);

--- a/tests/Functional/Controller/AdminAsParameterControllerTest.php
+++ b/tests/Functional/Controller/AdminAsParameterControllerTest.php
@@ -42,7 +42,7 @@ final class AdminAsParameterControllerTest extends WebTestCase
         ];
     }
 
-    protected static function getKernelClass()
+    protected static function getKernelClass(): string
     {
         return AppKernel::class;
     }

--- a/tests/Functional/Controller/CRUDControllerTest.php
+++ b/tests/Functional/Controller/CRUDControllerTest.php
@@ -100,7 +100,7 @@ final class CRUDControllerTest extends WebTestCase
         ];
     }
 
-    protected static function getKernelClass()
+    protected static function getKernelClass(): string
     {
         return AppKernel::class;
     }


### PR DESCRIPTION
Fixes some of the deprecations shown in https://github.com/sonata-project/SonataAdminBundle/pull/7486

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Deprecations triggered with Symfony 5.4
```