### PR TITLE
fix SonataBlockBundle deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "knplabs/knp-menu-bundle": "^3.0",
         "psr/container": "^1.0 || ^2.0",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
-        "sonata-project/block-bundle": "^4.7",
+        "sonata-project/block-bundle": "^4.11",
         "sonata-project/doctrine-extensions": "^1.8",
         "sonata-project/exporter": "^2.11",
         "sonata-project/form-extensions": "^1.7.1",

--- a/src/Block/AdminListBlockService.php
+++ b/src/Block/AdminListBlockService.php
@@ -54,7 +54,7 @@ final class AdminListBlockService extends AbstractBlockService
             }
         }
 
-        return $this->renderPrivateResponse($this->templateRegistry->getTemplate('list_block'), [
+        return $this->renderResponse($this->templateRegistry->getTemplate('list_block'), [
             'block' => $blockContext->getBlock(),
             'settings' => $settings,
             'groups' => $visibleGroups,

--- a/src/Block/AdminPreviewBlockService.php
+++ b/src/Block/AdminPreviewBlockService.php
@@ -52,7 +52,7 @@ final class AdminPreviewBlockService extends AbstractBlockService
 
         $datagrid = $admin->getDatagrid();
 
-        return $this->renderPrivateResponse($template, [
+        return $this->renderResponse($template, [
             'block' => $blockContext->getBlock(),
             'settings' => $blockContext->getSettings(),
             'admin' => $admin,

--- a/src/Block/AdminSearchBlockService.php
+++ b/src/Block/AdminSearchBlockService.php
@@ -95,7 +95,7 @@ final class AdminSearchBlockService extends AbstractBlockService
             static fn (FilterInterface $filter): bool => $filter instanceof SearchableFilterInterface && $filter->isSearchEnabled()
         );
 
-        return $this->renderPrivateResponse($this->templateRegistry->getTemplate('search_result_block'), [
+        return $this->renderResponse($this->templateRegistry->getTemplate('search_result_block'), [
             'block' => $blockContext->getBlock(),
             'settings' => $blockContext->getSettings(),
             'pager' => $pager,

--- a/src/Block/AdminStatsBlockService.php
+++ b/src/Block/AdminStatsBlockService.php
@@ -57,7 +57,7 @@ final class AdminStatsBlockService extends AbstractBlockService
 
         $datagrid->buildPager();
 
-        return $this->renderPrivateResponse($template, [
+        return $this->renderResponse($template, [
             'block' => $blockContext->getBlock(),
             'settings' => $blockContext->getSettings(),
             'admin' => $admin,

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -124,6 +124,11 @@ final class AppKernel extends Kernel
         ]);
 
         $loader->load(sprintf('%s/config/services.yml', $this->getProjectDir()));
+
+        // TODO: Remove when support for SonataBlockBundle 4 is dropped.
+        $containerBuilder->loadFromExtension('sonata_block', [
+            'http_cache' => false,
+        ]);
     }
 
     private function getBaseDir(): string

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -681,7 +681,8 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
         $this->container->setAlias('translator', 'translator.default');
 
         $blockExtension = new SonataBlockExtension();
-        $blockExtension->load([], $this->container);
+        // TODO: remove "http_cache" parameter when support for SonataBlockBundle 4 is dropped.
+        $blockExtension->load(['sonata_block' => ['http_cache' => false]], $this->container);
     }
 
     private function allowToResolveChildren(): void

--- a/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -463,7 +463,8 @@ final class ExtensionCompilerPassTest extends TestCase
             ->setClass(FileLocatorInterface::class);
 
         $blockExtension = new SonataBlockExtension();
-        $blockExtension->load([], $container);
+        // TODO: remove "http_cache" parameter when support for SonataBlockBundle 4 is dropped.
+        $blockExtension->load(['sonata_block' => ['http_cache' => false]], $container);
 
         return $container;
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Fixes deprecations for SonataBlockBundle 4.11+

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its BC.

Does this need a Changelog entry?

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS  -->
```markdown
### Changed
- in preparation for SonataBlockBundle 5.0 we are not rendering block responses as private anymore
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
