### PR TITLE
fix deprecations for tests running with block-bundle 5

### DIFF
--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Tests\App;
 
 use Knp\Bundle\MenuBundle\KnpMenuBundle;
 use Sonata\AdminBundle\SonataAdminBundle;
+use Sonata\BlockBundle\Cache\HttpCacheHandler;
 use Sonata\BlockBundle\SonataBlockBundle;
 use Sonata\Doctrine\Bridge\Symfony\SonataDoctrineBundle;
 use Sonata\Form\Bridge\Symfony\SonataFormBundle;
@@ -126,9 +127,7 @@ final class AppKernel extends Kernel
         $loader->load(sprintf('%s/config/services.yml', $this->getProjectDir()));
 
         // TODO: Remove when support for SonataBlockBundle 4 is dropped.
-        $containerBuilder->loadFromExtension('sonata_block', [
-            'http_cache' => false,
-        ]);
+        $containerBuilder->loadFromExtension('sonata_block', class_exists(HttpCacheHandler::class) ? ['http_cache' => false] : []);
     }
 
     private function getBaseDir(): string

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -19,6 +19,7 @@ use Sonata\AdminBundle\DependencyInjection\Admin\TaggedAdminInterface;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
 use Sonata\AdminBundle\Tests\Fixtures\Controller\FooAdminController;
+use Sonata\BlockBundle\Cache\HttpCacheHandler;
 use Sonata\BlockBundle\DependencyInjection\SonataBlockExtension;
 use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
@@ -682,7 +683,12 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
 
         $blockExtension = new SonataBlockExtension();
         // TODO: remove "http_cache" parameter when support for SonataBlockBundle 4 is dropped.
-        $blockExtension->load(['sonata_block' => ['http_cache' => false]], $this->container);
+        $blockExtension->load(
+            [
+                'sonata_block' => class_exists(HttpCacheHandler::class) ? ['http_cache' => false] : [],
+            ],
+            $this->container
+        );
     }
 
     private function allowToResolveChildren(): void

--- a/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -22,6 +22,7 @@ use Sonata\AdminBundle\Admin\AdminExtensionInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
+use Sonata\BlockBundle\Cache\HttpCacheHandler;
 use Sonata\BlockBundle\DependencyInjection\SonataBlockExtension;
 use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Component\Config\FileLocatorInterface;
@@ -464,7 +465,12 @@ final class ExtensionCompilerPassTest extends TestCase
 
         $blockExtension = new SonataBlockExtension();
         // TODO: remove "http_cache" parameter when support for SonataBlockBundle 4 is dropped.
-        $blockExtension->load(['sonata_block' => ['http_cache' => false]], $container);
+        $blockExtension->load(
+            [
+                'sonata_block' => class_exists(HttpCacheHandler::class) ? ['http_cache' => false] : [],
+            ],
+            $container
+        );
 
         return $container;
     }


### PR DESCRIPTION
Fixes

```
  23x: Since sonata-project/block-bundle 5.0: The "http_cache" option is deprecated and not doing anything anymore since sonata-project/block-bundle 5.0. It will be removed in 6.0.
