### PR TITLE
doc: Overriding translation domain in 4.0.0

### DIFF
--- a/docs/reference/translation.rst
+++ b/docs/reference/translation.rst
@@ -11,32 +11,23 @@ There are two main catalogue names in an Admin class:
 Ideally the ``messages`` catalogue should be changed to avoid any issues with
 other Admin classes.
 
-You have two options to configure the catalogue for the Admin class:
+You can configure the catalogue for the Admin class by injecting the value through the container:
 
-* override the ``$translationDomain`` property::
+.. configuration-block::
 
-      final class PageAdmin extends AbstractAdmin
-      {
-          protected $translationDomain = 'SonataPageBundle'; // default is 'messages'
-      }
+    .. code-block:: xml
 
-* inject the value through the container
+        <!-- config/services.xml -->
 
-    .. configuration-block::
-
-        .. code-block:: xml
-
-            <!-- config/services.xml -->
-
-            <service id="sonata.page.admin.page" class="Sonata\PageBundle\Admin\PageAdmin">
-                <tag name="sonata.admin" manager_type="orm" group="sonata_page" label="Page"/>
-                <argument/>
-                <argument>Application\Sonata\PageBundle\Entity\Page</argument>
-                <argument/>
-                <call method="setTranslationDomain">
-                    <argument>SonataPageBundle</argument>
-                </call>
-            </service>
+        <service id="sonata.page.admin.page" class="Sonata\PageBundle\Admin\PageAdmin">
+            <tag name="sonata.admin" manager_type="orm" group="sonata_page" label="Page"/>
+            <argument/>
+            <argument>Application\Sonata\PageBundle\Entity\Page</argument>
+            <argument/>
+            <call method="setTranslationDomain">
+                <argument>SonataPageBundle</argument>
+            </call>
+        </service>
 
 An Admin instance always gets the ``translator`` instance, so it can be used to
 translate messages within the ``configureFields`` method or in templates.


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Update the doc following changes made in https://github.com/sonata-project/SonataAdminBundle/pull/7220

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because a doc improvement is backward compatible.
