### PR TITLE
Remove isNew occurence in the doc

### DIFF
--- a/docs/cookbook/recipe_dynamic_form_modification.rst
+++ b/docs/cookbook/recipe_dynamic_form_modification.rst
@@ -36,7 +36,8 @@ Then, you should be able to dynamically add needed fields to the form::
 
             $subject = $this->getSubject();
 
-            if ($this->isNew()) {
+            // If you're using auto-generated identifiers
+            if ($subject->getId() === null) {
                 // The thumbnail field will only be added when the edited item is created
                 $form->add('thumbnail', FileType::class);
             }


### PR DESCRIPTION
The `$this->isNew` method let think the AbstractAdmin has a isNew method.
Let's just give the id check instead, which is a check I often saw in project on sonata.