### PR TITLE
Use AdminCode as key instead of id in the AdminSearchCompilerPass

### DIFF
--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -28,7 +28,7 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Add all dependencies to the Admin class, this avoid to write too many lines
+ * Add all dependencies to the Admin class, this avoids writing too many lines
  * in the configuration files.
  *
  * @internal

--- a/src/DependencyInjection/Compiler/AdminSearchCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AdminSearchCompilerPass.php
@@ -39,26 +39,15 @@ final class AdminSearchCompilerPass implements CompilerPassInterface
         $adminSearch = [];
 
         foreach ($container->findTaggedServiceIds(TaggedAdminInterface::ADMIN_TAG) as $id => $tags) {
-            $adminClass = $this->validateAdminClass($container, $id);
-
-            $argument = $container->getDefinition($id)->getArgument(0);
-            $adminCode = $container->getParameterBag()->resolveValue($argument);
-            if (!\is_string($adminCode)) {
-                throw new \TypeError(sprintf(
-                    'Argument "%s" for admin class "%s" must be of type string, %s given.',
-                    $argument,
-                    $adminClass,
-                    \is_object($adminCode) ? \get_class($adminCode) : \gettype($adminCode)
-                ));
-            }
+            $this->validateAdminClass($container, $id);
 
             foreach ($tags as $attributes) {
                 $globalSearch = $this->getGlobalSearchValue($attributes, $id);
-
                 if (null === $globalSearch) {
                     continue;
                 }
 
+                $adminCode = $attributes['code'] ?? $id;
                 $adminSearch[$adminCode] = $globalSearch;
             }
         }
@@ -70,10 +59,8 @@ final class AdminSearchCompilerPass implements CompilerPassInterface
     /**
      * @throws LogicException if the class in the given service definition is not
      *                        a subclass of `AdminInterface`
-     *
-     * @return class-string<AdminInterface<object>>
      */
-    private function validateAdminClass(ContainerBuilder $container, string $id): string
+    private function validateAdminClass(ContainerBuilder $container, string $id): void
     {
         $definition = $container->getDefinition($id);
 
@@ -91,8 +78,6 @@ final class AdminSearchCompilerPass implements CompilerPassInterface
                 AdminInterface::class
             ));
         }
-
-        return $adminClass;
     }
 
     /**

--- a/src/DependencyInjection/Compiler/AdminSearchCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AdminSearchCompilerPass.php
@@ -41,6 +41,7 @@ final class AdminSearchCompilerPass implements CompilerPassInterface
         foreach ($container->findTaggedServiceIds(TaggedAdminInterface::ADMIN_TAG) as $id => $tags) {
             $this->validateAdminClass($container, $id);
 
+            $adminCode = $container->getDefinition($id)->getArgument(0);
             foreach ($tags as $attributes) {
                 $globalSearch = $this->getGlobalSearchValue($attributes, $id);
 
@@ -48,7 +49,7 @@ final class AdminSearchCompilerPass implements CompilerPassInterface
                     continue;
                 }
 
-                $adminSearch[$id] = $globalSearch;
+                $adminSearch[$adminCode] = $globalSearch;
             }
         }
 

--- a/src/SonataAdminBundle.php
+++ b/src/SonataAdminBundle.php
@@ -34,7 +34,7 @@ final class SonataAdminBundle extends Bundle
     {
         $container->addCompilerPass(new AddDependencyCallsCompilerPass());
         $container->addCompilerPass(new AddFilterTypeCompilerPass());
-        $container->addCompilerPass(new AdminSearchCompilerPass());
+        $container->addCompilerPass(new AdminSearchCompilerPass(), PassConfig::TYPE_BEFORE_OPTIMIZATION, -1);
         $container->addCompilerPass(new ExtensionCompilerPass());
         $container->addCompilerPass(new GlobalVariablesCompilerPass());
         $container->addCompilerPass(new ModelManagerCompilerPass());

--- a/tests/DependencyInjection/Compiler/AdminSearchCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AdminSearchCompilerPassTest.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\DependencyInjection\Compiler;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
-use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AdminSearchCompilerPass;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\PostAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Post;
@@ -28,25 +27,28 @@ final class AdminSearchCompilerPassTest extends AbstractCompilerPassTestCase
 {
     public function testProcess(): void
     {
-        $adminFooDefinition = new Definition(
-            PostAdmin::class,
-            ['admin_foo_code', Post::class, CRUDController::class]
-        );
-        $adminFooDefinition->addTag('sonata.admin', ['global_search' => true]);
+        $adminFooDefinition = new Definition(PostAdmin::class);
+        $adminFooDefinition->addTag('sonata.admin', [
+            'code' => 'admin_foo_code',
+            'model_class' => Post::class,
+            'global_search' => true,
+        ]);
         $this->setDefinition('admin.foo', $adminFooDefinition);
 
-        $adminBarDefinition = new Definition(
-            PostAdmin::class,
-            ['admin_bar_code', Post::class, CRUDController::class]
-        );
-        $adminBarDefinition->addTag('sonata.admin', ['global_search' => false]);
+        $adminBarDefinition = new Definition(PostAdmin::class);
+        $adminBarDefinition->addTag('sonata.admin', [
+            'code' => 'admin_bar_code',
+            'model_class' => Post::class,
+            'global_search' => false,
+        ]);
         $this->setDefinition('admin.bar', $adminBarDefinition);
 
-        $adminBazDefinition = new Definition(
-            PostAdmin::class,
-            ['admin_baz_code', Post::class, CRUDController::class]
-        );
-        $adminBazDefinition->addTag('sonata.admin', ['some_attribute' => 42]);
+        $adminBazDefinition = new Definition(PostAdmin::class);
+        $adminBazDefinition->addTag('sonata.admin', [
+            'code' => 'admin_baz_code',
+            'model_class' => Post::class,
+            'some_attribute' => 42,
+        ]);
         $this->setDefinition('admin.baz', $adminBazDefinition);
 
         $searchHandlerDefinition = new Definition();

--- a/tests/DependencyInjection/Compiler/AdminSearchCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AdminSearchCompilerPassTest.php
@@ -44,7 +44,7 @@ final class AdminSearchCompilerPassTest extends AbstractCompilerPassTestCase
 
         $adminBazDefinition = new Definition(
             PostAdmin::class,
-            ['admin_bar_code', Post::class, CRUDController::class]
+            ['admin_baz_code', Post::class, CRUDController::class]
         );
         $adminBazDefinition->addTag('sonata.admin', ['some_attribute' => 42]);
         $this->setDefinition('admin.baz', $adminBazDefinition);

--- a/tests/DependencyInjection/Compiler/AdminSearchCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AdminSearchCompilerPassTest.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\DependencyInjection\Compiler;
 
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AdminSearchCompilerPass;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\PostAdmin;
+use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Post;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
@@ -26,15 +28,24 @@ final class AdminSearchCompilerPassTest extends AbstractCompilerPassTestCase
 {
     public function testProcess(): void
     {
-        $adminFooDefinition = new Definition(PostAdmin::class);
+        $adminFooDefinition = new Definition(
+            PostAdmin::class,
+            ['admin_foo_code', Post::class, CRUDController::class]
+        );
         $adminFooDefinition->addTag('sonata.admin', ['global_search' => true]);
         $this->setDefinition('admin.foo', $adminFooDefinition);
 
-        $adminBarDefinition = new Definition(PostAdmin::class);
+        $adminBarDefinition = new Definition(
+            PostAdmin::class,
+            ['admin_bar_code', Post::class, CRUDController::class]
+        );
         $adminBarDefinition->addTag('sonata.admin', ['global_search' => false]);
         $this->setDefinition('admin.bar', $adminBarDefinition);
 
-        $adminBazDefinition = new Definition(PostAdmin::class);
+        $adminBazDefinition = new Definition(
+            PostAdmin::class,
+            ['admin_bar_code', Post::class, CRUDController::class]
+        );
         $adminBazDefinition->addTag('sonata.admin', ['some_attribute' => 42]);
         $this->setDefinition('admin.baz', $adminBazDefinition);
 
@@ -46,7 +57,7 @@ final class AdminSearchCompilerPassTest extends AbstractCompilerPassTestCase
         self::assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'sonata.admin.search.handler',
             'configureAdminSearch',
-            [['admin.foo' => true, 'admin.bar' => false]]
+            [['admin_foo_code' => true, 'admin_bar_code' => false]]
         );
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #7510.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Disabling `global_search` for admin with non-default code.
```