### PR TITLE
Allow to hide select button in ajax mode

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -3727,7 +3727,11 @@ EOT;
             $extension->configureListFields($mapper);
         }
 
-        if ($this->hasRequest() && $this->getRequest()->isXmlHttpRequest()) {
+        if ($this->hasRequest()
+            && $this->getRequest()->isXmlHttpRequest()
+            && $this->getRequest()->query->getBoolean('select', true) // NEXT_MAJOR: Change the default value to `false` in version 5
+        ) {
+            $mapper->remove(ListMapper::NAME_ACTIONS);
             $mapper->add(ListMapper::NAME_SELECT, ListMapper::TYPE_SELECT, [
                 'label' => false,
                 // NEXT_MAJOR: Remove this code.

--- a/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_to_one.html.twig
@@ -60,7 +60,7 @@ file that was distributed with this source code.
             {% if display_btn_list or display_btn_add %}
             <div class="btn-group">
                 {% if display_btn_list %}
-                    <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('list', sonata_admin.field_description.getOption('link_parameters', {})) }}"
+                    <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('list', {select: true}|sonata_admin.field_description.getOption('link_parameters', {})) }}"
                         onclick="return start_field_dialog_form_list_{{ id }}(this);"
                         class="btn btn-info btn-sm sonata-ba-action"
                         title="{{ btn_list|trans({}, btn_catalogue) }}"

--- a/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_one_to_one.html.twig
@@ -60,7 +60,7 @@ file that was distributed with this source code.
             {% if display_btn_list or display_btn_add %}
             <div class="btn-group">
                 {% if display_btn_list %}
-                    <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('list', sonata_admin.field_description.getOption('link_parameters', {})) }}"
+                    <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('list', {select: true}|sonata_admin.field_description.getOption('link_parameters', {})) }}"
                         onclick="return start_field_dialog_form_list_{{ id }}(this);"
                         class="btn btn-info btn-sm sonata-ba-action"
                         title="{{ btn_list|trans({}, btn_catalogue) }}"

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -59,6 +59,7 @@ file that was distributed with this source code.
                                         {% elseif field_description.name == constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_SELECT') %}
                                             <th class="sonata-ba-list-field-header sonata-ba-list-field-header-select"></th>
                                         {% elseif field_description.name == constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_ACTIONS') and app.request.isXmlHttpRequest %}
+                                            {# NEXT_MAJOR: Remove this case in version 5 and recommend using the option `ajax_hidden` instead. #}
                                             {# Action buttons disabled in ajax view! #}
                                         {% elseif field_description.getOption('ajax_hidden') == true and app.request.isXmlHttpRequest %}
                                             {# Disable fields with 'ajax_hidden' option set to true #}

--- a/src/Resources/views/CRUD/base_list_flat_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_flat_field.html.twig
@@ -9,6 +9,8 @@ file that was distributed with this source code.
 
 #}
 
+{# NEXT_MAJOR: Deprecate this template in version 4. Remove it in version 5. #}
+
 <span class="sonata-ba-list-field sonata-ba-list-field-{{ field_description.type }}" objectId="{{ admin.id(object) }}">
     {% if
         field_description.option('identifier', false)

--- a/src/Resources/views/CRUD/base_list_flat_inner_row.html.twig
+++ b/src/Resources/views/CRUD/base_list_flat_inner_row.html.twig
@@ -9,6 +9,8 @@ file that was distributed with this source code.
 
 #}
 
+{# NEXT_MAJOR: Deprecate this template in version 4. Remove it in version 5. #}
+
 {% if admin.list.has(constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_BATCH')) and not app.request.isXmlHttpRequest %}
     <td class="sonata-ba-list-field sonata-ba-list-field-batch">
         {{ object|render_list_element(admin.list[constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_BATCH')]) }}

--- a/src/Resources/views/CRUD/base_list_inner_row.html.twig
+++ b/src/Resources/views/CRUD/base_list_inner_row.html.twig
@@ -11,6 +11,7 @@ file that was distributed with this source code.
 
 {% for field_description in admin.list.elements %}
     {% if field_description.name == constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_ACTIONS') and app.request.isXmlHttpRequest %}
+        {# NEXT_MAJOR: Remove this case in version 5 and recommend using the option `ajax_hidden` instead. #}
         {# Action buttons disabled in ajax view! #}
     {% elseif field_description.getOption('ajax_hidden') == true and app.request.isXmlHttpRequest %}
         {# Disable fields with 'ajax_hidden' option set to true #}

--- a/src/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
+++ b/src/Resources/views/CRUD/list_outer_rows_mosaic.html.twig
@@ -10,14 +10,21 @@ file that was distributed with this source code.
 #}
 
 <!--
-This template can be customized to match your needs. You should only extends the template and used the differents block to customize the view:
+This template can be customized to match your needs. You should only extends the template and used the different blocks to customize the view:
     - sonata_mosaic_default_view
     - sonata_mosaic_hover_view
     - sonata_mosaic_description
 -->
 
 <tr>
-    <td colspan="{{ admin.list.elements|length - (app.request.isXmlHttpRequest ? (admin.list.has(constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_ACTIONS')) + admin.list.has(constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_BATCH'))) : 0) }}">
+    {# NEXT_MAJOR: Remove the NAME_ACTIONS check in version 5 and recommend using the option `ajax_hidden` instead. #}
+    <td colspan="{{
+        app.request.isXmlHttpRequest
+            ? admin.list.elements|filter(element => element.getOption('ajax_hidden') != true)|length
+                - admin.list.has(constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_ACTIONS'))
+                - admin.list.has(constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_BATCH'))
+            : admin.list.elements|length
+    }}">
         <div class="row">
             {% for object in admin.datagrid.results %}
                 {% set meta = admin.getObjectMetadata(object) %}

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -618,7 +618,7 @@ file that was distributed with this source code.
         <span id="field_actions_{{ id }}" class="field-actions">
             <span class="btn-group">
                 {% if sonata_admin.field_description.associationadmin.hasroute('list') and sonata_admin.field_description.associationadmin.hasAccess('list') and btn_list %}
-                    <a href="{{ sonata_admin.field_description.associationadmin.generateUrl('list') }}"
+                    <a href="{{ sonata_admin.field_description.associationadmin.generateUrl('list', {select: true}) }}"
                        onclick="return start_field_dialog_form_list_{{ id }}(this);"
                        class="btn btn-info btn-sm sonata-ba-action"
                        title="{{ btn_list|trans({}, btn_catalogue) }}"


### PR DESCRIPTION
## Subject

I am targeting this branch, because this is not possible in 4.x since `getList` is final and this will allow me to solve deprecation to update from 3.x to 4.x.

Closes #7552.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- The ability to not add a `select` column when accessing to the List with AJAX.
```