### PR TITLE
Use dynamic action variable to template

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1340,9 +1340,6 @@ class CRUDController extends AbstractController
         return $translator->trans($id, $parameters, $domain, $locale);
     }
 
-    /**
-     * @psalm-suppress PossiblyUndefinedMethod https://github.com/psalm/psalm-plugin-symfony/pull/243
-     */
     protected function handleXmlHttpRequestErrorResponse(Request $request, FormInterface $form): ?JsonResponse
     {
         if ([] === array_intersect(['application/json', '*/*'], $request->getAcceptableContentTypes())) {

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -80,7 +80,7 @@ file that was distributed with this source code.
 
                                             {% apply spaceless %}
                                                 <th class="sonata-ba-list-field-header-{{ field_description.type }}{% if sortable %} sonata-ba-list-field-header-order-{{ sort_by|lower }} {{ sort_active_class }}{% endif %}{% if field_description.option('header_class') %} {{ field_description.option('header_class') }}{% endif %}"{% if field_description.option('header_style') %} style="{{ field_description.option('header_style') }}"{% endif %}>
-                                                    {% if sortable %}<a href="{{ admin.generateUrl('list', sort_parameters|merge({_list_mode: admin.getListMode()})) }}">{% endif %}
+                                                    {% if sortable %}<a href="{{ admin.generateUrl(action|default('list'), sort_parameters|merge({_list_mode: admin.getListMode()})) }}">{% endif %}
                                                     {% if field_description.getOption('label_icon') %}
                                                         <span class="sonata-ba-list-field-header-label-icon">
                                                             {{ field_description.getOption('label_icon')|parse_icon }}
@@ -125,7 +125,7 @@ file that was distributed with this source code.
                                     <ul class="list-inline">
                                         {%- if admin.datagrid.pager.countResults() > 0 -%}
                                             <li>
-                                                <a href="{{ admin.generateUrl('list', admin.datagrid.getPaginationParameters(1)) }}">
+                                                <a href="{{ admin.generateUrl(action|default('list'), admin.datagrid.getPaginationParameters(1)) }}">
                                                     {{- 'go_to_the_first_page'|trans({}, 'SonataAdminBundle') -}}
                                                 </a>
                                             </li>
@@ -297,7 +297,7 @@ file that was distributed with this source code.
                 <div class="box-body">
                     <form
                         class="sonata-filter-form form-horizontal {{ admin.isChild and 1 == admin.datagrid.filters|length ? 'hide' : '' }}"
-                        action="{{ admin.generateUrl('list') }}"
+                        action="{{ admin.generateUrl(action|default('list')) }}"
                         method="GET"
                         role="form"
                         data-default-values="{{ admin.defaultFilterParameters|json_encode }}"
@@ -357,7 +357,7 @@ file that was distributed with this source code.
                                         <i class="fas fa-filter" aria-hidden="true"></i> {{ 'btn_filter'|trans({}, 'SonataAdminBundle') }}
                                     </button>
 
-                                    <a class="btn btn-default" href="{{ admin.generateUrl('list', {filters: 'reset'}) }}">
+                                    <a class="btn btn-default" href="{{ admin.generateUrl(action|default('list'), {filters: 'reset'}) }}">
                                         {{ 'link_reset_filter'|trans({}, 'SonataAdminBundle') }}
                                     </a>
                                 </div>

--- a/src/Resources/views/CRUD/list__select.html.twig
+++ b/src/Resources/views/CRUD/list__select.html.twig
@@ -12,7 +12,7 @@ file that was distributed with this source code.
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
-    <a class="btn btn-primary" href="{{ admin.generateUrl('list') }}">
+    <a class="btn btn-primary" href="{{ admin.generateUrl(action|default('list')) }}">
         <i class="fas fa-check" aria-hidden="true"></i>
         {{ 'list_select'|trans({}, 'SonataAdminBundle') }}
     </a>

--- a/src/Resources/views/CRUD/tree.html.twig
+++ b/src/Resources/views/CRUD/tree.html.twig
@@ -9,10 +9,8 @@ file that was distributed with this source code.
 
 #}
 
-{#
-    This template is not used at all, it is just a template that you can use to create
-    your own custom tree view.
-#}
+{% deprecated 'The "tree.html.twig" template is deprecated since sonata-project/admin-bundle version 4.x and will be removed in 5.0.' %}
+
 {% extends '@SonataAdmin/CRUD/base_list.html.twig' %}
 
 {% import _self as tree %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Allow reusing the templates with different actions. The `action` should be set inside the `CRUDController`.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this feature is BC.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Use dynamic action variable to template

### Deprecated
- `tree.html.twig` template
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
