### PR TITLE
Move appendParentObject into createNewInstance

### DIFF
--- a/UPGRADE-4.x.md
+++ b/UPGRADE-4.x.md
@@ -1,7 +1,7 @@
 UPGRADE 4.x
 ===========
 
-UPGRADE FROM 4.0.1 to 4.0.2
+UPGRADE FROM 4.x to 4.x
 ===========================
 
 ### appendParentObject is called inside createNewInstance with child admins

--- a/UPGRADE-4.x.md
+++ b/UPGRADE-4.x.md
@@ -1,0 +1,38 @@
+UPGRADE 4.x
+===========
+
+UPGRADE FROM 4.0.1 to 4.0.2
+===========================
+
+### appendParentObject is called inside createNewInstance with child admins
+
+In a child admin, if you were overriding `createNewInstance` and relying on sonata to provide the needed "parent" entity
+to the instance, now you have to call `appendParentObject` manually.
+
+Before:
+```php
+final class PostAdmin extends AbstractAdmin
+{
+    public function createNewInstance(): object
+    {
+        return new Post();
+    }
+}
+```
+
+After:
+```php
+
+final class PostAdmin extends AbstractAdmin
+{
+    public function createNewInstance(): object
+    {
+        $object = new Post();
+
+         // set the post author if the parent admin is "AuthorAdmin"
+        $this->appendParentObject($object);
+
+        return $object;
+    }
+}
+```

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -855,7 +855,6 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
     {
         $object = $this->createNewInstance();
 
-        $this->appendParentObject($object);
         $this->alterNewInstance($object);
 
         foreach ($this->getExtensions() as $extension) {
@@ -1845,7 +1844,10 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
      */
     protected function createNewInstance(): object
     {
-        return Instantiator::instantiate($this->getClass());
+        $object = Instantiator::instantiate($this->getClass());
+        $this->appendParentObject($object);
+
+        return $object;
     }
 
     /**

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -61,6 +61,7 @@ use Sonata\AdminBundle\Tests\Fixtures\Admin\PostCategoryAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\PostWithCustomRouteAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\PostWithoutBatchRouteAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\TagAdmin;
+use Sonata\AdminBundle\Tests\Fixtures\Admin\TagWithoutPostAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\BlogPost;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Comment;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\CommentVote;
@@ -1421,6 +1422,23 @@ final class AdminTest extends TestCase
         $tag = $tagAdmin->getNewInstance();
 
         static::assertSame($post, $tag->getPost());
+    }
+
+    public function testGetNewInstanceForChildAdminWithParentValueCanBeDisabled(): void
+    {
+        $postAdmin = $this->getMockBuilder(PostAdmin::class)->setConstructorArgs([
+            'post',
+            Post::class,
+            CRUDController::class,
+        ])->getMock();
+        $postAdmin->expects(static::never())->method('getIdParameter');
+
+        $tagAdmin = new TagWithoutPostAdmin('admin.tag', Tag::class, 'MyBundle\MyController');
+        $tagAdmin->setParent($postAdmin, 'post');
+
+        $tag = $tagAdmin->getNewInstance();
+
+        static::assertNull($tag->getPost());
     }
 
     public function testGetNewInstanceForChildAdminWithCollectionParentValue(): void

--- a/tests/Fixtures/Admin/TagWithoutPostAdmin.php
+++ b/tests/Fixtures/Admin/TagWithoutPostAdmin.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Admin;
+
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Tag;
+
+/**
+ * @phpstan-extends AbstractAdmin<Tag>
+ */
+final class TagWithoutPostAdmin extends AbstractAdmin
+{
+    protected function createNewInstance(): object
+    {
+        return new Tag();
+    }
+}


### PR DESCRIPTION
Move appendParentObject into createNewInstance to allow creating new instances for which the parent entity will not be managed by sonata

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because i think it is a bug.

Closes https://github.com/sonata-project/SonataAdminBundle/issues/7548

## Changelog
```markdown
### Changed
- Move appendParentObject call into createNewInstance
```