### PR TITLE
CallbackFilter returns a boolean

### DIFF
--- a/docs/reference/action_list.rst
+++ b/docs/reference/action_list.rst
@@ -604,7 +604,7 @@ If you have the **SonataDoctrineORMAdminBundle** installed you can use the
                 ]);
         }
 
-        public function getFullTextFilter(ProxyQueryInterface $query, string $alias, string $field, FilterData $data): void
+        public function getFullTextFilter(ProxyQueryInterface $query, string $alias, string $field, FilterData $data): bool
         {
             if (!$data->hasValue()) {
                 return false;
@@ -631,10 +631,10 @@ type of your condition(s)::
 
     final class UserAdmin extends Sonata\UserBundle\Admin\Model\UserAdmin
     {
-        public function getFullTextFilter(ProxyQueryInterface $query, string $alias, string $field, FilterData $data): void
+        public function getFullTextFilter(ProxyQueryInterface $query, string $alias, string $field, FilterData $data): bool
         {
             if (!$data->hasValue()) {
-                return;
+                return false;
             }
 
             $operator = $data->isType(EqualType::TYPE_IS_EQUAL) ? '=' : '!=';


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Fixed some return values in the CallbackFilter documentation.

The callback must return a boolean

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it's a bug in documentation.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
 
 