### PR TITLE
Allow to display a custom error message

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -169,11 +169,11 @@ class CRUDController extends AbstractController
                 $this->trans('flash_batch_delete_error', [], 'SonataAdminBundle')
             );
         } catch (ModelManagerThrowable $e) {
-            $this->handleModelManagerThrowable($e);
+            $errorMessage = $this->handleModelManagerThrowable($e);
 
             $this->addFlash(
                 'sonata_flash_error',
-                $this->trans('flash_batch_delete_error', [], 'SonataAdminBundle')
+                $errorMessage ?? $this->trans('flash_batch_delete_error', [], 'SonataAdminBundle')
             );
         }
 
@@ -240,7 +240,7 @@ class CRUDController extends AbstractController
                     )
                 );
             } catch (ModelManagerThrowable $e) {
-                $this->handleModelManagerThrowable($e);
+                $errorMessage = $this->handleModelManagerThrowable($e);
 
                 if ($this->isXmlHttpRequest($request)) {
                     return $this->renderJson(['result' => 'error'], Response::HTTP_OK, []);
@@ -248,7 +248,7 @@ class CRUDController extends AbstractController
 
                 $this->addFlash(
                     'sonata_flash_error',
-                    $this->trans(
+                    $errorMessage ?? $this->trans(
                         'flash_delete_error',
                         ['%name%' => $this->escapeHtml($objectName)],
                         'SonataAdminBundle'
@@ -334,7 +334,7 @@ class CRUDController extends AbstractController
 
                     $isFormValid = false;
                 } catch (ModelManagerThrowable $e) {
-                    $this->handleModelManagerThrowable($e);
+                    $errorMessage = $this->handleModelManagerThrowable($e);
 
                     $isFormValid = false;
                 } catch (LockException $e) {
@@ -354,7 +354,7 @@ class CRUDController extends AbstractController
 
                 $this->addFlash(
                     'sonata_flash_error',
-                    $this->trans(
+                    $errorMessage ?? $this->trans(
                         'flash_edit_error',
                         ['%name%' => $this->escapeHtml($this->admin->toString($existingObject))],
                         'SonataAdminBundle'
@@ -599,7 +599,7 @@ class CRUDController extends AbstractController
 
                     $isFormValid = false;
                 } catch (ModelManagerThrowable $e) {
-                    $this->handleModelManagerThrowable($e);
+                    $errorMessage = $this->handleModelManagerThrowable($e);
 
                     $isFormValid = false;
                 }
@@ -613,7 +613,7 @@ class CRUDController extends AbstractController
 
                 $this->addFlash(
                     'sonata_flash_error',
-                    $this->trans(
+                    $errorMessage ?? $this->trans(
                         'flash_create_error',
                         ['%name%' => $this->escapeHtml($this->admin->toString($newObject))],
                         'SonataAdminBundle'
@@ -1078,9 +1078,13 @@ class CRUDController extends AbstractController
     }
 
     /**
+     * NEXT_MAJOR: Add typehint.
+     *
      * @throws ModelManagerThrowable
+     *
+     * @return string|null A custom error message to display in the flag bag instead of the generic one
      */
-    protected function handleModelManagerThrowable(ModelManagerThrowable $exception): void
+    protected function handleModelManagerThrowable(ModelManagerThrowable $exception)
     {
         $debug = $this->getParameter('kernel.debug');
         \assert(\is_bool($debug));
@@ -1093,6 +1097,8 @@ class CRUDController extends AbstractController
             $context['previous_exception_message'] = $exception->getPrevious()->getMessage();
         }
         $this->getLogger()->error($exception->getMessage(), $context);
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #7759.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- CrudController::handleModelManagerThrowable can now return a custom error message to display in the flashbag instead of the generic one from Sonata.
```