### PR TITLE
Re-add lost feature from merge 3.x into 4.x

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2437,7 +2437,10 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
             $extension->configureListFields($mapper);
         }
 
-        if ($this->hasRequest() && $this->getRequest()->isXmlHttpRequest()) {
+        if ($this->hasRequest()
+            && $this->getRequest()->isXmlHttpRequest()
+            && $this->getRequest()->query->getBoolean('select', true) // NEXT_MAJOR: Change the default value to `false` in version 5
+        ) {
             $mapper->add(ListMapper::NAME_SELECT, ListMapper::TYPE_SELECT, [
                 'label' => false,
                 'sortable' => false,

--- a/src/Resources/views/CRUD/base_list_flat_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_flat_field.html.twig
@@ -9,7 +9,8 @@ file that was distributed with this source code.
 
 #}
 
-{# NEXT_MAJOR: Deprecate this template in version 4. Remove it in version 5. #}
+{# NEXT_MAJOR: Remove this #}
+{% deprecated 'The "base_list_flat_field.html.twig" template is deprecated since sonata-project/admin-bundle version 4.3 and will be removed in 5.0.' %}
 
 <span class="sonata-ba-list-field sonata-ba-list-field-{{ field_description.type }}" objectId="{{ admin.id(object) }}">
     {% set route_name = field_description.option('route').name|default(sonata_config.getOption('default_admin_route')) %}

--- a/src/Resources/views/CRUD/base_list_flat_inner_row.html.twig
+++ b/src/Resources/views/CRUD/base_list_flat_inner_row.html.twig
@@ -9,7 +9,8 @@ file that was distributed with this source code.
 
 #}
 
-{# NEXT_MAJOR: Deprecate this template in version 4. Remove it in version 5. #}
+{# NEXT_MAJOR: Remove this #}
+{% deprecated 'The "base_list_flat_inner_row.html.twig" template is deprecated since sonata-project/admin-bundle version 4.3 and will be removed in 5.0.' %}
 
 {% if admin.list.has(constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_BATCH')) and not app.request.isXmlHttpRequest %}
     <td class="sonata-ba-list-field sonata-ba-list-field-batch">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This was added in https://github.com/sonata-project/SonataAdminBundle/pull/7564/files
and lost in the merge https://github.com/sonata-project/SonataAdminBundle/pull/7570/files

## Changelog

```markdown
### Added
- The ability to not add a `select` column when accessing to the List with AJAX.

### Deprecated
- template `src/Resources/views/CRUD/base_list_flat_field.html.twig`
- template `src/Resources/views/CRUD/base_list_flat_inner_row.html.twig`
```