### PR TITLE
Allow to remove an admin extension dynamically

### DIFF
--- a/docs/reference/extensions.rst
+++ b/docs/reference/extensions.rst
@@ -30,7 +30,7 @@ created objects and other admin features::
 Configuration
 ~~~~~~~~~~~~~
 
-There are two ways to configure your extensions and connect them to an admin.
+There are three ways to configure your extensions and connect them to an admin.
 
 You can include this information in the service definition of your extension.
 Add the tag *sonata.admin.extension* and use the *target* attribute to point to
@@ -132,3 +132,24 @@ priority:
                         -  App\Document\Page
                     uses:
                         -  App\Trait\Timestampable
+
+
+If those options doesn't fill your need, you can still dynamically add/remove
+an extensions in the `AdminInterface::configure()` method of your admin with
+the methods `addExtension` and `removeExtension`::
+
+    use Sonata\AdminBundle\Admin\AbstractAdminExtension;
+    use Sonata\AdminBundle\Form\FormMapper;
+    use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+
+    final class PublishStatusAdmin extends AbstractAdmin
+    {
+        protected function configure(): void
+        {
+            // ...
+
+            if ($someCondition) {
+                $this->addExtension(new PublishStatusAdminExtension());
+            }
+        }
+    }

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2937,6 +2937,18 @@ EOT;
         $this->extensions[] = $extension;
     }
 
+    final public function removeExtension(AdminExtensionInterface $extension): void
+    {
+        $key = array_search($extension, $this->extensions, true);
+        if (false === $key) {
+            throw new \InvalidArgumentException(
+                sprintf('The extension "%s" was not set to the "%s" admin.', \get_class($extension), __CLASS__)
+            );
+        }
+
+        unset($this->extensions[$key]);
+    }
+
     /**
      * @final since sonata-project/admin-bundle 3.102.
      */

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -31,8 +31,11 @@ use Symfony\Component\HttpFoundation\Request;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
- * NEXT_MAJOR: Add all these methods to the interface by uncommenting them.
+ * NEXT_MAJOR: Add all these methods to the interface by uncommenting them for Sonata 5.
  *
+ * @method void removeExtension(AdminExtensionInterface $extension)
+ *
+ * NEXT_MAJOR: Add all these methods to the interface by uncommenting them.
  * @method string                          getSearchResultLink(object $object)
  * @method array                           getDefaultFilterParameters()
  * @method bool                            isCurrentRoute(string $name, ?string $adminCode)
@@ -262,6 +265,9 @@ interface AdminInterface extends TaggedAdminInterface, AccessRegistryInterface, 
      * @return void
      */
     public function addExtension(AdminExtensionInterface $extension);
+
+    // NEXT_MAJOR: Uncomment this for Sonata 5
+    //public function removeExtension(AdminExtensionInterface $extension): void;
 
     /**
      * Returns an array of extension related to the current Admin.

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -948,6 +948,9 @@ class AdminTest extends TestCase
         $admin->addExtension($adminExtension1);
         $admin->addExtension($adminExtension2);
         static::assertSame([$adminExtension1, $adminExtension2], $admin->getExtensions());
+
+        $admin->removeExtension($adminExtension2);
+        static::assertSame([$adminExtension1], $admin->getExtensions());
     }
 
     public function testGetFilterTheme(): void

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -953,6 +953,18 @@ class AdminTest extends TestCase
         static::assertSame([$adminExtension1], $admin->getExtensions());
     }
 
+    public function testRemovingNonExistingExtensions(): void
+    {
+        $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
+
+        static::assertSame([], $admin->getExtensions());
+
+        $adminExtension1 = $this->createMock(AdminExtensionInterface::class);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $admin->removeExtension($adminExtension1);
+    }
+
     public function testGetFilterTheme(): void
     {
         $admin = new PostAdmin('sonata.post.admin.post', 'NewsBundle\Entity\Post', 'Sonata\NewsBundle\Controller\PostAdminController');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because this is not possible in 4.x since getList is final and this will allow me to solve deprecation to update from 3.x to 4.x.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- AbstractAdmin::removeExtension()
```

