### PR TITLE
Allow to use Admin without constructor

### DIFF
--- a/UPGRADE-4.x.md
+++ b/UPGRADE-4.x.md
@@ -1,6 +1,34 @@
 UPGRADE 4.x
 ===========
 
+UPGRADE FROM 4.x to 4.x
+=======================
+
+## Admin definitions
+
+Deprecate passing the code, the model class and the controller in the arguments section.
+
+Before
+```yaml
+    services:
+        app.admin.car:
+            class: App\Admin\CarAdmin
+            tags:
+                - { name: sonata.admin, manager_type: orm, group: Demo, label: Car }
+            arguments:
+                - admin_car
+                - App\Entity\Car
+                - App\Controller\CarAdminController
+```
+After
+```yaml
+    services:
+        app.admin.car:
+            class: App\Admin\CarAdmin
+            tags:
+                - { name: sonata.admin, code: admin_car, model_class: App\Entity\Car, controller: App\Controller\CarAdminController, manager_type: orm, group: Demo, label: Car }
+```
+
 UPGRADE FROM 4.0 to 4.1
 =======================
 

--- a/docs/cookbook/recipe_custom_action.rst
+++ b/docs/cookbook/recipe_custom_action.rst
@@ -46,10 +46,7 @@ Either by using XML:
         <!-- config/services.xml -->
 
         <service id="app.admin.car" class="App\Admin\CarAdmin">
-            <tag name="sonata.admin" manager_type="orm" group="Demo" label="Car"/>
-            <argument/>
-            <argument>App\Entity\Car</argument>
-            <argument>App\Controller\CarAdminController</argument>
+            <tag name="sonata.admin" model_class="App\Entity\Car" controller="App\Controller\CarAdminController" manager_type="orm" group="Demo" label="Car"/>
         </service>
 
 or by adding it to your ``services.yaml``:
@@ -62,11 +59,7 @@ or by adding it to your ``services.yaml``:
         app.admin.car:
             class: App\Admin\CarAdmin
             tags:
-                - { name: sonata.admin, manager_type: orm, group: Demo, label: Car }
-            arguments:
-                - ~
-                - App\Entity\Car
-                - App\Controller\CarAdminController
+                - { name: sonata.admin, model_class: App\Entity\Car, controller: App\Controller\CarAdminController, manager_type: orm, group: Demo, label: Car }
 
 For more information about service configuration please refer to Step 3 of :doc:`../getting_started/creating_an_admin`
 

--- a/docs/cookbook/recipe_customizing_a_mosaic_list.rst
+++ b/docs/cookbook/recipe_customizing_a_mosaic_list.rst
@@ -30,9 +30,6 @@ First, configure the ``outer_list_rows_mosaic`` template key:
       <!-- config/services.xml -->
 
        <service id="sonata.media.admin.media" class="%sonata.media.admin.media.class%">
-            <argument/>
-            <argument>%sonata.media.admin.media.entity%</argument>
-            <argument>%sonata.media.admin.media.controller%</argument>
             <call method="setTemplates">
                 <argument type="collection">
                     <argument key="outer_list_rows_mosaic">@SonataMedia/MediaAdmin/list_outer_rows_mosaic.html.twig</argument>
@@ -40,6 +37,8 @@ First, configure the ``outer_list_rows_mosaic`` template key:
             </call>
             <tag
                 name="sonata.admin"
+                model_class="%sonata.media.admin.media.entity%"
+                controller="%sonata.media.admin.media.controller%"
                 manager_type="orm"
                 group="sonata_media"
                 label_catalogue="%sonata.media.admin.media.translation_domain%"
@@ -144,11 +143,9 @@ the ``$pool`` variable and override the constructor::
 
     private $pool;
 
-    public function __construct(string $code, string $class, string $baseControllerName, Pool $pool)
+    public function __construct(Pool $pool)
     {
        $this->pool = $pool;
-
-       parent::__construct($code, $class, $baseControllerName);
     }
 
 Then add ``'@sonata.media.pool'`` to your service definition arguments:
@@ -161,13 +158,11 @@ Then add ``'@sonata.media.pool'`` to your service definition arguments:
         app.admin.post:
             class: App\Admin\PostAdmin
             arguments:
-                - ~
-                - App\Entity\Post
-                - ~
                 - '@sonata.media.pool'
             tags:
                 -
                     name: sonata.admin
+                    model_class: App\Entity\Post
                     manager_type: orm
                     group: 'Content'
                     label: 'Post'

--- a/docs/cookbook/recipe_improve_performance_large_datasets.rst
+++ b/docs/cookbook/recipe_improve_performance_large_datasets.rst
@@ -24,22 +24,15 @@ To use ``SimplePager`` in your admin,  define ``pager_type`` in the service defi
         services:
             app.admin.post:
                 class: App\Admin\PostAdmin
-                arguments:
-                    - ~
-                    - App\Entity\Post
-                    - ~
                 tags:
-                    - { name: sonata.admin, manager_type: orm, group: 'Content', label: 'Post', pager_type: 'simple' }
+                    - { name: sonata.admin, model_class: App\Entity\Post, manager_type: orm, group: 'Content', label: 'Post', pager_type: 'simple' }
 
     .. code-block:: xml
 
         <!-- config/services.xml -->
 
         <service id="app.admin.post" class="App\Admin\PostAdmin">
-            <argument/>
-            <argument>App\Entity\Post</argument>
-            <argument/>
-            <tag name="sonata.admin" manager_type="orm" group="Content" label="Post" pager_type="simple"/>
+            <tag name="sonata.admin" model_class="App\Entity\Post" manager_type="orm" group="Content" label="Post" pager_type="simple"/>
         </service>
 
 .. note::

--- a/docs/cookbook/recipe_knp_menu.rst
+++ b/docs/cookbook/recipe_knp_menu.rst
@@ -194,9 +194,8 @@ your admin services or remove menu items from the ``sonata_admin`` dashboard gro
 
     sonata_admin.admin.post:
         class: Sonata\AdminBundle\Admin\PostAdmin
-        arguments: [~, Sonata\AdminBundle\Entity\Post, Sonata\AdminBundle\Controller\CRUDController]
         tags:
-            - { name: sonata.admin, manager_type: orm, group: admin, label: Post, show_in_dashboard: false }
+            - { name: sonata.admin, model_class: Sonata\AdminBundle\Entity\Post, controller: Sonata\AdminBundle\Controller\CRUDController, manager_type: orm, group: admin, label: Post, show_in_dashboard: false }
 
 .. code-block:: yaml
 
@@ -253,9 +252,8 @@ or in sonata_admin dashboard group configuration:
 
     sonata_admin.admin.post:
         class: Sonata\AdminBundle\Admin\PostAdmin
-        arguments: [~, Sonata\AdminBundle\Entity\Post, Sonata\AdminBundle\Controller\CRUDController]
         tags:
-            - { name: sonata.admin, manager_type: orm, group: admin, label: Post, on_top: true }
+            - { name: sonata.admin, model_class: Sonata\AdminBundle\Entity\Post, controller: Sonata\AdminBundle\Controller\CRUDController, manager_type: orm, group: admin, label: Post, on_top: true }
 
 .. code-block:: yaml
 

--- a/docs/cookbook/recipe_overwrite_admin_configuration.rst
+++ b/docs/cookbook/recipe_overwrite_admin_configuration.rst
@@ -40,9 +40,9 @@ If you need to override the service of a specific admin, you can do it during th
     services:
         admin.blog_post:
             class: App\Admin\BlogPostAdmin
-            arguments: [~, App\Entity\BlogPost, ~]
             tags:
                 - name: sonata.admin
+                  model_class: App\Entity\BlogPost
                   manager_type: orm
                   label: 'Blog post'
                   label_translator_strategy: sonata.admin.label.strategy.native

--- a/docs/cookbook/recipe_persisting_filters.rst
+++ b/docs/cookbook/recipe_persisting_filters.rst
@@ -58,13 +58,10 @@ Per Admin :
         services:
             app.admin.user:
                 class: App\Admin\UserAdmin
-                arguments:
-                    - ~
-                    - App\Entity\User
-                    - ~
                 tags:
                     -
                         name: sonata.admin
+                        model_class: App\Entity\User
                         manager_type: orm
                         filter_persister: filter_persister_service_id
 
@@ -73,11 +70,9 @@ Per Admin :
         <!-- config/services.xml -->
 
         <service id="app.admin.user" class="App\Admin\UserAdmin">
-            <argument/>
-            <argument>App\Entity\User</argument>
-            <argument/>
             <tag
                 name="sonata.admin"
+                model_class="App\Entity\User"
                 manager_type="orm"
                 filter_persister="filter_persister_service_id"
                 />
@@ -101,22 +96,15 @@ You can disable it per Admin if you want.
         services:
             app.admin.user:
                 class: App\Admin\UserAdmin
-                arguments:
-                    - ~
-                    - App\Entity\User
-                    - ~
                 tags:
-                    - { name: sonata.admin, manager_type: orm, persist_filters: false }
+                    - { name: sonata.admin, model_class: App\Entity\User,  manager_type: orm, persist_filters: false }
 
     .. code-block:: xml
 
         <!-- config/services.xml -->
 
         <service id="app.admin.user" class="App\Admin\UserAdmin">
-            <argument/>
-            <argument>App\Entity\User</argument>
-            <argument/>
-            <tag name="sonata.admin" manager_type="orm" persist_filters="false"/>
+            <tag name="sonata.admin" model_class="App\Entity\User" manager_type="orm" persist_filters="false"/>
         </service>
 
 .. note::

--- a/docs/cookbook/recipe_row_templates.rst
+++ b/docs/cookbook/recipe_row_templates.rst
@@ -33,9 +33,6 @@ Two template keys need to be set:
         <!-- config/services.xml -->
 
         <service id="sonata.admin.comment" class="%sonata.admin.comment.class%">
-            <argument/>
-            <argument>%sonata.admin.comment.entity%</argument>
-            <argument>%sonata.admin.comment.controller%</argument>
             <call method="setTemplates">
                 <argument type="collection">
                     <argument key="inner_list_row">
@@ -48,6 +45,8 @@ Two template keys need to be set:
             </call>
             <tag
                 name="sonata.admin"
+                model_class="%sonata.admin.comment.entity%"
+                controller="%sonata.admin.comment.controller%"
                 manager_type="orm"
                 group="sonata_blog"
                 label="comments"

--- a/docs/cookbook/recipe_sortable_listing.rst
+++ b/docs/cookbook/recipe_sortable_listing.rst
@@ -103,12 +103,8 @@ Now you can update your ``services.yaml`` to use the handler provided by the ``p
     services:
         app.admin.client:
             class: App\Admin\ClientAdmin
-            arguments:
-                - ~
-                - App\Entity\Client
-                - 'PixSortableBehaviorBundle:SortableAdmin' # define the new controller via the third argument
             tags:
-                - { name: sonata.admin, manager_type: orm, label: 'Clients' }
+                - { name: sonata.admin, model_class: App\Entity\Client, controller: 'PixSortableBehaviorBundle:SortableAdmin', manager_type: orm, label: 'Clients' }
 
 Now we need to define the sort by field to be ``$position``::
 

--- a/docs/cookbook/recipe_sortable_sonata_type_model.rst
+++ b/docs/cookbook/recipe_sortable_sonata_type_model.rst
@@ -268,10 +268,7 @@ So we are going to start by creating this ``UserBundle\Admin\UserHasExpectations
 .. code-block:: xml
 
     <service id="user.admin.user_has_expectations" class="UserBundle\Admin\UserHasExpectationsAdmin">
-        <tag name="sonata.admin" manager_type="orm" group="UserHasExpectations" label="UserHasExpectations"/>
-        <argument/>
-        <argument>UserBundle\Entity\UserHasExpectations</argument>
-        <argument/>
+        <tag name="sonata.admin" model_class="UserBundle\Entity\UserHasExpectations" manager_type="orm" group="UserHasExpectations" label="UserHasExpectations"/>
     </service>
 
 Now update the ``UserBundle\Admin\UserAdmin.php`` by adding the ``sonata_type_model`` field::

--- a/docs/cookbook/recipe_workflow_integration.rst
+++ b/docs/cookbook/recipe_workflow_integration.rst
@@ -59,12 +59,8 @@ You can use the provided extension to take care of your entity admin.
    services:
        app.admin.blog_post:
            class: App\Admin\BlogPostAdmin
-           arguments:
-               - ~
-               - App\Entity\BlogPost
-               - Yokai\SonataWorkflow\Controller\WorkflowController
            tags:
-               - { name: sonata.admin, manager_type: orm }
+               - { name: sonata.admin, model_class: App\Entity\BlogPost, controller: Yokai\SonataWorkflow\Controller\WorkflowController, manager_type: orm }
 
        app.admin.extension.workflow.blog_post:
            class: Yokai\SonataWorkflow\Admin\Extension\WorkflowExtension

--- a/docs/getting_started/creating_an_admin.rst
+++ b/docs/getting_started/creating_an_admin.rst
@@ -175,9 +175,8 @@ service and tag it with the ``sonata.admin`` tag:
             # ...
             admin.category:
                 class: App\Admin\CategoryAdmin
-                arguments: [~, App\Entity\Category, ~]
                 tags:
-                    - { name: sonata.admin, manager_type: orm, label: Category }
+                    - { name: sonata.admin, model_class: App\Entity\Category, manager_type: orm, label: Category }
 
 The constructor of the base Admin class has many arguments. SonataAdminBundle
 provides a compiler pass which takes care of configuring it correctly for you.

--- a/docs/getting_started/the_form_view.rst
+++ b/docs/getting_started/the_form_view.rst
@@ -42,9 +42,8 @@ The same applies to the service definition:
     services:
         admin.blog_post:
             class: App\Admin\BlogPostAdmin
-            arguments: [~, App\Entity\BlogPost, ~]
             tags:
-                - { name: sonata.admin, manager_type: orm, label: 'Blog post' }
+                - { name: sonata.admin, model_class: App\Entity\BlogPost, manager_type: orm, label: 'Blog post' }
 
 Configuring the Form Mapper
 ---------------------------

--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -700,15 +700,13 @@ You need to add option ``show_mosaic_button`` in your admin services:
 
     sonata_admin.admin.post:
         class: Sonata\AdminBundle\Admin\PostAdmin
-        arguments: [~, Sonata\AdminBundle\Entity\Post, ~]
         tags:
-            - { name: sonata.admin, manager_type: orm, group: admin, label: Post, show_mosaic_button: true }
+            - { name: sonata.admin, model_class: Sonata\AdminBundle\Entity\Post, manager_type: orm, group: admin, label: Post, show_mosaic_button: true }
 
     sonata_admin.admin.news:
         class: Sonata\AdminBundle\Admin\NewsAdmin
-        arguments: [~, Sonata\AdminBundle\Entity\News, ~]
         tags:
-            - { name: sonata.admin, manager_type: orm, group: admin, label: News, show_mosaic_button: false }
+            - { name: sonata.admin, model_class: Sonata\AdminBundle\Entity\News, manager_type: orm, group: admin, label: News, show_mosaic_button: false }
 
 Show Icons on Action Buttons
 ----------------------------

--- a/docs/reference/advanced_configuration.rst
+++ b/docs/reference/advanced_configuration.rst
@@ -45,13 +45,10 @@ With a tag attribute (less verbose)
 
         app.admin.project:
             class: App\Admin\ProjectAdmin
-            arguments:
-                - ~
-                - App\Entity\Project
-                - ~
             tags:
                 -
                     name: sonata.admin
+                    model_class: App\Entity\Project
                     manager_type: orm
                     group: 'Project'
                     label: 'Project'
@@ -63,11 +60,9 @@ With a tag attribute (less verbose)
         <!-- config/services.xml -->
 
         <service id="app.admin.project" class="App\Admin\ProjectAdmin">
-            <argument/>
-            <argument>App\Entity\Project</argument>
-            <argument/>
             <tag
                 name="sonata.admin"
+                model_class="App\Entity\Project"
                 manager_type="orm"
                 group="Project"
                 label="Project"
@@ -87,31 +82,24 @@ With a method call (more verbose)
 
         app.admin.project:
             class: App\Admin\ProjectAdmin
-            arguments:
-                - ~
-                - App\Entity\Project
-                - ~
             calls:
                 - [setLabelTranslatorStrategy, ['@sonata.admin.label.strategy.native']]
                 - [setRouteBuilder, ['@sonata.admin.route.path_info']]
             tags:
-                - { name: sonata.admin, manager_type: orm, group: 'Project', label: 'Project' }
+                - { name: sonata.admin, model_class: App\Entity\Project, manager_type: orm, group: 'Project', label: 'Project' }
 
     .. code-block:: xml
 
         <!-- config/services.xml -->
 
         <service id="app.admin.project" class="App\Admin\ProjectAdmin">
-            <argument/>
-            <argument>App\Entity\Project</argument>
-            <argument/>
             <call method="setLabelTranslatorStrategy">
                 <argument type="service" id="sonata.admin.label.strategy.native"/>
             </call>
             <call method="setRouteBuilder">
                 <argument type="service" id="sonata.admin.route.path_info"/>
             </call>
-            <tag name="sonata.admin" manager_type="orm" group="Project" label="Project"/>
+            <tag name="sonata.admin" model_class="App\Entity\Project" manager_type="orm" group="Project" label="Project"/>
         </service>
 
 If you want to modify the service that is going to be injected, add the following code to your
@@ -201,10 +189,6 @@ Lets consider a base class named ``Person`` and its subclasses ``Student`` and `
 
         app.admin.person:
             class: App\Admin\PersonAdmin
-            arguments:
-                - ~
-                - App\Entity\Person
-                - ~
             calls:
                 -
                     - setSubClasses
@@ -212,23 +196,20 @@ Lets consider a base class named ``Person`` and its subclasses ``Student`` and `
                         student: App\Entity\Student
                         teacher: App\Entity\Teacher
             tags:
-                - { name: sonata.admin, manager_type: orm, group: "admin", label: "Person" }
+                - { name: sonata.admin, model_class: App\Entity\Person, manager_type: orm, group: "admin", label: "Person" }
 
     .. code-block:: xml
 
         <!-- config/services.xml -->
 
         <service id="app.admin.person" class="App\Admin\PersonAdmin">
-            <argument/>
-            <argument>App\Entity\Person</argument>
-            <argument></argument>
             <call method="setSubClasses">
                 <argument type="collection">
                     <argument key="student">App\Entity\Student</argument>
                     <argument key="teacher">App\Entity\Teacher</argument>
                 </argument>
             </call>
-            <tag name="sonata.admin" manager_type="orm" group="admin" label="Person"/>
+            <tag name="sonata.admin" model_class="App\Entity\Person" manager_type="orm" group="admin" label="Person"/>
         </service>
 
 You will need to change the way forms are configured in order to
@@ -507,9 +488,8 @@ for specific Admin class:
             # ...
             admin.custom:
                 class: App\Admin\CustomAdmin
-                arguments: [~, App\Entity\Custom, ~]
                 tags:
-                    - { name: sonata.admin, manager_type: orm, label: Category, security_handler: App\Security\Handler\CustomSecurityHandler }
+                    - { name: sonata.admin, model_class: App\Entity\Custom, manager_type: orm, label: Category, security_handler: App\Security\Handler\CustomSecurityHandler }
 
 You can also use the default SecurityHandler (defined in global configuration)
 in your custom SecurityHandler::

--- a/docs/reference/architecture.rst
+++ b/docs/reference/architecture.rst
@@ -70,25 +70,18 @@ your ``Admin`` services. This is done using a ``call`` to the matching ``setter`
         services:
             app.admin.post:
                 class: App\Admin\PostAdmin
-                arguments:
-                    - ~
-                    - App\Entity\Post
-                    - ~
                 calls:
                     - [setLabelTranslatorStrategy, ['@sonata.admin.label.strategy.underscore']]
                 tags:
-                    - { name: sonata.admin, manager_type: orm, group: 'Content', label: 'Post' }
+                    - { name: sonata.admin, model_class: App\Entity\Post, manager_type: orm, group: 'Content', label: 'Post' }
 
     .. code-block:: xml
 
         <service id="app.admin.post" class="App\Admin\PostAdmin">
-              <argument/>
-              <argument>App\Entity\Post</argument>
-              <argument/>
               <call method="setLabelTranslatorStrategy">
                   <argument type="service" id="sonata.admin.label.strategy.underscore"/>
               </call>
-              <tag name="sonata.admin" manager_type="orm" group="Content" label="Post"/>
+              <tag name="sonata.admin" model_class="App\Entity\Post" manager_type="orm" group="Content" label="Post"/>
           </service>
 
 Here, we declare the same ``Admin`` service as in the :doc:`../getting_started/creating_an_admin`
@@ -125,25 +118,18 @@ to set the controller to ``App\Controller\PostAdminController``:
         services:
             app.admin.post:
                 class: App\Admin\PostAdmin
-                arguments:
-                    - ~
-                    - App\Entity\Post
-                    - App\Controller\PostAdminController
                 calls:
                     - [setTranslationDomain, ['App']]
                 tags:
-                    - { name: sonata.admin, manager_type: orm, group: 'Content', label: 'Post' }
+                    - { name: sonata.admin, model_class: App\Entity\Post, controller: App\Controller\PostAdminController, manager_type: orm, group: 'Content', label: 'Post' }
 
     .. code-block:: xml
 
         <service id="app.admin.post" class="App\Admin\PostAdmin">
-            <argument/>
-            <argument>App\Entity\Post</argument>
-            <argument>App\Controller\PostAdminController</argument>
             <call method="setTranslationDomain">
                 <argument>App</argument>
             </call>
-            <tag name="sonata.admin" manager_type="orm" group="Content" label="Post"/>
+            <tag name="sonata.admin" model_class="App\Entity\Post" controller="App\Controller\PostAdminController" manager_type="orm" group="Content" label="Post"/>
         </service>
 
 When extending ``CRUDController``, remember that the ``Admin`` class already has

--- a/docs/reference/dashboard.rst
+++ b/docs/reference/dashboard.rst
@@ -70,22 +70,15 @@ services:
         services:
             app.admin.post:
                 class: App\Admin\PostAdmin
-                arguments:
-                    - ~
-                    - App\Entity\Post
-                    - ~
                 tags:
-                    - { name: sonata.admin, manager_type: orm, group: 'Content', label: 'Post' }
+                    - { name: sonata.admin, model_class: App\Entity\Post, manager_type: orm, group: 'Content', label: 'Post' }
 
     .. code-block:: xml
 
         <!-- config/services.xml -->
 
         <service id="app.admin.post" class="App\Admin\PostAdmin">
-              <argument/>
-              <argument>App\Entity\Post</argument>
-              <argument/>
-              <tag name="sonata.admin" manager_type="orm" group="Content" label="Post"/>
+              <tag name="sonata.admin" model_class="App\Entity\Post" manager_type="orm" group="Content" label="Post"/>
           </service>
 
 In these examples, notice the ``group`` tag, stating that this particular ``Admin``
@@ -100,12 +93,9 @@ service belongs to the ``Content`` group.
         services:
             app.admin.post:
                 class: App\Admin\PostAdmin
-                arguments:
-                    - ~
-                    - App\Entity\Post
-                    - ~
                 tags:
                     - name: sonata.admin
+                      model_class: App\Entity\Post
                       manager_type: orm
                       group: 'app.admin.group.content'
                       label: 'app.admin.model.post'
@@ -116,11 +106,9 @@ service belongs to the ``Content`` group.
         <!-- config/services.xml -->
 
         <service id="app.admin.post" class="App\Admin\PostAdmin">
-              <argument/>
-              <argument>App\Entity\Post</argument>
-              <argument/>
               <tag
                   name="sonata.admin"
+                  model_class="App\Entity\Post"
                   manager_type="orm"
                   group="app.admin.group.content"
                   label="app.admin.model.post"

--- a/docs/reference/form_types.rst
+++ b/docs/reference/form_types.rst
@@ -554,14 +554,10 @@ that looks like this:
         services:
             app.admin.image:
                 class: App\Admin\ImageAdmin
-                arguments:
-                    - ~
-                    - App\Entity\Image
-                    - 'Sonata\AdminBundle\Controller\CRUDController'
                 calls:
                     - [setTranslationDomain, ['App']]
                 tags:
-                    - { name: sonata.admin, manager_type: orm, label: 'Image' }
+                    - { name: sonata.admin, model_class: App\Entity\Image, controller: 'Sonata\AdminBundle\Controller\CRUDController', manager_type: orm, label: 'Image' }
 
 To embed ``ImageAdmin`` within ``PageAdmin`` we need to change the reference
 for the ``image1`` field to ``AdminType`` in our ``PageAdmin`` class::

--- a/docs/reference/routing.rst
+++ b/docs/reference/routing.rst
@@ -207,12 +207,8 @@ For example, lets change the Controller for our MediaAdmin class to ``App\Contro
 
         app.admin.media:
             class: App\Admin\MediaAdmin
-            arguments:
-                - ~
-                - App\Entity\Page
-                - App\Controller\MediaCRUDController # define the new controller via the third argument
             tags:
-                - { name: sonata.admin, manager_type: orm, label: 'Media' }
+                - { name: sonata.admin, model_class: App\Entity\Page, controller: App\Controller\MediaCRUDController, manager_type: orm, label: 'Media' }
 
 We now need to create our Controller, the easiest way is to extend the
 basic Sonata CRUD controller::

--- a/docs/reference/saving_hooks.rst
+++ b/docs/reference/saving_hooks.rst
@@ -91,13 +91,10 @@ The service declaration where the ``UserManager`` is injected into the Admin cla
     .. code-block:: xml
 
         <service id="fos.user.admin.user" class="%fos.user.admin.user.class%">
-            <argument/>
-            <argument>%fos.user.admin.user.entity%</argument>
-            <argument/>
             <call method="setUserManager">
                 <argument type="service" id="fos_user.user_manager"/>
             </call>
-            <tag name="sonata.admin" manager_type="orm" group="fos_user"/>
+            <tag name="sonata.admin" model_class="%fos.user.admin.user.entity%" manager_type="orm" group="fos_user"/>
         </service>
 
 Hooking in the Controller

--- a/docs/reference/search.rst
+++ b/docs/reference/search.rst
@@ -22,10 +22,7 @@ to ``false`` at your admin definition using the tag ``sonata.admin``.
     .. code-block:: xml
 
         <service id="app.admin.post" class="App\Admin\PostAdmin">
-            <tag name="sonata.admin" global_search="false" manager_type="orm" group="Content" label="Post"/>
-            <argument/>
-            <argument>App\Entity\Post</argument>
-            <argument/>
+            <tag name="sonata.admin" global_search="false" model_class="App\Entity\Post" manager_type="orm" group="Content" label="Post"/>
         </service>
 
 Customization
@@ -71,10 +68,7 @@ You can also configure the block template per admin while defining the admin:
     .. code-block:: xml
 
         <service id="app.admin.post" class="App\Admin\PostAdmin">
-              <tag name="sonata.admin" manager_type="orm" group="Content" label="Post"/>
-              <argument/>
-              <argument>App\Entity\Post</argument>
-              <argument/>
+              <tag name="sonata.admin" model_class="App\Entity\Post" manager_type="orm" group="Content" label="Post"/>
               <call method="setTemplate">
                   <argument>search_result_block</argument>
                   <argument>@SonataPost/Block/block_search_result.html.twig</argument>

--- a/docs/reference/templates.rst
+++ b/docs/reference/templates.rst
@@ -169,24 +169,17 @@ can specify the templates to use in the ``Admin`` service definition:
         services:
             app.admin.post:
                 class: App\Admin\PostAdmin
-                arguments:
-                    - ~
-                    - App\Entity\Post
-                    - ~
                 calls:
                     - [setTemplate, ['edit', 'PostAdmin/edit.html.twig']]
                 tags:
-                    - { name: sonata.admin, manager_type: orm, group: 'Content', label: 'Post' }
+                    - { name: sonata.admin, model_class: App\Entity\Post, manager_type: orm, group: 'Content', label: 'Post' }
 
     .. code-block:: xml
 
        <!-- config/services.xml -->
 
         <service id="app.admin.post" class="App\Admin\PostAdmin">
-            <tag name="sonata.admin" manager_type="orm" group="Content" label="Post"/>
-            <argument/>
-            <argument>App\Entity\Post</argument>
-            <argument/>
+            <tag name="sonata.admin" model_class="App\Entity\Post" manager_type="orm" group="Content" label="Post"/>
             <call method="setTemplate">
                 <argument>edit</argument>
                 <argument>PostAdmin/edit.html.twig</argument>

--- a/docs/reference/translation.rst
+++ b/docs/reference/translation.rst
@@ -20,10 +20,7 @@ You can configure the catalogue for the Admin class by injecting the value throu
         <!-- config/services.xml -->
 
         <service id="sonata.page.admin.page" class="Sonata\PageBundle\Admin\PageAdmin">
-            <tag name="sonata.admin" manager_type="orm" group="sonata_page" label="Page"/>
-            <argument/>
-            <argument>Application\Sonata\PageBundle\Entity\Page</argument>
-            <argument/>
+            <tag name="sonata.admin" model_class="Application\Sonata\PageBundle\Entity\Page" manager_type="orm" group="sonata_page" label="Page"/>
             <call method="setTranslationDomain">
                 <argument>SonataPageBundle</argument>
             </call>
@@ -155,14 +152,12 @@ the Container:
         <service id="app.admin.project" class="App\Admin\ProjectAdmin">
             <tag
                 name="sonata.admin"
+                model_class="App\Entity\Project"
                 manager_type="orm"
                 group="Project"
                 label="Project"
                 label_translator_strategy="sonata.admin.label.strategy.native"
              />
-            <argument/>
-            <argument>App\Entity\Project</argument>
-            <argument/>
         </service>
 
 .. note::

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -564,7 +564,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         if ($this->isChild()) { // the admin class is a child, prefix it with the parent route pattern
             $baseRoutePattern = $this->baseRoutePattern;
             if (null === $baseRoutePattern) {
-                preg_match(self::CLASS_REGEX, $this->class, $matches);
+                preg_match(self::CLASS_REGEX, $this->getModelClass(), $matches);
 
                 if (!$matches) {
                     throw new \LogicException(sprintf(
@@ -584,7 +584,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         } elseif (null !== $this->baseRoutePattern) {
             $this->cachedBaseRoutePattern = $this->baseRoutePattern;
         } else {
-            preg_match(self::CLASS_REGEX, $this->class, $matches);
+            preg_match(self::CLASS_REGEX, $this->getModelClass(), $matches);
 
             if (!$matches) {
                 throw new \LogicException(sprintf(
@@ -618,7 +618,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         if ($this->isChild()) { // the admin class is a child, prefix it with the parent route name
             $baseRouteName = $this->baseRouteName;
             if (null === $baseRouteName) {
-                preg_match(self::CLASS_REGEX, $this->class, $matches);
+                preg_match(self::CLASS_REGEX, $this->getModelClass(), $matches);
 
                 if (!$matches) {
                     throw new \LogicException(sprintf(
@@ -638,7 +638,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         } elseif (null !== $this->baseRouteName) {
             $this->cachedBaseRouteName = $this->baseRouteName;
         } else {
-            preg_match(self::CLASS_REGEX, $this->class, $matches);
+            preg_match(self::CLASS_REGEX, $this->getModelClass(), $matches);
 
             if (!$matches) {
                 throw new \LogicException(sprintf(
@@ -685,7 +685,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
             return $class;
         }
 
-        return $this->class;
+        return $this->getModelClass();
     }
 
     final public function getSubClasses(): array
@@ -1010,16 +1010,6 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         }
 
         return $this->getParentFieldDescription()->getAdmin()->getRoot();
-    }
-
-    final public function setBaseControllerName(string $baseControllerName): void
-    {
-        $this->baseControllerName = $baseControllerName;
-    }
-
-    final public function getBaseControllerName(): string
-    {
-        return $this->baseControllerName;
     }
 
     final public function getMaxPerPage(): int
@@ -1561,11 +1551,6 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
     final public function hasRequest(): bool
     {
         return null !== $this->request;
-    }
-
-    final public function getCode(): string
-    {
-        return $this->code;
     }
 
     final public function getBaseCodeRoute(): string

--- a/src/DependencyInjection/Admin/AbstractTaggedAdmin.php
+++ b/src/DependencyInjection/Admin/AbstractTaggedAdmin.php
@@ -213,10 +213,25 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
      */
     public function __construct(?string $code = null, ?string $class = null, ?string $baseControllerName = null)
     {
-        $this->code = $code;
+        if (\func_num_args() > 0) {
+            @trigger_error(
+                'Setting the code, the model class and the base controller name with the constructor is deprecated'
+                .' since sonata-project/admin-bundle version 4.x and will not be possible in 5.0 version.'
+                .' Use the `code`, `model_class` and `controller` attribute of the `sonata.admin` tag or'
+                .' the method "setCode()", "setModelClass()" and "setBaseControllerName()" instead.',
+                \E_USER_DEPRECATED
+            );
+        }
+
+        if (null !== $code) {
+            $this->code = $code;
+        }
         $this->class = $class;
         $this->modelClass = $class;
-        $this->baseControllerName = $baseControllerName;
+
+        if (null !== $baseControllerName) {
+            $this->baseControllerName = $baseControllerName;
+        }
     }
 
     abstract public function initialize(): void;
@@ -229,7 +244,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     final public function getCode(): string
     {
         if (null === $this->code) {
-            throw new \LogicException(sprintf('Admin "%s" has no code.', static::class));
+            return static::class;
         }
 
         return $this->code;

--- a/src/DependencyInjection/Admin/AbstractTaggedAdmin.php
+++ b/src/DependencyInjection/Admin/AbstractTaggedAdmin.php
@@ -39,27 +39,44 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 abstract class AbstractTaggedAdmin implements TaggedAdminInterface
 {
     /**
+     * NEXT_MAJOR: Change visibility to private.
+     *
      * The code related to the admin.
      *
-     * @var string
+     * @var string|null
      */
     protected $code;
 
     /**
+     * NEXT_MAJOR: Remove this property.
+     *
+     * @deprecated since sonata-project/admin-bundle version 4.x use $modelClass instead.
+     *
      * The class name managed by the admin class.
      *
-     * @var string
+     * @var string|null
      *
-     * @phpstan-var class-string<T>
+     * @phpstan-var class-string<T>|null
      */
     protected $class;
 
     /**
+     * NEXT_MAJOR: Change visibility to private.
+     *
      * The base name controller used to generate the routing information.
      *
-     * @var string
+     * @var string|null
      */
     protected $baseControllerName;
+
+    /**
+     * The class name managed by the admin class.
+     *
+     * @var string|null
+     *
+     * @phpstan-var class-string<T>|null
+     */
+    private $modelClass;
 
     /**
      * @var string|null
@@ -190,16 +207,67 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     private $templateRegistry;
 
     /**
-     * @phpstan-param class-string<T> $class
+     * NEXT_MAJOR: Remove the __construct method.
+     *
+     * @phpstan-param class-string<T>|null $class
      */
-    public function __construct(string $code, string $class, string $baseControllerName)
+    public function __construct(?string $code = null, ?string $class = null, ?string $baseControllerName = null)
     {
         $this->code = $code;
         $this->class = $class;
+        $this->modelClass = $class;
         $this->baseControllerName = $baseControllerName;
     }
 
     abstract public function initialize(): void;
+
+    final public function setCode(string $code): void
+    {
+        $this->code = $code;
+    }
+
+    final public function getCode(): string
+    {
+        if (null === $this->code) {
+            throw new \LogicException(sprintf('Admin "%s" has no code.', static::class));
+        }
+
+        return $this->code;
+    }
+
+    /**
+     * @param class-string<T> $modelClass
+     */
+    final public function setModelClass(string $modelClass): void
+    {
+        $this->modelClass = $modelClass;
+    }
+
+    /**
+     * @return class-string<T>
+     */
+    final public function getModelClass(): string
+    {
+        if (null === $this->modelClass) {
+            throw new \LogicException(sprintf('Admin "%s" has no model class.', static::class));
+        }
+
+        return $this->modelClass;
+    }
+
+    final public function setBaseControllerName(string $baseControllerName): void
+    {
+        $this->baseControllerName = $baseControllerName;
+    }
+
+    final public function getBaseControllerName(): string
+    {
+        if (null === $this->baseControllerName) {
+            throw new \LogicException(sprintf('Admin "%s" has no base controller name.', static::class));
+        }
+
+        return $this->baseControllerName;
+    }
 
     final public function setLabel(?string $label): void
     {

--- a/src/DependencyInjection/Admin/TaggedAdminInterface.php
+++ b/src/DependencyInjection/Admin/TaggedAdminInterface.php
@@ -43,6 +43,13 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  *     - The first and third argument are automatically injected by the AddDependencyCallsCompilerPass.
  *     - The second one is used as a reference of the Admin in the Pool, with the `setAdminClasses` call.
  *
+ * @method void   setCode(string $code)
+ * @method string getCode()
+ * @method void   setModelClass(string $modelClass)
+ * @method string getModelClass()
+ * @method void   setBaseControllerName(string $baseControllerName)
+ * @method string getBaseControllerName()
+ *
  * @phpstan-template T of object
  */
 interface TaggedAdminInterface extends MutableTemplateRegistryAwareInterface

--- a/src/DependencyInjection/Admin/TaggedAdminInterface.php
+++ b/src/DependencyInjection/Admin/TaggedAdminInterface.php
@@ -35,14 +35,6 @@ use Symfony\Contracts\Translation\TranslatorInterface;
  * This interface should be implemented to work with the AddDependencyCallsCompilerPass.
  * All the setter are called by this compiler pass.
  *
- * Note that the constructor should also have the following signature
- * ```
- * public function __construct(string $code, string $class, string $controller, ...);
- * ```
- * so that the admin class works correctly with the AddDependencyCallsCompilerPass. Indeed:
- *     - The first and third argument are automatically injected by the AddDependencyCallsCompilerPass.
- *     - The second one is used as a reference of the Admin in the Pool, with the `setAdminClasses` call.
- *
  * @method void   setCode(string $code)
  * @method string getCode()
  * @method void   setModelClass(string $modelClass)

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -18,7 +18,6 @@ use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Datagrid\Pager;
 use Sonata\AdminBundle\DependencyInjection\Admin\TaggedAdminInterface;
 use Sonata\AdminBundle\Templating\MutableTemplateRegistry;
-use function sprintf;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
@@ -114,7 +113,7 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
                 $default = (bool) (isset($attributes['default']) ? $parameterBag->resolveValue($attributes['default']) : false);
                 if ($default) {
                     if (isset($classes[$modelClass][Pool::DEFAULT_ADMIN_KEY])) {
-                        throw new \RuntimeException(\sprintf(
+                        throw new \RuntimeException(sprintf(
                             'The class %s has two admins %s and %s with the "default" attribute set to true. Only one is allowed.',
                             $modelClass,
                             $classes[$modelClass][Pool::DEFAULT_ADMIN_KEY],
@@ -314,7 +313,7 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
         $managerType = $attributes['manager_type'] ?? null;
         if (null === $managerType) {
-            throw new InvalidArgumentException(\sprintf('Missing tag information "manager_type" on service "%s".', $serviceId));
+            throw new InvalidArgumentException(sprintf('Missing tag information "manager_type" on service "%s".', $serviceId));
         }
 
         $defaultController = $container->getParameter('sonata.admin.configuration.default_controller');
@@ -324,13 +323,13 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
         \assert(\is_array($overwriteAdminConfiguration));
 
         $defaultAddServices = [
-            'model_manager' => \sprintf('sonata.admin.manager.%s', $managerType),
-            'data_source' => \sprintf('sonata.admin.data_source.%s', $managerType),
-            'field_description_factory' => \sprintf('sonata.admin.field_description_factory.%s', $managerType),
-            'form_contractor' => \sprintf('sonata.admin.builder.%s_form', $managerType),
-            'show_builder' => \sprintf('sonata.admin.builder.%s_show', $managerType),
-            'list_builder' => \sprintf('sonata.admin.builder.%s_list', $managerType),
-            'datagrid_builder' => \sprintf('sonata.admin.builder.%s_datagrid', $managerType),
+            'model_manager' => sprintf('sonata.admin.manager.%s', $managerType),
+            'data_source' => sprintf('sonata.admin.data_source.%s', $managerType),
+            'field_description_factory' => sprintf('sonata.admin.field_description_factory.%s', $managerType),
+            'form_contractor' => sprintf('sonata.admin.builder.%s_form', $managerType),
+            'show_builder' => sprintf('sonata.admin.builder.%s_show', $managerType),
+            'list_builder' => sprintf('sonata.admin.builder.%s_list', $managerType),
+            'datagrid_builder' => sprintf('sonata.admin.builder.%s_datagrid', $managerType),
             'translator' => 'translator',
             'configuration_pool' => 'sonata.admin.pool',
             'route_generator' => 'sonata.admin.route.default_generator',
@@ -468,7 +467,7 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
         $definition->setMethodCalls($methods);
 
-        $templateRegistryId = \sprintf('%s.template_registry', $serviceId);
+        $templateRegistryId = sprintf('%s.template_registry', $serviceId);
         $templateRegistryDefinition = $container
             ->register($templateRegistryId, MutableTemplateRegistry::class)
             ->addTag('sonata.admin.template_registry')
@@ -503,7 +502,7 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
             $argumentValue = $declaredInParent ? $parentArguments[$index] : $arguments[$index] ?? null;
 
             if (null === $argumentValue || '' === $argumentValue) {
-                $arguments[$declaredInParent ? \sprintf('index_%s', $index) : $index] = $value;
+                $arguments[$declaredInParent ? sprintf('index_%s', $index) : $index] = $value;
             }
         }
 

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -488,7 +488,7 @@ final class AdminTest extends TestCase
     }
 
     /**
-     * @psalm-suppress ArgumentTypeCoercion, UndefinedClass
+     * @psalm-suppress ArgumentTypeCoercion
      */
     public function testGetBaseRoutePatternWithUnreconizedClassname(): void
     {
@@ -583,7 +583,7 @@ final class AdminTest extends TestCase
     }
 
     /**
-     * @psalm-suppress ArgumentTypeCoercion, UndefinedClass
+     * @psalm-suppress ArgumentTypeCoercion
      */
     public function testGetBaseRouteNameWithUnreconizedClassname(): void
     {

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -28,7 +28,6 @@ use Sonata\AdminBundle\Builder\FormContractorInterface;
 use Sonata\AdminBundle\Builder\ListBuilderInterface;
 use Sonata\AdminBundle\Builder\RouteBuilderInterface;
 use Sonata\AdminBundle\Builder\ShowBuilderInterface;
-use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Datagrid\PagerInterface;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
@@ -102,6 +101,10 @@ final class AdminTest extends TestCase
     }
 
     /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     *
      * @covers \Sonata\AdminBundle\Admin\AbstractAdmin::__construct
      */
     public function testConstructor(): void
@@ -117,10 +120,8 @@ final class AdminTest extends TestCase
 
     public function testGetClass(): void
     {
-        $class = Post::class;
-        $baseControllerName = 'Sonata\NewsBundle\Controller\PostAdminController';
-
-        $admin = new PostAdmin('sonata.post.admin.post', $class, $baseControllerName);
+        $admin = new PostAdmin();
+        $admin->setModelClass(Post::class);
 
         $admin->setModelManager($this->createMock(ModelManagerInterface::class));
 
@@ -132,7 +133,7 @@ final class AdminTest extends TestCase
 
         $admin->setSubject(null);
         $admin->setSubClasses([]);
-        static::assertSame($class, $admin->getClass());
+        static::assertSame(Post::class, $admin->getClass());
 
         $admin->setSubClasses(['foo' => Foo::class]);
         $admin->setRequest(new Request(['subclass' => 'foo']));
@@ -144,10 +145,8 @@ final class AdminTest extends TestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('Feature not implemented: an embedded admin cannot have subclass');
 
-        $class = Post::class;
-        $baseControllerName = 'Sonata\NewsBundle\Controller\PostAdminController';
-
-        $admin = new PostAdmin('sonata.post.admin.post', $class, $baseControllerName);
+        $admin = new PostAdmin();
+        $admin->setModelClass(Post::class);
         $admin->setParentFieldDescription(new FieldDescription('name'));
         $admin->setSubClasses(['foo' => Foo::class]);
         $admin->setRequest(new Request(['subclass' => 'foo']));
@@ -156,11 +155,7 @@ final class AdminTest extends TestCase
 
     public function testCheckAccessThrowsExceptionOnMadeUpAction(): void
     {
-        $admin = new PostAdmin(
-            'sonata.post.admin.post',
-            Post::class,
-            'Sonata\NewsBundle\Controller\PostAdminController'
-        );
+        $admin = new PostAdmin();
         $this->expectException(
             \InvalidArgumentException::class
         );
@@ -172,11 +167,7 @@ final class AdminTest extends TestCase
 
     public function testCheckAccessThrowsAccessDeniedException(): void
     {
-        $admin = new PostAdmin(
-            'sonata.post.admin.post',
-            Post::class,
-            'Sonata\NewsBundle\Controller\PostAdminController'
-        );
+        $admin = new PostAdmin();
         $securityHandler = $this->createStub(SecurityHandlerInterface::class);
         $securityHandler->method('isGranted')->willReturnMap([
             [$admin, 'CUSTOM_ROLE', $admin, true],
@@ -199,22 +190,14 @@ final class AdminTest extends TestCase
 
     public function testHasAccessOnMadeUpAction(): void
     {
-        $admin = new PostAdmin(
-            'sonata.post.admin.post',
-            Post::class,
-            'Sonata\NewsBundle\Controller\PostAdminController'
-        );
+        $admin = new PostAdmin();
 
         static::assertFalse($admin->hasAccess('made-up'));
     }
 
     public function testHasAccess(): void
     {
-        $admin = new PostAdmin(
-            'sonata.post.admin.post',
-            Post::class,
-            'Sonata\NewsBundle\Controller\PostAdminController'
-        );
+        $admin = new PostAdmin();
         $securityHandler = $this->createStub(SecurityHandlerInterface::class);
         $securityHandler->method('isGranted')->willReturnMap([
             [$admin, 'CUSTOM_ROLE', $admin, true],
@@ -232,11 +215,7 @@ final class AdminTest extends TestCase
 
     public function testHasAccessAllowsAccess(): void
     {
-        $admin = new PostAdmin(
-            'sonata.post.admin.post',
-            Post::class,
-            'Sonata\NewsBundle\Controller\PostAdminController'
-        );
+        $admin = new PostAdmin();
         $securityHandler = $this->createStub(SecurityHandlerInterface::class);
         $securityHandler->method('isGranted')->willReturnMap([
             [$admin, 'CUSTOM_ROLE', $admin, true],
@@ -254,11 +233,7 @@ final class AdminTest extends TestCase
 
     public function testHasAccessAllowsAccessEditAction(): void
     {
-        $admin = new PostAdmin(
-            'sonata.post.admin.post',
-            Post::class,
-            'Sonata\NewsBundle\Controller\PostAdminController'
-        );
+        $admin = new PostAdmin();
         $securityHandler = $this->createMock(SecurityHandlerInterface::class);
         $securityHandler->method('isGranted')->with($admin, 'EDIT_ROLE', $admin)->willReturn(true);
         $customExtension = $this->createMock(AbstractAdminExtension::class);
@@ -281,11 +256,13 @@ final class AdminTest extends TestCase
      */
     public function testChildren(): void
     {
-        $postAdmin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $postAdmin = new PostAdmin();
+        $postAdmin->setCode('sonata.post.admin.post');
         static::assertFalse($postAdmin->hasChildren());
         static::assertFalse($postAdmin->hasChild('comment'));
 
-        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', Comment::class, 'Sonata\NewsBundle\Controller\CommentAdminController');
+        $commentAdmin = new CommentAdmin();
+        $commentAdmin->setCode('sonata.post.admin.comment');
         $postAdmin->addChild($commentAdmin, 'post');
 
         static::assertTrue($postAdmin->hasChildren());
@@ -308,8 +285,8 @@ final class AdminTest extends TestCase
      */
     public function testParent(): void
     {
-        $postAdmin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
-        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', Comment::class, 'Sonata\NewsBundle\Controller\CommentAdminController');
+        $postAdmin = new PostAdmin();
+        $commentAdmin = new CommentAdmin();
         static::assertFalse($commentAdmin->isChild());
         static::assertFalse($commentAdmin->hasParentFieldDescription());
 
@@ -324,14 +301,16 @@ final class AdminTest extends TestCase
      */
     public function testConfigure(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
+        $admin->setModelClass(Post::class);
         static::assertNotNull($admin->getUniqId());
 
         $admin->initialize();
         static::assertNotNull($admin->getUniqId());
         static::assertSame('Post', $admin->getClassnameLabel());
 
-        $admin = new CommentAdmin('sonata.post.admin.comment', Comment::class, 'Sonata\NewsBundle\Controller\CommentAdminController');
+        $admin = new CommentAdmin();
+        $admin->setModelClass(Comment::class);
         $admin->setClassnameLabel('postcomment');
 
         $admin->initialize();
@@ -340,9 +319,11 @@ final class AdminTest extends TestCase
 
     public function testConfigureWithValidParentAssociationMapping(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
+        $admin->setModelClass(Post::class);
 
-        $comment = new CommentAdmin('sonata.post.admin.comment', Comment::class, 'Sonata\NewsBundle\Controller\CommentAdminController');
+        $comment = new CommentAdmin();
+        $comment->setModelClass(Comment::class);
         $comment->addChild($admin, 'comment');
 
         $admin->initialize();
@@ -428,7 +409,8 @@ final class AdminTest extends TestCase
      */
     public function testGetBaseRoutePattern(string $objFqn, string $expected): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', $objFqn, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
+        $admin->setModelClass($objFqn);
         static::assertSame($expected, $admin->getBaseRoutePattern());
     }
 
@@ -439,8 +421,10 @@ final class AdminTest extends TestCase
      */
     public function testGetBaseRoutePatternWithChildAdmin(string $objFqn, string $expected): void
     {
-        $postAdmin = new PostAdmin('sonata.post.admin.post', $objFqn, 'Sonata\NewsBundle\Controller\PostAdminController');
-        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', Comment::class, 'Sonata\NewsBundle\Controller\CommentAdminController');
+        $postAdmin = new PostAdmin();
+        $postAdmin->setModelClass($objFqn);
+        $commentAdmin = new CommentAdmin();
+        $commentAdmin->setModelClass(Comment::class);
         $commentAdmin->setParent($postAdmin, 'post');
 
         static::assertSame(sprintf('%s/{id}/comment', $expected), $commentAdmin->getBaseRoutePattern());
@@ -453,49 +437,51 @@ final class AdminTest extends TestCase
      */
     public function testGetBaseRoutePatternWithTwoNestedChildAdmin(string $objFqn, string $expected): void
     {
-        $postAdmin = new PostAdmin('sonata.post.admin.post', $objFqn, 'Sonata\NewsBundle\Controller\PostAdminController');
-        $commentAdmin = new CommentAdmin(
-            'sonata.post.admin.comment',
-            Comment::class,
-            'Sonata\NewsBundle\Controller\CommentAdminController'
-        );
+        $postAdmin = new PostAdmin();
+        $postAdmin->setModelClass($objFqn);
 
-        $commentVoteAdmin = new CommentVoteAdmin(
-            'sonata.post.admin.comment_vote',
-            CommentVote::class,
-            'Sonata\NewsBundle\Controller\CommentVoteAdminController'
-        );
+        $commentAdmin = new CommentAdmin();
+        $commentAdmin->setModelClass(Comment::class);
+
+        $commentVoteAdmin = new CommentVoteAdmin();
+        $commentVoteAdmin->setModelClass(CommentVote::class);
+
         $commentAdmin->setParent($postAdmin, 'post');
         $commentVoteAdmin->setParent($commentAdmin, 'comment');
 
         static::assertSame(sprintf('%s/{id}/comment/{childId}/commentvote', $expected), $commentVoteAdmin->getBaseRoutePattern());
     }
 
-    public function testGetBaseRoutePatternWithSpecifedPattern(): void
+    public function testGetBaseRoutePatternWithSpecifiedPattern(): void
     {
-        $postAdmin = new PostWithCustomRouteAdmin('sonata.post.admin.post_with_custom_route', Post::class, 'Sonata\NewsBundle\Controller\PostWithCustomRouteAdminController');
+        $postAdmin = new PostWithCustomRouteAdmin();
+        $postAdmin->setModelClass(Post::class);
 
         static::assertSame('/post-custom', $postAdmin->getBaseRoutePattern());
     }
 
-    public function testGetBaseRoutePatternWithChildAdminAndWithSpecifedPattern(): void
+    public function testGetBaseRoutePatternWithChildAdminAndWithSpecifiedPattern(): void
     {
-        $postAdmin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
-        $commentAdmin = new CommentWithCustomRouteAdmin('sonata.post.admin.comment_with_custom_route', Comment::class, 'Sonata\NewsBundle\Controller\CommentWithCustomRouteAdminController');
+        $postAdmin = new PostAdmin();
+        $postAdmin->setModelClass(Post::class);
+
+        $commentAdmin = new CommentWithCustomRouteAdmin();
+        $commentAdmin->setModelClass(Comment::class);
         $commentAdmin->setParent($postAdmin, 'post');
 
         static::assertSame('/fixtures/bundle/post/{id}/comment-custom', $commentAdmin->getBaseRoutePattern());
     }
 
     /**
-     * @psalm-suppress ArgumentTypeCoercion
+     * @psalm-suppress ArgumentTypeCoercion, UndefinedClass
      */
-    public function testGetBaseRoutePatternWithUnreconizedClassname(): void
+    public function testGetBaseRoutePatternWithUnrecognizedClassname(): void
     {
         $this->expectException(\LogicException::class);
 
+        $admin = new PostAdmin();
         // @phpstan-ignore-next-line
-        $admin = new PostAdmin('sonata.post.admin.post', 'News\Thing\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin->setModelClass('News\Thing\Post');
         $admin->getBaseRoutePattern();
     }
 
@@ -577,34 +563,40 @@ final class AdminTest extends TestCase
      */
     public function testGetBaseRouteName(string $objFqn, string $expected): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', $objFqn, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
+        $admin->setModelClass($objFqn);
 
         static::assertSame($expected, $admin->getBaseRouteName());
     }
 
     /**
-     * @psalm-suppress ArgumentTypeCoercion
+     * @psalm-suppress ArgumentTypeCoercion, UndefinedClass
      */
-    public function testGetBaseRouteNameWithUnreconizedClassname(): void
+    public function testGetBaseRouteNameWithUnrecognizedClassname(): void
     {
         $this->expectException(\LogicException::class);
 
+        $admin = new PostAdmin();
         // @phpstan-ignore-next-line
-        $admin = new PostAdmin('sonata.post.admin.post', 'News\Thing\Post', 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin->setModelClass('News\Thing\Post');
         $admin->getBaseRouteName();
     }
 
     public function testGetBaseRouteNameWithSpecifiedName(): void
     {
-        $postAdmin = new PostWithCustomRouteAdmin('sonata.post.admin.post_with_custom_route', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $postAdmin = new PostWithCustomRouteAdmin();
+        $postAdmin->setModelClass(Post::class);
 
         static::assertSame('post_custom', $postAdmin->getBaseRouteName());
     }
 
     public function testGetBaseRouteNameWithChildAdminAndWithSpecifiedName(): void
     {
-        $postAdmin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
-        $commentAdmin = new CommentWithCustomRouteAdmin('sonata.post.admin.comment_with_custom_route', Comment::class, 'Sonata\NewsBundle\Controller\CommentWithCustomRouteAdminController');
+        $postAdmin = new PostAdmin();
+        $postAdmin->setModelClass(Post::class);
+
+        $commentAdmin = new CommentWithCustomRouteAdmin();
+        $commentAdmin->setModelClass(Comment::class);
         $commentAdmin->setParent($postAdmin, 'post');
 
         static::assertSame('admin_fixtures_bundle_post_comment_custom', $commentAdmin->getBaseRouteName());
@@ -612,21 +604,15 @@ final class AdminTest extends TestCase
 
     public function testGetBaseRouteNameWithTwoNestedChildAdminAndWithSpecifiedName(): void
     {
-        $postAdmin = new PostAdmin(
-            'sonata.post.admin.post',
-            Post::class,
-            'Sonata\NewsBundle\Controller\PostAdminController'
-        );
-        $commentAdmin = new CommentWithCustomRouteAdmin(
-            'sonata.post.admin.comment_with_custom_route',
-            Comment::class,
-            'Sonata\NewsBundle\Controller\CommentWithCustomRouteAdminController'
-        );
-        $commentVoteAdmin = new CommentVoteAdmin(
-            'sonata.post.admin.comment_vote',
-            CommentVote::class,
-            'Sonata\NewsBundle\Controller\CommentVoteAdminController'
-        );
+        $postAdmin = new PostAdmin();
+        $postAdmin->setModelClass(Post::class);
+
+        $commentAdmin = new CommentWithCustomRouteAdmin();
+        $commentAdmin->setModelClass(Comment::class);
+
+        $commentVoteAdmin = new CommentVoteAdmin();
+        $commentVoteAdmin->setModelClass(CommentVote::class);
+
         $commentAdmin->setParent($postAdmin, 'post');
         $commentVoteAdmin->setParent($commentAdmin, 'comment');
 
@@ -639,7 +625,7 @@ final class AdminTest extends TestCase
      */
     public function testSetUniqId(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $uniqId = uniqid();
         $admin->setUniqId($uniqId);
@@ -649,7 +635,7 @@ final class AdminTest extends TestCase
 
     public function testToString(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $s = new \stdClass();
 
@@ -665,7 +651,7 @@ final class AdminTest extends TestCase
             static::markTestSkipped('PHP 8.0 does not allow __toString() method to return null');
         }
 
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         // To string method is implemented, but returns null
         $s = new FooToStringNull();
@@ -674,12 +660,12 @@ final class AdminTest extends TestCase
 
     public function testIsAclEnabled(): void
     {
-        $postAdmin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $postAdmin = new PostAdmin();
 
         $postAdmin->setSecurityHandler($this->createMock(SecurityHandlerInterface::class));
         static::assertFalse($postAdmin->isAclEnabled());
 
-        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', Comment::class, 'Sonata\NewsBundle\Controller\CommentAdminController');
+        $commentAdmin = new CommentAdmin();
         $commentAdmin->setSecurityHandler($this->createMock(AclSecurityHandlerInterface::class));
         static::assertTrue($commentAdmin->isAclEnabled());
     }
@@ -696,11 +682,9 @@ final class AdminTest extends TestCase
      */
     public function testSubClass(): void
     {
-        $admin = new PostAdmin(
-            'sonata.post.admin.post',
-            Post::class,
-            'Sonata\NewsBundle\Controller\PostAdminController'
-        );
+        $admin = new PostAdmin();
+        $admin->setModelClass(Post::class);
+
         static::assertFalse($admin->hasSubClass('test'));
         static::assertFalse($admin->hasActiveSubClass());
         static::assertCount(0, $admin->getSubClasses());
@@ -758,7 +742,8 @@ final class AdminTest extends TestCase
 
     public function testNonExistantSubclass(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
+        $admin->setModelClass(Post::class);
         $admin->setModelManager($this->createMock(ModelManagerInterface::class));
 
         $admin->setRequest(new Request(['subclass' => 'inject']));
@@ -785,7 +770,8 @@ final class AdminTest extends TestCase
      */
     public function testOnlyOneSubclassNeededToBeActive(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
+        $admin->setModelClass(Post::class);
 
         /** @var class-string $postExtended1 */
         $postExtended1 = 'NewsBundle\Entity\PostExtended1';
@@ -798,7 +784,7 @@ final class AdminTest extends TestCase
 
     public function testGetPerPageOptions(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $perPageOptions = $admin->getPerPageOptions();
 
@@ -807,7 +793,7 @@ final class AdminTest extends TestCase
 
     public function testGetLabelTranslatorStrategy(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $labelTranslatorStrategy = $this->createMock(LabelTranslatorStrategyInterface::class);
         $admin->setLabelTranslatorStrategy($labelTranslatorStrategy);
@@ -816,7 +802,7 @@ final class AdminTest extends TestCase
 
     public function testGetLabelTranslatorStrategyWithException(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage(sprintf(
@@ -829,7 +815,7 @@ final class AdminTest extends TestCase
 
     public function testGetRouteBuilder(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $routeBuilder = $this->createMock(RouteBuilderInterface::class);
         $admin->setRouteBuilder($routeBuilder);
@@ -838,7 +824,7 @@ final class AdminTest extends TestCase
 
     public function testGetMenuFactory(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $menuFactory = $this->createMock(FactoryInterface::class);
         $admin->setMenuFactory($menuFactory);
@@ -847,7 +833,7 @@ final class AdminTest extends TestCase
 
     public function testGetExtensions(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         static::assertSame([], $admin->getExtensions());
 
@@ -864,7 +850,7 @@ final class AdminTest extends TestCase
 
     public function testRemovingNonExistingExtensions(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         static::assertSame([], $admin->getExtensions());
 
@@ -876,7 +862,7 @@ final class AdminTest extends TestCase
 
     public function testGetFilterTheme(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         static::assertSame([], $admin->getFilterTheme());
 
@@ -886,7 +872,7 @@ final class AdminTest extends TestCase
 
     public function testGetFormTheme(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         static::assertSame([], $admin->getFormTheme());
 
@@ -897,7 +883,7 @@ final class AdminTest extends TestCase
 
     public function testGetSecurityHandler(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $securityHandler = $this->createMock(SecurityHandlerInterface::class);
         $admin->setSecurityHandler($securityHandler);
@@ -906,7 +892,7 @@ final class AdminTest extends TestCase
 
     public function testGetSecurityInformation(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         static::assertSame([], $admin->getSecurityInformation());
 
@@ -921,7 +907,7 @@ final class AdminTest extends TestCase
 
     public function testGetManagerType(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $admin->setManagerType('foo_orm');
         static::assertSame('foo_orm', $admin->getManagerType());
@@ -929,7 +915,7 @@ final class AdminTest extends TestCase
 
     public function testGetModelManager(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $modelManager = $this->createMock(ModelManagerInterface::class);
 
@@ -939,7 +925,7 @@ final class AdminTest extends TestCase
 
     public function testGetModelManagerWithException(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage(sprintf(
@@ -952,16 +938,11 @@ final class AdminTest extends TestCase
 
     public function testGetBaseCodeRoute(): void
     {
-        $postAdmin = new PostAdmin(
-            'sonata.post.admin.post',
-            Post::class,
-            'Sonata\NewsBundle\Controller\PostAdminController'
-        );
-        $commentAdmin = new CommentAdmin(
-            'sonata.post.admin.comment',
-            Comment::class,
-            'Sonata\NewsBundle\Controller\CommentAdminController'
-        );
+        $postAdmin = new PostAdmin();
+        $postAdmin->setCode('sonata.post.admin.post');
+
+        $commentAdmin = new CommentAdmin();
+        $commentAdmin->setCode('sonata.post.admin.comment');
 
         static::assertSame($postAdmin->getCode(), $postAdmin->getBaseCodeRoute());
 
@@ -975,7 +956,7 @@ final class AdminTest extends TestCase
 
     public function testGetRouteGenerator(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $routeGenerator = $this->createMock(RouteGeneratorInterface::class);
 
@@ -985,7 +966,7 @@ final class AdminTest extends TestCase
 
     public function testGetRouteGeneratorWithException(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage(sprintf('Admin "%s" has no route generator.', PostAdmin::class));
@@ -995,7 +976,7 @@ final class AdminTest extends TestCase
 
     public function testGetConfigurationPool(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $pool = new Pool(new Container());
 
@@ -1005,7 +986,7 @@ final class AdminTest extends TestCase
 
     public function testGetConfigurationPoolWithException(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage(sprintf('Admin "%s" has no pool.', PostAdmin::class));
@@ -1015,7 +996,7 @@ final class AdminTest extends TestCase
 
     public function testGetShowBuilder(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $showBuilder = $this->createMock(ShowBuilderInterface::class);
 
@@ -1025,7 +1006,7 @@ final class AdminTest extends TestCase
 
     public function testGetListBuilder(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $listBuilder = $this->createMock(ListBuilderInterface::class);
 
@@ -1035,7 +1016,7 @@ final class AdminTest extends TestCase
 
     public function testGetDatagridBuilder(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $datagridBuilder = $this->createMock(DatagridBuilderInterface::class);
 
@@ -1045,7 +1026,7 @@ final class AdminTest extends TestCase
 
     public function testGetFormContractor(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $formContractor = $this->createMock(FormContractorInterface::class);
 
@@ -1055,7 +1036,7 @@ final class AdminTest extends TestCase
 
     public function testGetRequest(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         static::assertFalse($admin->hasRequest());
 
@@ -1071,13 +1052,13 @@ final class AdminTest extends TestCase
         $this->expectException(\LogicException::class);
         $this->expectExceptionMessage('The Request object has not been set');
 
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
         $admin->getRequest();
     }
 
     public function testGetTranslationDomain(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         static::assertSame('messages', $admin->getTranslationDomain());
 
@@ -1087,7 +1068,7 @@ final class AdminTest extends TestCase
 
     public function testGetTranslator(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $translator = $this->createMock(TranslatorInterface::class);
 
@@ -1097,7 +1078,7 @@ final class AdminTest extends TestCase
 
     public function testGetShowGroups(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         static::assertSame([], $admin->getShowGroups());
 
@@ -1109,7 +1090,7 @@ final class AdminTest extends TestCase
 
     public function testGetFormGroups(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         static::assertSame([], $admin->getFormGroups());
 
@@ -1121,7 +1102,7 @@ final class AdminTest extends TestCase
 
     public function testGetMaxPageLinks(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         static::assertSame(25, $admin->getMaxPageLinks());
 
@@ -1133,7 +1114,7 @@ final class AdminTest extends TestCase
     {
         $modelManager = $this->createStub(ModelManagerInterface::class);
 
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
         $admin->setModelManager($modelManager);
 
         static::assertSame(25, $admin->getMaxPerPage());
@@ -1141,7 +1122,7 @@ final class AdminTest extends TestCase
 
     public function testGetLabel(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         static::assertNull($admin->getLabel());
 
@@ -1151,9 +1132,7 @@ final class AdminTest extends TestCase
 
     public function testGetBaseController(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
-
-        static::assertSame('Sonata\NewsBundle\Controller\PostAdminController', $admin->getBaseControllerName());
+        $admin = new PostAdmin();
 
         $admin->setBaseControllerName('Sonata\NewsBundle\Controller\FooAdminController');
         static::assertSame('Sonata\NewsBundle\Controller\FooAdminController', $admin->getBaseControllerName());
@@ -1161,30 +1140,18 @@ final class AdminTest extends TestCase
 
     public function testGetIdParameter(): void
     {
-        $postAdmin = new PostAdmin(
-            'sonata.post.admin.post',
-            Post::class,
-            'Sonata\NewsBundle\Controller\PostAdminController'
-        );
+        $postAdmin = new PostAdmin();
 
         static::assertSame('id', $postAdmin->getIdParameter());
         static::assertFalse($postAdmin->isChild());
 
-        $commentAdmin = new CommentAdmin(
-            'sonata.post.admin.comment',
-            Comment::class,
-            'Sonata\NewsBundle\Controller\CommentAdminController'
-        );
+        $commentAdmin = new CommentAdmin();
         $commentAdmin->setParent($postAdmin, 'post');
 
         static::assertTrue($commentAdmin->isChild());
         static::assertSame('childId', $commentAdmin->getIdParameter());
 
-        $commentVoteAdmin = new CommentVoteAdmin(
-            'sonata.post.admin.comment_vote',
-            CommentVote::class,
-            'Sonata\NewsBundle\Controller\CommentVoteAdminController'
-        );
+        $commentVoteAdmin = new CommentVoteAdmin();
         $commentVoteAdmin->setParent($commentAdmin, 'comment');
 
         static::assertTrue($commentVoteAdmin->isChild());
@@ -1193,14 +1160,14 @@ final class AdminTest extends TestCase
 
     public function testGetExportFormats(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         static::assertSame([], $admin->getExportFormats());
     }
 
-    public function testGetUrlsafeIdentifier(): void
+    public function testGetUrlSafeIdentifier(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $model = new \stdClass();
 
@@ -1218,7 +1185,7 @@ final class AdminTest extends TestCase
     {
         $modelManager = $this->createStub(ModelManagerInterface::class);
 
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
         $admin->setModelManager($modelManager);
 
         static::assertFalse($admin->determinedPerPageValue(123));
@@ -1227,7 +1194,7 @@ final class AdminTest extends TestCase
 
     public function testIsGranted(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
         $modelManager = $this->createStub(ModelManagerInterface::class);
         $modelManager
             ->method('getNormalizedIdentifier')
@@ -1283,7 +1250,7 @@ final class AdminTest extends TestCase
 
     public function testSupportsPreviewMode(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         static::assertFalse($admin->supportsPreviewMode());
     }
@@ -1295,7 +1262,7 @@ final class AdminTest extends TestCase
      */
     public function testShowIn(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $securityHandler = $this->createMock(AclSecurityHandlerInterface::class);
         $securityHandler
@@ -1313,7 +1280,7 @@ final class AdminTest extends TestCase
 
     public function testShowInDashboard(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $securityHandler = $this->createMock(AclSecurityHandlerInterface::class);
         $securityHandler
@@ -1329,7 +1296,8 @@ final class AdminTest extends TestCase
 
     public function testGetObjectIdentifier(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
+        $admin->setCode('sonata.post.admin.post');
 
         static::assertSame('sonata.post.admin.post', $admin->getObjectIdentifier());
     }
@@ -1339,7 +1307,7 @@ final class AdminTest extends TestCase
      */
     public function testSetFilterPersister(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'SonataNewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $filterPersister = $this->createMock(FilterPersisterInterface::class);
 
@@ -1348,11 +1316,14 @@ final class AdminTest extends TestCase
 
     public function testGetRootCode(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
+        $admin->setCode('sonata.post.admin.post');
 
         static::assertSame('sonata.post.admin.post', $admin->getRootCode());
 
-        $parentAdmin = new PostAdmin('sonata.post.admin.post.parent', Post::class, 'Sonata\NewsBundle\Controller\PostParentAdminController');
+        $parentAdmin = new PostAdmin();
+        $parentAdmin->setCode('sonata.post.admin.post.parent');
+
         $parentFieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $parentFieldDescription->expects(static::once())
             ->method('getAdmin')
@@ -1366,11 +1337,11 @@ final class AdminTest extends TestCase
 
     public function testGetRoot(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         static::assertSame($admin, $admin->getRoot());
 
-        $parentAdmin = new PostAdmin('sonata.post.admin.post.parent', Post::class, 'Sonata\NewsBundle\Controller\PostParentAdminController');
+        $parentAdmin = new PostAdmin();
         $parentFieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $parentFieldDescription->expects(static::once())
             ->method('getAdmin')
@@ -1384,7 +1355,8 @@ final class AdminTest extends TestCase
 
     public function testGetExportFields(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
+        $admin->setModelClass(Post::class);
 
         $modelManager = $this->createMock(ModelManagerInterface::class);
         $modelManager->expects(static::once())
@@ -1398,7 +1370,7 @@ final class AdminTest extends TestCase
 
     public function testGetPersistentParametersWithNoExtension(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         static::assertEmpty($admin->getPersistentParameters());
     }
@@ -1409,7 +1381,7 @@ final class AdminTest extends TestCase
             'context' => 'foobar',
         ];
 
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $extension = $this->createMock(AdminExtensionInterface::class);
         $extension->method('configurePersistentParameters')->willReturn($expected);
@@ -1422,7 +1394,7 @@ final class AdminTest extends TestCase
 
     public function testGetPersistentParameterDefaultValue(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         static::assertNull($admin->getPersistentParameter('foo'));
         static::assertSame('bar', $admin->getPersistentParameter('foo', 'bar'));
@@ -1432,11 +1404,8 @@ final class AdminTest extends TestCase
     {
         $post = new Post();
 
-        $postAdmin = $this->getMockBuilder(PostAdmin::class)->setConstructorArgs([
-            'post',
-            Post::class,
-            CRUDController::class,
-        ])->getMock();
+        $postAdmin = $this->createMock(PostAdmin::class);
+        $postAdmin->setModelClass(Post::class);
 
         $modelManager = $this->createStub(ModelManagerInterface::class);
         $modelManager->method('find')->willReturn($post);
@@ -1444,7 +1413,8 @@ final class AdminTest extends TestCase
 
         $postAdmin->method('getIdParameter')->willReturn('parent_id');
 
-        $tagAdmin = new TagAdmin('admin.tag', Tag::class, 'MyBundle\MyController');
+        $tagAdmin = new TagAdmin();
+        $tagAdmin->setModelClass(Tag::class);
         $tagAdmin->setParent($postAdmin, 'post');
 
         $request = $this->createMock(Request::class);
@@ -1458,14 +1428,12 @@ final class AdminTest extends TestCase
 
     public function testGetNewInstanceForChildAdminWithParentValueCanBeDisabled(): void
     {
-        $postAdmin = $this->getMockBuilder(PostAdmin::class)->setConstructorArgs([
-            'post',
-            Post::class,
-            CRUDController::class,
-        ])->getMock();
+        $postAdmin = $this->createMock(PostAdmin::class);
+        $postAdmin->setModelClass(Post::class);
         $postAdmin->expects(static::never())->method('getIdParameter');
 
-        $tagAdmin = new TagWithoutPostAdmin('admin.tag', Tag::class, 'MyBundle\MyController');
+        $tagAdmin = new TagWithoutPostAdmin();
+        $tagAdmin->setModelClass(Tag::class);
         $tagAdmin->setParent($postAdmin, 'post');
 
         $tag = $tagAdmin->getNewInstance();
@@ -1477,11 +1445,8 @@ final class AdminTest extends TestCase
     {
         $post = new Post();
 
-        $postAdmin = $this->getMockBuilder(PostAdmin::class)->setConstructorArgs([
-            'post',
-            Post::class,
-            CRUDController::class,
-        ])->getMock();
+        $postAdmin = $this->createMock(PostAdmin::class);
+        $postAdmin->setModelClass(Post::class);
 
         $modelManager = $this->createMock(ModelManagerInterface::class);
         $modelManager->method('find')->willReturn($post);
@@ -1489,7 +1454,8 @@ final class AdminTest extends TestCase
 
         $postAdmin->method('getIdParameter')->willReturn('parent_id');
 
-        $postCategoryAdmin = new PostCategoryAdmin('admin.post_category', PostCategory::class, 'MyBundle\MyController');
+        $postCategoryAdmin = new PostCategoryAdmin();
+        $postCategoryAdmin->setModelClass(PostCategory::class);
         $postCategoryAdmin->setParent($postAdmin, 'posts');
 
         $request = $this->createMock(Request::class);
@@ -1503,15 +1469,12 @@ final class AdminTest extends TestCase
         static::assertContains($post, $postCategory->getPosts());
     }
 
-    public function testGetNewInstanceForEmbededAdminWithParentValue(): void
+    public function testGetNewInstanceForEmbeddedAdminWithParentValue(): void
     {
         $post = new Post();
 
-        $postAdmin = $this->getMockBuilder(PostAdmin::class)->setConstructorArgs([
-            'post',
-            Post::class,
-            CRUDController::class,
-        ])->getMock();
+        $postAdmin = $this->createMock(PostAdmin::class);
+        $postAdmin->setModelClass(Post::class);
 
         $modelManager = $this->createMock(ModelManagerInterface::class);
         $modelManager->method('find')->willReturn($post);
@@ -1524,7 +1487,8 @@ final class AdminTest extends TestCase
         $parentField->method('getParentAssociationMappings')->willReturn([]);
         $parentField->method('getAssociationMapping')->willReturn(['fieldName' => 'tag', 'mappedBy' => 'post']);
 
-        $tagAdmin = new TagAdmin('admin.tag', Tag::class, 'MyBundle\MyController');
+        $tagAdmin = new TagAdmin();
+        $tagAdmin->setModelClass(Tag::class);
         $tagAdmin->setParentFieldDescription($parentField);
 
         $request = $this->createMock(Request::class);
@@ -1547,7 +1511,7 @@ final class AdminTest extends TestCase
             ],
         ];
 
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
         $admin->setFormGroups($formGroups);
 
         $admin->removeFieldFromFormGroup('foo');
@@ -1567,9 +1531,9 @@ final class AdminTest extends TestCase
     {
         $authorId = uniqid();
 
-        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', Comment::class, 'Sonata\NewsBundle\Controller\CommentAdminController');
+        $commentAdmin = new CommentAdmin();
 
-        $postAdmin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $postAdmin = new PostAdmin();
         $postAdmin->addChild($commentAdmin, 'post__author');
 
         $request = new Request();
@@ -1593,11 +1557,7 @@ final class AdminTest extends TestCase
 
     public function testGetFilterParametersWithoutRequest(): void
     {
-        $commentAdmin = new CommentAdmin(
-            'sonata.post.admin.comment',
-            Comment::class,
-            'Sonata\NewsBundle\Controller\CommentAdminController'
-        );
+        $commentAdmin = new CommentAdmin();
 
         $parameters = $commentAdmin->getFilterParameters();
 
@@ -1607,7 +1567,8 @@ final class AdminTest extends TestCase
 
     public function testGetFilterFieldDescription(): void
     {
-        $modelAdmin = new ModelAdmin('sonata.post.admin.model', Post::class, 'Sonata\FooBundle\Controller\ModelAdminController');
+        $modelAdmin = new ModelAdmin();
+        $modelAdmin->setModelClass(Post::class);
         $modelAdmin->setLabelTranslatorStrategy(new NoopLabelTranslatorStrategy());
 
         $fooFieldDescription = new FieldDescription('foo');
@@ -1688,7 +1649,8 @@ final class AdminTest extends TestCase
             ->expects(static::never())
             ->method('find');
 
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
+        $admin->setModelClass(Post::class);
         $admin->setModelManager($modelManager);
 
         static::assertFalse($admin->hasSubject());
@@ -1712,7 +1674,7 @@ final class AdminTest extends TestCase
             ->method('createItem')
             ->willReturn($item);
 
-        $modelAdmin = new ModelAdmin('sonata.post.admin.model', Post::class, 'Sonata\FooBundle\Controller\ModelAdminController');
+        $modelAdmin = new ModelAdmin();
         $modelAdmin->setMenuFactory($menuFactory);
         $modelAdmin->setTranslationDomain('foo_bar_baz');
 
@@ -1747,7 +1709,8 @@ final class AdminTest extends TestCase
             ->with(Post::class, $id)
             ->willReturn(null); // entity not found
 
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
+        $admin->setModelClass(Post::class);
         $admin->setModelManager($modelManager);
 
         $admin->setRequest(new Request(['id' => $id]));
@@ -1770,7 +1733,8 @@ final class AdminTest extends TestCase
             ->with(Post::class, $id)
             ->willReturn($model);
 
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
+        $admin->setModelClass(Post::class);
         $admin->setModelManager($modelManager);
 
         $admin->setRequest(new Request(['id' => $id]));
@@ -1793,10 +1757,12 @@ final class AdminTest extends TestCase
 
         $request = new Request(['id' => $adminId]);
 
-        $postAdmin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $postAdmin = new PostAdmin();
+        $postAdmin->setModelClass(Post::class);
         $postAdmin->setRequest($request);
 
-        $commentAdmin = new CommentAdmin('sonata.post.admin.comment', Comment::class, 'Sonata\NewsBundle\Controller\CommentAdminController');
+        $commentAdmin = new CommentAdmin();
+        $commentAdmin->setModelClass(Comment::class);
         $commentAdmin->setRequest($request);
         $commentAdmin->setModelManager($modelManager);
 
@@ -1820,7 +1786,7 @@ final class AdminTest extends TestCase
             ],
         ];
 
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $templateRegistry = $this->createMock(MutableTemplateRegistryInterface::class);
         $templateRegistry->method('getTemplate')->with('button_create')->willReturn('Foo.html.twig');
@@ -1851,7 +1817,7 @@ final class AdminTest extends TestCase
      */
     public function testGetActionButtonsListCreateDisabled(): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
 
         $securityHandler = $this->createMock(SecurityHandlerInterface::class);
         $securityHandler
@@ -1925,7 +1891,7 @@ final class AdminTest extends TestCase
                 return sprintf('%s.%s_%s', $context, $type, $label);
             });
 
-        $admin = new PostAdmin('sonata.post.admin.model', Post::class, 'Sonata\FooBundle\Controller\ModelAdminController');
+        $admin = new PostAdmin();
         $admin->setRouteBuilder($pathInfo);
         $admin->setTranslationDomain('SonataAdminBundle');
         $admin->setLabelTranslatorStrategy($labelTranslatorStrategy);
@@ -1961,7 +1927,9 @@ final class AdminTest extends TestCase
             new RoutesCache($this->cacheTempFolder, true)
         );
 
-        $admin = new PostWithoutBatchRouteAdmin('sonata.post.admin.model', Post::class, 'Sonata\FooBundle\Controller\ModelAdminController');
+        $admin = new PostWithoutBatchRouteAdmin();
+        $admin->setModelClass(Post::class);
+        $admin->setBaseControllerName('Sonata\FooBundle\Controller\ModelAdminController');
         $admin->setRouteBuilder($pathInfo);
         $admin->setRouteGenerator($routeGenerator);
         $admin->initialize();
@@ -1977,7 +1945,9 @@ final class AdminTest extends TestCase
      */
     public function testGetListMode(string $expected, ?Request $request = null): void
     {
-        $admin = new PostAdmin('sonata.post.admin.post', Post::class, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
+        $admin->setCode('sonata.post.admin.post');
+
         if (null !== $request) {
             $admin->setRequest($request);
         }
@@ -2031,7 +2001,9 @@ final class AdminTest extends TestCase
             new RoutesCache($this->cacheTempFolder, true)
         );
 
-        $admin = new PostAdmin('sonata.post.admin.post', $objFqn, 'Sonata\NewsBundle\Controller\PostAdminController');
+        $admin = new PostAdmin();
+        $admin->setModelClass(Post::class);
+        $admin->setBaseControllerName('Sonata\NewsBundle\Controller\PostAdminController');
         $admin->setRouteBuilder($pathInfo);
         $admin->setRouteGenerator($routeGenerator);
         $admin->initialize();
@@ -2056,9 +2028,7 @@ final class AdminTest extends TestCase
 
     public function testDefaultFilters(): void
     {
-        $admin = new FilteredAdmin('sonata.post.admin.model', Post::class, 'Sonata\FooBundle\Controller\ModelAdminController');
-
-        $subjectId = uniqid();
+        $admin = new FilteredAdmin();
 
         $request = new Request([
             'filter' => [
@@ -2102,16 +2072,12 @@ final class AdminTest extends TestCase
             'Circular reference detected! The child admin `sonata.post.admin.post` is already in the parent tree of the `sonata.post.admin.comment` admin.'
         );
 
-        $postAdmin = new PostAdmin(
-            'sonata.post.admin.post',
-            Post::class,
-            'Sonata\NewsBundle\Controller\PostAdminController'
-        );
-        $commentAdmin = new CommentAdmin(
-            'sonata.post.admin.comment',
-            Comment::class,
-            'Sonata\NewsBundle\Controller\CommentAdminController'
-        );
+        $postAdmin = new PostAdmin();
+        $postAdmin->setCode('sonata.post.admin.post');
+
+        $commentAdmin = new CommentAdmin();
+        $commentAdmin->setCode('sonata.post.admin.comment');
+
         $postAdmin->addChild($commentAdmin, 'post');
         $commentAdmin->addChild($postAdmin, 'comment');
     }
@@ -2123,21 +2089,15 @@ final class AdminTest extends TestCase
             'Circular reference detected! The child admin `sonata.post.admin.post` is already in the parent tree of the `sonata.post.admin.comment_vote` admin.'
         );
 
-        $postAdmin = new PostAdmin(
-            'sonata.post.admin.post',
-            Post::class,
-            'Sonata\NewsBundle\Controller\PostAdminController'
-        );
-        $commentAdmin = new CommentAdmin(
-            'sonata.post.admin.comment',
-            Comment::class,
-            'Sonata\NewsBundle\Controller\CommentAdminController'
-        );
-        $commentVoteAdmin = new CommentVoteAdmin(
-            'sonata.post.admin.comment_vote',
-            CommentVote::class,
-            'Sonata\NewsBundle\Controller\CommentVoteAdminController'
-        );
+        $postAdmin = new PostAdmin();
+        $postAdmin->setCode('sonata.post.admin.post');
+
+        $commentAdmin = new CommentAdmin();
+        $commentAdmin->setCode('sonata.post.admin.comment');
+
+        $commentVoteAdmin = new CommentVoteAdmin();
+        $commentVoteAdmin->setCode('sonata.post.admin.comment_vote');
+
         $postAdmin->addChild($commentAdmin, 'post');
         $commentAdmin->addChild($commentVoteAdmin, 'comment');
         $commentVoteAdmin->addChild($postAdmin, 'post');
@@ -2150,31 +2110,16 @@ final class AdminTest extends TestCase
             'Circular reference detected! The child admin `sonata.post.admin.post` is already in the parent tree of the `sonata.post.admin.post` admin.'
         );
 
-        $postAdmin = new PostAdmin(
-            'sonata.post.admin.post',
-            Post::class,
-            'Sonata\NewsBundle\Controller\PostAdminController'
-        );
+        $postAdmin = new PostAdmin();
+        $postAdmin->setCode('sonata.post.admin.post');
         $postAdmin->addChild($postAdmin, 'post');
     }
 
     public function testGetRootAncestor(): void
     {
-        $postAdmin = new PostAdmin(
-            'sonata.post.admin.post',
-            Post::class,
-            'Sonata\NewsBundle\Controller\PostAdminController'
-        );
-        $commentAdmin = new CommentAdmin(
-            'sonata.post.admin.comment',
-            Comment::class,
-            'Sonata\NewsBundle\Controller\CommentAdminController'
-        );
-        $commentVoteAdmin = new CommentVoteAdmin(
-            'sonata.post.admin.comment_vote',
-            CommentVote::class,
-            'Sonata\NewsBundle\Controller\CommentVoteAdminController'
-        );
+        $postAdmin = new PostAdmin();
+        $commentAdmin = new CommentAdmin();
+        $commentVoteAdmin = new CommentVoteAdmin();
 
         // Workaround for static analysis
         $commentAdminRootAncestor = $commentAdmin->getRootAncestor();
@@ -2198,21 +2143,9 @@ final class AdminTest extends TestCase
 
     public function testGetChildDepth(): void
     {
-        $postAdmin = new PostAdmin(
-            'sonata.post.admin.post',
-            Post::class,
-            'Sonata\NewsBundle\Controller\PostAdminController'
-        );
-        $commentAdmin = new CommentAdmin(
-            'sonata.post.admin.comment',
-            Comment::class,
-            'Sonata\NewsBundle\Controller\CommentAdminController'
-        );
-        $commentVoteAdmin = new CommentVoteAdmin(
-            'sonata.post.admin.comment_vote',
-            CommentVote::class,
-            'Sonata\NewsBundle\Controller\CommentVoteAdminController'
-        );
+        $postAdmin = new PostAdmin();
+        $commentAdmin = new CommentAdmin();
+        $commentVoteAdmin = new CommentVoteAdmin();
 
         static::assertSame(0, $postAdmin->getChildDepth());
         static::assertSame(0, $commentAdmin->getChildDepth());
@@ -2233,21 +2166,9 @@ final class AdminTest extends TestCase
 
     public function testGetCurrentLeafChildAdmin(): void
     {
-        $postAdmin = new PostAdmin(
-            'sonata.post.admin.post',
-            Post::class,
-            'Sonata\NewsBundle\Controller\PostAdminController'
-        );
-        $commentAdmin = new CommentAdmin(
-            'sonata.post.admin.comment',
-            Comment::class,
-            'Sonata\NewsBundle\Controller\CommentAdminController'
-        );
-        $commentVoteAdmin = new CommentVoteAdmin(
-            'sonata.post.admin.comment_vote',
-            CommentVote::class,
-            'Sonata\NewsBundle\Controller\CommentVoteAdminController'
-        );
+        $postAdmin = new PostAdmin();
+        $commentAdmin = new CommentAdmin();
+        $commentVoteAdmin = new CommentVoteAdmin();
 
         $postAdmin->addChild($commentAdmin, 'post');
         $commentAdmin->addChild($commentVoteAdmin, 'comment');
@@ -2272,14 +2193,15 @@ final class AdminTest extends TestCase
         static::assertNull($commentVoteAdmin->getCurrentLeafChildAdmin());
     }
 
-    public function testAdminAvoidInifiniteLoop(): void
+    public function testAdminAvoidInfiniteLoop(): void
     {
         $this->expectNotToPerformAssertions();
 
         $registry = new FormRegistry([], new ResolvedFormTypeFactory());
         $formFactory = new FormFactory($registry);
 
-        $admin = new AvoidInfiniteLoopAdmin('code', \stdClass::class, 'controller');
+        $admin = new AvoidInfiniteLoopAdmin();
+        $admin->setModelClass(\stdClass::class);
         $admin->setSubject(new \stdClass());
 
         $admin->setFormContractor(new FormContractor($formFactory, $registry));
@@ -2311,11 +2233,8 @@ final class AdminTest extends TestCase
         $proxyQuery = $this->createStub(ProxyQueryInterface::class);
         $sourceIterator = $this->createStub(SourceIteratorInterface::class);
 
-        $admin = new PostAdmin(
-            'sonata.post.admin.post',
-            Post::class,
-            'Sonata\NewsBundle\Controller\PostAdminController'
-        );
+        $admin = new PostAdmin();
+        $admin->setModelClass(Post::class);
 
         $formFactory = new FormFactory(new FormRegistry([], new ResolvedFormTypeFactory()));
         $datagridBuilder = new DatagridBuilder($formFactory, $pager, $proxyQuery);

--- a/tests/Admin/BaseAdminModelManagerTest.php
+++ b/tests/Admin/BaseAdminModelManagerTest.php
@@ -29,7 +29,7 @@ final class BaseAdminModelManagerTest extends TestCase
         $modelManager->expects(static::once())->method('update');
         $modelManager->expects(static::once())->method('delete');
 
-        $admin = new BaseAdminModelManager_Admin('code', \stdClass::class, 'controller');
+        $admin = new BaseAdminModelManager_Admin();
         $admin->setModelManager($modelManager);
         $admin->setSecurityHandler($securityHandler);
 
@@ -53,7 +53,8 @@ final class BaseAdminModelManagerTest extends TestCase
             }
         });
 
-        $admin = new BaseAdminModelManager_Admin('code', \stdClass::class, 'controller');
+        $admin = new BaseAdminModelManager_Admin();
+        $admin->setModelClass(\stdClass::class);
         $admin->setModelManager($modelManager);
         $admin->getObject(10);
     }
@@ -68,7 +69,8 @@ final class BaseAdminModelManagerTest extends TestCase
             ->with(\stdClass::class)
             ->willReturn($query);
 
-        $admin = new BaseAdminModelManager_Admin('code', \stdClass::class, 'controller');
+        $admin = new BaseAdminModelManager_Admin();
+        $admin->setModelClass(\stdClass::class);
         $admin->setModelManager($modelManager);
         $admin->createQuery();
     }
@@ -81,7 +83,7 @@ final class BaseAdminModelManagerTest extends TestCase
             ->method('getNormalizedIdentifier')
             ->willReturn('42');
 
-        $admin = new BaseAdminModelManager_Admin('code', \stdClass::class, 'controller');
+        $admin = new BaseAdminModelManager_Admin();
         $admin->setModelManager($modelManager);
 
         $admin->id(new \stdClass());

--- a/tests/App/config/services.yml
+++ b/tests/App/config/services.yml
@@ -52,26 +52,21 @@ services:
         class: Sonata\AdminBundle\Tests\App\FieldDescription\FieldDescriptionFactory
 
     Sonata\AdminBundle\Tests\App\Admin\FooAdmin:
-        arguments: [~, Sonata\AdminBundle\Tests\App\Model\Foo, 'sonata.admin.controller.crud']
         tags:
-            - {name: sonata.admin, manager_type: test, label: Foo}
+            - {name: sonata.admin, model_class: Sonata\AdminBundle\Tests\App\Model\Foo, controller: 'sonata.admin.controller.crud', manager_type: test, label: Foo}
 
     Sonata\AdminBundle\Tests\App\Admin\FooAdminWithCustomController:
-        arguments: [~, Sonata\AdminBundle\Tests\App\Model\Foo, Sonata\AdminBundle\Tests\App\Controller\CustomCRUDController]
         tags:
-            - {name: sonata.admin, manager_type: test, label: Foo}
+            - {name: sonata.admin, model_class: Sonata\AdminBundle\Tests\App\Model\Foo, controller: Sonata\AdminBundle\Tests\App\Controller\CustomCRUDController, manager_type: test, label: Foo}
 
     Sonata\AdminBundle\Tests\App\Admin\AdminAsParameterAdmin:
-        arguments: [~, Sonata\AdminBundle\Tests\App\Model\Foo, ~]
         tags:
-            - {name: sonata.admin, manager_type: test}
+            - {name: sonata.admin, model_class: Sonata\AdminBundle\Tests\App\Model\Foo, manager_type: test}
 
     Sonata\AdminBundle\Tests\App\Admin\EmptyAdmin:
-        arguments: [~, Sonata\AdminBundle\Tests\App\Model\Foo, ~]
         tags:
-            - {name: sonata.admin, manager_type: test, label: Empty}
+            - {name: sonata.admin, model_class: Sonata\AdminBundle\Tests\App\Model\Foo, manager_type: test, label: Empty}
 
     Sonata\AdminBundle\Tests\App\Admin\TranslatedAdmin:
-        arguments: [~, Sonata\AdminBundle\Tests\App\Model\Translated, ~]
         tags:
-            - {name: sonata.admin, manager_type: test, group: 'group_label', label: 'admin_label'}
+            - {name: sonata.admin, model_class: Sonata\AdminBundle\Tests\App\Model\Translated, manager_type: test, group: 'group_label', label: 'admin_label'}

--- a/tests/ArgumentResolver/AdminValueResolverTest.php
+++ b/tests/ArgumentResolver/AdminValueResolverTest.php
@@ -19,7 +19,6 @@ use Sonata\AdminBundle\ArgumentResolver\AdminValueResolver;
 use Sonata\AdminBundle\Request\AdminFetcher;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\CommentAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Admin\PostAdmin;
-use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Post;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
@@ -38,7 +37,8 @@ final class AdminValueResolverTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->admin = new PostAdmin('sonata.admin.post', Post::class, '');
+        $this->admin = new PostAdmin();
+        $this->admin->setCode('sonata.admin.post');
 
         $container = new Container();
         $container->set('sonata.admin.post', $this->admin);

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -473,6 +473,8 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
     }
 
     /**
+     * NEXT_MAJOR: Remove this test.
+     *
      * @group legacy
      */
     public function testProcessAbstractAdminServiceInServiceDefinition(): void

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -550,10 +550,10 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
 
         $this->compile();
 
-        self::assertContainerBuilderHasServiceDefinitionWithArgument(
+        self::assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'sonata_without_controller',
-            2,
-            FooAdminController::class
+            'setBaseControllerName',
+            [FooAdminController::class]
         );
     }
 

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -416,8 +416,7 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
         $this->container
             ->register('sonata_report_one_admin')
             ->setClass(CustomAdmin::class)
-            ->setArguments(['', ReportOne::class, 'sonata.admin.controller.crud'])
-            ->addTag('sonata.admin', ['group' => 'sonata_report_group', 'manager_type' => 'orm', 'on_top' => true]);
+            ->addTag('sonata.admin', ['model_class' => ReportOne::class, 'controller' => 'sonata.admin.controller.crud', 'group' => 'sonata_report_group', 'manager_type' => 'orm', 'on_top' => true]);
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('You can\'t use "on_top" option with multiple same name groups.');
@@ -437,8 +436,7 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
         $this->container
             ->register('sonata_report_two_admin')
             ->setClass(CustomAdmin::class)
-            ->setArguments(['', ReportOne::class, 'sonata.admin.controller.crud'])
-            ->addTag('sonata.admin', ['group' => 'sonata_report_group', 'manager_type' => 'orm', 'on_top' => false]);
+            ->addTag('sonata.admin', ['model_class' => ReportOne::class, 'controller' => 'sonata.admin.controller.crud', 'group' => 'sonata_report_group', 'manager_type' => 'orm', 'on_top' => false]);
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('You can\'t use "on_top" option with multiple same name groups.');
@@ -461,13 +459,11 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
         $this->container
             ->register('sonata_document_one_admin')
             ->setClass(CustomAdmin::class)
-            ->setArguments(['', ReportOne::class, 'sonata.admin.controller.crud'])
-            ->addTag('sonata.admin', ['group' => 'sonata_document_group', 'manager_type' => 'orm', 'on_top' => false]);
+            ->addTag('sonata.admin', ['model_class' => ReportOne::class, 'controller' => 'sonata.admin.controller.crud', 'group' => 'sonata_document_group', 'manager_type' => 'orm', 'on_top' => false]);
         $this->container
             ->register('sonata_document_two_admin')
             ->setClass(CustomAdmin::class)
-            ->setArguments(['', ReportOne::class, 'sonata.admin.controller.crud'])
-            ->addTag('sonata.admin', ['group' => 'sonata_document_group', 'manager_type' => 'orm', 'on_top' => false]);
+            ->addTag('sonata.admin', ['model_class' => ReportOne::class, 'controller' => 'sonata.admin.controller.crud', 'group' => 'sonata_document_group', 'manager_type' => 'orm', 'on_top' => false]);
 
         try {
             $this->compile();
@@ -476,6 +472,9 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
         }
     }
 
+    /**
+     * @group legacy
+     */
     public function testProcessAbstractAdminServiceInServiceDefinition(): void
     {
         $this->setUpContainer();
@@ -545,8 +544,7 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
         $this->container
             ->register('sonata_without_controller')
             ->setClass(CustomAdmin::class)
-            ->setArguments(['', ReportTwo::class, ''])
-            ->addTag('sonata.admin', ['group' => 'sonata_report_two_group', 'manager_type' => 'orm']);
+            ->addTag('sonata.admin', ['model_class' => ReportTwo::class, 'group' => 'sonata_report_two_group', 'manager_type' => 'orm']);
 
         $this->extension->load([$config], $this->container);
 
@@ -566,8 +564,7 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
             ->register('sonata_post_admin_2')
             ->setClass(CustomAdmin::class)
             ->setPublic(true)
-            ->setArguments(['', PostEntity::class, 'sonata.admin.controller.crud'])
-            ->addTag('sonata.admin', ['default' => true, 'group' => 'sonata_group_one', 'manager_type' => 'orm']);
+            ->addTag('sonata.admin', ['model_class' => PostEntity::class, 'controller' => 'sonata.admin.controller.crud', 'default' => true, 'group' => 'sonata_group_one', 'manager_type' => 'orm']);
 
         $config = $this->config;
 
@@ -654,39 +651,33 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
             ->register('sonata_news_admin')
             ->setPublic(true)
             ->setClass(CustomAdmin::class)
-            ->setArguments(['', NewsEntity::class, 'sonata.admin.controller.crud'])
-            ->addTag('sonata.admin', ['group' => 'sonata_group_two', 'label' => '5 Entry', 'manager_type' => 'orm'])
+            ->addTag('sonata.admin', ['model_class' => NewsEntity::class, 'controller' => 'sonata.admin.controller.crud', 'group' => 'sonata_group_two', 'label' => '5 Entry', 'manager_type' => 'orm'])
             ->addMethodCall('setModelManager', [new Reference('my.model.manager')]);
         $this->container
             ->register('sonata_post_admin')
             ->setClass(CustomAdmin::class)
             ->setPublic(true)
-            ->setArguments(['', PostEntity::class, 'sonata.admin.controller.crud'])
-            ->addTag('sonata.admin', ['default' => true, 'group' => 'sonata_group_one', 'manager_type' => 'orm']);
+            ->addTag('sonata.admin', ['model_class' => PostEntity::class, 'controller' => 'sonata.admin.controller.crud', 'default' => true, 'group' => 'sonata_group_one', 'manager_type' => 'orm']);
         $this->container
             ->register('sonata_article_admin')
             ->setPublic(true)
             ->setClass(CustomAdmin::class)
-            ->setArguments(['', ArticleEntity::class, 'sonata.admin.controller.crud'])
-            ->addTag('sonata.admin', ['group' => 'sonata_group_one', 'label' => '1 Entry', 'manager_type' => 'doctrine_mongodb'])
+            ->addTag('sonata.admin', ['model_class' => ArticleEntity::class, 'controller' => 'sonata.admin.controller.crud', 'group' => 'sonata_group_one', 'label' => '1 Entry', 'manager_type' => 'doctrine_mongodb'])
             ->addMethodCall('setFormTheme', [['custom_form_theme.twig']])
             ->addMethodCall('setFilterTheme', [['custom_filter_theme.twig']]);
         $this->container
             ->register('sonata_report_admin')
             ->setPublic(true)
             ->setClass(CustomAdmin::class)
-            ->setArguments(['', Report::class, 'sonata.admin.controller.crud'])
-            ->addTag('sonata.admin', ['group' => 'sonata_report_group', 'manager_type' => 'orm', 'on_top' => true]);
+            ->addTag('sonata.admin', ['model_class' => Report::class, 'controller' => 'sonata.admin.controller.crud', 'group' => 'sonata_report_group', 'manager_type' => 'orm', 'on_top' => true]);
         $this->container
             ->register('sonata_report_one_admin')
             ->setClass(CustomAdmin::class)
-            ->setArguments(['', ReportOne::class, 'sonata.admin.controller.crud'])
-            ->addTag('sonata.admin', ['group' => 'sonata_report_one_group', 'manager_type' => 'orm', 'show_mosaic_button' => false]);
+            ->addTag('sonata.admin', ['model_class' => ReportOne::class, 'controller' => 'sonata.admin.controller.crud', 'group' => 'sonata_report_one_group', 'manager_type' => 'orm', 'show_mosaic_button' => false]);
         $this->container
             ->register('sonata_report_two_admin')
             ->setClass(CustomAdmin::class)
-            ->setArguments(['', ReportTwo::class, 'sonata.admin.controller.crud'])
-            ->addTag('sonata.admin', ['group' => 'sonata_report_two_group', 'manager_type' => 'orm', 'show_mosaic_button' => true]);
+            ->addTag('sonata.admin', ['model_class' => ReportTwo::class, 'controller' => 'sonata.admin.controller.crud', 'group' => 'sonata_report_two_group', 'manager_type' => 'orm', 'show_mosaic_button' => true]);
 
         // translator
         $this->container

--- a/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -409,20 +409,17 @@ final class ExtensionCompilerPassTest extends TestCase
             ->register('sonata_post_admin')
             ->setPublic(true)
             ->setClass(MockAdmin::class)
-            ->setArguments(['', Post::class, 'sonata.admin.controller.crud'])
-            ->addTag('sonata.admin');
+            ->addTag('sonata.admin', ['model_class' => Post::class]);
         $container
             ->register('sonata_news_admin')
             ->setPublic(true)
             ->setClass(MockAdmin::class)
-            ->setArguments(['', News::class, 'sonata.admin.controller.crud'])
-            ->addTag('sonata.admin');
+            ->addTag('sonata.admin', ['model_class' => News::class]);
         $container
             ->register('sonata_article_admin')
             ->setPublic(true)
             ->setClass(MockAdmin::class)
-            ->setArguments(['', Article::class, 'sonata.admin.controller.crud'])
-            ->addTag('sonata.admin');
+            ->addTag('sonata.admin', ['model_class' => Article::class]);
         $container
             ->register('event_dispatcher')
             ->setClass(EventDispatcher::class);

--- a/tests/Form/FormMapperTest.php
+++ b/tests/Form/FormMapperTest.php
@@ -62,7 +62,8 @@ final class FormMapperTest extends TestCase
         $formFactory->method('createNamedBuilder')->willReturn($formBuilder);
         $this->contractor->method('getFormBuilder')->willReturn($formBuilder2);
 
-        $this->admin = new CleanAdmin('code', \stdClass::class, 'controller');
+        $this->admin = new CleanAdmin();
+        $this->admin->setModelClass(\stdClass::class);
         $this->admin->setSubject(new \stdClass());
 
         $securityHandler = $this->createMock(SecurityHandlerInterface::class);

--- a/tests/Show/ShowMapperTest.php
+++ b/tests/Show/ShowMapperTest.php
@@ -529,7 +529,8 @@ final class ShowMapperTest extends TestCase
                 $list->add($fieldDescription);
             });
         $this->fieldDescriptionCollection = new FieldDescriptionCollection();
-        $this->admin = new CleanAdmin('code', \stdClass::class, 'controller');
+        $this->admin = new CleanAdmin();
+        $this->admin->setModelClass(\stdClass::class);
         $securityHandler = $this->createMock(SecurityHandlerInterface::class);
         $securityHandler
             ->method('isGranted')


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This would allow to use admin definition without passing argument in the constructor.
Instead the code/model_class/controller would be an attribute of the admin tag.

This allow CompilerPass to more easily access to some value like the code or the model_class.
This allow also to remove the __construct() method in the next major.

Currently both way is supported but passing those value in the constructor will be deprecated.

<!-- Describe your Pull Request content here -->
I am targeting this branch, because BC.

Closes #6723 .

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- `code`, `model_class` and `controller` attribute to the `sonata.admin` service tag

### Deprecated
- Passing the code, the model class and the controller name as first, second and third argument of the Admin constructor. Use the `sonata.admin` attributes instead.
```