### PR TITLE
Stop using deprecated SourceIteratorInterface

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,6 @@ jobs:
         strategy:
             matrix:
                 php-version:
-                    - '7.3'
                     - '7.4'
                     - '8.0'
                     - '8.1'
@@ -37,7 +36,7 @@ jobs:
                 symfony-require: ['']
                 variant: [normal]
                 include:
-                    - php-version: '7.3'
+                    - php-version: '7.4'
                       dependencies: lowest
                       allowed-to-fail: false
                       variant: normal

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "homepage": "https://docs.sonata-project.org/projects/SonataAdminBundle",
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "doctrine/collections": "^1.6",
         "doctrine/common": "^3.0",
@@ -36,7 +36,7 @@
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "sonata-project/block-bundle": "^4.7",
         "sonata-project/doctrine-extensions": "^1.8",
-        "sonata-project/exporter": "^2.1",
+        "sonata-project/exporter": "^2.11",
         "sonata-project/form-extensions": "^1.7.1",
         "sonata-project/twig-extensions": "^1.4.1",
         "symfony/asset": "^4.4 || ^5.3 || ^6.0",

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -35,7 +35,6 @@ use Sonata\AdminBundle\Security\Handler\AclSecurityHandlerInterface;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\AdminBundle\Util\Instantiator;
 use Sonata\AdminBundle\Util\ParametersManipulator;
-use Sonata\Exporter\Source\SourceIteratorInterface;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
@@ -370,7 +369,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $fields;
     }
 
-    final public function getDataSourceIterator(): SourceIteratorInterface
+    final public function getDataSourceIterator(): \Iterator
     {
         $datagrid = $this->getDatagrid();
         $datagrid->buildPager();

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -21,7 +21,6 @@ use Sonata\AdminBundle\FieldDescription\FieldDescriptionCollection;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionRegistryInterface;
 use Sonata\AdminBundle\Object\MetadataInterface;
-use Sonata\Exporter\Source\SourceIteratorInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -247,7 +246,10 @@ interface AdminInterface extends TaggedAdminInterface, AccessRegistryInterface, 
      */
     public function getExportFields(): array;
 
-    public function getDataSourceIterator(): SourceIteratorInterface;
+    /**
+     * @return \Iterator<array<mixed>>
+     */
+    public function getDataSourceIterator(): \Iterator;
 
     /**
      * Call before the batch action, allow you to alter the query and the idx.

--- a/src/Exporter/DataSourceInterface.php
+++ b/src/Exporter/DataSourceInterface.php
@@ -14,12 +14,13 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Exporter;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
-use Sonata\Exporter\Source\SourceIteratorInterface;
 
 interface DataSourceInterface
 {
     /**
      * @param string[] $fields
+     *
+     * @return \Iterator<array<mixed>>
      */
-    public function createIterator(ProxyQueryInterface $query, array $fields): SourceIteratorInterface;
+    public function createIterator(ProxyQueryInterface $query, array $fields): \Iterator;
 }

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -74,7 +74,6 @@ use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
 use Sonata\AdminBundle\Translator\NoopLabelTranslatorStrategy;
 use Sonata\AdminBundle\Translator\UnderscoreLabelTranslatorStrategy;
 use Sonata\Doctrine\Adapter\AdapterInterface;
-use Sonata\Exporter\Source\SourceIteratorInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Form\FormFactory;
@@ -2231,7 +2230,7 @@ final class AdminTest extends TestCase
         $modelManager = $this->createMock(ModelManagerInterface::class);
         $dataSource = $this->createMock(DataSourceInterface::class);
         $proxyQuery = $this->createStub(ProxyQueryInterface::class);
-        $sourceIterator = $this->createStub(SourceIteratorInterface::class);
+        $sourceIterator = $this->createStub(\Iterator::class);
 
         $admin = new PostAdmin();
         $admin->setModelClass(Post::class);

--- a/tests/App/Exporter/DataSource.php
+++ b/tests/App/Exporter/DataSource.php
@@ -16,11 +16,10 @@ namespace Sonata\AdminBundle\Tests\App\Exporter;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Exporter\DataSourceInterface;
 use Sonata\Exporter\Source\ArraySourceIterator;
-use Sonata\Exporter\Source\SourceIteratorInterface;
 
 final class DataSource implements DataSourceInterface
 {
-    public function createIterator(ProxyQueryInterface $query, array $fields): SourceIteratorInterface
+    public function createIterator(ProxyQueryInterface $query, array $fields): \Iterator
     {
         return new ArraySourceIterator([]);
     }

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -38,7 +38,6 @@ use Sonata\AdminBundle\Tests\Fixtures\Entity\Entity;
 use Sonata\AdminBundle\Tests\Fixtures\Util\DummyDomainObject;
 use Sonata\AdminBundle\Util\AdminObjectAclManipulator;
 use Sonata\Exporter\Exporter;
-use Sonata\Exporter\Source\SourceIteratorInterface;
 use Sonata\Exporter\Writer\JsonWriter;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -2575,7 +2574,7 @@ final class CRUDControllerTest extends TestCase
             ->method('getClass')
             ->willReturn(\stdClass::class);
 
-        $dataSourceIterator = $this->createMock(SourceIteratorInterface::class);
+        $dataSourceIterator = $this->createMock(\Iterator::class);
 
         $this->admin->expects(static::once())
             ->method('getDataSourceIterator')


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because this should be BC since php 7.3 is dropped.

## Changelog

```markdown
### Changed
- Some typehint from SourceIteratorInterface to \Iterator to allow using this library without deprecation
```