### PR TITLE
Add missing class option

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2394,6 +2394,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
                     'field_type' => ModelHiddenType::class,
                     'field_options' => [
                         'model_manager' => $this->getModelManager(),
+                        'class' => $this->getClass(),
                     ],
                     'operator_type' => HiddenType::class,
                 ], [

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -2393,8 +2393,8 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
                     'label' => false,
                     'field_type' => ModelHiddenType::class,
                     'field_options' => [
-                        'model_manager' => $this->getModelManager(),
-                        'class' => $this->getClass(),
+                        'model_manager' => $this->getParent()->getModelManager(),
+                        'class' => $this->getParent()->getClass(),
                     ],
                     'operator_type' => HiddenType::class,
                 ], [


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

When using the `ModelHiddenType`, the option class is required.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Correctly pass the class to the ModelHiddentType when using child admin without parentAssociationMapping.
```