### PR TITLE
Introduce ModelManagerThrowable

### DIFF
--- a/src/Admin/LifecycleHookProviderInterface.php
+++ b/src/Admin/LifecycleHookProviderInterface.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Admin;
 
 use Sonata\AdminBundle\Exception\LockException;
-use Sonata\AdminBundle\Exception\ModelManagerException;
+use Sonata\AdminBundle\Exception\ModelManagerThrowable;
 
 /**
  * This interface can be implemented to provide hooks that will be called
@@ -31,7 +31,7 @@ interface LifecycleHookProviderInterface
      *
      * @param object $object
      *
-     * @throws ModelManagerException
+     * @throws ModelManagerThrowable
      * @throws LockException
      *
      * @return object
@@ -46,7 +46,7 @@ interface LifecycleHookProviderInterface
      *
      * @param object $object
      *
-     * @throws ModelManagerException
+     * @throws ModelManagerThrowable
      *
      * @return object
      *
@@ -60,7 +60,7 @@ interface LifecycleHookProviderInterface
      *
      * @param object $object
      *
-     * @throws ModelManagerException
+     * @throws ModelManagerThrowable
      *
      * @phpstan-param T $object
      */

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1336,7 +1336,7 @@ class CRUDController implements ContainerAwareInterface
         }
 
         @trigger_error(sprintf(
-            'The method %s is deprecated since sonata-project/admin-bundle 3.107 and will be removed in 5.0.',
+            'The method "%s()" is deprecated since sonata-project/admin-bundle 3.107 and will be removed in 5.0.',
             __METHOD__
         ), \E_USER_DEPRECATED);
 

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -20,7 +20,7 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Exception\LockException;
-use Sonata\AdminBundle\Exception\ModelManagerException;
+use Sonata\AdminBundle\Exception\ModelManagerThrowable;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionCollection;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Sonata\AdminBundle\Util\AdminObjectAclData;
@@ -190,7 +190,7 @@ class CRUDController implements ContainerAwareInterface
                 'sonata_flash_success',
                 $this->trans('flash_batch_delete_success', [], 'SonataAdminBundle')
             );
-        } catch (ModelManagerException $e) {
+        } catch (ModelManagerThrowable $e) {
             $this->handleModelManagerException($e);
             $this->addFlash(
                 'sonata_flash_error',
@@ -251,7 +251,7 @@ class CRUDController implements ContainerAwareInterface
                         'SonataAdminBundle'
                     )
                 );
-            } catch (ModelManagerException $e) {
+            } catch (ModelManagerThrowable $e) {
                 $this->handleModelManagerException($e);
 
                 if ($this->isXmlHttpRequest()) {
@@ -358,7 +358,7 @@ class CRUDController implements ContainerAwareInterface
 
                     // redirect to edit mode
                     return $this->redirectTo($existingObject);
-                } catch (ModelManagerException $e) {
+                } catch (ModelManagerThrowable $e) {
                     $this->handleModelManagerException($e);
 
                     $isFormValid = false;
@@ -632,7 +632,7 @@ class CRUDController implements ContainerAwareInterface
 
                     // redirect to edit mode
                     return $this->redirectTo($newObject);
-                } catch (ModelManagerException $e) {
+                } catch (ModelManagerThrowable $e) {
                     $this->handleModelManagerException($e);
 
                     $isFormValid = false;

--- a/src/Exception/ModelManagerThrowable.php
+++ b/src/Exception/ModelManagerThrowable.php
@@ -13,11 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Exception;
 
-/**
- * @final since sonata-project/admin-bundle 3.52
- *
- * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
- */
-class ModelManagerException extends \Exception implements ModelManagerThrowable
+interface ModelManagerThrowable extends \Throwable
 {
 }

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -15,7 +15,7 @@ namespace Sonata\AdminBundle\Model;
 
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
-use Sonata\AdminBundle\Exception\ModelManagerException;
+use Sonata\AdminBundle\Exception\ModelManagerThrowable;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 use Sonata\Exporter\Source\SourceIteratorInterface;
 
@@ -49,7 +49,7 @@ interface ModelManagerInterface extends DatagridManagerInterface
     /**
      * @param object $object
      *
-     * @throws ModelManagerException
+     * @throws ModelManagerThrowable
      *
      * @phpstan-param T $object
      */
@@ -58,7 +58,7 @@ interface ModelManagerInterface extends DatagridManagerInterface
     /**
      * @param object $object
      *
-     * @throws ModelManagerException
+     * @throws ModelManagerThrowable
      *
      * @phpstan-param T $object
      */
@@ -67,7 +67,7 @@ interface ModelManagerInterface extends DatagridManagerInterface
     /**
      * @param object $object
      *
-     * @throws ModelManagerException
+     * @throws ModelManagerThrowable
      *
      * @phpstan-param T $object
      */
@@ -109,7 +109,7 @@ interface ModelManagerInterface extends DatagridManagerInterface
     /**
      * @param string $class
      *
-     * @throws ModelManagerException
+     * @throws ModelManagerThrowable
      *
      * @phpstan-param class-string<T> $class
      */

--- a/src/Util/ObjectAclManipulatorInterface.php
+++ b/src/Util/ObjectAclManipulatorInterface.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Util;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\AdminBundle\Exception\ModelManagerException;
+use Sonata\AdminBundle\Exception\ModelManagerThrowable;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
 
@@ -28,7 +28,7 @@ interface ObjectAclManipulatorInterface
      *
      * @param AdminInterface<object> $admin
      *
-     * @throws ModelManagerException
+     * @throws ModelManagerThrowable
      *
      * @return void
      */


### PR DESCRIPTION
## Subject

There is an extension point to handle differently the ModelManagerException in the CRUDController: 
https://github.com/sonata-project/SonataAdminBundle/blob/4.x/src/Controller/CRUDController.php#L1006

A nice way to have different behaviour was to extend the ModelManagerException and doing some instanceof checks.
ModelManagerException is final in 4.x. So introducing the interface, allow to implements it instead.

I didn't introduce interfaces for others exception because I didn't really find the needs. But same could be done

## Changelog

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- `ModelManagerThrowable`
- `CRUDController::handleModelManagerThrowable()`

### Deprecated
- `CRUDController::handleModelManagerException()`
```