### PR TITLE
Use ContainsOperatorType instead of ChoiceType

### DIFF
--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -472,7 +472,7 @@ given the default type ``is equal`` is used::
     protected function configureDefaultFilterValues(array &$filterValues): void
     {
         $filterValues['foo'] = [
-            'type'  => ChoiceType::TYPE_CONTAINS,
+            'type'  => ContainsOperatorType::TYPE_CONTAINS,
             'value' => 'bar',
         ];
     }


### PR DESCRIPTION
Replace deprecated ChoiceType constants with ContainsOperatorType constants

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a doc change.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
