### PR TITLE
Fix batch confirmation translations

### DIFF
--- a/src/Resources/translations/SonataAdminBundle.de.xliff
+++ b/src/Resources/translations/SonataAdminBundle.de.xliff
@@ -208,7 +208,7 @@
       </trans-unit>
       <trans-unit id="message_delete_confirmation">
         <source>message_delete_confirmation</source>
-        <target>Sind Sie sicher, dass Sie das ausgewählte Element löschen wollen?</target>
+        <target>Sind Sie sicher, dass Sie das ausgewählte Element '%object%' löschen wollen?</target>
       </trans-unit>
       <trans-unit id="btn_delete">
         <source>btn_delete</source>

--- a/src/Resources/translations/SonataAdminBundle.it.xliff
+++ b/src/Resources/translations/SonataAdminBundle.it.xliff
@@ -208,7 +208,7 @@
       </trans-unit>
       <trans-unit id="message_delete_confirmation">
         <source>message_delete_confirmation</source>
-        <target>Sei sicuro di voler eliminare l'elemento selezionato?</target>
+        <target>Sei sicuro di voler eliminare l'elemento selezionato "%object%"?</target>
       </trans-unit>
       <trans-unit id="btn_delete">
         <source>btn_delete</source>
@@ -216,7 +216,7 @@
       </trans-unit>
       <trans-unit id="title_batch_confirmation">
         <source>title_batch_confirmation</source>
-        <target>Conferma l'azione multipla</target>
+        <target>Conferma l'azione multipla "%action%"</target>
       </trans-unit>
       <trans-unit id="message_batch_confirmation">
         <source>message_batch_confirmation</source>

--- a/src/Resources/translations/SonataAdminBundle.nl.xliff
+++ b/src/Resources/translations/SonataAdminBundle.nl.xliff
@@ -208,7 +208,7 @@
       </trans-unit>
       <trans-unit id="message_delete_confirmation">
         <source>message_delete_confirmation</source>
-        <target>Weet je zeker dat het geselecteerde item moet worden verwijderd?</target>
+        <target>Weet je zeker dat het geselecteerde item "%object%" moet worden verwijderd?</target>
       </trans-unit>
       <trans-unit id="btn_delete">
         <source>btn_delete</source>
@@ -216,7 +216,7 @@
       </trans-unit>
       <trans-unit id="title_batch_confirmation">
         <source>title_batch_confirmation</source>
-        <target>Bevestig groep handeling</target>
+        <target>Bevestig groep handeling "%action%"</target>
       </trans-unit>
       <trans-unit id="message_batch_confirmation">
         <source>message_batch_confirmation</source>

--- a/src/Resources/translations/SonataAdminBundle.nl.xliff
+++ b/src/Resources/translations/SonataAdminBundle.nl.xliff
@@ -156,19 +156,19 @@
       </trans-unit>
       <trans-unit id="flash_create_success">
         <source>flash_create_success</source>
-        <target>Het item is succesvol aangemaakt.</target>
+        <target>Het item "%name%" is succesvol aangemaakt.</target>
       </trans-unit>
       <trans-unit id="flash_create_error">
         <source>flash_create_error</source>
-        <target>Het item kon door een fout niet worden aangemaakt.</target>
+        <target>Het item "%name%" kon door een fout niet worden aangemaakt.</target>
       </trans-unit>
       <trans-unit id="flash_edit_success">
         <source>flash_edit_success</source>
-        <target>Het item is succesvol bijgewerkt.</target>
+        <target>Het item "%name%" is succesvol bijgewerkt.</target>
       </trans-unit>
       <trans-unit id="flash_edit_error">
         <source>flash_edit_error</source>
-        <target>Het item kon door een fout niet worden bijgewerkt.</target>
+        <target>Het item "%name%" kon door een fout niet worden bijgewerkt.</target>
       </trans-unit>
       <trans-unit id="flash_lock_error">
         <source>flash_lock_error</source>
@@ -188,11 +188,11 @@
       </trans-unit>
       <trans-unit id="flash_delete_error">
         <source>flash_delete_error</source>
-        <target>Het item kon door een fout niet worden verwijderd.</target>
+        <target>Het item "%name%" kon door een fout niet worden verwijderd.</target>
       </trans-unit>
       <trans-unit id="flash_delete_success">
         <source>flash_delete_success</source>
-        <target>Het item is succesvol verwijderd.</target>
+        <target>Het item "%name%" is succesvol verwijderd.</target>
       </trans-unit>
       <trans-unit id="form_not_available">
         <source>form_not_available</source>
@@ -432,7 +432,7 @@
       </trans-unit>
       <trans-unit id="title_search_results">
         <source>title_search_results</source>
-        <target>Zoek resultaten</target>
+        <target>Zoek resultaten: %query%</target>
       </trans-unit>
       <trans-unit id="search_placeholder">
         <source>search_placeholder</source>

--- a/src/Resources/translations/SonataAdminBundle.no.xliff
+++ b/src/Resources/translations/SonataAdminBundle.no.xliff
@@ -209,7 +209,7 @@
       </trans-unit>
       <trans-unit id="message_delete_confirmation">
         <source>message_delete_confirmation</source>
-        <target>Er du sikker på at du vil slette det valgte objektet"%object%" ?</target>
+        <target>Er du sikker på at du vil slette det valgte objektet "%object%"?</target>
       </trans-unit>
       <trans-unit id="btn_delete">
         <source>btn_delete</source>


### PR DESCRIPTION
## Subject

While implementing a custom batch action, I noticed that for the English translations the batch action confirmation screen is mentioning the selected action: `Confirm batch action "%action%"`, however in the Dutch translation the `"%action%"` is missing. So the screen does not show you the batch action you have selected to execute.

For comparison:

🇬🇧 ![Screenshot from 2021-12-07 10-28-37](https://user-images.githubusercontent.com/2794908/145003151-fdbcdd97-99a9-483b-af88-74b86076623d.png)

:netherlands: ![Screenshot from 2021-12-07 10-29-09](https://user-images.githubusercontent.com/2794908/145003381-8daadd30-746c-49a9-a4bf-267304abec08.png)

So what will I be doing to these 2 items? I don't know 🤷🏻‍♂️ 😄  

I am targeting the 3.x branch, because I think this is a bug.

## Changelog
```markdown
### Fixed
- Fixed batch confirmation translations to include mentioning the selected action or object
- Fixed (other) Dutch translations that were missing a placeholder compared to the English file
```

## To do

- [x] Should I update other languages where this is also applicable and this lies within my abilities?
- [x] Should I update other messages where there are also placeholders missing in comparison to the English messages?
