### PR TITLE
Remove modelClass and Controller from services configuration of admins

### DIFF
--- a/docs/getting_started/creating_an_admin.rst
+++ b/docs/getting_started/creating_an_admin.rst
@@ -178,6 +178,22 @@ service and tag it with the ``sonata.admin`` tag:
                 tags:
                     - { name: sonata.admin, model_class: App\Entity\Category, manager_type: orm, label: Category }
 
++---------------------------------------+-----------------------------------------------------------------------------------------+
+| Tag option                            | Description                                                                             |
++=======================================+=========================================================================================+
+| name                                  | Service tag's name                                                                      |
++---------------------------------------+-----------------------------------------------------------------------------------------+
+| model_class                           | The entity class e.g: ``App\Entity\Category``                                           |
++---------------------------------------+-----------------------------------------------------------------------------------------+
+| manager_type                          | Manager type (``orm``, ``odm``)                                                         |
++---------------------------------------+-----------------------------------------------------------------------------------------+
+| label                                 | Label, e.g Category                                                                     |
++---------------------------------------+-----------------------------------------------------------------------------------------+
+| group (``optional``)                  | The admins group, it will be used to group in menu on the left side, e.g ``Category``   |
++---------------------------------------+-----------------------------------------------------------------------------------------+
+| controller (``optional``)             | In case you want to use a custom controller, pass the class name.                       |
++---------------------------------------+-----------------------------------------------------------------------------------------+
+
 The constructor of the base Admin class has many arguments. SonataAdminBundle
 provides a compiler pass which takes care of configuring it correctly for you.
 You can often tweak things using tag attributes. The code shown here is the

--- a/src/Manipulator/ServicesManipulator.php
+++ b/src/Manipulator/ServicesManipulator.php
@@ -31,10 +31,8 @@ final class ServicesManipulator
      */
     private $template = '    %s:
         class: %s
-        arguments: [~, %s, %s]
         tags:
-            - { name: sonata.admin, manager_type: %s, group: admin, label: %s }
-        public: true
+            - { name: sonata.admin, model_class: %s, controller: %s, manager_type: %s, group: admin, label: %s }
 ';
 
     public function __construct(string $file)

--- a/tests/Manipulator/ServicesManipulatorTest.php
+++ b/tests/Manipulator/ServicesManipulatorTest.php
@@ -56,10 +56,8 @@ final class ServicesManipulatorTest extends TestCase
             "services:
     service_id:
         class: Sonata\AdminBundle\Admin\AdminInterface
-        arguments: [~, stdClass, controller_name]
         tags:
-            - { name: sonata.admin, manager_type: manager_type, group: admin, label: stdClass }
-        public: true\n",
+            - { name: sonata.admin, model_class: stdClass, controller: controller_name, manager_type: manager_type, group: admin, label: stdClass }\n",
             file_get_contents($this->file)
         );
         $this->servicesManipulator->addResource(
@@ -73,17 +71,13 @@ final class ServicesManipulatorTest extends TestCase
             "services:
     service_id:
         class: Sonata\AdminBundle\Admin\AdminInterface
-        arguments: [~, stdClass, controller_name]
         tags:
-            - { name: sonata.admin, manager_type: manager_type, group: admin, label: stdClass }
-        public: true
+            - { name: sonata.admin, model_class: stdClass, controller: controller_name, manager_type: manager_type, group: admin, label: stdClass }
 
     another_service_id:
         class: Sonata\AdminBundle\Admin\AdminInterface
-        arguments: [~, stdClass, another_controller_name]
         tags:
-            - { name: sonata.admin, manager_type: another_manager_type, group: admin, label: stdClass }
-        public: true\n",
+            - { name: sonata.admin, model_class: stdClass, controller: another_controller_name, manager_type: another_manager_type, group: admin, label: stdClass }\n",
             file_get_contents($this->file)
         );
     }
@@ -123,10 +117,8 @@ final class ServicesManipulatorTest extends TestCase
             "services:
     service_id:
         class: Sonata\AdminBundle\Admin\AdminInterface
-        arguments: [~, stdClass, controller_name]
         tags:
-            - { name: sonata.admin, manager_type: manager_type, group: admin, label: stdClass }
-        public: true\n",
+            - { name: sonata.admin, model_class: stdClass, controller: controller_name, manager_type: manager_type, group: admin, label: stdClass }\n",
             file_get_contents($this->file)
         );
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Improve make:sonata:admin for the new configurations

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it's the current version used.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Improve `make:sonata:admin` command, now it's passing modelClass and Controller in services tag.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

## To do
- [x] update the  [documentation](https://docs.sonata-project.org/projects/SonataAdminBundle/en/4.x/getting_started/creating_an_admin/#step-2-register-the-admin-class)

**the main idea is remove the code generated in `arguments` because it's deprecated and shouldn't be used anymore!**


how it was generating!
```yaml
admin.category:
        class: App\Admin\CategoryAdmin
        arguments: [ ~, App\Entity\Category, ~]
        tags:
            - { name: sonata.admin, manager_type: orm, label: Category }
        public: true
```

how it should generate after changes

```yaml
admin.category:
        class: App\Admin\CategoryAdmin
        tags:
            - { name: sonata.admin, model_class: App\Entity\Category, controller: ~, manager_type: orm, label: Category }
        public: true
```


But I removed some others things that I guess we don't need this from symfony 4+
```diff
- admin.category:
-        class: App\Admin\CategoryAdmin
+ App\Admin\CategoryAdmin:
        tags:
            - { name: sonata.admin, model_class: App\Entity\Category, controller: ~, manager_type: orm, label: Category }
--        public: true
```

I removed `service_id`, `class` and `public: true`, is it fine for you remove this for new admins or it's necessary and I'm missing something?