### PR TITLE
Fix error on getNewInstance() when parent object property in uninitialised.

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -45,6 +45,8 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\PropertyAccess\Exception\AccessException;
+use Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface as RoutingUrlGeneratorInterface;
@@ -3953,7 +3955,16 @@ EOT;
                 $propertyAccessor = PropertyAccess::createPropertyAccessor();
                 $propertyPath = new PropertyPath($this->getParentAssociationMapping());
 
-                $value = $propertyAccessor->getValue($object, $propertyPath);
+                try {
+                    $value = $propertyAccessor->getValue($object, $propertyPath);
+                } catch (AccessException $e) {
+                    // @todo: Catching and checking AccessException here as BC for symfony/property-access < 5.1.
+                    //        Catch UninitializedPropertyException and remove the check when dropping support < 5.1
+                    if (!$e instanceof UninitializedPropertyException && AccessException::class !== \get_class($e)) {
+                        throw $e; // Re-throw. We only want to "ignore" pure AccessException (Sf < 5.1) and UninitializedPropertyException (Sf >= 5.1)
+                    }
+                    $value = null;
+                }
 
                 if (\is_array($value) || $value instanceof \ArrayAccess) {
                     $value[] = $parentObject;


### PR DESCRIPTION
## Subject

When creating a new object instance, the admin will check if there is a parent object that needs to be appended. The appendParentObject() method will check the current value of the property that holds the parent object. But if this property is typed and not yet initialised, Symfony's PropertyAccess will throw an AccessException. This fix catches that exception and continues as if the current value is `null`.

Note:
I'm catching `\Symfony\Component\PropertyAccess\Exception\AccessException`. The `\Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException` (child of `AccessException`) was introduced in Symfony 5.1 and thus not yet available in Symfony 4.4.


<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting the 3.x branch, because this is a bug.

Closes #7703.

## Changelog

```markdown
### Fixed
- Catch AccessException in AbstractAdmin::appendParentObject() to prevent an error when the property for the parent object is uninitialised.
```
