### PR TITLE
Add next major about batch action delete

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -143,6 +143,8 @@ class CRUDController extends AbstractController
     }
 
     /**
+     * NEXT_MAJOR: Change signature to `(ProxyQueryInterface $query, Request $request).
+     *
      * Execute a batch delete.
      *
      * @throws AccessDeniedException If access is not granted


### PR DESCRIPTION
Pedantic

We pass the request as second param to all the batch action method.
Since this method can be overriden by the user, it's better to define the signature of the method with all the possible param.