### PR TITLE
Deprecate passing an array of role to isGranted

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1586,7 +1586,11 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
 
     final public function showIn(string $context): bool
     {
-        return $this->isGranted($this->getPermissionsShow($context));
+        $permissionShow = $this->getPermissionsShow($context);
+        // Avoid isGranted deprecation if there is only one permission show.
+        $permission = 1 === \count($permissionShow) ? reset($permissionShow) : $permissionShow;
+
+        return $this->isGranted($permission);
     }
 
     final public function createObjectSecurity(object $object): void
@@ -1596,6 +1600,17 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
 
     final public function isGranted($name, ?object $object = null): bool
     {
+        if (\is_array($name)) {
+            @trigger_error(
+                sprintf(
+                    'Passing an array as argument 1 of "%s()" is deprecated since sonata-project/admin-bundle 4.x'
+                    .' and will throw an error in 5.0. You MUST pass a string instead.',
+                    __METHOD__
+                ),
+                \E_USER_DEPRECATED
+            );
+        }
+
         $objectRef = null !== $object ? sprintf('/%s#%s', spl_object_hash($object), $this->id($object) ?? '') : '';
         $key = md5(json_encode($name).$objectRef);
 

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -115,6 +115,8 @@ interface AdminInterface extends TaggedAdminInterface, AccessRegistryInterface, 
     public function hasRoute(string $name): bool;
 
     /**
+     * NEXT_MAJOR: Restrict $name typehint to string.
+     *
      * @param string|string[] $name
      *
      * @phpstan-param T|null $object

--- a/src/Resources/config/security.php
+++ b/src/Resources/config/security.php
@@ -44,9 +44,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->set('sonata.admin.security.handler.role', '%sonata.admin.security.handler.role.class%')
             ->args([
                 new ReferenceConfigurator('security.authorization_checker'),
-                [
-                    '%sonata.admin.configuration.security.role_super_admin%',
-                ],
+                '%sonata.admin.configuration.security.role_super_admin%',
             ])
 
         ->set('sonata.admin.security.handler.acl', '%sonata.admin.security.handler.acl.class%')
@@ -55,9 +53,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 new ReferenceConfigurator('security.authorization_checker'),
                 (new ReferenceConfigurator('security.acl.provider'))->nullOnInvalid(),
                 '%sonata.admin.security.mask.builder.class%',
-                [
-                    '%sonata.admin.configuration.security.role_super_admin%',
-                ],
+                '%sonata.admin.configuration.security.role_super_admin%',
             ])
             ->call('setAdminPermissions', ['%sonata.admin.configuration.security.admin_permissions%'])
             ->call('setObjectPermissions', ['%sonata.admin.configuration.security.object_permissions%'])

--- a/src/Security/Handler/AclSecurityHandler.php
+++ b/src/Security/Handler/AclSecurityHandler.php
@@ -70,7 +70,7 @@ final class AclSecurityHandler implements AclSecurityHandlerInterface
     private $maskBuilderClass;
 
     /**
-     * @param string[] $superAdminRoles
+     * @param string|string[] $superAdminRoles
      * @phpstan-param class-string<MaskBuilderInterface> $maskBuilderClass
      */
     public function __construct(
@@ -78,13 +78,31 @@ final class AclSecurityHandler implements AclSecurityHandlerInterface
         AuthorizationCheckerInterface $authorizationChecker,
         MutableAclProviderInterface $aclProvider,
         string $maskBuilderClass,
-        array $superAdminRoles
+        $superAdminRoles
     ) {
         $this->tokenStorage = $tokenStorage;
         $this->authorizationChecker = $authorizationChecker;
         $this->aclProvider = $aclProvider;
         $this->maskBuilderClass = $maskBuilderClass;
-        $this->superAdminRoles = $superAdminRoles;
+
+        // NEXT_MAJOR: Keep only the elseif part and add typehint.
+        if (\is_array($superAdminRoles)) {
+            @trigger_error(sprintf(
+                'Passing an array as argument 1 of "%s()" is deprecated since sonata-project/admin-bundle 4.x'
+                .' and will throw an error in 5.0. You MUST pass a string instead.',
+                __METHOD__
+            ), \E_USER_DEPRECATED);
+
+            $this->superAdminRoles = $superAdminRoles;
+        } elseif (\is_string($superAdminRoles)) {
+            $this->superAdminRoles = [$superAdminRoles];
+        } else {
+            throw new \TypeError(sprintf(
+                'Argument 1 passed to "%s()" must be of type "array" or "string", %s given.',
+                __METHOD__,
+                \is_object($superAdminRoles) ? 'instance of "'.\get_class($superAdminRoles).'"' : '"'.\gettype($superAdminRoles).'"'
+            ));
+        }
     }
 
     public function setAdminPermissions(array $permissions): void
@@ -109,11 +127,22 @@ final class AclSecurityHandler implements AclSecurityHandlerInterface
 
     public function isGranted(AdminInterface $admin, $attributes, ?object $object = null): bool
     {
+        // NEXT_MAJOR: Remove this and add string typehint to $attributes and rename it $attribute.
+        if (\is_array($attributes)) {
+            @trigger_error(sprintf(
+                'Passing an array as argument 1 of "%s()" is deprecated since sonata-project/admin-bundle 4.x'
+                .' and will throw an error in 5.0. You MUST pass a string instead.',
+                __METHOD__
+            ), \E_USER_DEPRECATED);
+        }
+
+        // NEXT_MAJOR: Remove this check.
         if (!\is_array($attributes)) {
             $attributes = [$attributes];
         }
 
         try {
+            // NEXT_MAJOR: Remove the method isAnyGranted and use $this->authorizationChecker->isGranted instead.
             return $this->isAnyGranted($this->superAdminRoles) ||
                 $this->isAnyGranted($attributes, $object);
         } catch (AuthenticationCredentialsNotFoundException $e) {

--- a/src/Security/Handler/RoleSecurityHandler.php
+++ b/src/Security/Handler/RoleSecurityHandler.php
@@ -33,20 +33,49 @@ final class RoleSecurityHandler implements SecurityHandlerInterface
     private $superAdminRoles = [];
 
     /**
-     * @param string[] $superAdminRoles
+     * @param string|string[] $superAdminRoles
      */
-    public function __construct(AuthorizationCheckerInterface $authorizationChecker, array $superAdminRoles)
+    public function __construct(AuthorizationCheckerInterface $authorizationChecker, $superAdminRoles)
     {
         $this->authorizationChecker = $authorizationChecker;
-        $this->superAdminRoles = $superAdminRoles;
+
+        // NEXT_MAJOR: Keep only the elseif part and add typehint.
+        if (\is_array($superAdminRoles)) {
+            @trigger_error(sprintf(
+                'Passing an array as argument 1 of "%s()" is deprecated since sonata-project/admin-bundle 4.x'
+                .' and will throw an error in 5.0. You MUST pass a string instead.',
+                __METHOD__
+            ), \E_USER_DEPRECATED);
+
+            $this->superAdminRoles = $superAdminRoles;
+        } elseif (\is_string($superAdminRoles)) {
+            $this->superAdminRoles = [$superAdminRoles];
+        } else {
+            throw new \TypeError(sprintf(
+                'Argument 1 passed to "%s()" must be of type "array" or "string", %s given.',
+                __METHOD__,
+                \is_object($superAdminRoles) ? 'instance of "'.\get_class($superAdminRoles).'"' : '"'.\gettype($superAdminRoles).'"'
+            ));
+        }
     }
 
     public function isGranted(AdminInterface $admin, $attributes, ?object $object = null): bool
     {
+        // NEXT_MAJOR: Remove this and add string typehint to $attributes and rename it $attribute.
+        if (\is_array($attributes)) {
+            @trigger_error(sprintf(
+                'Passing an array as argument 1 of "%s()" is deprecated since sonata-project/admin-bundle 4.x'
+                .' and will throw an error in 5.0. You MUST pass a string instead.',
+                __METHOD__
+            ), \E_USER_DEPRECATED);
+        }
+
+        // NEXT_MAJOR: Remove this check.
         if (!\is_array($attributes)) {
             $attributes = [$attributes];
         }
 
+        // NEXT_MAJOR: Change the foreach to a single check.
         $useAll = false;
         foreach ($attributes as $pos => $attribute) {
             // If the attribute is not already a ROLE_ we generate the related role.
@@ -60,6 +89,7 @@ final class RoleSecurityHandler implements SecurityHandlerInterface
         $allRole = sprintf($this->getBaseRole($admin), 'ALL');
 
         try {
+            // NEXT_MAJOR: Remove the method isAnyGranted and use $this->authorizationChecker->isGranted instead.
             return $this->isAnyGranted($this->superAdminRoles)
                 || $this->isAnyGranted($attributes, $object)
                 || $useAll && $this->isAnyGranted([$allRole], $object);

--- a/src/Security/Handler/SecurityHandlerInterface.php
+++ b/src/Security/Handler/SecurityHandlerInterface.php
@@ -21,6 +21,8 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 interface SecurityHandlerInterface
 {
     /**
+     * NEXT_MAJOR: Restrict $attributes typehint to string and rename it $attribute.
+     *
      * @param AdminInterface<object> $admin
      * @param string|string[]        $attributes
      */

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1295,8 +1295,8 @@ final class AdminTest extends TestCase
         $securityHandler = $this->createMock(AclSecurityHandlerInterface::class);
         $securityHandler
             ->method('isGranted')
-            ->willReturnCallback(static function (AdminInterface $adminIn, array $attributes, ?object $object = null) use ($admin): bool {
-                return $admin === $adminIn && $attributes === ['LIST'];
+            ->willReturnCallback(static function (AdminInterface $adminIn, $attributes, ?object $object = null) use ($admin): bool {
+                return $admin === $adminIn && 'LIST' === $attributes;
             });
 
         $admin->setSecurityHandler($securityHandler);

--- a/tests/Security/Handler/AclSecurityHandlerTest.php
+++ b/tests/Security/Handler/AclSecurityHandlerTest.php
@@ -25,6 +25,11 @@ use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundE
 
 final class AclSecurityHandlerTest extends TestCase
 {
+    /**
+     * NEXT_MAJOR: Remove the group legacy.
+     *
+     * @group legacy
+     */
     public function testAcl(): void
     {
         $admin = $this->createMock(AdminInterface::class);
@@ -39,8 +44,9 @@ final class AclSecurityHandlerTest extends TestCase
 
         $aclProvider = $this->createMock(MutableAclProviderInterface::class);
 
-        $handler = new AclSecurityHandler($this->createMock(TokenStorageInterface::class), $authorizationChecker, $aclProvider, MaskBuilder::class, []);
+        $handler = new AclSecurityHandler($this->createMock(TokenStorageInterface::class), $authorizationChecker, $aclProvider, MaskBuilder::class, 'ROLE_SUPER_ADMIN');
 
+        // NEXT_MAJOR: Remove the next line.
         static::assertTrue($handler->isGranted($admin, ['TOTO']));
         static::assertTrue($handler->isGranted($admin, 'TOTO'));
 
@@ -49,8 +55,9 @@ final class AclSecurityHandlerTest extends TestCase
             ->method('isGranted')
             ->willReturn(false);
 
-        $handler = new AclSecurityHandler($this->createMock(TokenStorageInterface::class), $authorizationChecker, $aclProvider, MaskBuilder::class, []);
+        $handler = new AclSecurityHandler($this->createMock(TokenStorageInterface::class), $authorizationChecker, $aclProvider, MaskBuilder::class, 'ROLE_SUPER_ADMIN');
 
+        // NEXT_MAJOR: Remove the next line.
         static::assertFalse($handler->isGranted($admin, ['TOTO']));
         static::assertFalse($handler->isGranted($admin, 'TOTO'));
     }
@@ -73,7 +80,7 @@ final class AclSecurityHandlerTest extends TestCase
 
         $aclProvider = $this->createMock(MutableAclProviderInterface::class);
 
-        $handler = new AclSecurityHandler($this->createMock(TokenStorageInterface::class), $authorizationChecker, $aclProvider, MaskBuilder::class, []);
+        $handler = new AclSecurityHandler($this->createMock(TokenStorageInterface::class), $authorizationChecker, $aclProvider, MaskBuilder::class, 'ROLE_SUPER_ADMIN');
 
         $results = $handler->buildSecurityInformation($admin);
 
@@ -91,7 +98,7 @@ final class AclSecurityHandlerTest extends TestCase
 
         $aclProvider = $this->createMock(MutableAclProviderInterface::class);
 
-        $handler = new AclSecurityHandler($this->createMock(TokenStorageInterface::class), $authorizationChecker, $aclProvider, MaskBuilder::class, []);
+        $handler = new AclSecurityHandler($this->createMock(TokenStorageInterface::class), $authorizationChecker, $aclProvider, MaskBuilder::class, 'ROLE_SUPER_ADMIN');
 
         static::assertFalse($handler->isGranted($admin, 'raise exception', $admin));
     }
@@ -109,7 +116,7 @@ final class AclSecurityHandlerTest extends TestCase
 
         $aclProvider = $this->createMock(MutableAclProviderInterface::class);
 
-        $handler = new AclSecurityHandler($this->createMock(TokenStorageInterface::class), $authorizationChecker, $aclProvider, MaskBuilder::class, []);
+        $handler = new AclSecurityHandler($this->createMock(TokenStorageInterface::class), $authorizationChecker, $aclProvider, MaskBuilder::class, 'ROLE_SUPER_ADMIN');
 
         static::assertFalse($handler->isGranted($admin, 'raise exception', $admin));
     }
@@ -129,7 +136,7 @@ final class AclSecurityHandlerTest extends TestCase
             $this->createMock(AuthorizationCheckerInterface::class),
             $aclProvider,
             MaskBuilder::class,
-            []
+            'ROLE_SUPER_ADMIN'
         );
         $handler->updateAcl($acl);
     }

--- a/tests/Security/Handler/RoleSecurityHandlerTest.php
+++ b/tests/Security/Handler/RoleSecurityHandlerTest.php
@@ -46,7 +46,7 @@ final class RoleSecurityHandlerTest extends TestCase
      */
     public function testGetBaseRole(string $expected, string $code): void
     {
-        $handler = new RoleSecurityHandler($this->authorizationChecker, ['ROLE_BATMAN', 'ROLE_IRONMAN']);
+        $handler = new RoleSecurityHandler($this->authorizationChecker, 'ROLE_BATMAN');
 
         $this->admin->expects(static::once())
             ->method('getCode')
@@ -69,12 +69,16 @@ final class RoleSecurityHandlerTest extends TestCase
     }
 
     /**
-     * @param string[]        $superAdminRoles
+     * NEXT_MAJOR: Remove the group legacy and only keep string $superAdminRoles and string $operation in dataProvider.
+     *
+     * @group legacy
+     *
+     * @param string|string[] $superAdminRoles
      * @param string|string[] $operation
      *
      * @dataProvider getIsGrantedTests
      */
-    public function testIsGranted(bool $expected, array $superAdminRoles, string $adminCode, $operation, ?object $object = null): void
+    public function testIsGranted(bool $expected, $superAdminRoles, string $adminCode, $operation, ?object $object = null): void
     {
         $handler = $this->getRoleSecurityHandler($superAdminRoles);
 
@@ -105,38 +109,38 @@ final class RoleSecurityHandlerTest extends TestCase
     }
 
     /**
-     * @phpstan-return array<array{bool, string[], string, string|string[]}>
+     * @phpstan-return array<array{bool, string|array<string>, string, string|array<string>}>
      */
     public function getIsGrantedTests(): array
     {
         return [
             //empty
-            [false, [''], 'foo.bar', ''],
-            [false, [''], 'foo.bar', ['']],
-            [false, [''], 'foo.bar.abc', ['']],
-            [false, [''], 'foo.bar.def', ['']],
-            [false, [''], 'foo.bar.baz.xyz', ''],
-            [false, [''], 'foo.bar.baz.xyz', ['']],
+            [false, '', 'foo.bar', ''],
+            [false, '', 'foo.bar', ['']],
+            [false, '', 'foo.bar.abc', ['']],
+            [false, '', 'foo.bar.def', ['']],
+            [false, '', 'foo.bar.baz.xyz', ''],
+            [false, '', 'foo.bar.baz.xyz', ['']],
 
             //superadmins
             [true, ['ROLE_BATMAN', 'ROLE_IRONMAN'], 'foo.bar', 'BAZ'],
             [true, ['ROLE_BATMAN', 'ROLE_IRONMAN'], 'foo.bar', 'ANYTHING'],
             [true, ['ROLE_BATMAN', 'ROLE_IRONMAN'], 'foo.bar', ['BAZ', 'ANYTHING']],
-            [true, ['ROLE_IRONMAN'], 'foo.bar', 'BAZ'],
-            [true, ['ROLE_IRONMAN'], 'foo.bar', 'ANYTHING'],
-            [true, ['ROLE_IRONMAN'], 'foo.bar.baz.xyz', 'ANYTHING'],
-            [true, ['ROLE_IRONMAN'], 'foo.bar', ''],
-            [true, ['ROLE_IRONMAN'], 'foo.bar', ['']],
+            [true, 'ROLE_IRONMAN', 'foo.bar', 'BAZ'],
+            [true, 'ROLE_IRONMAN', 'foo.bar', 'ANYTHING'],
+            [true, 'ROLE_IRONMAN', 'foo.bar.baz.xyz', 'ANYTHING'],
+            [true, 'ROLE_IRONMAN', 'foo.bar', ''],
+            [true, 'ROLE_IRONMAN', 'foo.bar', ['']],
 
             //operations
-            [true, ['ROLE_SPIDERMAN'], 'foo.bar', 'ABC'],
-            [true, ['ROLE_SPIDERMAN'], 'foo.bar', ['ABC']],
-            [true, ['ROLE_SPIDERMAN'], 'foo.bar', ['ABC', 'DEF']],
-            [true, ['ROLE_SPIDERMAN'], 'foo.bar', ['BAZ', 'ABC']],
-            [false, ['ROLE_SPIDERMAN'], 'foo.bar', 'DEF'],
-            [false, ['ROLE_SPIDERMAN'], 'foo.bar', ['DEF']],
-            [false, ['ROLE_SPIDERMAN'], 'foo.bar', 'BAZ'],
-            [false, ['ROLE_SPIDERMAN'], 'foo.bar', ['BAZ']],
+            [true, 'ROLE_SPIDERMAN', 'foo.bar', 'ABC'],
+            [true, 'ROLE_SPIDERMAN', 'foo.bar', ['ABC']],
+            [true, 'ROLE_SPIDERMAN', 'foo.bar', ['ABC', 'DEF']],
+            [true, 'ROLE_SPIDERMAN', 'foo.bar', ['BAZ', 'ABC']],
+            [false, 'ROLE_SPIDERMAN', 'foo.bar', 'DEF'],
+            [false, 'ROLE_SPIDERMAN', 'foo.bar', ['DEF']],
+            [false, 'ROLE_SPIDERMAN', 'foo.bar', 'BAZ'],
+            [false, 'ROLE_SPIDERMAN', 'foo.bar', ['BAZ']],
             [true, [], 'foo.bar', 'ABC'],
             [true, [], 'foo.bar', ['ABC']],
             [false, [], 'foo.bar', 'DEF'],
@@ -152,15 +156,15 @@ final class RoleSecurityHandlerTest extends TestCase
             [false, [], 'foo.bar.baz.xyz', ['BAZ']],
 
             //objects
-            [true, ['ROLE_SPIDERMAN'], 'foo.bar', ['DEF'], new \stdClass()],
-            [true, ['ROLE_SPIDERMAN'], 'foo.bar', ['ABC'], new \stdClass()],
-            [true, ['ROLE_SPIDERMAN'], 'foo.bar', ['ABC', 'DEF'], new \stdClass()],
-            [true, ['ROLE_SPIDERMAN'], 'foo.bar', ['BAZ', 'DEF'], new \stdClass()],
-            [true, ['ROLE_SPIDERMAN'], 'foo.bar', 'DEF', new \stdClass()],
-            [true, ['ROLE_SPIDERMAN'], 'foo.bar', 'ABC', new \stdClass()],
-            [false, ['ROLE_SPIDERMAN'], 'foo.bar', 'BAZ', new \stdClass()],
-            [false, ['ROLE_SPIDERMAN'], 'foo.bar.baz.xyz', 'DEF', new \stdClass()],
-            [false, ['ROLE_SPIDERMAN'], 'foo.bar.baz.xyz', 'ABC', new \stdClass()],
+            [true, 'ROLE_SPIDERMAN', 'foo.bar', ['DEF'], new \stdClass()],
+            [true, 'ROLE_SPIDERMAN', 'foo.bar', ['ABC'], new \stdClass()],
+            [true, 'ROLE_SPIDERMAN', 'foo.bar', ['ABC', 'DEF'], new \stdClass()],
+            [true, 'ROLE_SPIDERMAN', 'foo.bar', ['BAZ', 'DEF'], new \stdClass()],
+            [true, 'ROLE_SPIDERMAN', 'foo.bar', 'DEF', new \stdClass()],
+            [true, 'ROLE_SPIDERMAN', 'foo.bar', 'ABC', new \stdClass()],
+            [false, 'ROLE_SPIDERMAN', 'foo.bar', 'BAZ', new \stdClass()],
+            [false, 'ROLE_SPIDERMAN', 'foo.bar.baz.xyz', 'DEF', new \stdClass()],
+            [false, 'ROLE_SPIDERMAN', 'foo.bar.baz.xyz', 'ABC', new \stdClass()],
             [true, [], 'foo.bar', ['ABC'], new \stdClass()],
             [true, [], 'foo.bar', 'ABC', new \stdClass()],
             [true, [], 'foo.bar', ['DEF'], new \stdClass()],
@@ -169,7 +173,7 @@ final class RoleSecurityHandlerTest extends TestCase
             [false, [], 'foo.bar', 'BAZ', new \stdClass()],
             [false, [], 'foo.bar.baz.xyz', 'BAZ', new \stdClass()],
             [false, [], 'foo.bar.baz.xyz', ['BAZ'], new \stdClass()],
-            [false, ['ROLE_AUTH_EXCEPTION'], 'foo.bar.baz.xyz', ['BAZ'], new \stdClass()],
+            [false, 'ROLE_AUTH_EXCEPTION', 'foo.bar.baz.xyz', ['BAZ'], new \stdClass()],
 
             //role
             [false, [], 'foo.bar', ['CUSTOM']],
@@ -197,7 +201,7 @@ final class RoleSecurityHandlerTest extends TestCase
                 throw new \RuntimeException('Something is wrong');
             });
 
-        $handler = $this->getRoleSecurityHandler(['ROLE_BATMAN']);
+        $handler = $this->getRoleSecurityHandler('ROLE_BATMAN');
         $handler->isGranted($this->admin, 'BAZ');
     }
 
@@ -206,7 +210,7 @@ final class RoleSecurityHandlerTest extends TestCase
      */
     public function testCreateObjectSecurity(): void
     {
-        $handler = $this->getRoleSecurityHandler(['ROLE_FOO']);
+        $handler = $this->getRoleSecurityHandler('ROLE_FOO');
         $handler->createObjectSecurity($this->getSonataAdminObject(), new \stdClass());
     }
 
@@ -215,20 +219,20 @@ final class RoleSecurityHandlerTest extends TestCase
      */
     public function testDeleteObjectSecurity(): void
     {
-        $handler = $this->getRoleSecurityHandler(['ROLE_FOO']);
+        $handler = $this->getRoleSecurityHandler('ROLE_FOO');
         $handler->deleteObjectSecurity($this->getSonataAdminObject(), new \stdClass());
     }
 
     public function testBuildSecurityInformation(): void
     {
-        $handler = $this->getRoleSecurityHandler(['ROLE_FOO']);
+        $handler = $this->getRoleSecurityHandler('ROLE_FOO');
         static::assertSame([], $handler->buildSecurityInformation($this->getSonataAdminObject()));
     }
 
     /**
-     * @param string[] $superAdminRoles
+     * @param string|string[] $superAdminRoles
      */
-    private function getRoleSecurityHandler(array $superAdminRoles): RoleSecurityHandler
+    private function getRoleSecurityHandler($superAdminRoles): RoleSecurityHandler
     {
         return new RoleSecurityHandler($this->authorizationChecker, $superAdminRoles);
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #7601.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- Passing an array of role to `AdminInterface::isGranted()`
- Passing an array of role to `AbstractAdmin::isGranted()`
- Passing an array of role to `SecurityHandlerInterface::isGranted()`
- Passing an array of role to `RoleSecurityHandler::isGranted()`
- Passing an array of role to `AclSecurityHandler::isGranted()`
```