### PR TITLE
Fix compatibility with PHP 8.1 in base_show_field.html.twig

### DIFF
--- a/src/Resources/views/CRUD/base_show_field.html.twig
+++ b/src/Resources/views/CRUD/base_show_field.html.twig
@@ -32,7 +32,7 @@ file that was distributed with this source code.
                       data-readmore-more="{{ collapse.more|default('read_more')|trans({}, 'SonataAdminBundle') }}"
                       data-readmore-less="{{ collapse.less|default('read_less')|trans({}, 'SonataAdminBundle') }}">
                     {% block field_value %}
-                        {% if field_description.option('safe', false) %}{{ value|raw }}{% else %}{{ value|nl2br }}{% endif %}
+                        {% if field_description.option('safe', false) %}{{ value|raw }}{% else %}{{ value|default('')|nl2br }}{% endif %}
                     {% endblock %}
                 </div>
             {% else %}


### PR DESCRIPTION
## Subject

Fixes Twig\Error\RuntimeError: `nl2br(): Passing null to parameter #1 ($string) of type string is deprecated` during rendering nullable text field.

I am targeting 4.x branch, because the change is backwards compatible and just fixes a deprecation notice.

## Changelog

```markdown
### Fixed
- Fixed PHP 8.1 deprecation notice for nl2br usage in base_show_field.html.twig.
```