### PR TITLE
Restrict form_types values

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -37,7 +37,7 @@ Full Configuration Options
         # Default configuration for extension with alias: "sonata_admin"
         sonata_admin:
             security:
-                handler:              sonata.admin.security.handler.noop
+                handler: sonata.admin.security.handler.noop
 
                 role_admin: ROLE_ADMIN
                 role_super_admin: ROLE_SUPER_ADMIN
@@ -45,7 +45,7 @@ Full Configuration Options
                 information:
 
                     # Prototype
-                    id:                   []
+                    id: []
                 admin_permissions:
 
                     # Defaults:
@@ -85,7 +85,7 @@ Full Configuration Options
                 use_bootlint: false
                 use_stickyforms: true
                 pager_links: null
-                form_type: standard
+                form_type: 'standard' # One of "standard"; "horizontal"
                 default_admin_route: show
                 default_group: default
                 default_label_catalogue: SonataAdminBundle

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -169,7 +169,12 @@ final class Configuration implements ConfigurationInterface
                         ->booleanNode('use_bootlint')->defaultFalse()->end()
                         ->booleanNode('use_stickyforms')->defaultTrue()->end()
                         ->integerNode('pager_links')->defaultNull()->end()
+                        // NEXT_MAJOR: Remove this line and uncomment the following line instead.
                         ->scalarNode('form_type')->defaultValue('standard')->end()
+//                        ->enumNode('form_type')
+//                            ->defaultValue('standard')
+//                            ->values(['standard', 'horizontal'])
+//                        ->end()
                         ->scalarNode('default_admin_route')
                             ->defaultValue('show')
                             ->info('Name of the admin route to be used as a default to generate the link to the object')

--- a/src/SonataConfiguration.php
+++ b/src/SonataConfiguration.php
@@ -20,7 +20,7 @@ namespace Sonata\AdminBundle;
  *  default_icon: string,
  *  default_label_catalogue: string,
  *  dropdown_number_groups_per_colums: int,
- *  form_type: string,
+ *  form_type: 'standard'|'horizontal',
  *  html5_validate: bool,
  *  javascripts: list<string>,
  *  js_debug: bool,


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Just discovered this option. I think the only two options are `standard` and `horizontal`.
So I added a Next_major to restrict the values.

I don't think we want to allow others values for some users creating custom ones because we never did this for others options, like `logo_content`.

Pedantic as far