### PR TITLE
Updated configuration key that delays the ajax requests.

### DIFF
--- a/src/Form/Type/ModelAutocompleteType.php
+++ b/src/Form/Type/ModelAutocompleteType.php
@@ -163,9 +163,11 @@ final class ModelAutocompleteType extends AbstractType
             ...$this->deprecationParameters(
                 '4.x',
                 static function (Options $options, $value): string {
-                    if($value !== 100) {
+                    if ($value !== 100) {
                         return 'Passing a value to option "quiet_millis" is deprecated! Use "delay" instead!';
                     }
+
+                    return '';
                 }
             )
         ); // NEXT_MAJOR: Remove this deprecation notice.

--- a/src/Form/Type/ModelAutocompleteType.php
+++ b/src/Form/Type/ModelAutocompleteType.php
@@ -163,7 +163,7 @@ final class ModelAutocompleteType extends AbstractType
             ...$this->deprecationParameters(
                 '4.x',
                 static function (Options $options, $value): string {
-                    if ($value !== 100) {
+                    if (100 !== $value) {
                         return 'Passing a value to option "quiet_millis" is deprecated! Use "delay" instead!';
                     }
 

--- a/src/Form/Type/ModelAutocompleteType.php
+++ b/src/Form/Type/ModelAutocompleteType.php
@@ -163,7 +163,7 @@ final class ModelAutocompleteType extends AbstractType
             ...$this->deprecationParameters(
                 '4.x',
                 static function (Options $options, $value): string {
-                    if(!is_null($value)) {
+                    if($value !== 100) {
                         return 'Passing a value to option "quiet_millis" is deprecated! Use "delay" instead!';
                     }
                 }

--- a/src/Form/Type/ModelAutocompleteType.php
+++ b/src/Form/Type/ModelAutocompleteType.php
@@ -78,7 +78,7 @@ final class ModelAutocompleteType extends AbstractType
             'req_param_name_search',
             'req_param_name_page_number',
             'req_param_name_items_per_page',
-            'quiet_millis', // NEXT_MAJOR: `quiet_millis` is deprecated. Use `delay` instead.
+            'quiet_millis', // NEXT_MAJOR: Remove this line.
             'delay',
             'cache',
             // CSS classes
@@ -119,7 +119,7 @@ final class ModelAutocompleteType extends AbstractType
             'placeholder' => '',
             'minimum_input_length' => 3, //minimum 3 chars should be typed to load ajax data
             'items_per_page' => 10, //number of items per page
-            'quiet_millis' => 100, // NEXT_MAJOR: `quiet_millis` is deprecated. Use `delay` instead.
+            'quiet_millis' => 100, // NEXT_MAJOR: Remove this line.
             'delay' => 100,
             'cache' => false,
 
@@ -158,11 +158,43 @@ final class ModelAutocompleteType extends AbstractType
         $resolver->setAllowedTypes('model_manager', ModelManagerInterface::class);
         $resolver->setAllowedTypes('class', 'string');
         $resolver->setAllowedTypes('property', ['string', 'array']);
-        $resolver->setDeprecated('quiet_millis', 'Using `quiet_millis` is deprecated! Use `delay` instead!'); // NEXT_MAJOR: Remove this deprecation notice.
+        $resolver->setDeprecated(
+            'quiet_millis',
+            ...$this->deprecationParameters(
+                '4.x',
+                static function (Options $options, $value): string {
+                    if(!is_null($value)) {
+                        return 'Passing a value to option "quiet_millis" is deprecated! Use "delay" instead!';
+                    }
+                }
+            )
+        ); // NEXT_MAJOR: Remove this deprecation notice.
     }
 
     public function getBlockPrefix(): string
     {
         return 'sonata_type_model_autocomplete';
+    }
+
+    /**
+     * This class is a BC layer for deprecation messages for symfony/options-resolver < 5.1.
+     * Remove this class when dropping support for symfony/options-resolver < 5.1.
+     *
+     * @param string|\Closure $message
+     *
+     * @return mixed[]
+     */
+    private function deprecationParameters(string $version, $message): array
+    {
+        // @phpstan-ignore-next-line
+        if (method_exists(OptionsResolver::class, 'define')) {
+            return [
+                'sonata-project/admin-bundle',
+                $version,
+                $message,
+            ];
+        }
+
+        return [$message];
     }
 }

--- a/src/Form/Type/ModelAutocompleteType.php
+++ b/src/Form/Type/ModelAutocompleteType.php
@@ -78,7 +78,8 @@ final class ModelAutocompleteType extends AbstractType
             'req_param_name_search',
             'req_param_name_page_number',
             'req_param_name_items_per_page',
-            'quiet_millis',
+            'quiet_millis', // NEXT_MAJOR: `quiet_millis` is deprecated. Use `delay` instead.
+            'delay',
             'cache',
             // CSS classes
             'container_css_class',
@@ -118,7 +119,8 @@ final class ModelAutocompleteType extends AbstractType
             'placeholder' => '',
             'minimum_input_length' => 3, //minimum 3 chars should be typed to load ajax data
             'items_per_page' => 10, //number of items per page
-            'quiet_millis' => 100,
+            'quiet_millis' => 100, // NEXT_MAJOR: `quiet_millis` is deprecated. Use `delay` instead.
+            'delay' => 100,
             'cache' => false,
 
             'to_string_callback' => null,
@@ -156,6 +158,7 @@ final class ModelAutocompleteType extends AbstractType
         $resolver->setAllowedTypes('model_manager', ModelManagerInterface::class);
         $resolver->setAllowedTypes('class', 'string');
         $resolver->setAllowedTypes('property', ['string', 'array']);
+        $resolver->setDeprecated('quiet_millis', 'Using `quiet_millis` is deprecated! Use `delay` instead!'); // NEXT_MAJOR: Remove this deprecation notice.
     }
 
     public function getBlockPrefix(): string

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -74,7 +74,7 @@ file that was distributed with this source code.
                 ajax: {
                     url:  '{{ url ?: path(route.name, route.parameters|default([])) }}',
                     dataType: 'json',
-                    delay: {{ delay === 100 and quiet_millis !== 100 ? quiet_millis : delay }}, // NEXT_MAJOR: `quiet_millis` is deprecated. Use `delay` instead.
+                    delay: {{ delay === 100 and quiet_millis !== 100 ? quiet_millis : delay }}, // NEXT_MAJOR: Replace by `{{ delay }}` instead.
                     cache: {{ cache ? 'true' : 'false' }},
                     processResults: function (data, params) {
                         return {

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -74,7 +74,7 @@ file that was distributed with this source code.
                 ajax: {
                     url:  '{{ url ?: path(route.name, route.parameters|default([])) }}',
                     dataType: 'json',
-                    delay: {{ quiet_millis }}, // Update variable name in the next updates. Keep it now for compatibility issues.
+                    delay: {{ delay === 100 and quiet_millis !== 100 ? quiet_millis : delay }}, // NEXT_MAJOR: `quiet_millis` is deprecated. Use `delay` instead.
                     cache: {{ cache ? 'true' : 'false' }},
                     processResults: function (data, params) {
                         return {

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -74,7 +74,7 @@ file that was distributed with this source code.
                 ajax: {
                     url:  '{{ url ?: path(route.name, route.parameters|default([])) }}',
                     dataType: 'json',
-                    quietMillis: {{ quiet_millis }},
+                    delay: {{ quiet_millis }}, // Update variable name in the next updates. Keep it now for compatibility issues.
                     cache: {{ cache ? 'true' : 'false' }},
                     processResults: function (data, params) {
                         return {


### PR DESCRIPTION
I observed that ajax requests for ModelAutocompleteType is not delayed anymore. I started to investigate what's going on with the  functionality and I observed that they renamed **quietMillis** to **delay**

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- ModelAutocompleteType delay option

### Fixed
- ModelAutocompleteType quietMillis option

### Deprecated
- ModelAutocompleteType quietMillis option
```