### PR TITLE
Backport #7646 to 3.x

### DIFF
--- a/src/Route/DefaultRouteGenerator.php
+++ b/src/Route/DefaultRouteGenerator.php
@@ -135,11 +135,6 @@ class DefaultRouteGenerator implements RouteGeneratorInterface
     {
         $this->loadCache($admin);
 
-        // someone provide the fullname
-        if (!$admin->isChild() && \array_key_exists($name, $this->caches)) {
-            return $name;
-        }
-
         // NEXT_MAJOR: Uncomment the following line.
         // $codePrefix = $admin->getBaseCodeRoute();
 
@@ -153,6 +148,11 @@ class DefaultRouteGenerator implements RouteGeneratorInterface
         // someone provide a code, so it is a child
         if (strpos($name, '.')) {
             return sprintf('%s|%s', $codePrefix, $name);
+        }
+
+        // someone provide the fullname
+        if (!$admin->isChild() && \array_key_exists($name, $this->caches)) {
+            return $name;
         }
 
         return sprintf('%s.%s', $codePrefix, $name);

--- a/tests/Route/DefaultRouteGeneratorTest.php
+++ b/tests/Route/DefaultRouteGeneratorTest.php
@@ -151,6 +151,10 @@ class DefaultRouteGeneratorTest extends TestCase
         $collection->add('foo');
         $collection->addCollection($childCollection);
 
+        $nochildCollection = new RouteCollection('base.Code.Child', 'admin_child', '/foo/', 'BundleName:ControllerName');
+        $nochildCollection->add('bar');
+        $collection->addCollection($nochildCollection);
+
         $admin = $this->getMockForAbstractClass(AdminInterface::class);
         $admin->method('isChild')->willReturn(true);
         $admin->method('getCode')->willReturn('base.Code.Child');
@@ -201,6 +205,10 @@ class DefaultRouteGeneratorTest extends TestCase
                         return sprintf('/foo%s', $params);
                     case 'admin_acme_child_bar':
                         return sprintf('/foo/bar%s', $params);
+                    case 'admin_child_bar':
+                        return sprintf('/bar%s', $params);
+                    default:
+                        throw new \LogicException('Not implemented');
                 }
             });
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because of backporting #7646 to 3.x

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added

### Changed

### Deprecated

### Removed

### Fixed

- [#7647] DefaultRouteGenerator Routes generation for nested admins (@Devristo)

### Security
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
