### PR TITLE
Fix no subject error on nested collection

### DIFF
--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -224,6 +224,10 @@ class AdminHelper
             return $associationAdmin->getClass();
         }
 
+        if (!$associationAdmin->hasSubject()) {
+            $associationAdmin->setSubject($associationAdmin->getNewInstance());
+        }
+
         return $this->getModelClassName($associationAdmin, $elements);
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Nested collection in form not work with more than 2 levels.
This PR fix error 'Admin has no subject'.
<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it's probably a bug.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #7532.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
- Set subject of $associationAdmin when collection is append to childs collections.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
