### PR TITLE
Allow batch action from another controller

### DIFF
--- a/UPGRADE-4.x.md
+++ b/UPGRADE-4.x.md
@@ -1,6 +1,15 @@
 UPGRADE 4.x
 ===========
 
+UPGRADE FROM 4.12.0 to 4.13.0
+=============================
+
+## Batch action is relevant
+
+Deprecate `batchAction%sIsRelevant` hook. You must handle the specific logic in your
+batch action controller directly.
+
+
 UPGRADE FROM 4.11.1 to 4.12.0
 =============================
 

--- a/docs/reference/batch_actions.rst
+++ b/docs/reference/batch_actions.rst
@@ -74,7 +74,7 @@ the context of this request. There is no requirement on the base class or any ot
 
             $target = $modelManager->find($admin->getClass(), $request->get('targetId'));
 
-            if ($target === null){
+            if ($target === null) {
                 $this->addFlash('sonata_flash_info', 'flash_batch_merge_no_target');
 
                 return new RedirectResponse(

--- a/docs/reference/batch_actions.rst
+++ b/docs/reference/batch_actions.rst
@@ -51,7 +51,7 @@ Define the core action logic
 Define a regular Symfony controller like you normally would (without a route). Make sure you configure your controller
 as a service and tag it with **controller.service_arguments**. The parameter will be automatically injected.
 The AdminInterface is done via a param converter already available in **SonataAdminBundle**. The $query is unique to
-the context of this request. There is no requirement on the base class or any other logic, this is just an example:
+the context of this request. There is no requirement on the base class or any other logic, this is just an example::
 
     // src/Controller/MergeController.php
 
@@ -107,6 +107,8 @@ the context of this request. There is no requirement on the base class or any ot
 
         // ...
     }
+
+.. note::
 
 (Deprecated) Define the core action logic
 ----------------------------

--- a/docs/reference/batch_actions.rst
+++ b/docs/reference/batch_actions.rst
@@ -36,7 +36,7 @@ merges them onto a single target item. It should only be available when two cond
           $this->hasRoute('delete') && $this->hasAccess('delete')
         ) {
             $actions['merge'] = [
-                'ask_confirmation' => true
+                'ask_confirmation' => true,
                 'controller' => 'app.controller.merge::batchMergeAction'
                 // Or 'App/Controller/MergeController::batchMergeAction' base on how you declare your controller service.
             ];

--- a/docs/reference/batch_actions.rst
+++ b/docs/reference/batch_actions.rst
@@ -37,7 +37,7 @@ merges them onto a single target item. It should only be available when two cond
         ) {
             $actions['merge'] = [
                 'ask_confirmation' => true,
-                'controller' => 'app.controller.merge::batchMergeAction'
+                'controller' => 'app.controller.merge::batchMergeAction',
                 // Or 'App/Controller/MergeController::batchMergeAction' base on how you declare your controller service.
             ];
         }

--- a/docs/reference/batch_actions.rst
+++ b/docs/reference/batch_actions.rst
@@ -37,6 +37,8 @@ merges them onto a single target item. It should only be available when two cond
         ) {
             $actions['merge'] = [
                 'ask_confirmation' => true
+                'controller' => 'app.controller.merge::batchMergeAction'
+                // Or 'App/Controller/MergeController::batchMergeAction' base on how you declare your controller service.
             ];
         }
 
@@ -45,6 +47,71 @@ merges them onto a single target item. It should only be available when two cond
 
 Define the core action logic
 ----------------------------
+
+Define a regular Symfony controller like you normally would (without a route). Make sure you configure your controller
+as a service and tag it with **controller.service_arguments**. The parameter will be automatically injected.
+The AdminInterface is done via a param converter already available in **SonataAdminBundle**. The $query is unique to
+the context of this request. There is no requirement on the base class or any other logic, this is just an example:
+
+    // src/Controller/MergeController.php
+
+    namespace App\Controller;
+
+    use Sonata\AdminBundle\Admin\AdminInterface;
+    use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+    use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+    use Symfony\Component\HttpFoundation\RedirectResponse;
+    use Symfony\Component\HttpFoundation\Request;
+
+    class MergeController extends AbstractController
+    {
+        public function batchMergeAction(ProxyQueryInterface $query, AdminInterface $admin): RedirectResponse
+        {
+            $admin->checkAccess('edit');
+            $admin->checkAccess('delete');
+
+            $modelManager = $admin->getModelManager();
+
+            $target = $modelManager->find($admin->getClass(), $request->get('targetId'));
+
+            if ($target === null){
+                $this->addFlash('sonata_flash_info', 'flash_batch_merge_no_target');
+
+                return new RedirectResponse(
+                    $admin->generateUrl('list', [
+                        'filter' => $admin->getFilterParameters()
+                    ])
+                );
+            }
+
+            $selectedModels = $selectedModelQuery->execute();
+
+            // do the merge work here
+
+            try {
+                foreach ($selectedModels as $selectedModel) {
+                    $modelManager->delete($selectedModel);
+                }
+
+                $this->addFlash('sonata_flash_success', 'flash_batch_merge_success');
+            } catch (\Exception $e) {
+                $this->addFlash('sonata_flash_error', 'flash_batch_merge_error');
+            } finally {
+                return new RedirectResponse(
+                    $admin->generateUrl('list', [
+                        'filter' => $admin->getFilterParameters()
+                    ])
+                );
+            }
+        }
+
+        // ...
+    }
+
+(Deprecated) Define the core action logic
+----------------------------
+
+**Deprecated**: This is the old way to do this. Will be removed in version 5.x.
 
 The method ``batchAction<MyAction>`` will be executed to process your batch in your ``CRUDController`` class. The selected
 objects are passed to this method through a query argument which can be used to retrieve them.
@@ -149,8 +216,10 @@ a radio button to choose the target object.
         <input type="radio" name="targetId" value="{{ admin.id(object) }}"/>
     {% endblock %}
 
-(Optional) Overriding the default relevancy check function
+(Optional|Deprecated) Overriding the default relevancy check function
 ----------------------------------------------------------
+
+**Deprecated**: Make this check in your controller directly. This will be remove in version 5.x
 
 By default, batch actions are not executed if no object was selected, and
 the user is notified of this lack of selection. If your custom batch action

--- a/docs/reference/batch_actions.rst
+++ b/docs/reference/batch_actions.rst
@@ -108,10 +108,8 @@ the context of this request. There is no requirement on the base class or any ot
         // ...
     }
 
-.. note::
-
 (Deprecated) Define the core action logic
-----------------------------
+-----------------------------------------
 
 **Deprecated**: This is the old way to do this. Will be removed in version 5.x.
 
@@ -219,7 +217,7 @@ a radio button to choose the target object.
     {% endblock %}
 
 (Optional|Deprecated) Overriding the default relevancy check function
-----------------------------------------------------------
+---------------------------------------------------------------------
 
 **Deprecated**: Make this check in your controller directly. This will be remove in version 5.x
 

--- a/docs/reference/batch_actions.rst
+++ b/docs/reference/batch_actions.rst
@@ -84,7 +84,7 @@ the context of this request. There is no requirement on the base class or any ot
                 );
             }
 
-            $selectedModels = $selectedModelQuery->execute();
+            $selectedModels = $query->execute();
 
             // do the merge work here
 

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -45,6 +45,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyPath;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -94,6 +95,8 @@ class CRUDController extends AbstractController
             'sonata.admin.admin_exporter' => '?'.AdminExporter::class,
             'sonata.admin.security.acl_user_manager' => '?'.AdminAclUserManagerInterface::class,
 
+            'controller_resolver' => 'controller_resolver',
+            'http_kernel' => HttpKernelInterface::class,
             'logger' => '?'.LoggerInterface::class,
             'translator' => TranslatorInterface::class,
         ] + parent::getSubscribedServices();
@@ -439,12 +442,15 @@ class CRUDController extends AbstractController
             throw new \RuntimeException('The action is not defined');
         }
 
-        $batchActions = $this->admin->getBatchActions();
-        if (!\array_key_exists($action, $batchActions)) {
-            throw new \RuntimeException(sprintf('The `%s` batch action is not defined', $action));
+        $camelizedAction = InflectorFactory::create()->build()->classify($action);
+
+        if (!$this->canBatchActionBeExecuted($action)) {
+            $finalAction = sprintf('batchAction%s', $camelizedAction);
+            throw new \RuntimeException(sprintf('A `%s::%s` method must be callable or create add a `controller` configuration', static::class, $finalAction));
         }
 
-        $camelizedAction = InflectorFactory::create()->build()->classify($action);
+        $batchAction = $this->admin->getBatchActions()[$action];
+
         $isRelevantAction = sprintf('batchAction%sIsRelevant', $camelizedAction);
 
         if (method_exists($this, $isRelevantAction)) {
@@ -469,18 +475,17 @@ class CRUDController extends AbstractController
             return $this->redirectToList();
         }
 
-        $askConfirmation = $batchActions[$action]['ask_confirmation'] ?? true;
+        $askConfirmation = $batchAction['ask_confirmation'] ?? true;
 
         if (true === $askConfirmation && 'ok' !== $confirmation) {
-            $actionLabel = $batchActions[$action]['label'];
-            $batchTranslationDomain = $batchActions[$action]['translation_domain'] ??
+            $actionLabel = $batchAction['label'];
+            $batchTranslationDomain = $batchAction['translation_domain'] ??
                 $this->admin->getTranslationDomain();
 
             $formView = $datagrid->getForm()->createView();
             $this->setFormTheme($formView, $this->admin->getFilterTheme());
 
-            $template = $batchActions[$action]['template']
-                ?? $this->templateRegistry->getTemplate('batch_confirmation');
+            $template = $batchAction['template'] ?? $this->templateRegistry->getTemplate('batch_confirmation');
 
             return $this->renderWithExtraParams($template, [
                 'action' => 'list',
@@ -491,12 +496,6 @@ class CRUDController extends AbstractController
                 'data' => $data,
                 'csrf_token' => $this->getCsrfToken('sonata.batch'),
             ]);
-        }
-
-        // execute the action, batchActionXxxxx
-        $finalAction = sprintf('batchAction%s', $camelizedAction);
-        if (!method_exists($this, $finalAction)) {
-            throw new \RuntimeException(sprintf('A `%s::%s` method must be callable', static::class, $finalAction));
         }
 
         $query = $datagrid->getQuery();
@@ -524,7 +523,60 @@ class CRUDController extends AbstractController
             return $this->redirectToList();
         }
 
-        return $this->$finalAction($query, $forwardedRequest);
+        return call_user_func($this->getBatchActionExecutable($action), $query, $forwardedRequest);
+    }
+
+    final protected function canBatchActionBeExecuted(string $action): bool
+    {
+        $batchActions = $this->admin->getBatchActions();
+        if (!\array_key_exists($action, $batchActions)) {
+            throw new \RuntimeException(sprintf('The `%s` batch action is not defined', $action));
+        }
+
+        $controller = $batchActions[$action]['controller'] ?? null;
+
+        if ($controller) {
+            $request = new Request();
+            $request->attributes->set('_controller', $controller);
+            try {
+                return false !== $this->container->get('controller_resolver')->getController($request);
+            } catch (\Throwable $error) {
+                return false;
+            }
+        } else {
+            $camelizedAction = InflectorFactory::create()->build()->classify($action);
+            $finalAction = sprintf('batchAction%s', $camelizedAction);
+
+            if (method_exists($this, $finalAction)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    final protected function getBatchActionExecutable(string $action): callable
+    {
+        if (!$this->canBatchActionBeExecuted($action)) {
+            throw new \LogicException(sprintf('Batch action `%s` cannot be executed. You must call `%s::canBatchActionBeExecuted` first.', $action, static::class));
+        }
+
+        $controller = $this->admin->getBatchActions()[$action]['controller'];
+
+        if ($controller) {
+            return function (ProxyQueryInterface $query, Request $request) use ($controller) {
+                $request->attributes->set('_controller', $controller);
+                $request->attributes->set('query', $query);
+                return $this->container->get('http_kernel')->handle($request, HttpKernelInterface::SUB_REQUEST);
+            };
+        } else {
+            $camelizedAction = InflectorFactory::create()->build()->classify($action);
+            $finalAction = sprintf('batchAction%s', $camelizedAction);
+
+            return function (ProxyQueryInterface $query, Request $request) use ($finalAction) {
+                return $this->$finalAction($query, $request);
+            };
+        }
     }
 
     /**

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -456,7 +456,7 @@ class CRUDController extends AbstractController
         $isRelevantAction = sprintf('batchAction%sIsRelevant', $camelizedAction);
 
         if (method_exists($this, $isRelevantAction)) {
-            // TODO: Remove if above in sonata-project/admin-bundle 5.0
+            // NEXT_MAJOR: Remove if above in sonata-project/admin-bundle 5.0
             @trigger_error(sprintf(
                 'The is relevant hook via "%s()" is deprecated since sonata-project/admin-bundle 4.12'
                 .' and will not be call in 5.0. Move the logic to your controller.',

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -551,14 +551,11 @@ class CRUDController extends AbstractController
             throw new \RuntimeException(sprintf('The `%s` batch action is not defined', $action));
         }
 
-        $controller = $batchActions[$action]['controller'] ?? null;
-        if (null ?? $controller) {
-            $controller = sprintf(
-                '%s::%s',
-                static::class,
-                sprintf('batchAction%s',  InflectorFactory::create()->build()->classify($action))
-            );
-        }
+        $controller = $batchActions[$action]['controller'] ?? sprintf(
+            '%s::%s',
+            static::class,
+            sprintf('batchAction%s',  InflectorFactory::create()->build()->classify($action))
+       );
 
         return $controller;
     }

--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -126,6 +126,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->tag('container.service_subscriber')
             ->call('setContainer', [new ReferenceConfigurator(ContainerInterface::class)])
 
+        // Aliasing service doesn't work when using service as a controller
+        ->set(CRUDController::class, CRUDController::class)
+            ->public()
+            ->tag('container.service_subscriber')
+            ->call('setContainer', [new ReferenceConfigurator(ContainerInterface::class)])
+
         ->set('sonata.admin.event.extension', AdminEventExtension::class)
             ->tag('sonata.admin.extension', ['global' => true])
             ->args([

--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -126,12 +126,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->tag('container.service_subscriber')
             ->call('setContainer', [new ReferenceConfigurator(ContainerInterface::class)])
 
-        // Aliasing service doesn't work when using service as a controller
-        ->set(CRUDController::class, CRUDController::class)
-            ->public()
-            ->tag('container.service_subscriber')
-            ->call('setContainer', [new ReferenceConfigurator(ContainerInterface::class)])
-
         ->set('sonata.admin.event.extension', AdminEventExtension::class)
             ->tag('sonata.admin.extension', ['global' => true])
             ->args([

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -3529,10 +3529,7 @@ final class CRUDControllerTest extends TestCase
             ->method('getBatchActions')
             ->willReturn($batchActions);
 
-        $this->controllerResolver
-            ->expects(static::once())
-            ->method('getController')
-            ->willReturn(false);
+        $this->expectGetController(null, false);
 
         $this->admin->expects(static::any())
             ->method('getBaseControllerName')
@@ -3562,18 +3559,7 @@ final class CRUDControllerTest extends TestCase
             ->method('getBaseControllerName')
             ->willReturn($baseControllerName = 'sonata.admin.controller.crud');
 
-        $this->controllerResolver->expects(static::any())
-            ->method('getController')
-            ->with(
-                static::callback(static function (Request $request) use ($baseControllerName) {
-                    static::assertSame(
-                        $baseControllerName.'::batchActionDelete',
-                        $request->attributes->get('_controller')
-                    );
-
-                    return true;
-                })
-            );
+        $this->expectGetController($baseControllerName.'::batchActionDelete');
 
         $datagrid = $this->createMock(DatagridInterface::class);
 
@@ -3644,18 +3630,7 @@ final class CRUDControllerTest extends TestCase
             ->method('getBaseControllerName')
             ->willReturn($baseControllerName = 'sonata.admin.controller.crud');
 
-        $this->controllerResolver->expects(static::any())
-            ->method('getController')
-            ->with(
-                static::callback(static function (Request $request) use ($baseControllerName) {
-                    static::assertSame(
-                        $baseControllerName.'::batchActionDelete',
-                        $request->attributes->get('_controller')
-                    );
-
-                    return true;
-                })
-            );
+        $this->expectGetController($baseControllerName.'::batchActionDelete');
 
         $datagrid = $this->createMock(DatagridInterface::class);
 
@@ -3741,18 +3716,7 @@ final class CRUDControllerTest extends TestCase
             ->method('getBaseControllerName')
             ->willReturn($baseControllerName = 'sonata.admin.controller.crud');
 
-        $this->controllerResolver->expects(static::any())
-            ->method('getController')
-            ->with(
-                static::callback(static function (Request $request) use ($baseControllerName) {
-                    static::assertSame(
-                        $baseControllerName.'::batchActionDelete',
-                        $request->attributes->get('_controller')
-                    );
-
-                    return true;
-                })
-            );
+        $this->expectGetController($baseControllerName.'::batchActionDelete');
 
         $this->request->setMethod(Request::METHOD_POST);
         $this->request->request->set('data', json_encode($data, \JSON_THROW_ON_ERROR));
@@ -3802,6 +3766,10 @@ final class CRUDControllerTest extends TestCase
 
     /**
      * @dataProvider provideActionNames
+     *
+     * @group legacy
+     *
+     * NEXT_MAJOR: Remove this test
      */
     public function testBatchActionNonRelevantAction(string $actionName): void
     {
@@ -3814,6 +3782,8 @@ final class CRUDControllerTest extends TestCase
         $this->admin->expects(static::exactly(2))
             ->method('getBatchActions')
             ->willReturn($batchActions);
+
+        $this->expectGetController();
 
         $datagrid = $this->createMock(DatagridInterface::class);
 
@@ -3857,6 +3827,8 @@ final class CRUDControllerTest extends TestCase
             ->method('getBatchActions')
             ->willReturn($batchActions);
 
+        $this->expectGetController();
+
         $data = ['action' => 'delete', 'idx' => ['123', '456'], 'all_elements' => false];
 
         $this->request->setMethod(Request::METHOD_POST);
@@ -3887,6 +3859,11 @@ final class CRUDControllerTest extends TestCase
         $this->controller->batchAction($this->request);
     }
 
+    /**
+     * @group legacy
+     *
+     * NEXT_MAJOR: Remove this test
+     */
     public function testBatchActionNonRelevantAction2(): void
     {
         $controller = new BatchAdminController();
@@ -3898,6 +3875,8 @@ final class CRUDControllerTest extends TestCase
         $this->admin->expects(static::exactly(2))
             ->method('getBatchActions')
             ->willReturn($batchActions);
+
+        $this->expectGetController();
 
         $datagrid = $this->createMock(DatagridInterface::class);
 
@@ -3927,6 +3906,8 @@ final class CRUDControllerTest extends TestCase
             ->method('getBatchActions')
             ->willReturn($batchActions);
 
+        $this->expectGetController();
+
         $datagrid = $this->createMock(DatagridInterface::class);
 
         $this->admin->expects(static::once())
@@ -3947,6 +3928,11 @@ final class CRUDControllerTest extends TestCase
         static::assertSame('list', $result->getTargetUrl());
     }
 
+    /**
+     * @group legacy
+     *
+     * NEXT_MAJOR: Remove this test
+     */
     public function testBatchActionNoItemsEmptyQuery(): void
     {
         $controller = new BatchAdminController();
@@ -3958,6 +3944,8 @@ final class CRUDControllerTest extends TestCase
         $this->admin->expects(static::exactly(2))
             ->method('getBatchActions')
             ->willReturn($batchActions);
+
+        $this->expectGetController();
 
         $datagrid = $this->createMock(DatagridInterface::class);
 
@@ -4002,6 +3990,8 @@ final class CRUDControllerTest extends TestCase
         $this->admin->expects(static::exactly(2))
             ->method('getBatchActions')
             ->willReturn($batchActions);
+
+        $this->expectGetController();
 
         $datagrid = $this->createMock(DatagridInterface::class);
 
@@ -4091,5 +4081,24 @@ final class CRUDControllerTest extends TestCase
             ->method('trans')
             ->with(static::equalTo($id), static::equalTo($parameters), static::equalTo($domain), static::equalTo($locale))
             ->willReturn($id);
+    }
+
+    private function expectGetController(?string $controllerName = null, bool $exists = true): void
+    {
+        $this->controllerResolver->expects(static::any())
+            ->method('getController')
+            ->with(
+                static::callback(static function (Request $request) use ($controllerName) {
+                    if (null !== $controllerName) {
+                        static::assertSame(
+                            $controllerName,
+                            $request->attributes->get('_controller')
+                        );
+                    }
+
+                    return true;
+                })
+            )
+            ->willReturn($exists ? static function () {} : false);
     }
 }

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -3565,7 +3565,7 @@ final class CRUDControllerTest extends TestCase
         $this->controllerResolver->expects(static::any())
             ->method('getController')
             ->with(
-                static::callback(function (Request $request) use ($baseControllerName) {
+                static::callback(static function (Request $request) use ($baseControllerName) {
                     static::assertSame(
                         $baseControllerName.'::batchActionDelete',
                         $request->attributes->get('_controller')
@@ -3589,7 +3589,7 @@ final class CRUDControllerTest extends TestCase
         $this->httpKernel->expects(static::once())
             ->method('handle')
             ->with(
-                static::callback(function (Request $request) use ($baseControllerName, $query) {
+                static::callback(static function (Request $request) use ($baseControllerName, $query) {
                     static::assertSame(
                         $baseControllerName.'::batchActionDelete',
                         $request->attributes->get('_controller')
@@ -3647,7 +3647,7 @@ final class CRUDControllerTest extends TestCase
         $this->controllerResolver->expects(static::any())
             ->method('getController')
             ->with(
-                static::callback(function (Request $request) use ($baseControllerName) {
+                static::callback(static function (Request $request) use ($baseControllerName) {
                     static::assertSame(
                         $baseControllerName.'::batchActionDelete',
                         $request->attributes->get('_controller')
@@ -3671,7 +3671,7 @@ final class CRUDControllerTest extends TestCase
         $this->httpKernel->expects(static::once())
             ->method('handle')
             ->with(
-                static::callback(function (Request $request) use ($baseControllerName, $query) {
+                static::callback(static function (Request $request) use ($baseControllerName, $query) {
                     static::assertSame(
                         $baseControllerName.'::batchActionDelete',
                         $request->attributes->get('_controller')
@@ -3744,7 +3744,7 @@ final class CRUDControllerTest extends TestCase
         $this->controllerResolver->expects(static::any())
             ->method('getController')
             ->with(
-                static::callback(function (Request $request) use ($baseControllerName) {
+                static::callback(static function (Request $request) use ($baseControllerName) {
                     static::assertSame(
                         $baseControllerName.'::batchActionDelete',
                         $request->attributes->get('_controller')

--- a/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -31,6 +31,8 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Routing\RouterInterface;
@@ -399,6 +401,12 @@ final class ExtensionCompilerPassTest extends TestCase
         $container
             ->register('security.authorization_checker')
             ->setClass(AuthorizationCheckerInterface::class);
+        $container
+            ->register('controller_resolver')
+            ->setClass(ControllerResolverInterface::class);
+        $container
+            ->register(HttpKernelInterface::class)
+            ->setClass(HttpKernelInterface::class);
 
         // Add admin definition's
         $container


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Allow batch action from another controller

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because I am adding a feature that is backward compatible.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added support to batch action via another controller with 'controller' configuration

### Deprecated
- batchAction{actionName}IsRelevant will be remove in version 5.0. Move logic to your action.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [x] Update the tests;
- [x] Update the documentation;
- [ ] Add an upgrade note.
-->
