### PR TITLE
Added an example to filter with custom values

### DIFF
--- a/docs/getting_started/the_list_view.rst
+++ b/docs/getting_started/the_list_view.rst
@@ -192,6 +192,36 @@ This way you can filter by a selected category.
    :alt: Sonata Category filter
    :width: 700px
 
+Another way to filter, if you have custom values to select from, is by using ``ChoiceFilter`` ::
+
+    // src/Admin/BlogPostAdmin.php
+
+    namespace App\Admin;
+
+    use Sonata\AdminBundle\Datagrid\DatagridMapper;
+    use Sonata\DoctrineORMAdminBundle\Filter\ChoiceFilter;
+    use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+
+    final class BlogPostAdmin extends AbstractAdmin
+    {
+        protected function configureDatagridFilters(DatagridMapper $datagrid): void
+        {
+            $datagrid
+                ->add('title')
+                ->add('state',   ChoiceFilter::class, [
+                    'label' => 'State',
+                    'field_type' => ChoiceType::class,
+                    'field_options' => [
+                        'choices' => [
+                            'new' => 'new',
+                            'open' => 'open',
+                            'closed' => 'closed'],                        
+                    ]
+                ])
+            ;
+        }
+    }
+
 Round Up
 --------
 


### PR DESCRIPTION
## New example for the filter section in the docs

While upgrading to 4.x, I couldn't find any example to replace 'doctrine_orm_choice', I think an example could be a nice addition to the docs.

I am targeting this branch, because this is a feature ? (Really not sure here)

- [x] Update the documentation;

