### PR TITLE
Deprecate BuilderInterface

### DIFF
--- a/src/Builder/BuilderInterface.php
+++ b/src/Builder/BuilderInterface.php
@@ -17,6 +17,10 @@ use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * NEXT_MAJOR: Remove this interface
+ *
+ * @deprecated since sonata-project/admin-bundle version 4.x and will be removed in 5.0.
  */
 interface BuilderInterface
 {

--- a/src/Builder/FormContractorInterface.php
+++ b/src/Builder/FormContractorInterface.php
@@ -24,6 +24,13 @@ use Symfony\Component\Form\FormBuilderInterface;
 interface FormContractorInterface extends BuilderInterface
 {
     /**
+     * Adds missing information to the given field description and the given admin.
+     *
+     * @param FieldDescriptionInterface $fieldDescription will be modified
+     */
+    public function fixFieldDescription(FieldDescriptionInterface $fieldDescription): void;
+
+    /**
      * @param array<string, mixed> $formOptions
      */
     public function getFormBuilder(string $name, array $formOptions = []): FormBuilderInterface;

--- a/src/Builder/FormContractorInterface.php
+++ b/src/Builder/FormContractorInterface.php
@@ -25,8 +25,6 @@ interface FormContractorInterface extends BuilderInterface
 {
     /**
      * Adds missing information to the given field description and the given admin.
-     *
-     * @param FieldDescriptionInterface $fieldDescription will be modified
      */
     public function fixFieldDescription(FieldDescriptionInterface $fieldDescription): void;
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because BC.

Only the FormContractorInterface need this method.
This allow to reduce visibility of this method in the persistence bundle.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `Sonata\AdminBundle\Builder\BuilderInterface`
```