### PR TITLE
Always use raw on icon

### DIFF
--- a/src/Resources/views/Block/block_admin_preview.html.twig
+++ b/src/Resources/views/Block/block_admin_preview.html.twig
@@ -19,10 +19,7 @@ file that was distributed with this source code.
     {% set results_count = attribute(admin.datagrid.pager, 'countResults') is defined ? admin.datagrid.pager.countResults : admin.datagrid.pager.nbResults %}
     <div class="box box-primary" id="{{ inlineAnchor }}">
         <div class="box-header with-border">
-            {% set icon = settings.icon|default('')|parse_icon %}
-            {% if icon %}
-                {{ icon }}
-            {% endif %}
+            {{ settings.icon|default('')|parse_icon }}
             <h3 class="box-title">
                 <a href="#{{ inlineAnchor }}">
                     {% if translation_domain is same as(false) %}

--- a/src/Resources/views/Block/block_search_result.html.twig
+++ b/src/Resources/views/Block/block_search_result.html.twig
@@ -27,8 +27,7 @@ file that was distributed with this source code.
     <div class="col-lg-4 col-md-6 search-box-item {{ visibility_class }}">
         <div class="box box-solid {{ visibility_class }}">
             <div class="box-header with-border {{ visibility_class }}">
-                {% set icon = settings.icon|default('')|parse_icon %}
-                {{ icon }}
+                {{ settings.icon|default('')|parse_icon }}
                 <h3 class="box-title">
                     {% if admin.label is not empty %}
                         {{ admin.label|trans({}, admin.translationdomain) }}

--- a/src/Resources/views/Menu/sonata_menu.html.twig
+++ b/src/Resources/views/Menu/sonata_menu.html.twig
@@ -38,7 +38,7 @@
         <a href="#">
             {%- set translation_domain = item.extra('label_catalogue', 'messages') -%}
             {%- set icon = item.extra('icon')|default('')|parse_icon -%}
-            {{ icon }}
+            {{ icon|raw }}
             {{ parent() }}
             {%- if item.extra('keep_open') is not defined or not item.extra('keep_open') -%}
                 <span class="pull-right-container"><i class="fa pull-right fa-angle-left"></i></span>


### PR DESCRIPTION
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because bugfix.

The issue is that parse icon do two thing
- Modifying `fa fa-foo` to the html syntax
- Using `|raw`.

When creating a `icon` variable, if we don't use the `parse_icon` filter, people have to use them, so the PR which introduce this wasn't fully BC. But, if we use the filter on the variable, we still need to use `|raw` when rendering the variable.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #7523.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Html icon rendering in the menu 
```