### PR TITLE
Fix array to string conversion exception

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -927,6 +927,10 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         if (null === $id) {
             return null;
         }
+        
+        if (\is_array($id) && \array_key_exists('value', $id)) {
+            $id = $id['value'];
+        }
 
         $object = $this->getModelManager()->find($this->getClass(), $id);
         if (null === $object) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!--  -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because I would like to make a patch to fix an issue, below is the explanation for issue:
When you use `configureDatagridFilters` and put `id` field in then filter by ID from user's POV.   The `id` field will be treated same as any other filter parameters, which will convert it into an array, so when you call back the `list` route with list of parameters it will throw an array to string exception. check attached screenshots to be clearer I hope it can makes sense, tested from our project for the behaviors, freely to change and correct if I am wrong.

<!--
    Array to string conversion exception (when putting object's id as filter parameter)
-->

Closes #{put_issue_number_here}. sorry I haven't open an issue here, it's about `Array to string conversion` exception (when putting object's id as filter parameter)

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added check if `id` is an array in AbstractAdmin->getObject()

### Changed

### Deprecated

### Removed

### Fixed
Array to string conversion exception

### Security
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->

Attached screenshot for the issue (happened on our own project) :

If you put `id` in `configureDatagridFilters` -> this will call from `CRUDController->assertObjectExists() line 1311`  passing the `id` as an array into `$admin->getObject($objectId);` then encounter array to string conversion 
![request-admin-id-param](https://user-images.githubusercontent.com/64844393/139519991-a95aec45-bbb1-4ccc-81c4-81d818a84743.PNG)