### PR TITLE
Make getBatchActions return an empty array when the admin does not have a batch route

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -746,6 +746,10 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
 
     final public function getBatchActions(): array
     {
+        if (!$this->hasRoute('batch')) {
+            return [];
+        }
+
         $actions = [];
 
         if ($this->hasRoute('delete') && $this->hasAccess('delete')) {

--- a/tests/Fixtures/Admin/PostWithoutBatchRouteAdmin.php
+++ b/tests/Fixtures/Admin/PostWithoutBatchRouteAdmin.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Admin;
+
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Route\RouteCollectionInterface;
+
+/**
+ * @phpstan-extends AbstractAdmin<object>
+ */
+final class PostWithoutBatchRouteAdmin extends AbstractAdmin
+{
+    protected function configureRoutes(RouteCollectionInterface $collection): void
+    {
+        $collection->remove('batch');
+    }
+}


### PR DESCRIPTION
## Subject

`getBatchActions()` should return an empty array when the admin does not have a `'batch'` route

I am targeting the 4.x branch, because this is fixing #7527 .

Closes #7527 .

## Changelog

```markdown
### Fixed
- Made `getBatchActions()` return an empty array when the admin does not have a batch route
```
