### PR TITLE
Replace $container `has` check with `hasParameter`

### DIFF
--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -144,7 +144,7 @@ final class SonataAdminExtension extends Extension
 
                 break;
             case 'sonata.admin.security.handler.acl':
-                if (!$container->has('security.acl.provider')) {
+                if (!$container->hasParameter('security.acl.provider')) {
                     throw new \RuntimeException(
                         'The "security.acl.provider" service is needed to use ACL as security handler.'
                         .' You MUST install and enable the "symfony/acl-bundle" bundle.'

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -144,9 +144,9 @@ final class SonataAdminExtension extends Extension
 
                 break;
             case 'sonata.admin.security.handler.acl':
-                if (!$container->hasParameter('security.acl.provider')) {
+                if (!isset($bundles['AclBundle'])) {
                     throw new \RuntimeException(
-                        'The "security.acl.provider" service is needed to use ACL as security handler.'
+                        'The "symfony/acl-bundle" is needed to use ACL as security handler.'
                         .' You MUST install and enable the "symfony/acl-bundle" bundle.'
                     );
                 }


### PR DESCRIPTION
When extensions are being loaded one by one into tmpContainer inside
`vendor/symfony/dependency-injection/Compiler/MergeExtensionConfigurationPass.php`
`sonata_admin` configuration is loaded alone, and other extension services are not present.
By replacing `has` check with `hasParameter` check we can make sure parameter exists instead of service.
Since we can easily configure extra parameter,
but to get service we would need to load most of the acl bundle extension services.

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because I'm working with this and it's the latest branch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #7768.

## Changelog

```markdown
### Fixed
- Improve detection of Symfony ACL bundle installation
```