### PR TITLE
Update form_types.rst

### DIFF
--- a/docs/reference/form_types.rst
+++ b/docs/reference/form_types.rst
@@ -663,6 +663,12 @@ The available options (which can be passed as a third parameter to ``FormMapper:
 
     You can check / uncheck a range of checkboxes by clicking a first one,
     then a second one with shift + click.
+    
+.. warning::
+
+    If you are using the ``sonata.admin.security.handler.role``, you must set, at least, the CREATE permission to the Admin of the relation, to be able to add more rows to the collection.
+    In order to delete rows, you must set the DELETE permission.
+    For more infos about permissions, check the :doc:`security` page.
 
 Sonata\\AdminBundle\\Form\\Type\\CollectionType
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -683,6 +689,12 @@ This bundle handle the native Symfony ``collection`` form type by adding:
     or before deleted (``sonata-collection-item-deleted``).
     A jQuery event is fired after a row has been deleted successfully (``sonata-collection-item-deleted-successful``)
     You can listen to these events to trigger custom JavaScript.
+    
+.. warning::
+
+    If you are using the ``sonata.admin.security.handler.role``, you must set, at least, the CREATE permission to the Admin of the relation, to be able to add more rows to the collection.
+    In order to delete rows, you must set the DELETE permission.
+    For more infos about permissions, check the :doc:`security` page.
 
 .. _form_types_fielddescription_options:
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Add warnings for the Sonata\Form\Type\CollectionType and the Sonata\AdminBundle\Form\Type\CollectionType

<!-- Describe your Pull Request content here -->
Add warnings line 667 and line 693, to reminder users to set the rights for the Admin of the relation.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because I use this version and I was facing this problem with this version.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #7589.
