### PR TITLE
Symfony maker already supports Symfony 6

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -87,7 +87,7 @@ jobs:
 
             - name: Remove dev dependencies not compatible with Symfony 6
               if: matrix.symfony-require == '6.0.*'
-              run: composer remove psalm/plugin-symfony symfony/maker-bundle symfony/panther --dev --no-update --no-interaction
+              run: composer remove psalm/plugin-symfony --dev --no-update --no-interaction
 
             - name: Install Composer dependencies (${{ matrix.dependencies }})
               uses: ramsey/composer-install@v1

--- a/tests/Maker/AdminMakerTest.php
+++ b/tests/Maker/AdminMakerTest.php
@@ -21,7 +21,6 @@ use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Foo;
 use Symfony\Bundle\MakerBundle\ConsoleStyle;
 use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
-use Symfony\Bundle\MakerBundle\MakerBundle;
 use Symfony\Bundle\MakerBundle\Util\AutoloaderUtil;
 use Symfony\Bundle\MakerBundle\Util\MakerFileLinkFormatter;
 use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
@@ -81,11 +80,6 @@ final class AdminMakerTest extends TestCase
 
     protected function setUp(): void
     {
-        // TODO: Remove this and restore this dependency on Github workflows when MakerBundle supports Symfony 6.
-        if (!class_exists(MakerBundle::class)) {
-            static::markTestSkipped('Maker bundle is not installed');
-        }
-
         $managerOrmProxy = $this->createMock(ModelManagerInterface::class);
         $managerOrmProxy->method('getExportFields')->with(Foo::class)
             ->willReturn(['bar', 'baz']);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Dev-kit PR: https://github.com/sonata-project/dev-kit/pull/1765