### PR TITLE
Add preBatchAction to Admin Extension and add a pre_batch_action event

### DIFF
--- a/docs/reference/events.rst
+++ b/docs/reference/events.rst
@@ -46,3 +46,10 @@ Block events help you customize your templates. Available events are :
 
 If you want more information about block events, you should check the
 `"Event" section of block bundle documentation <https://docs.sonata-project.org/projects/SonataBlockBundle/en/3.x/reference/events>`_.
+
+BatchActionEvent
+^^^^^^^^^^^^^^^^
+
+This event is dispatched when a batch action is being executed. The event name is:
+
+- ``sonata.admin.event.batch_action.pre_batch_action``

--- a/src/Admin/AbstractAdminExtension.php
+++ b/src/Admin/AbstractAdminExtension.php
@@ -96,6 +96,15 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
         return $actions;
     }
 
+    // NEXT_MAJOR: Remove the PHPDoc block as the interface will then specify the types
+    /**
+     * @param mixed[] $idx
+     * @phpstan-param AdminInterface<T> $admin
+     */
+    public function preBatchAction(AdminInterface $admin, string $actionName, ProxyQueryInterface $query, array &$idx, bool $allElements): void
+    {
+    }
+
     public function configureExportFields(AdminInterface $admin, array $fields): array
     {
         return $fields;

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -24,6 +24,10 @@ use Sonata\AdminBundle\Show\ShowMapper;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
+ * NEXT_MAJOR: Uncomment the actual definition of below methods inside the interface and remove these annotations.
+ *
+ * @method void preBatchAction(AdminInterface $admin, string $actionName, ProxyQueryInterface $query, array &$idx, bool $allElements)
+ *
  * @phpstan-template T of object
  */
 interface AdminExtensionInterface
@@ -126,6 +130,13 @@ interface AdminExtensionInterface
      * @phpstan-param AdminInterface<T> $admin
      */
     public function configureBatchActions(AdminInterface $admin, array $actions): array;
+
+    // NEXT_MAJOR: Uncomment the method definition
+    ///**
+    // * @param mixed[] $idx
+    // * @phpstan-param AdminInterface<T> $admin
+    // */
+    //public function preBatchAction(AdminInterface $admin, string $actionName, ProxyQueryInterface $query, array &$idx, bool $allElements): void;
 
     /**
      * Get a chance to modify export fields.

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -469,6 +469,13 @@ class CRUDController extends AbstractController
         $query->setMaxResults(null);
 
         $this->admin->preBatchAction($action, $query, $idx, $allElements);
+        foreach ($this->admin->getExtensions() as $extension) {
+            // NEXT_MAJOR: Remove the if-statement around the call to `$extension->preBatchAction()`
+            // @phpstan-ignore-next-line
+            if (method_exists($extension, 'preBatchAction')) {
+                $extension->preBatchAction($this->admin, $action, $query, $idx, $allElements);
+            }
+        }
 
         if (\count($idx) > 0) {
             $this->admin->getModelManager()->addIdentifiersToQuery($this->admin->getClass(), $query, $idx);

--- a/src/Event/AdminEventExtension.php
+++ b/src/Event/AdminEventExtension.php
@@ -126,4 +126,12 @@ final class AdminEventExtension extends AbstractAdminExtension
             'sonata.admin.event.persistence.post_remove'
         );
     }
+
+    public function preBatchAction(AdminInterface $admin, string $actionName, ProxyQueryInterface $query, array &$idx, bool $allElements): void
+    {
+        $this->eventDispatcher->dispatch(
+            new BatchActionEvent($admin, BatchActionEvent::TYPE_PRE_BATCH_ACTION, $actionName, $query, $idx, $allElements),
+            'sonata.admin.event.batch_action.pre_batch_action'
+        );
+    }
 }

--- a/src/Event/BatchActionEvent.php
+++ b/src/Event/BatchActionEvent.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Event;
+
+use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * This event is sent by hook:
+ *   - preBatchAction.
+ *
+ * You can register the listener to the event dispatcher by using:
+ *   - sonata.admin.event.batch_action.pre_batch_action)
+ *
+ * @author Jochem Klaver <info@7ochem.nl>
+ *
+ * @phpstan-template T of object
+ */
+final class BatchActionEvent extends Event
+{
+    public const TYPE_PRE_BATCH_ACTION = 'pre_batch_action';
+
+    /**
+     * @var AdminInterface<object>
+     * @phpstan-var AdminInterface<T>
+     */
+    private $admin;
+
+    /**
+     * @var string
+     * @phpstan-var self::TYPE_*
+     */
+    private $type;
+
+    /**
+     * @var string
+     */
+    private $actionName;
+
+    /**
+     * @var ProxyQueryInterface
+     */
+    private $proxyQuery;
+
+    /**
+     * @var mixed[]
+     */
+    private $idx;
+
+    /**
+     * @var bool
+     */
+    private $allElements;
+
+    /**
+     * @param mixed[] $idx
+     * @phpstan-param AdminInterface<T> $admin
+     * @phpstan-param self::TYPE_* $type
+     */
+    public function __construct(AdminInterface $admin, string $type, string $actionName, ProxyQueryInterface $proxyQuery, array &$idx, bool $allElements)
+    {
+        $this->admin = $admin;
+        $this->type = $type;
+        $this->actionName = $actionName;
+        $this->proxyQuery = $proxyQuery;
+        $this->idx = &$idx;
+        $this->allElements = $allElements;
+    }
+
+    /**
+     * @phpstan-return AdminInterface<T>
+     */
+    public function getAdmin(): AdminInterface
+    {
+        return $this->admin;
+    }
+
+    /**
+     * @phpstan-return self::TYPE_*
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getActionName(): string
+    {
+        return $this->actionName;
+    }
+
+    public function getProxyQuery(): ProxyQueryInterface
+    {
+        return $this->proxyQuery;
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function &getIdx(): array
+    {
+        return $this->idx;
+    }
+
+    public function isAllElements(): bool
+    {
+        return $this->allElements;
+    }
+}


### PR DESCRIPTION
## Subject

This adds a `preBatchAction()` method to the `AbstractAdminExtension` and `AdminExtensionInterface` (in a backwards compatible way). This enables the AdminEventExtension to dispatch a `BatchActionEvent` of type `pre_batch_action`. Both the extension and the event provide points to hook into within your own code, just like this is possible for pre/post persist/update/delete.

I am targeting 4.x as this is a  feature that is backwards compatible (made in a BC way)

Fixes #7516 "Implement an event for batch actions"
Relates to #6550 "Delete Event isn't triggered in Batch delete"

## Changelog

```markdown
### Added
- Added `AbstractAdminExtension::preBatchAction()` and `AdminExtensionInterface::preBatchAction()` (as annotation for BC) to have an extension point on batch actions.
- Added `AdminEventExtension::preBatchAction()` that dispatches a `sonata.admin.event.batch_action.pre_batch_action` event with a BatchActionEvent object containing the data
- Added BatchActionEvent class as a transport for (newly introduced) batch action events
```

## To do

- [x] Update the documentation;
