### PR TITLE
Restrict form options types

### DIFF
--- a/src/Form/Type/ModelAutocompleteType.php
+++ b/src/Form/Type/ModelAutocompleteType.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Form\Type;
 
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Form\DataTransformer\ModelToIdPropertyTransformer;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\EventListener\ResizeFormListener;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -108,8 +109,6 @@ final class ModelAutocompleteType extends AbstractType
             'attr' => [],
             'compound' => $compound,
             'error_bubbling' => false,
-            'model_manager' => null,
-            'class' => null,
             'admin_code' => null,
             'callback' => null,
             'multiple' => false,
@@ -153,7 +152,10 @@ final class ModelAutocompleteType extends AbstractType
             'template' => '@SonataAdmin/Form/Type/sonata_type_model_autocomplete.html.twig',
         ]);
 
-        $resolver->setRequired(['property']);
+        $resolver->setRequired(['property', 'model_manager', 'class']);
+        $resolver->setAllowedTypes('model_manager', ModelManagerInterface::class);
+        $resolver->setAllowedTypes('class', 'string');
+        $resolver->setAllowedTypes('property', ['string', 'array']);
     }
 
     public function getBlockPrefix(): string

--- a/src/Form/Type/ModelHiddenType.php
+++ b/src/Form/Type/ModelHiddenType.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Form\Type;
 
 use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -39,12 +40,14 @@ final class ModelHiddenType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'model_manager' => null,
-            'class' => null,
             'attr' => [
                 'hidden' => true,
             ],
         ]);
+
+        $resolver->setRequired(['model_manager', 'class']);
+        $resolver->setAllowedTypes('model_manager', ModelManagerInterface::class);
+        $resolver->setAllowedTypes('class', 'string');
     }
 
     /**

--- a/src/Form/Type/ModelListType.php
+++ b/src/Form/Type/ModelListType.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Form\Type;
 
 use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -73,14 +74,16 @@ final class ModelListType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'model_manager' => null,
-            'class' => null,
             'btn_add' => 'link_add',
             'btn_edit' => 'link_edit',
             'btn_list' => 'link_list',
             'btn_delete' => 'link_delete',
             'btn_catalogue' => 'SonataAdminBundle',
         ]);
+
+        $resolver->setRequired(['model_manager', 'class']);
+        $resolver->setAllowedTypes('model_manager', ModelManagerInterface::class);
+        $resolver->setAllowedTypes('class', 'string');
     }
 
     /**

--- a/src/Form/Type/ModelReferenceType.php
+++ b/src/Form/Type/ModelReferenceType.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Form\Type;
 
 use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -37,9 +38,11 @@ final class ModelReferenceType extends AbstractType
     {
         $resolver->setDefaults([
             'compound' => false,
-            'model_manager' => null,
-            'class' => null,
         ]);
+
+        $resolver->setRequired(['model_manager', 'class']);
+        $resolver->setAllowedTypes('model_manager', ModelManagerInterface::class);
+        $resolver->setAllowedTypes('class', 'string');
     }
 
     /**

--- a/src/Form/Type/ModelType.php
+++ b/src/Form/Type/ModelType.php
@@ -17,6 +17,7 @@ use Sonata\AdminBundle\Form\ChoiceList\ModelChoiceLoader;
 use Sonata\AdminBundle\Form\DataTransformer\ModelsToArrayTransformer;
 use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
 use Sonata\AdminBundle\Form\EventListener\MergeCollectionListener;
+use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\ChoiceList\ChoiceListInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -117,8 +118,6 @@ final class ModelType extends AbstractType
             'template' => 'choice',
             'multiple' => false,
             'expanded' => false,
-            'model_manager' => null,
-            'class' => null,
             'property' => null,
             'query' => null,
             'choices' => null,
@@ -128,6 +127,10 @@ final class ModelType extends AbstractType
             'btn_delete' => 'link_delete',
             'btn_catalogue' => 'SonataAdminBundle',
         ]));
+
+        $resolver->setRequired(['model_manager', 'class']);
+        $resolver->setAllowedTypes('model_manager', ModelManagerInterface::class);
+        $resolver->setAllowedTypes('class', 'string');
     }
 
     /**

--- a/tests/Form/Type/ModelListTypeTest.php
+++ b/tests/Form/Type/ModelListTypeTest.php
@@ -36,15 +36,15 @@ final class ModelListTypeTest extends TypeTestCase
     public function testGetDefaultOptions(): void
     {
         $type = new ModelListType();
-
+        $modelManager = $this->createMock(ModelManagerInterface::class);
         $optionResolver = new OptionsResolver();
 
         $type->configureOptions($optionResolver);
 
-        $options = $optionResolver->resolve();
+        $options = $optionResolver->resolve(['model_manager' => $modelManager, 'class' => '\Foo']);
 
-        static::assertNull($options['model_manager']);
-        static::assertNull($options['class']);
+        static::assertInstanceOf(ModelManagerInterface::class, $options['model_manager']);
+        static::assertSame('\Foo', $options['class']);
         static::assertSame('link_add', $options['btn_add']);
         static::assertSame('link_edit', $options['btn_edit']);
         static::assertSame('link_list', $options['btn_list']);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because BC.

Solve https://github.com/sonata-project/SonataAdminBundle/issues/7505#issuecomment-925570165

## Changelog

```markdown
### Changed
- Improved error message when a required option is not passed to the FormType.
```