### PR TITLE
Add #[\ReturnTypeWillChange] to \ArrayAccess and \Countable methods of FieldDescriptionCollection for compatibility with PHP 8

### DIFF
--- a/src/FieldDescription/FieldDescriptionCollection.php
+++ b/src/FieldDescription/FieldDescriptionCollection.php
@@ -86,6 +86,7 @@ class FieldDescriptionCollection implements \ArrayAccess, \Countable
         unset($this->elements[$name]);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $this->has($offset);
@@ -98,21 +99,25 @@ class FieldDescriptionCollection implements \ArrayAccess, \Countable
      *
      * @phpstan-return TValue
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->get($offset);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         throw new \RuntimeException('Cannot set value, use add');
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         $this->remove($offset);
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return \count($this->elements);


### PR DESCRIPTION
## Subject

This fix prevents an error like `Return type of Sonata\AdminBundle\FieldDescription\FieldDescriptionCollection::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice` for PHP 8

I am targeting this branch, because this error happens in version 3.x which is supposed to support PHP ^8.0 according to its composer.json specification.

## Changelog

```markdown
### Fixed
- Added `#[\ReturnTypeWillChange]` to \ArrayAccess and \Countable methods of FieldDescriptionCollection for compatibility with PHP 8
```
