### PR TITLE
Allow to have an other default list mode than list

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1757,11 +1757,12 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
 
     final public function getListMode(): string
     {
+        $defaultListMode = array_keys($this->getListModes())[0];
         if (!$this->hasRequest() || !$this->getRequest()->hasSession()) {
-            return 'list';
+            return $defaultListMode;
         }
 
-        return $this->getRequest()->getSession()->get(sprintf('%s.list_mode', $this->getCode()), 'list');
+        return $this->getRequest()->getSession()->get(sprintf('%s.list_mode', $this->getCode()), $defaultListMode);
     }
 
     final public function checkAccess(string $action, ?object $object = null): void

--- a/src/DependencyInjection/Admin/AbstractTaggedAdmin.php
+++ b/src/DependencyInjection/Admin/AbstractTaggedAdmin.php
@@ -84,7 +84,7 @@ abstract class AbstractTaggedAdmin implements TaggedAdminInterface
     private $label;
 
     /**
-     * @var array<string, array<string, mixed>>
+     * @var non-empty-array<string, array<string, mixed>>
      */
     private $listModes = TaggedAdminInterface::DEFAULT_LIST_MODES;
 

--- a/src/DependencyInjection/Admin/TaggedAdminInterface.php
+++ b/src/DependencyInjection/Admin/TaggedAdminInterface.php
@@ -49,8 +49,16 @@ interface TaggedAdminInterface extends MutableTemplateRegistryAwareInterface
     public const ADMIN_TAG = 'sonata.admin';
 
     public const DEFAULT_LIST_MODES = [
-        'list' => ['class' => 'fas fa-list fa-fw'],
-        'mosaic' => ['class' => 'fas fa-th-large fa-fw'],
+        'list' => [
+            'icon' => '<i class="fas fa-list fa-fw" aria-hidden="true"></i>',
+            // NEXT_MAJOR: Remove the class part.
+            'class' => 'fas fa-list fa-fw',
+        ],
+        'mosaic' => [
+            'icon' => '<i class="fas fa-th-large fa-fw" aria-hidden="true"></i>',
+            // NEXT_MAJOR: Remove the class part.
+            'class' => 'fas fa-th-large fa-fw',
+        ],
     ];
 
     /**
@@ -63,12 +71,12 @@ interface TaggedAdminInterface extends MutableTemplateRegistryAwareInterface
     public function getLabel(): ?string;
 
     /**
-     * @param array<string, array<string, mixed>> $listModes
+     * @param non-empty-array<string, array<string, mixed>> $listModes
      */
     public function setListModes(array $listModes): void;
 
     /**
-     * @return array<string, array<string, mixed>>
+     * @return non-empty-array<string, array<string, mixed>>
      */
     public function getListModes(): array;
 

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -368,8 +368,7 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
             $methodCalls[] = ['setFilterPersister', [new Reference($filtersPersister)]];
         }
 
-        $showMosaicButton = $overwriteAdminConfiguration['show_mosaic_button']
-            ?? $attributes['show_mosaic_button']
+        $showMosaicButton = $attributes['show_mosaic_button']
             ?? $container->getParameter('sonata.admin.configuration.show.mosaic.button');
         \assert(\is_bool($showMosaicButton));
 

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -80,7 +80,9 @@ file that was distributed with this source code.
 
                                             {% apply spaceless %}
                                                 <th class="sonata-ba-list-field-header-{{ field_description.type }}{% if sortable %} sonata-ba-list-field-header-order-{{ sort_by|lower }} {{ sort_active_class }}{% endif %}{% if field_description.option('header_class') %} {{ field_description.option('header_class') }}{% endif %}"{% if field_description.option('header_style') %} style="{{ field_description.option('header_style') }}"{% endif %}>
-                                                    {% if sortable %}<a href="{{ admin.generateUrl(action|default('list'), sort_parameters|merge({_list_mode: admin.getListMode()})) }}">{% endif %}
+                                                    {% if sortable %}
+                                                        <a href="{{ admin.generateUrl(action|'list', sort_parameters|merge({_list_mode: admin.getListMode()})) }}">
+                                                    {% endif %}
                                                     {% if field_description.getOption('label_icon') %}
                                                         <span class="sonata-ba-list-field-header-label-icon">
                                                             {{ field_description.getOption('label_icon')|parse_icon }}

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -81,7 +81,7 @@ file that was distributed with this source code.
                                             {% apply spaceless %}
                                                 <th class="sonata-ba-list-field-header-{{ field_description.type }}{% if sortable %} sonata-ba-list-field-header-order-{{ sort_by|lower }} {{ sort_active_class }}{% endif %}{% if field_description.option('header_class') %} {{ field_description.option('header_class') }}{% endif %}"{% if field_description.option('header_style') %} style="{{ field_description.option('header_style') }}"{% endif %}>
                                                     {% if sortable %}
-                                                        <a href="{{ admin.generateUrl(action|'list', sort_parameters|merge({_list_mode: admin.getListMode()})) }}">
+                                                        <a href="{{ admin.generateUrl(action|default('list'), sort_parameters|merge({_list_mode: admin.getListMode()})) }}">
                                                     {% endif %}
                                                     {% if field_description.getOption('label_icon') %}
                                                         <span class="sonata-ba-list-field-header-label-icon">

--- a/src/Resources/views/ajax_layout.html.twig
+++ b/src/Resources/views/ajax_layout.html.twig
@@ -28,7 +28,15 @@ file that was distributed with this source code.
                         {% if admin is defined and action is defined and action == 'list' and admin.listModes|length > 1 %}
                             <div class="nav navbar-right btn-group">
                                 {% for mode, settings in admin.listModes %}
-                                    <a href="{{ admin.generateUrl('list', app.request.query.all|merge({_list_mode: mode})) }}" class="btn btn-default navbar-btn btn-sm{% if admin.getListMode() == mode %} active{% endif %}"><i class="{{ settings.class }}"></i></a>
+                                    <a href="{{ admin.generateUrl('list', app.request.query.all|merge({_list_mode: mode})) }}" class="btn btn-default navbar-btn btn-sm{% if admin.getListMode() == mode %} active{% endif %}">
+                                        {# NEXT_MAJOR: Remove the if and keep the else part #}
+                                        {% if settings.icon is not defined and settings.class is defined %}
+                                            {% deprecated 'Relying on the "class" setting is deprecated since sonata-project/admin-bundle 4.x, use the "icon" setting instead' %}
+                                            <i class="{{ settings.class }}" aria-hidden="true"></i>
+                                        {% else %}
+                                            {{ settings.icon|default('')|parse_icon }}
+                                        {% endif %}
+                                    </a>
                                 {% endfor %}
                             </div>
                         {% endif %}

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -257,7 +257,15 @@ file that was distributed with this source code.
                                                 {% if admin is defined and action is defined and action == 'list' and admin.listModes|length > 1 %}
                                                     <div class="nav navbar-right btn-group">
                                                         {% for mode, settings in admin.listModes %}
-                                                            <a href="{{ admin.generateUrl('list', app.request.query.all|merge({_list_mode: mode})) }}" class="btn btn-default navbar-btn btn-sm{% if admin.getListMode() == mode %} active{% endif %}"><i class="{{ settings.class }}"></i></a>
+                                                            <a href="{{ admin.generateUrl('list', app.request.query.all|merge({_list_mode: mode})) }}" class="btn btn-default navbar-btn btn-sm{% if admin.getListMode() == mode %} active{% endif %}">
+                                                                {# NEXT_MAJOR: Remove the if and keep the else part #}
+                                                                {% if settings.icon is not defined and settings.class is defined %}
+                                                                    {% deprecated 'Relying on the "class" setting is deprecated since sonata-project/admin-bundle 4.x, use the "icon" setting instead' %}
+                                                                    <i class="{{ settings.class }}" aria-hidden="true"></i>
+                                                                {% else %}
+                                                                    {{ settings.icon|default('')|parse_icon }}
+                                                                {% endif %}
+                                                            </a>
                                                         {% endfor %}
                                                     </div>
                                                 {% endif %}

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1984,6 +1984,53 @@ final class AdminTest extends TestCase
     }
 
     /**
+     * @dataProvider getListModeProvider2
+     */
+    public function testGetListModeWithCustomListModes(string $expected, ?Request $request = null): void
+    {
+        $admin = new PostAdmin();
+        $admin->setListModes([
+            'mosaic' => ['icon' => '<i class="fas fa-th-large fa-fw" aria-hidden="true"></i>'],
+            'list' => ['icon' => '<i class="fas fa-list fa-fw" aria-hidden="true"></i>'],
+        ]);
+        $admin->setCode('sonata.post.admin.post');
+
+        if (null !== $request) {
+            $admin->setRequest($request);
+        }
+
+        static::assertSame($expected, $admin->getListMode());
+    }
+
+    /**
+     * @phpstan-return iterable<array-key, array{string, Request|null}>
+     */
+    public function getListModeProvider2(): iterable
+    {
+        yield ['mosaic', null];
+
+        yield ['mosaic', new Request()];
+
+        $request = new Request();
+        $session = $this->createMock(SessionInterface::class);
+        $session
+            ->method('get')
+            ->with('sonata.post.admin.post.list_mode', 'mosaic')
+            ->willReturn('list');
+        $request->setSession($session);
+        yield ['list', $request];
+
+        $session = $this->createMock(SessionInterface::class);
+        $session
+            ->method('get')
+            ->with('sonata.post.admin.post.list_mode', 'mosaic')
+            ->willReturn('some_list_mode');
+        $request = new Request();
+        $request->setSession($session);
+        yield ['some_list_mode', $request];
+    }
+
+    /**
      * @param class-string $objFqn
      *
      * @covers \Sonata\AdminBundle\Admin\AbstractAdmin::getDashboardActions

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -338,7 +338,11 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
         self::assertContainerBuilderHasServiceDefinitionWithMethodCall(
             'sonata_report_one_admin',
             'setListModes',
-            [['list' => ['class' => 'fas fa-list fa-fw']]]
+            [['list' => [
+                'icon' => '<i class="fas fa-list fa-fw" aria-hidden="true"></i>',
+                // NEXT_MAJOR: Remove the class part.
+                'class' => 'fas fa-list fa-fw',
+            ]]]
         );
 
         self::assertContainerBuilderHasServiceDefinitionWithMethodCall(


### PR DESCRIPTION
## Subject

Closes #7700.

The solution I proposed in https://github.com/sonata-project/SonataAdminBundle/issues/7700#issuecomment-1008331437 since over-complicated. We should just stop hard-coded `list` as the default list mode and instead return the first value configured (which is currently `list`). If someone wants to have the mosaic as default, he just need to call setListModes with another order of list modes. This also change the order of the button, but I don't think it's a big issue (Always having the first button being the default value seems natural to me).

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- The default list mode is now the first one of the `getListModes` method.

### Deprecated
- Defining a list mode with a "class" setting, use the "icon" setting instead.
```