### PR TITLE
Process NEXT_MAJOR hints for "Add pre batch action event"

### DIFF
--- a/UPGRADE-5.0.md
+++ b/UPGRADE-5.0.md
@@ -9,3 +9,7 @@ Please read [4.x](https://github.com/sonata-project/SonataAdminBundle/tree/4.x) 
 
 See also the [diff code](https://github.com/sonata-project/SonataAdminBundle/compare/4.x...5.x).
 
+## AdminExtension
+If you have implemented a custom admin extension, which does not extend the `AbstractAdminExtension` then you should add the following methods which were newly introduced in the `AdminExtensionInterface`:
+ * `preBatchAction`
+

--- a/src/Admin/AbstractAdminExtension.php
+++ b/src/Admin/AbstractAdminExtension.php
@@ -96,11 +96,6 @@ abstract class AbstractAdminExtension implements AdminExtensionInterface
         return $actions;
     }
 
-    // NEXT_MAJOR: Remove the PHPDoc block as the interface will then specify the types
-    /**
-     * @param mixed[] $idx
-     * @phpstan-param AdminInterface<T> $admin
-     */
     public function preBatchAction(AdminInterface $admin, string $actionName, ProxyQueryInterface $query, array &$idx, bool $allElements): void
     {
     }

--- a/src/Admin/AdminExtensionInterface.php
+++ b/src/Admin/AdminExtensionInterface.php
@@ -24,10 +24,6 @@ use Sonata\AdminBundle\Show\ShowMapper;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
- * NEXT_MAJOR: Uncomment the actual definition of below methods inside the interface and remove these annotations.
- *
- * @method void preBatchAction(AdminInterface $admin, string $actionName, ProxyQueryInterface $query, array &$idx, bool $allElements)
- *
  * @phpstan-template T of object
  */
 interface AdminExtensionInterface
@@ -131,12 +127,11 @@ interface AdminExtensionInterface
      */
     public function configureBatchActions(AdminInterface $admin, array $actions): array;
 
-    // NEXT_MAJOR: Uncomment the method definition
-    ///**
-    // * @param mixed[] $idx
-    // * @phpstan-param AdminInterface<T> $admin
-    // */
-    //public function preBatchAction(AdminInterface $admin, string $actionName, ProxyQueryInterface $query, array &$idx, bool $allElements): void;
+    /**
+     * @param mixed[] $idx
+     * @phpstan-param AdminInterface<T> $admin
+     */
+    public function preBatchAction(AdminInterface $admin, string $actionName, ProxyQueryInterface $query, array &$idx, bool $allElements): void;
 
     /**
      * Get a chance to modify export fields.

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -501,11 +501,7 @@ class CRUDController extends AbstractController
 
         $this->admin->preBatchAction($action, $query, $idx, $allElements);
         foreach ($this->admin->getExtensions() as $extension) {
-            // NEXT_MAJOR: Remove the if-statement around the call to `$extension->preBatchAction()`
-            // @phpstan-ignore-next-line
-            if (method_exists($extension, 'preBatchAction')) {
-                $extension->preBatchAction($this->admin, $action, $query, $idx, $allElements);
-            }
+            $extension->preBatchAction($this->admin, $action, $query, $idx, $allElements);
         }
 
         if (\count($idx) > 0) {


### PR DESCRIPTION
## Subject

A pre batch action event was added to 4.x through #7579. This PR processes all the NEXT_MAJOR comments for 5.x for this specific feature.

I am targeting this branch, because this has been implemented in a backwards compatible manner in 4.x and has been forward merged into 5.x. This PR changes that backwards compatibility into a BC break: Introducing the new `preBatchAction()` method in the AdminExtensionInterface.

## Changelog

```markdown
### Changed
- Introducing the new `preBatchAction()` method in the AdminExtensionInterface.
```

## To do

- [x] Rebase on 5.x when #7621 has been merged and add a section to the UPGRADE-5.0 guide
