### PR TITLE
Apply tag calls before configuration calls

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -16,12 +16,6 @@
         </NullableReturnStatement>
     </file>
     <!-- https://github.com/vimeo/psalm/issues/4295 -->
-    <file src="src/Block/AdminSearchBlockService.php">
-        <InvalidScalarArgument occurrences="1">
-            <code>$exception-&gt;getCode()</code>
-        </InvalidScalarArgument>
-    </file>
-    <!-- https://github.com/vimeo/psalm/issues/4295 -->
     <file src="src/FieldDescription/BaseFieldDescription.php">
         <InvalidScalarArgument occurrences="1">
             <code>$exception-&gt;getCode()</code>

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1340,6 +1340,9 @@ class CRUDController extends AbstractController
         return $translator->trans($id, $parameters, $domain, $locale);
     }
 
+    /**
+     * @psalm-suppress PossiblyUndefinedMethod https://github.com/psalm/psalm-plugin-symfony/pull/243
+     */
     protected function handleXmlHttpRequestErrorResponse(Request $request, FormInterface $form): ?JsonResponse
     {
         if ([] === array_intersect(['application/json', '*/*'], $request->getAcceptableContentTypes())) {

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -31,7 +31,6 @@ use Sonata\AdminBundle\Util\AdminObjectAclData;
 use Sonata\AdminBundle\Util\AdminObjectAclManipulator;
 use Sonata\Exporter\Exporter;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormRenderer;
 use Symfony\Component\Form\FormView;
@@ -1349,7 +1348,6 @@ class CRUDController extends AbstractController
 
         $errors = [];
         foreach ($form->getErrors(true) as $error) {
-            \assert($error instanceof FormError);
             $errors[] = $error->getMessage();
         }
 

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -274,7 +274,7 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
      *
      * @param array<string, mixed> $attributes
      *
-     * @return array<array<string, array<mixed>>>
+     * @return array<array{string, array<mixed>}>
      */
     private function getDefaultMethodCalls(ContainerBuilder $container, string $serviceId, array $attributes = []): array
     {

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -100,6 +100,8 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
                     $definition->getMethodCalls()
                 ));
 
+                $this->fixTemplates($id, $container, $definition);
+
                 $arguments = null !== $parentDefinition ?
                     array_merge($parentDefinition->getArguments(), $definition->getArguments()) :
                     $definition->getArguments();
@@ -376,8 +378,6 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
             unset($listModes['mosaic']);
         }
         $methodCalls[] = ['setListModes', [$listModes]];
-
-        $this->fixTemplates($serviceId, $container, $definition);
 
         if ($container->hasParameter('sonata.admin.configuration.security.information') && !$definition->hasMethodCall('setSecurityInformation')) {
             $methodCalls[] = ['setSecurityInformation', ['%sonata.admin.configuration.security.information%']];

--- a/src/Form/DataTransformer/ArrayToModelTransformer.php
+++ b/src/Form/DataTransformer/ArrayToModelTransformer.php
@@ -75,6 +75,8 @@ final class ArrayToModelTransformer implements DataTransformerInterface
     }
 
     /**
+     * @psalm-suppress MethodSignatureMustProvideReturnType https://github.com/vimeo/psalm/issues/7518
+     *
      * @param object|null $value
      *
      * @return object|null

--- a/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
+++ b/src/Form/DataTransformer/ModelToIdPropertyTransformer.php
@@ -83,6 +83,8 @@ final class ModelToIdPropertyTransformer implements DataTransformerInterface
     }
 
     /**
+     * @psalm-suppress MethodSignatureMustProvideReturnType https://github.com/vimeo/psalm/issues/7518
+     *
      * @param int|string|array<int|string|array<string>>|null $value
      *
      * @throws \UnexpectedValueException

--- a/src/Form/DataTransformer/ModelsToArrayTransformer.php
+++ b/src/Form/DataTransformer/ModelsToArrayTransformer.php
@@ -82,6 +82,8 @@ final class ModelsToArrayTransformer implements DataTransformerInterface
     }
 
     /**
+     * @psalm-suppress MethodSignatureMustProvideReturnType https://github.com/vimeo/psalm/issues/7518
+     *
      * @param array<int|string>|null $value
      *
      * @throws UnexpectedTypeException

--- a/tests/App/Admin/BarAdmin.php
+++ b/tests/App/Admin/BarAdmin.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\App\Admin;
+
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Show\ShowMapper;
+use Sonata\AdminBundle\Tests\App\Model\Bar;
+
+/**
+ * @phpstan-extends AbstractAdmin<Bar>
+ */
+class BarAdmin extends AbstractAdmin
+{
+    protected function createNewInstance(): object
+    {
+        return new Bar('test_id');
+    }
+
+    protected function configureListFields(ListMapper $list): void
+    {
+        $list->add('id');
+    }
+
+    protected function configureFormFields(FormMapper $form): void
+    {
+    }
+
+    protected function configureShowFields(ShowMapper $show): void
+    {
+        $show->add('id');
+    }
+}

--- a/tests/App/Admin/FooAdmin.php
+++ b/tests/App/Admin/FooAdmin.php
@@ -24,7 +24,7 @@ use Sonata\AdminBundle\Tests\App\Model\Foo;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 /**
- * @phpstan-extends AbstractAdmin<object>
+ * @phpstan-extends AbstractAdmin<Foo>
  */
 class FooAdmin extends AbstractAdmin
 {

--- a/tests/App/Model/Bar.php
+++ b/tests/App/Model/Bar.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\App\Model;
+
+final class Bar implements EntityInterface
+{
+    /**
+     * @var string
+     */
+    private $id;
+
+    /**
+     * @var Foo|null
+     */
+    private $foo;
+
+    public function __construct(string $id, ?Foo $foo = null)
+    {
+        $this->id = $id;
+        $this->foo = $foo;
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function getFoo(): ?Foo
+    {
+        return $this->foo;
+    }
+}

--- a/tests/App/Model/BarRepository.php
+++ b/tests/App/Model/BarRepository.php
@@ -14,29 +14,31 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\App\Model;
 
 /**
- * @phpstan-implements RepositoryInterface<Foo>
+ * @phpstan-implements RepositoryInterface<Bar>
  */
-final class FooRepository implements RepositoryInterface
+final class BarRepository implements RepositoryInterface
 {
     /**
-     * @var Foo[]
+     * @var Bar[]
      */
     private $elements;
 
-    public function __construct()
+    public function __construct(FooRepository $fooRepository)
     {
+        $fooRepository->byId('test_id');
+
         $this->elements = [
-            'test_id' => new Foo('test_id', 'foo_name'),
+            'test_id' => new Bar('test_id', $fooRepository->byId('test_id')),
         ];
     }
 
-    public function byId(string $id): ?Foo
+    public function byId(string $id): ?Bar
     {
         return $this->elements[$id] ?? null;
     }
 
     /**
-     * @return Foo[]
+     * @return Bar[]
      */
     public function all(): array
     {

--- a/tests/App/Model/EntityInterface.php
+++ b/tests/App/Model/EntityInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\App\Model;
+
+interface EntityInterface
+{
+    public function getId(): string;
+}

--- a/tests/App/Model/Foo.php
+++ b/tests/App/Model/Foo.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\App\Model;
 
-final class Foo
+final class Foo implements EntityInterface
 {
     /**
      * @var string

--- a/tests/App/Model/ModelManager.php
+++ b/tests/App/Model/ModelManager.php
@@ -18,19 +18,22 @@ use Sonata\AdminBundle\Model\LockInterface;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 
 /**
- * Class ModelManager.
+ * @phpstan-template T of EntityInterface
  *
- * @phpstan-implements LockInterface<Foo>
- * @phpstan-implements ModelManagerInterface<Foo>
+ * @phpstan-implements LockInterface<T>
+ * @phpstan-implements ModelManagerInterface<T>
  */
 final class ModelManager implements ModelManagerInterface, LockInterface
 {
     /**
-     * @var FooRepository
+     * @var RepositoryInterface<T>
      */
     private $repository;
 
-    public function __construct(FooRepository $repository)
+    /**
+     * @param RepositoryInterface<T> $repository
+     */
+    public function __construct(RepositoryInterface $repository)
     {
         $this->repository = $repository;
     }
@@ -101,7 +104,7 @@ final class ModelManager implements ModelManagerInterface, LockInterface
     }
 
     /**
-     * @return Foo[]
+     * @return array<T>
      */
     public function executeQuery(object $query): array
     {

--- a/tests/App/Model/RepositoryInterface.php
+++ b/tests/App/Model/RepositoryInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\App\Model;
+
+/**
+ * @phpstan-template T of EntityInterface
+ */
+interface RepositoryInterface
+{
+    /**
+     * @return T|null
+     */
+    public function byId(string $id);
+
+    /**
+     * @return array<T>
+     */
+    public function all(): array;
+}

--- a/tests/App/config/services.yml
+++ b/tests/App/config/services.yml
@@ -18,6 +18,13 @@ services:
         tags:
             - {name: sonata.admin.manager}
 
+    sonata.admin.manager.bar:
+        class: Sonata\AdminBundle\Tests\App\Model\ModelManager
+        arguments:
+            - '@Sonata\AdminBundle\Tests\App\Model\BarRepository'
+        tags:
+            - {name: sonata.admin.manager}
+
     sonata.admin.builder.test_form:
         class: Sonata\AdminBundle\Tests\App\Builder\FormContractor
         arguments:
@@ -51,9 +58,12 @@ services:
     sonata.admin.field_description_factory.test:
         class: Sonata\AdminBundle\Tests\App\FieldDescription\FieldDescriptionFactory
 
-    Sonata\AdminBundle\Tests\App\Admin\FooAdmin:
+    sonata_foo_admin:
+        class: Sonata\AdminBundle\Tests\App\Admin\FooAdmin
         tags:
             - {name: sonata.admin, model_class: Sonata\AdminBundle\Tests\App\Model\Foo, controller: 'sonata.admin.controller.crud', manager_type: test, label: Foo}
+        calls:
+            - [addChild, ['@sonata_bar_admin', 'foo']]
 
     Sonata\AdminBundle\Tests\App\Admin\FooAdminWithCustomController:
         tags:
@@ -70,3 +80,8 @@ services:
     Sonata\AdminBundle\Tests\App\Admin\TranslatedAdmin:
         tags:
             - {name: sonata.admin, model_class: Sonata\AdminBundle\Tests\App\Model\Translated, manager_type: test, group: 'group_label', label: 'admin_label'}
+
+    sonata_bar_admin:
+        class: Sonata\AdminBundle\Tests\App\Admin\BarAdmin
+        tags:
+            - {name: sonata.admin, model_class: Sonata\AdminBundle\Tests\App\Model\Bar, manager_type: test, model_manager: sonata.admin.manager.bar, label: Bar}

--- a/tests/Fixtures/Bundle/Entity/Comment.php
+++ b/tests/Fixtures/Bundle/Entity/Comment.php
@@ -15,7 +15,7 @@ namespace Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity;
 
 final class Comment
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'this is a comment';
     }

--- a/tests/Fixtures/Entity/Foo.php
+++ b/tests/Fixtures/Entity/Foo.php
@@ -25,7 +25,7 @@ final class Foo
      */
     private $baz;
 
-    public function __toString()
+    public function __toString(): string
     {
         return (string) $this->bar;
     }

--- a/tests/Fixtures/Entity/FooArrayAccess.php
+++ b/tests/Fixtures/Entity/FooArrayAccess.php
@@ -23,7 +23,7 @@ final class FooArrayAccess implements \ArrayAccess
      */
     private $bar;
 
-    public function __toString()
+    public function __toString(): string
     {
         return (string) $this->bar;
     }

--- a/tests/Fixtures/Entity/FooToString.php
+++ b/tests/Fixtures/Entity/FooToString.php
@@ -15,7 +15,7 @@ namespace Sonata\AdminBundle\Tests\Fixtures\Entity;
 
 final class FooToString
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'salut';
     }

--- a/tests/Fixtures/Entity/FooToStringNull.php
+++ b/tests/Fixtures/Entity/FooToStringNull.php
@@ -15,9 +15,12 @@ namespace Sonata\AdminBundle\Tests\Fixtures\Entity;
 
 final class FooToStringNull
 {
-    // In case __toString returns an attribute not yet set
+    /**
+     * @psalm-suppress MethodSignatureMustProvideReturnType
+     */
     public function __toString()
     {
+        // In case __toString returns an attribute not yet set
         return null;
     }
 }

--- a/tests/Functional/Controller/CRUDControllerTest.php
+++ b/tests/Functional/Controller/CRUDControllerTest.php
@@ -97,6 +97,7 @@ final class CRUDControllerTest extends WebTestCase
             ['/admin/tests/app/foo-with-custom-controller/create'],
             ['/admin/tests/app/foo-with-custom-controller/test_id/show'],
             ['/admin/tests/app/foo-with-custom-controller/test_id/edit'],
+            ['/admin/tests/app/foo/test_id/bar/list'],
         ];
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because bugfix.

Trying to solve https://github.com/sonata-project/SonataAdminBundle/pull/7684#issuecomment-1025104809

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Configure the admin with the `sonata_admin` tag before any custom `call` provided in the service configuration.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
