### PR TITLE
Ensure filters are in order when using multiple properties using autocomplete

### DIFF
--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -189,6 +189,8 @@ final class RetrieveAutocompleteItemsAction
 
                 $previousFilter = $filter;
             }
+
+            $datagrid->reorderFilters($property);
         } else {
             if (!$datagrid->hasFilter($property)) {
                 throw new \RuntimeException(sprintf(

--- a/tests/Action/RetrieveAutocompleteItemsActionTest.php
+++ b/tests/Action/RetrieveAutocompleteItemsActionTest.php
@@ -199,6 +199,10 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
             [DatagridInterface::PAGE, null, 1]
         );
 
+        $datagrid->expects(static::once())
+            ->method('reorderFilters')
+            ->with(['entity.property', 'entity2.property2']);
+
         $response = ($this->action)($request);
 
         static::assertSame(Filter::CONDITION_OR, $filter->getCondition());


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

When using multiple properties in a `ModelAutocompleteType` like:

```php
$form
    ->add('user', ModelAutocompleteType::class, ['property' => ['username', 'email']]);
```

These properties have to be in the same order that were defined in the `UserAdmin::configureDatagridFilters`, otherwise it creates wrong queries since the filters are not linked (`previousFilter` property) properly.

This PR reorders the datagrid filters before creating the query.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixed using multiple properties with `ModelAutocompleteType` with different order
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
