### PR TITLE
Remove doctrine/persistence requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "doctrine/collections": "^1.6",
         "doctrine/common": "^3.0",
         "doctrine/inflector": "^2.0",
-        "doctrine/persistence": "^2.0",
         "knplabs/knp-menu": "^3.1",
         "knplabs/knp-menu-bundle": "^3.0",
         "psr/container": "^1.0 || ^2.0",
@@ -69,6 +68,7 @@
     },
     "require-dev": {
         "doctrine/annotations": "^1.7",
+        "doctrine/persistence": "^2.0 || ^3.0",
         "friendsofphp/php-cs-fixer": "^3.4",
         "matthiasnoback/symfony-config-test": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",

--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,6 @@
     },
     "require-dev": {
         "doctrine/annotations": "^1.7",
-        "doctrine/persistence": "^2.0 || ^3.0",
         "friendsofphp/php-cs-fixer": "^3.4",
         "matthiasnoback/symfony-config-test": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

It was added because of `symfony-acl` package: https://github.com/sonata-project/SonataAdminBundle/pull/6258#discussion_r467454900 and at that time we had a reference in `src`
There is no reference in https://github.com/sonata-project/SonataAdminBundle/blob/19760ea1ff19cb94a7b8339bf15318431a32f119/src/Command/GenerateObjectAclCommand.php anymore, so we don't require it.

I've labeled as `minor`, but not sure if this could also be a `patch`.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Removed
- Removed `doctrine/persistence` dependency
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
