### PR TITLE
Introduce showInDashboard instead of showIn

### DIFF
--- a/docs/reference/security.rst
+++ b/docs/reference/security.rst
@@ -234,7 +234,7 @@ For example, you can `create your own voter`_
 Customizing the handler behavior
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you want to change the handler behavior, create your own handler implementing 
+If you want to change the handler behavior, create your own handler implementing
 ``Sonata\AdminBundle\Security\Handler\SecurityHandlerInterface``.
 
 And specify it as Sonata security handler on your configuration:
@@ -475,7 +475,7 @@ If you try to access to the admin class you should see the login form, log in
 with the ``root`` user.
 
 An Admin is displayed in the dashboard (and menu) when the user has the role
-``LIST``. To change this override the ``showIn`` method in the Admin class.
+``LIST``. To change this override the ``showInDashboard`` method in the Admin class.
 
 Roles and Access control lists
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -58,7 +58,10 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
  */
 abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterface, DomainObjectInterface, AdminTreeInterface
 {
+    // NEXT_MAJOR: Remove the CONTEXT constants.
+    /** @deprecated */
     public const CONTEXT_MENU = 'menu';
+    /** @deprecated */
     public const CONTEXT_DASHBOARD = 'dashboard';
 
     public const CLASS_REGEX =
@@ -1584,9 +1587,32 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $this->getCode();
     }
 
+    public function showInDashboard(): bool
+    {
+        // NEXT_MAJOR: Remove those lines and uncomment the last one.
+        $permissionShow = $this->getPermissionsShow(self::CONTEXT_DASHBOARD, 'sonata_deprecation_mute');
+        $permission = 1 === \count($permissionShow) ? reset($permissionShow) : $permissionShow;
+
+        return $this->isGranted($permission);
+        // return $this->isGranted('LIST');
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle version 4.x use showInDashboard instead
+     */
     final public function showIn(string $context): bool
     {
-        $permissionShow = $this->getPermissionsShow($context);
+        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
+            @trigger_error(sprintf(
+                'The "%s()" method is deprecated since sonata-project/admin-bundle version 4.x and will be'
+                .' removed in 5.0 version. Use showInDashboard() instead.',
+                __METHOD__
+            ), \E_USER_DEPRECATED);
+        }
+
+        $permissionShow = $this->getPermissionsShow($context, 'sonata_deprecation_mute');
         // Avoid isGranted deprecation if there is only one permission show.
         $permission = 1 === \count($permissionShow) ? reset($permissionShow) : $permissionShow;
 
@@ -2171,10 +2197,22 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
     /**
      * Return the list of permissions the user should have in order to display the admin.
      *
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle version 4.x
+     *
      * @return string[]
      */
     protected function getPermissionsShow(string $context): array
     {
+        if ('sonata_deprecation_mute' !== (\func_get_args()[1] ?? null)) {
+            @trigger_error(sprintf(
+                'The "%s()" method is deprecated since sonata-project/admin-bundle version 4.x and will be'
+                .' removed in 5.0 version.',
+                __METHOD__
+            ), \E_USER_DEPRECATED);
+        }
+
         return ['LIST'];
     }
 

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -31,6 +31,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * NEXT_MAJOR: Add all these methods to the interface by uncommenting them.
  *
+ * @method bool showInDashboard()
  * @method void removeExtension(AdminExtensionInterface $extension)
  *
  * @phpstan-import-type FieldDescriptionOptions from \Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface
@@ -269,7 +270,15 @@ interface AdminInterface extends TaggedAdminInterface, AccessRegistryInterface, 
      */
     public function getFilterParameters(): array;
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle version 4.x use showInDashboard instead
+     */
     public function showIn(string $context): bool;
+
+    // NEXT_MAJOR: Uncomment this for Sonata 5
+    //public function showInDashboard(): bool;
 
     /**
      * Add object security, fe. make the current user owner of the object.

--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -111,8 +111,23 @@ final class Pool
                 }
 
                 $admin = $this->getInstance($item['admin']);
-                if (!$admin->showIn(AbstractAdmin::CONTEXT_DASHBOARD)) {
-                    return null;
+
+                // NEXT_MAJOR: Keep the if part.
+                // @phpstan-ignore-next-line
+                if (method_exists($admin, 'showInDashboard')) {
+                    if (!$admin->showInDashboard()) {
+                        return null;
+                    }
+                } else {
+                    @trigger_error(sprintf(
+                        'Not implementing "%s::showInDashboard()" is deprecated since sonata-project/admin-bundle 4.x'
+                        .' and will fail in 5.0.',
+                        AdminInterface::class
+                    ), \E_USER_DEPRECATED);
+
+                    if (!$admin->showIn(AbstractAdmin::CONTEXT_DASHBOARD)) {
+                        return null;
+                    }
                 }
 
                 return $admin;

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1288,6 +1288,11 @@ final class AdminTest extends TestCase
         static::assertFalse($admin->supportsPreviewMode());
     }
 
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
     public function testShowIn(): void
     {
         $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
@@ -1304,6 +1309,22 @@ final class AdminTest extends TestCase
         static::assertTrue($admin->showIn(AbstractAdmin::CONTEXT_DASHBOARD));
         static::assertTrue($admin->showIn(AbstractAdmin::CONTEXT_MENU));
         static::assertTrue($admin->showIn('foo'));
+    }
+
+    public function testShowInDashboard(): void
+    {
+        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+
+        $securityHandler = $this->createMock(AclSecurityHandlerInterface::class);
+        $securityHandler
+            ->expects(static::once())
+            ->method('isGranted')
+            ->with($admin, 'LIST')
+            ->willReturn(true);
+
+        $admin->setSecurityHandler($securityHandler);
+
+        static::assertTrue($admin->showInDashboard());
     }
 
     public function testGetObjectIdentifier(): void

--- a/tests/Admin/PoolTest.php
+++ b/tests/Admin/PoolTest.php
@@ -41,7 +41,12 @@ final class PoolTest extends TestCase
         $this->pool = new Pool($this->container);
     }
 
-    public function testGetDashboardGroups(): void
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     */
+    public function testGetDashboardGroupsForLegacyAdmin(): void
     {
         $adminGroup1 = $this->createMock(AdminInterface::class);
         $adminGroup1->expects(static::once())->method('showIn')->willReturn(true);
@@ -51,6 +56,41 @@ final class PoolTest extends TestCase
 
         $adminGroup3 = $this->createMock(AdminInterface::class);
         $adminGroup3->expects(static::once())->method('showIn')->willReturn(false);
+
+        $this->container->set('sonata.user.admin.group1', $adminGroup1);
+        $this->container->set('sonata.user.admin.group2', $adminGroup2);
+        $this->container->set('sonata.user.admin.group3', $adminGroup3);
+
+        $pool = new Pool(
+            $this->container,
+            ['sonata.user.admin.group1', 'sonata.user.admin.group2', 'sonata.user.admin.group3'],
+            [
+                'adminGroup1' => $this->getGroupArray('sonata.user.admin.group1'),
+                'adminGroup2' => $this->getGroupArray('sonata.user.admin.group2'),
+                'adminGroup3' => $this->getGroupArray('sonata.user.admin.group3'),
+                'adminGroup4' => $this->getGroupArray(),
+            ]
+        );
+
+        $groups = $pool->getDashboardGroups();
+
+        static::assertCount(1, $groups);
+        static::assertSame($adminGroup1, $groups['adminGroup1']['items']['itemKey']);
+    }
+
+    public function testGetDashboardGroups(): void
+    {
+        // NEXT_MAJOR: Use $this->createMock(AdminInterface::class);
+        $adminGroup1 = $this->getMockBuilder(AdminInterface::class)->addMethods(['showInDashboard'])->getMockForAbstractClass();
+        $adminGroup1->expects(static::once())->method('showInDashboard')->willReturn(true);
+
+        // NEXT_MAJOR: Use $this->createMock(AdminInterface::class);
+        $adminGroup2 = $this->getMockBuilder(AdminInterface::class)->addMethods(['showInDashboard'])->getMockForAbstractClass();
+        $adminGroup2->expects(static::once())->method('showInDashboard')->willReturn(false);
+
+        // NEXT_MAJOR: Use $this->createMock(AdminInterface::class);
+        $adminGroup3 = $this->getMockBuilder(AdminInterface::class)->addMethods(['showInDashboard'])->getMockForAbstractClass();
+        $adminGroup3->expects(static::once())->method('showInDashboard')->willReturn(false);
 
         $this->container->set('sonata.user.admin.group1', $adminGroup1);
         $this->container->set('sonata.user.admin.group2', $adminGroup2);

--- a/tests/Twig/Extension/GroupExtensionTest.php
+++ b/tests/Twig/Extension/GroupExtensionTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Twig\Extension;
 
 use PHPUnit\Framework\TestCase;
-use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Twig\Extension\GroupExtension;
@@ -67,15 +66,15 @@ final class GroupExtensionTest extends TestCase
         ]);
         $twigExtension = new GroupExtension($pool);
 
-        $adminNonCreatable = $this->createMock(AdminInterface::class);
-        $adminCreatable = $this->createMock(AdminInterface::class);
+        // NEXT_MAJOR: Use createMock instead.
+        $adminNonCreatable = $this->getMockBuilder(AdminInterface::class)->addMethods(['showInDashboard'])->getMockForAbstractClass();
+        $adminCreatable = $this->getMockBuilder(AdminInterface::class)->addMethods(['showInDashboard'])->getMockForAbstractClass();
 
         $container->set('sonata_admin_non_creatable', $adminNonCreatable);
         $container->set('sonata_admin_creatable', $adminCreatable);
 
         $adminCreatable
-            ->method('showIn')
-            ->with(AbstractAdmin::CONTEXT_DASHBOARD)
+            ->method('showInDashboard')
             ->willReturn(true);
 
         $adminCreatable


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Closes #7642.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- `AdminInterface::showInDashboard()` method.

### Deprecated
- `AdminInterface::showIn()` method.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
