### PR TITLE
[BugFix] Always parse icon when creating a variable

### DIFF
--- a/src/Resources/views/Block/block_admin_preview.html.twig
+++ b/src/Resources/views/Block/block_admin_preview.html.twig
@@ -19,9 +19,9 @@ file that was distributed with this source code.
     {% set results_count = attribute(admin.datagrid.pager, 'countResults') is defined ? admin.datagrid.pager.countResults : admin.datagrid.pager.nbResults %}
     <div class="box box-primary" id="{{ inlineAnchor }}">
         <div class="box-header with-border">
-            {% set icon = settings.icon|default('') %}
+            {% set icon = settings.icon|default('')|parse_icon %}
             {% if icon %}
-                {{ icon|parse_icon }}
+                {{ icon }}
             {% endif %}
             <h3 class="box-title">
                 <a href="#{{ inlineAnchor }}">

--- a/src/Resources/views/Block/block_search_result.html.twig
+++ b/src/Resources/views/Block/block_search_result.html.twig
@@ -27,8 +27,8 @@ file that was distributed with this source code.
     <div class="col-lg-4 col-md-6 search-box-item {{ visibility_class }}">
         <div class="box box-solid {{ visibility_class }}">
             <div class="box-header with-border {{ visibility_class }}">
-                {% set icon = settings.icon|default('') %}
-                {{ icon|parse_icon }}
+                {% set icon = settings.icon|default('')|parse_icon %}
+                {{ icon }}
                 <h3 class="box-title">
                     {% if admin.label is not empty %}
                         {{ admin.label|trans({}, admin.translationdomain) }}

--- a/src/Resources/views/Menu/sonata_menu.html.twig
+++ b/src/Resources/views/Menu/sonata_menu.html.twig
@@ -24,9 +24,9 @@
     {% apply spaceless %}
         {%- set translation_domain = item.extra('label_catalogue', 'messages') -%}
         {%- if item.extra('on_top') is defined and not item.extra('on_top') -%}
-            {%- set icon = item.extra('icon')|default(item.level > 1 ? 'fa fa-angle-double-right' : '') -%}
+            {%- set icon = item.extra('icon')|default(item.level > 1 ? 'fa fa-angle-double-right' : '')|parse_icon -%}
         {%- else -%}
-            {%- set icon = item.extra('icon') -%}
+            {%- set icon = item.extra('icon')|parse_icon -%}
         {%- endif -%}
         {%- set is_link = true -%}
         {{ parent() }}
@@ -37,8 +37,8 @@
     {% apply spaceless %}
         <a href="#">
             {%- set translation_domain = item.extra('label_catalogue', 'messages') -%}
-            {%- set icon = item.extra('icon')|default('') -%}
-            {{ icon|parse_icon }}
+            {%- set icon = item.extra('icon')|default('')|parse_icon -%}
+            {{ icon }}
             {{ parent() }}
             {%- if item.extra('keep_open') is not defined or not item.extra('keep_open') -%}
                 <span class="pull-right-container"><i class="fa pull-right fa-angle-left"></i></span>


### PR DESCRIPTION
## Subject

I am targeting this branch, because bugfix.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Correctly display the default icon in the admin menu if none are provided.
```