### PR TITLE
Add missing use for example CategoryAdmin

### DIFF
--- a/docs/getting_started/creating_an_admin.rst
+++ b/docs/getting_started/creating_an_admin.rst
@@ -114,9 +114,10 @@ easiest way to do this is by extending ``Sonata\AdminBundle\Admin\AbstractAdmin`
     namespace App\Admin;
 
     use Sonata\AdminBundle\Admin\AbstractAdmin;
-    use Sonata\AdminBundle\Datagrid\ListMapper;
     use Sonata\AdminBundle\Datagrid\DatagridMapper;
+    use Sonata\AdminBundle\Datagrid\ListMapper;
     use Sonata\AdminBundle\Form\FormMapper;
+    use Sonata\AdminBundle\Show\ShowMapper;
     use Symfony\Component\Form\Extension\Core\Type\TextType;
 
     final class CategoryAdmin extends AbstractAdmin


### PR DESCRIPTION
A use is missing on example CategoryAdmin. 

It's just a small update to add this miss and reorder use.