### PR TITLE
Always set the parent when using a collectionType

### DIFF
--- a/src/Form/Type/AdminType.php
+++ b/src/Form/Type/AdminType.php
@@ -90,9 +90,8 @@ final class AdminType extends AbstractType
 
                         if (true === $options['collection_by_reference']) {
                             $subject = ObjectManipulator::addInstance($parentSubject, $subject, $parentFieldDescription);
-                        } else {
-                            $subject = ObjectManipulator::setObject($subject, $parentSubject, $parentFieldDescription);
                         }
+                        $subject = ObjectManipulator::setObject($subject, $parentSubject, $parentFieldDescription);
                     }
                 }
             }

--- a/tests/Form/Type/AdminTypeTest.php
+++ b/tests/Form/Type/AdminTypeTest.php
@@ -205,8 +205,16 @@ final class AdminTypeTest extends TypeTestCase
         $modelManager = $this->createStub(ModelManagerInterface::class);
 
         $newInstance = new class() {
+            private ?object $bar = null;
+
             public function setBar(object $bar): void
             {
+                $this->bar = $bar;
+            }
+
+            public function getBar(): ?object
+            {
+                return $this->bar;
             }
         };
 
@@ -236,6 +244,8 @@ final class AdminTypeTest extends TypeTestCase
         } catch (NoSuchPropertyException $exception) {
             static::fail($exception->getMessage());
         }
+
+        static::assertSame($parentSubject, $newInstance->getBar());
     }
 
     public function testArrayCollectionByReferenceNotFound(): void
@@ -261,8 +271,16 @@ final class AdminTypeTest extends TypeTestCase
         $modelManager = $this->createStub(ModelManagerInterface::class);
 
         $newInstance = new class() {
+            private ?object $bar = null;
+
             public function setBar(object $bar): void
             {
+                $this->bar = $bar;
+            }
+
+            public function getBar(): ?object
+            {
+                return $this->bar;
             }
         };
 
@@ -292,6 +310,8 @@ final class AdminTypeTest extends TypeTestCase
         } catch (NoSuchPropertyException $exception) {
             static::fail($exception->getMessage());
         }
+
+        static::assertSame($parentSubject, $newInstance->getBar());
     }
 
     /**

--- a/tests/Form/Type/AdminTypeTest.php
+++ b/tests/Form/Type/AdminTypeTest.php
@@ -255,12 +255,16 @@ final class AdminTypeTest extends TypeTestCase
         $parentField = $this->createMock(FieldDescriptionInterface::class);
         $parentField->expects(static::once())->method('setAssociationAdmin')->with(static::isInstanceOf(AdminInterface::class));
         $parentField->expects(static::once())->method('getAdmin')->willReturn($parentAdmin);
-        $parentField->expects(static::once())->method('getParentAssociationMappings')->willReturn([]);
-        $parentField->expects(static::once())->method('getAssociationMapping')->willReturn(['fieldName' => 'foo', 'mappedBy' => 'bar']);
+        $parentField->expects(static::atLeastOnce())->method('getParentAssociationMappings')->willReturn([]);
+        $parentField->expects(static::atLeastOnce())->method('getAssociationMapping')->willReturn(['fieldName' => 'foo', 'mappedBy' => 'bar']);
 
         $modelManager = $this->createStub(ModelManagerInterface::class);
 
-        $newInstance = new \stdClass();
+        $newInstance = new class() {
+            public function setBar(object $bar): void
+            {
+            }
+        };
 
         $admin = $this->createMock(AdminInterface::class);
         $admin->expects(static::exactly(2))->method('hasParentFieldDescription')->willReturn(true);
@@ -274,7 +278,7 @@ final class AdminTypeTest extends TypeTestCase
         $field = $this->createMock(FieldDescriptionInterface::class);
         $field->expects(static::once())->method('getAssociationAdmin')->willReturn($admin);
         $field->expects(static::atLeastOnce())->method('getFieldName')->willReturn('foo');
-        $field->expects(static::once())->method('getParentAssociationMappings')->willReturn([]);
+        $field->expects(static::atLeastOnce())->method('getParentAssociationMappings')->willReturn([]);
 
         $this->builder->add('foo');
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because bugfix.

Closes #7778.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Correctly set the parent object in AdminType with CollectionType passed by reference
```