### PR TITLE
configureShowFields method's category should be category.name

### DIFF
--- a/docs/getting_started/the_show_view.rst
+++ b/docs/getting_started/the_show_view.rst
@@ -24,7 +24,7 @@ If you're now familiar with the ``FormMapper`` and the ``ListMapper``, the
             ->add('id')
             ->add('title')
             ->add('body')
-            ->add('category')
+            ->add('category.name')
         ;
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
$show->add('category') should be $show->add('category.name') 

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
