### PR TITLE
Respect order of values provider in ModelsToArrayTransformer

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,7 +13,7 @@ parameters:
             message: '#^Method Sonata\\AdminBundle\\Tests\\Fixtures\\Entity\\FooToStringNull\:\:__toString\(\) should return string but returns null\.$#'
             path: tests/Fixtures/Entity/FooToStringNull.php
         - # The phpstan-param is less precise than the psalm-param https://github.com/phpstan/phpstan/issues/4703
-            message: '#^Parameter \#3 \$idx of method Sonata\\AdminBundle\\Model\\ModelManagerInterface\<T of object\>\:\:addIdentifiersToQuery\(\) expects non-empty-array\<int\|string\>, non-empty-array\<array\<string\>\|int\|string\> given\.$#'
+            message: '#^Parameter \#1 \$value of method Sonata\\AdminBundle\\Form\\DataTransformer\\ModelsToArrayTransformer\<T of object\>\:\:reverseTransform\(\) expects array\<int\|string\>\|null, array\<array\<string\>\|int\|string\> given\.$#'
             path: src/Form/DataTransformer/ModelToIdPropertyTransformer.php
         - # `treatPhpdocAsCertain: false` should not report this https://github.com/phpstan/phpstan/issues/5333
             message: '#^Instanceof between Symfony\\Component\\Routing\\Route and Symfony\\Component\\Routing\\Route will always evaluate to true\.$#'

--- a/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
+++ b/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
@@ -17,7 +17,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Util\ClassUtils;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
-use Sonata\AdminBundle\Util\TraversableToCollection;
 use Symfony\Component\Form\DataTransformerInterface;
 
 /**
@@ -118,15 +117,7 @@ final class ModelToIdPropertyTransformer implements DataTransformerInterface
 
         unset($value['_labels']);
 
-        if ([] === $value) {
-            $result = $value;
-        } else {
-            $query = $this->modelManager->createQuery($this->className);
-            $this->modelManager->addIdentifiersToQuery($this->className, $query, $value);
-            $result = $this->modelManager->executeQuery($query);
-        }
-
-        return TraversableToCollection::transform($result);
+        return (new ModelsToArrayTransformer($this->modelManager, $this->className))->reverseTransform($value);
     }
 
     /**

--- a/tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
+++ b/tests/Form/DataTransformer/ModelToIdPropertyTransformerTest.php
@@ -96,6 +96,13 @@ final class ModelToIdPropertyTransformerTest extends TestCase
 
                 return $collection;
             });
+        $modelManager
+            ->method('getNormalizedIdentifier')
+            ->willReturnMap([
+                [$entity1, '123'],
+                [$entity2, '456'],
+                [$entity3, '789'],
+            ]);
 
         $result = $transformer->reverseTransform($params);
         static::assertInstanceOf(Collection::class, $result);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because bugfix.

Closes #7550.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- `ModelsToArrayTransformer::reverseTransform()` now respect order of IDs provided
```