### PR TITLE
Fix phpdoc about parentAssociationMappings

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,6 +21,3 @@ parameters:
         - # https://github.com/phpstan/phpstan-symfony/pull/259
             message: '#Call to an undefined method Symfony\\Component\\Form\\FormError\|Symfony\\Component\\Form\\FormErrorIterator\:\:getMessage\(\)\.#'
             path: src/Controller/CRUDController.php
-        - # https://github.com/phpstan/phpstan/issues/6917
-            message: '#^Parameter \#3 \$admin of class Sonata\\AdminBundle\\Form\\FormMapper constructor expects Sonata\\AdminBundle\\Admin\\AdminInterface\<T of object\>, PHPUnit\\Framework\\MockObject\\Stub&Sonata\\AdminBundle\\Admin\\AdminInterface\<object\> given\.$#'
-            path: tests/Admin/Extension/LockExtensionTest.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -15,4 +15,10 @@
             <code>null</code>
         </NullableReturnStatement>
     </file>
+    <!-- https://github.com/vimeo/psalm/issues/7825 -->
+    <file src="tests/Datagrid/DatagridTest.php">
+        <InvalidArgument occurrences="1">
+            <code>new Datagrid($this-&gt;query, $this-&gt;columns, $pager, $this-&gt;formBuilder, [])</code>
+        </InvalidArgument>
+    </file>
 </files>

--- a/src/Datagrid/ProxyQueryInterface.php
+++ b/src/Datagrid/ProxyQueryInterface.php
@@ -28,8 +28,8 @@ interface ProxyQueryInterface
     public function execute();
 
     /**
-     * @param array<string, array<string, mixed>> $parentAssociationMappings
-     * @param array<string, mixed>                $fieldMapping
+     * @param array<array<string, mixed>> $parentAssociationMappings
+     * @param array<string, mixed>        $fieldMapping
      *
      * @return static
      */

--- a/src/FieldDescription/BaseFieldDescription.php
+++ b/src/FieldDescription/BaseFieldDescription.php
@@ -93,7 +93,7 @@ abstract class BaseFieldDescription implements FieldDescriptionInterface
     protected $fieldMapping = [];
 
     /**
-     * @var array<string, array<string, mixed>> parent mapping association
+     * @var array<array<string, mixed>> parent mapping association
      */
     protected $parentAssociationMappings = [];
 

--- a/tests/Datagrid/DatagridTest.php
+++ b/tests/Datagrid/DatagridTest.php
@@ -61,9 +61,12 @@ final class DatagridTest extends TestCase
     {
         $this->query = $this->createStub(ProxyQueryInterface::class);
         $this->columns = new FieldDescriptionCollection();
-        $this->pager = $this->createMock(PagerInterface::class);
         $this->formBuilder = Forms::createFormFactoryBuilder()->getFormFactory()->createBuilder();
-        $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, []);
+
+        /** @var PagerInterface<ProxyQueryInterface&Stub>&MockObject $pager */
+        $pager = $this->createMock(PagerInterface::class);
+        $this->pager = $pager;
+        $this->datagrid = new Datagrid($this->query, $this->columns, $pager, $this->formBuilder, []);
     }
 
     public function testGetPager(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Detected by https://github.com/sonata-project/SonataDoctrineMongoDBAdminBundle/pull/732
The key are never used in this bundle so int could be accepted too.

I am targeting this branch, because bugfix.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- ProxyQueryInterface::setSortBy phpdoc
```
