### PR TITLE
Avoid error when overriding part of template

### DIFF
--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -141,6 +141,11 @@ file that was distributed with this source code.
                 {{ sonata_block_render_event('sonata.admin.list.table.bottom', { 'admin': admin }) }}
             </div>
             {% block list_footer %}
+                {% if not datagrid_has_results is defined %}
+                    {# Prevent error if someone is overriding the list_table and not the list footer #}
+                    {% set datagrid_has_results = admin.datagrid.results|length > 0 %}
+                {% endif %}
+
                 {% if datagrid_has_results %}
                     <div class="box-footer">
                         <div class="form-inline clearfix">

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -30,6 +30,9 @@ file that was distributed with this source code.
     {{ admin.isChild and admin.parent.subject ? 'title_edit'|trans({'%name%': admin.parent.toString(admin.parent.subject)|u.truncate(100, '...') }, 'SonataAdminBundle') : '' }}
 {% endblock %}
 
+{# Define the variable out of the block to prevent error if someone is overriding the list_table and not the list_footer #}
+{% set datagrid_has_results = admin.datagrid.results|length > 0 %}
+
 {% block list_table %}
     <div class="col-xs-12 col-md-12">
         {% set batchactions = admin.batchactions %}
@@ -37,8 +40,6 @@ file that was distributed with this source code.
             <form action="{{ admin.generateUrl('batch', {'filter': admin.filterParameters}) }}" method="POST" >
             <input type="hidden" name="_sonata_csrf_token" value="{{ csrf_token }}">
         {% endif %}
-
-        {% set datagrid_has_results = admin.datagrid.results|length > 0 %}
 
         {# Add a margin if no pager to prevent dropdown cropping on window #}
         <div class="box box-primary"{% if admin.datagrid.pager.lastPage == 1 %} style="margin-bottom: 100px;"{% endif %}>
@@ -141,11 +142,6 @@ file that was distributed with this source code.
                 {{ sonata_block_render_event('sonata.admin.list.table.bottom', { 'admin': admin }) }}
             </div>
             {% block list_footer %}
-                {% if not datagrid_has_results is defined %}
-                    {# Prevent error if someone is overriding the list_table and not the list footer #}
-                    {% set datagrid_has_results = admin.datagrid.results|length > 0 %}
-                {% endif %}
-
                 {% if datagrid_has_results %}
                     <div class="box-footer">
                         <div class="form-inline clearfix">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

When overriding the list_table and not the list_footer, but still calling the block the variable `datagrid_has_result` is not defined. 

I am targeting this branch, because bugfix.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Accessing a non existing template variable in list_footer block when the list_table block is overriden.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
