### PR TITLE
Fix support for full name route

### DIFF
--- a/src/Route/DefaultRouteGenerator.php
+++ b/src/Route/DefaultRouteGenerator.php
@@ -140,14 +140,17 @@ final class DefaultRouteGenerator implements RouteGeneratorInterface
 
         $codePrefix = $admin->getBaseCodeRoute();
 
-        // someone provide a code, so it is a child
-        if (strpos($name, '.') > 0) {
-            return sprintf('%s|%s', $codePrefix, $name);
+        // Someone provided the full name
+        if (
+            0 === strpos($name, sprintf('%s|', $codePrefix)) // Child admin route already prefixed
+            || 0 === strpos($name, sprintf('%s.', $codePrefix)) // admin route already prefixed
+        ) {
+            return $name;
         }
 
-        // someone provide the fullname
-        if (!$admin->isChild() && \array_key_exists($name, $this->caches)) {
-            return $name;
+        // Someone provided a code, so it is a child
+        if (strpos($name, '.') > 0) {
+            return sprintf('%s|%s', $codePrefix, $name);
         }
 
         return sprintf('%s.%s', $codePrefix, $name);

--- a/tests/Route/DefaultRouteGeneratorTest.php
+++ b/tests/Route/DefaultRouteGeneratorTest.php
@@ -241,8 +241,11 @@ final class DefaultRouteGeneratorTest extends TestCase
     {
         return [
             ['parent', '/foo?id=123&default_param=default_val', 'foo', ['id' => 123, 'default_param' => 'default_val']],
+            ['parent', '/foo?id=123&default_param=default_val', 'base.Code.Parent.foo', ['id' => 123, 'default_param' => 'default_val']],
             ['parent', '/foo/bar?id=123&default_param=default_val', 'base.Code.Child.bar', ['id' => 123, 'default_param' => 'default_val']],
+            ['parent', '/foo/bar?id=123&default_param=default_val', 'base.Code.Parent|base.Code.Child.bar', ['id' => 123, 'default_param' => 'default_val']],
             ['child', '/foo/bar?abc=a123&efg=e456&default_param=default_val&childId=987654', 'bar', ['id' => 123, 'default_param' => 'default_val']],
+            ['child', '/foo/bar?abc=a123&efg=e456&default_param=default_val&childId=987654', 'base.Code.Parent|base.Code.Child.bar', ['id' => 123, 'default_param' => 'default_val']],
         ];
     }
 


### PR DESCRIPTION
## Subject

I am targeting this branch, because bugfix.

The https://github.com/sonata-project/SonataAdminBundle/pull/7647 PR introduced a regression.

Providing the full name of the route wasn't supported anymore since a `.` was found and the prefix was always added.
Now the full name check is done before the child check again, but I did it differently.
Both the test added in the previous PR and my tests are green.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- DefaultRouterGenerator route name generation when full name is given 
```