### PR TITLE
Fix PHP 8.1 compatibility for Datagrid Pager in 3.x

### DIFF
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -705,6 +705,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      *
      * @deprecated since sonata-project/admin-bundle 3.84
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         @trigger_error(sprintf(
@@ -724,6 +725,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      *
      * @deprecated since sonata-project/admin-bundle 3.84
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         @trigger_error(sprintf(
@@ -743,6 +745,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      *
      * @deprecated since sonata-project/admin-bundle 3.84
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         @trigger_error(sprintf(
@@ -765,6 +768,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      *
      * @deprecated since sonata-project/admin-bundle 3.84
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         @trigger_error(sprintf(
@@ -787,6 +791,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      *
      * @deprecated since sonata-project/admin-bundle 3.84
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         @trigger_error(sprintf(
@@ -806,6 +811,7 @@ abstract class Pager implements \Iterator, \Countable, \Serializable, PagerInter
      *
      * @deprecated since sonata-project/admin-bundle 3.84, use countResults instead
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         @trigger_error(sprintf(


### PR DESCRIPTION
## Subject

In addition to #7798.

I also got errors on `src/Datagrid/Pager.php` when running Psalm. I guess @aerrasti his code didn't touch this part and therefor his Psalm runs did not report errors there.

I am targeting this branch, because this error happens in version 3.x which is supposed to support PHP 8.1 according to its composer.json specification.

## Changelog

```markdown
### Fixed
- Added `#[\ReturnTypeWillChange]` to \ArrayAccess and \Countable methods of `Sonata\AdminBundle\Datagrid\Pager` for compatibility with PHP 8.1
```
