### PR TITLE
Make AuditReaderInterface generic

### DIFF
--- a/src/Model/AuditManagerInterface.php
+++ b/src/Model/AuditManagerInterface.php
@@ -39,7 +39,9 @@ interface AuditManagerInterface
      *
      * @throws \LogicException
      *
-     * @phpstan-param class-string $class
+     * @phpstan-template T of object
+     * @phpstan-param class-string<T> $class
+     * @phpstan-return AuditReaderInterface<T>
      */
     public function getReader(string $class): AuditReaderInterface;
 }

--- a/src/Model/AuditReaderInterface.php
+++ b/src/Model/AuditReaderInterface.php
@@ -15,6 +15,8 @@ namespace Sonata\AdminBundle\Model;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @phpstan-template T of object
  */
 interface AuditReaderInterface
 {
@@ -22,7 +24,6 @@ interface AuditReaderInterface
      * @param int|string $id
      * @param int|string $revisionId
      *
-     * @phpstan-template T of object
      * @phpstan-param class-string<T> $className
      * @phpstan-return T|null
      */
@@ -31,14 +32,14 @@ interface AuditReaderInterface
     /**
      * @return Revision[]
      *
-     * @phpstan-param class-string $className
+     * @phpstan-param class-string<T> $className
      */
     public function findRevisionHistory(string $className, int $limit = 20, int $offset = 0): array;
 
     /**
      * @param int|string $revisionId
      *
-     * @phpstan-param class-string $className
+     * @phpstan-param class-string<T> $className
      */
     public function findRevision(string $className, $revisionId): ?Revision;
 
@@ -47,7 +48,7 @@ interface AuditReaderInterface
      *
      * @return Revision[]
      *
-     * @phpstan-param class-string $className
+     * @phpstan-param class-string<T> $className
      */
     public function findRevisions(string $className, $id): array;
 
@@ -58,7 +59,7 @@ interface AuditReaderInterface
      *
      * @return array<string, array{old: mixed, new: mixed, same: mixed}>
      *
-     * @phpstan-param class-string $className
+     * @phpstan-param class-string<T> $className
      */
     public function diff(string $className, $id, $oldRevisionId, $newRevisionId): array;
 }

--- a/tests/Fixtures/Model/AuditReader.php
+++ b/tests/Fixtures/Model/AuditReader.php
@@ -16,6 +16,9 @@ namespace Sonata\AdminBundle\Tests\Fixtures\Model;
 use Sonata\AdminBundle\Model\AuditReaderInterface;
 use Sonata\AdminBundle\Model\Revision;
 
+/**
+ * @phpstan-implements AuditReaderInterface<object>
+ */
 final class AuditReader implements AuditReaderInterface
 {
     public function find(string $className, $id, $revisionId): ?object


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

I am targeting this branch, because BC.

Allow to fix the build in DoctrineORM with this https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1547/commits/d7b53303174106421aa05ae17b2cf47d569c20ba

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Make AuditReaderInterface generics.
```