### PR TITLE
Use twig to render forms

### DIFF
--- a/src/Resources/views/CRUD/base_acl_macro.html.twig
+++ b/src/Resources/views/CRUD/base_acl_macro.html.twig
@@ -10,13 +10,17 @@ file that was distributed with this source code.
 #}
 
 {% macro render_form(form, permissions, td_type, admin, admin_configuration, object) %}
-    <form class="form-horizontal"
-          action="{{ admin.generateUrl('acl', {(admin.idParameter): admin.id(object), 'uniqid': admin.uniqid, 'subclass': app.request.get('subclass')}) }}"
-          {% if form.vars.multipart %} enctype="multipart/form-data"{% endif %}
-          method="POST"
-            {% if not admin_configuration.getOption('html5_validate') %}novalidate="novalidate"{% endif %}
-            >
+    {%- set form_attr = {role: 'form'} -%}
+    {# NEXT_MAJOR: Move logic to the controller #}
+    {%- if not sonata_config.getOption('html5_validate') -%}
+        {%- set form_attr = form_attr|merge({novalidate: 'novalidate'}) -%}
+    {%- endif -%}
 
+    {{ form_start(form, {
+        method: 'POST',
+        action: admin.generateUrl('acl', {(admin.idParameter): admin.id(object), 'uniqid': admin.uniqid, 'subclass': app.request.get('subclass')}),
+        attr:   form_attr
+    }) }}
         {{ include('@SonataAdmin/Helper/render_form_dismissable_errors.html.twig') }}
 
         <div class="box box-success">
@@ -59,5 +63,5 @@ file that was distributed with this source code.
         <div class="well well-small form-actions">
             <input class="btn btn-primary" type="submit" name="btn_create_and_edit" value="{{ 'btn_update_acl'|trans({}, 'SonataAdminBundle') }}">
         </div>
-    </form>
+    {{ form_end(form) }}
 {% endmacro %}

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -8,16 +8,17 @@
             {{ "form_not_available"|trans({}, "SonataAdminBundle") }}
         </div>
     {% else %}
-        <form
-              {% if sonata_config.getOption('form_type') == 'horizontal' %}class="form-horizontal"{% endif %}
-              role="form"
-              action="{% block sonata_form_action_url %}{{ admin.generateUrl(url, {(admin.idParameter): objectId, 'uniqid': admin.uniqid, 'subclass': app.request.get('subclass')}) }}{% endblock %}"
-              {% if form.vars.multipart %} enctype="multipart/form-data"{% endif %}
-              method="POST"
-              {% if not sonata_config.getOption('html5_validate') %}novalidate="novalidate"{% endif %}
-              {% block sonata_form_attributes %}{% endblock %}
-              >
+        {%- set form_attr = {role: 'form'} -%}
+        {# NEXT_MAJOR: Move logic to the controller #}
+        {%- if not sonata_config.getOption('html5_validate') -%}
+            {%- set form_attr = form_attr|merge({novalidate: 'novalidate'}) -%}
+        {%- endif -%}
 
+        {{ form_start(form, {
+            method: 'POST',
+            action: admin.generateUrl(url, {(admin.idParameter): objectId, 'uniqid': admin.uniqid, 'subclass': app.request.get('subclass')}),
+            attr:   form_attr
+        }) }}
             {{ include('@SonataAdmin/Helper/render_form_dismissable_errors.html.twig') }}
 
             {% block sonata_pre_fieldsets %}
@@ -153,7 +154,7 @@
                 {% endblock %}
                 </div>
             {% endblock formactions %}
-        </form>
+        {{ form_end(form) }}
     {% endif %}
 
     {{ sonata_block_render_event('sonata.admin.edit.form.bottom', { 'admin': admin, 'object': object }) }}

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -37,7 +37,10 @@ file that was distributed with this source code.
     <div class="col-xs-12 col-md-12">
         {% set batchactions = admin.batchactions %}
         {% if admin.hasRoute('batch') and batchactions|length %}
-            <form action="{{ admin.generateUrl('batch', {'filter': admin.filterParameters}) }}" method="POST" >
+            {{ form_start(form, {
+                method: 'POST',
+                action: admin.generateUrl('batch', {'filter': admin.filterParameters})
+            }) }}
             <input type="hidden" name="_sonata_csrf_token" value="{{ csrf_token }}">
         {% endif %}
 
@@ -250,7 +253,7 @@ file that was distributed with this source code.
             {% endblock %}
         </div>
         {% if admin.hasRoute('batch') and batchactions|length %}
-            </form>
+            {{ form_end(form) }}
         {% endif %}
     </div>
 {% endblock %}
@@ -297,13 +300,15 @@ file that was distributed with this source code.
         <div class="col-xs-12 col-md-12 sonata-filters-box" style="display: {{ admin.datagrid.hasDisplayableFilters ? 'block' : 'none' }}" id="filter-container-{{ admin.uniqid() }}">
             <div class="box box-primary" >
                 <div class="box-body">
-                    <form
-                        class="sonata-filter-form form-horizontal {{ admin.isChild and 1 == admin.datagrid.filters|length ? 'hide' : '' }}"
-                        action="{{ admin.generateUrl(action|default('list')) }}"
-                        method="GET"
-                        role="form"
-                        data-default-values="{{ admin.defaultFilterParameters|json_encode }}"
-                    >
+                    {{ form_start(form, {
+                        method: 'GET',
+                        action: admin.generateUrl('list'),
+                        attr: {
+                            class: 'sonata-filter-form form-horizontal' ~ (admin.isChild and 1 == admin.datagrid.filters|length ? 'hide' : ''),
+                            role: 'form',
+                            'data-default-values': admin.defaultFilterParameters|json_encode
+                        }
+                    }) }}
                         {{ form_errors(form) }}
 
                         <div class="row">
@@ -378,7 +383,7 @@ file that was distributed with this source code.
                         {% for paramKey, paramValue in admin.persistentParameters %}
                             <input type="hidden" name="{{ paramKey }}" value="{{ paramValue }}">
                         {% endfor %}
-                    </form>
+                    {{ form_end(form) }}
                 </div>
             </div>
         </div>

--- a/src/Resources/views/CRUD/batch_confirmation.html.twig
+++ b/src/Resources/views/CRUD/batch_confirmation.html.twig
@@ -45,7 +45,10 @@ file that was distributed with this source code.
                 {% endif %}
             </div>
             <div class="box-footer clearfix">
-                <form action="{{ admin.generateUrl('batch', {'filter': admin.filterParameters}) }}" method="POST">
+                {{ form_start(form, {
+                    method: 'POST',
+                    action: admin.generateUrl('batch', {'filter': admin.filterParameters})
+                }) }}
                     <input type="hidden" name="confirmation" value="ok">
                     <input type="hidden" name="data" value="{{ data|json_encode }}">
                     <input type="hidden" name="_sonata_csrf_token" value="{{ csrf_token }}">
@@ -63,7 +66,7 @@ file that was distributed with this source code.
                             <i class="fas fa-list" aria-hidden="true"></i> {{ 'link_action_list'|trans({}, 'SonataAdminBundle') }}
                         </a>
                     {% endif %}
-                </form>
+                {{ form_end(form) }}
             </div>
         </div>
     </div>

--- a/src/Resources/views/CRUD/batch_confirmation.html.twig
+++ b/src/Resources/views/CRUD/batch_confirmation.html.twig
@@ -22,6 +22,12 @@ file that was distributed with this source code.
     }, 'twig') }}
 {%- endblock -%}
 
+{% form_theme form with ['form_div_layout.html.twig', _self] only %}
+
+{% block form_row %}
+    {{- form_widget(form, {attr: {style: 'display:none;'}}) -}}
+{% endblock %}
+
 {% block content %}
     <div class="sonata-ba-delete">
         <div class="box box-danger">
@@ -44,9 +50,7 @@ file that was distributed with this source code.
                     <input type="hidden" name="data" value="{{ data|json_encode }}">
                     <input type="hidden" name="_sonata_csrf_token" value="{{ csrf_token }}">
 
-                    <div style="display: none">
-                        {{ form_rest(form) }}
-                    </div>
+                    {{ form_rest(form) }}
 
                     <button type="submit" class="btn btn-danger">
                         {{ 'btn_execute_batch_action'|trans({}, 'SonataAdminBundle') }}

--- a/src/Resources/views/CRUD/delete.html.twig
+++ b/src/Resources/views/CRUD/delete.html.twig
@@ -33,7 +33,10 @@ file that was distributed with this source code.
                 {{ 'message_delete_confirmation'|trans({'%object%': admin.toString(object)}, 'SonataAdminBundle') }}
             </div>
             <div class="box-footer clearfix">
-                <form method="POST" action="{{ admin.generateObjectUrl('delete', object) }}">
+                {{ form_start(form, {
+                    method: 'POST',
+                    action: admin.generateObjectUrl('delete', object)
+                }) }}
                     <input type="hidden" name="_method" value="DELETE">
                     <input type="hidden" name="_sonata_csrf_token" value="{{ csrf_token }}">
 
@@ -45,7 +48,7 @@ file that was distributed with this source code.
                             <i class="fas fa-pencil-alt" aria-hidden="true"></i>
                             {{ 'link_action_edit'|trans({}, 'SonataAdminBundle') }}</a>
                     {% endif %}
-                </form>
+                {{ form_end(form) }}
             </div>
         </div>
     </div>

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -198,6 +198,7 @@ file that was distributed with this source code.
                         {% block sonata_side_nav %}
                             {% block sonata_sidebar_search %}
                                 {% if sonata_config.getOption('search') %}
+                                    {# NEXT_MAJOR: Replace form with symfony form #}
                                     <form action="{{ path('sonata_admin_search') }}" method="GET" class="sidebar-form" role="search">
                                         <div class="input-group custom-search-form">
                                             <input type="text" name="q" value="{{ app.request.get('q') }}" class="form-control" placeholder="{{ 'search_placeholder'|trans({}, 'SonataAdminBundle') }}">


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Use twig to render all forms, this way we can respect the form themes.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #4050, #4069

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Use twig to render forms
- Do not render hidden labels on confirmation page
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
