### PR TITLE
Downgrade translation-contracts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,8 +90,7 @@
         "vimeo/psalm": "^4.9.2"
     },
     "conflict": {
-        "doctrine/doctrine-bundle": ">=3",
-        "sonata-project/doctrine-orm-admin-bundle": "<=4.0.0-alpha-1"
+        "doctrine/doctrine-bundle": ">=3"
     },
     "suggest": {
         "twig/extra-bundle": "Auto configures the Twig Intl extension"
@@ -108,10 +107,5 @@
     },
     "config": {
         "sort-packages": true
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "4.x-dev"
-        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,8 @@
 {
     "name": "sonata-project/admin-bundle",
-    "type": "symfony-bundle",
     "description": "The missing Symfony Admin Generator",
+    "license": "MIT",
+    "type": "symfony-bundle",
     "keywords": [
         "admin",
         "admin-generator",
@@ -10,8 +11,6 @@
         "sonata",
         "symfony"
     ],
-    "homepage": "https://docs.sonata-project.org/projects/SonataAdminBundle",
-    "license": "MIT",
     "authors": [
         {
             "name": "Thomas Rabaix",
@@ -23,6 +22,7 @@
             "homepage": "https://github.com/sonata-project/SonataAdminBundle/contributors"
         }
     ],
+    "homepage": "https://docs.sonata-project.org/projects/SonataAdminBundle",
     "require": {
         "php": "^7.3 || ^8.0",
         "ext-json": "*",
@@ -67,10 +67,6 @@
         "twig/string-extra": "^3.0",
         "twig/twig": "^2.12.1 || ^3.0"
     },
-    "conflict": {
-        "doctrine/doctrine-bundle": ">=3",
-        "sonata-project/doctrine-orm-admin-bundle": "<=4.0.0-alpha-1"
-    },
     "require-dev": {
         "doctrine/annotations": "^1.7",
         "matthiasnoback/symfony-config-test": "^4.2",
@@ -93,16 +89,12 @@
         "symfony/yaml": "^4.4 || ^5.3 || ^6.0",
         "vimeo/psalm": "^4.9.2"
     },
+    "conflict": {
+        "doctrine/doctrine-bundle": ">=3",
+        "sonata-project/doctrine-orm-admin-bundle": "<=4.0.0-alpha-1"
+    },
     "suggest": {
         "twig/extra-bundle": "Auto configures the Twig Intl extension"
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "4.x-dev"
-        }
     },
     "autoload": {
         "psr-4": {
@@ -112,6 +104,14 @@
     "autoload-dev": {
         "psr-4": {
             "Sonata\\AdminBundle\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "sort-packages": true
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "4.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         "symfony/security-csrf": "^4.4 || ^5.3 || ^6.0",
         "symfony/string": "^5.3 || ^6.0",
         "symfony/translation": "^4.4 || ^5.3 || ^6.0",
-        "symfony/translation-contracts": "^1.1.10 || ^2.3 || ^3.0",
+        "symfony/translation-contracts": "^1.1.10 || ^2.3",
         "symfony/twig-bridge": "^4.4 || ^5.3 || ^6.0",
         "symfony/twig-bundle": "^4.4 || ^5.3 || ^6.0",
         "symfony/validator": "^4.4 || ^5.3 || ^6.0",

--- a/tests/Form/Type/ChoiceFieldMaskTypeTest.php
+++ b/tests/Form/Type/ChoiceFieldMaskTypeTest.php
@@ -122,7 +122,7 @@ final class ChoiceFieldMaskTypeTest extends TypeTestCase
             ],
         ];
 
-        static::assertSame(array_values($expectedAllFields), array_values($view->vars['all_fields']), '"all_fields" is not as expected');
+        static::assertSame($expectedAllFields, array_values($view->vars['all_fields']), '"all_fields" is not as expected');
         static::assertSame($expectedMap, $view->vars['map'], '"map" is not as expected');
     }
 
@@ -150,7 +150,7 @@ final class ChoiceFieldMaskTypeTest extends TypeTestCase
             'array' => ['field_1', 'field_2'],
         ];
 
-        static::assertSame(array_values($expectedAllFields), array_values($view->vars['all_fields']), '"all_fields" is not as expected');
+        static::assertSame($expectedAllFields, array_values($view->vars['all_fields']), '"all_fields" is not as expected');
         static::assertSame($expectedMap, $view->vars['map'], '"map" is not as expected');
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because the v3 cant be installed anyway.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Remove support for translation-contracts until it can be installed without relying on dev dependencies
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
