### PR TITLE
Handle Abstract class of mapped entities in autocompletion

### DIFF
--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -62,8 +62,7 @@ final class RetrieveAutocompleteItemsAction
             // subject will be empty to avoid unnecessary database requests and keep autocomplete function fast
             $admin->setSubject($admin->getNewInstance());
         } catch (AbstractClassException) {
-            // in case the subject is an abstract entity, we continue
-            // no-op
+            // in case the subject is an abstract entity, we continue because the admin subject is non-mandatory here
         }
 
         $field = $request->get('field');

--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Action;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
+use Sonata\AdminBundle\Exception\AbstractClassException;
 use Sonata\AdminBundle\Exception\BadRequestParamHttpException;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 use Sonata\AdminBundle\Filter\FilterInterface;
@@ -57,8 +58,13 @@ final class RetrieveAutocompleteItemsAction
             throw new AccessDeniedException();
         }
 
-        // subject will be empty to avoid unnecessary database requests and keep autocomplete function fast
-        $admin->setSubject($admin->getNewInstance());
+        try {
+            // subject will be empty to avoid unnecessary database requests and keep autocomplete function fast
+            $admin->setSubject($admin->getNewInstance());
+        } catch (AbstractClassException) {
+            // in case the subject is an abstract entity, we continue
+            // no-op
+        }
 
         $field = $request->get('field');
         if (!\is_string($field)) {

--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -61,7 +61,7 @@ final class RetrieveAutocompleteItemsAction
         try {
             // subject will be empty to avoid unnecessary database requests and keep autocomplete function fast
             $admin->setSubject($admin->getNewInstance());
-        } catch (AbstractClassException) {
+        } catch (AbstractClassException $e) {
             // in case the subject is an abstract entity, we continue because the admin subject is non-mandatory here
         }
 

--- a/src/Exception/AbstractClassException.php
+++ b/src/Exception/AbstractClassException.php
@@ -18,4 +18,11 @@ namespace Sonata\AdminBundle\Exception;
  */
 final class AbstractClassException extends \RuntimeException
 {
+    /**
+     * @param class-string $class
+     */
+    public function __construct(string $class)
+    {
+        parent::__construct(sprintf('Cannot initialize abstract class: %s', $class));
+    }
 }

--- a/src/Exception/AbstractClassException.php
+++ b/src/Exception/AbstractClassException.php
@@ -15,6 +15,8 @@ namespace Sonata\AdminBundle\Exception;
 
 /**
  * @author Morgan Abraham <morgan@geekimo.me>
+ *
+ * NEXT_MAJOR: extends \InvalidArgumentException
  */
 final class AbstractClassException extends \RuntimeException
 {

--- a/src/Exception/AbstractClassException.php
+++ b/src/Exception/AbstractClassException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Exception;
+
+/**
+ * @author Morgan Abraham <morgan@geekimo.me>
+ */
+final class AbstractClassException extends \RuntimeException
+{
+}

--- a/src/Util/Instantiator.php
+++ b/src/Util/Instantiator.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Util;
 
+use Sonata\AdminBundle\Exception\AbstractClassException;
+
 /**
  * @internal
  */
@@ -27,7 +29,7 @@ final class Instantiator
     {
         $r = new \ReflectionClass($class);
         if ($r->isAbstract()) {
-            throw new \RuntimeException(sprintf('Cannot initialize abstract class: %s', $class));
+            throw new AbstractClassException(sprintf('Cannot initialize abstract class: %s', $class));
         }
 
         $constructor = $r->getConstructor();

--- a/src/Util/Instantiator.php
+++ b/src/Util/Instantiator.php
@@ -29,7 +29,7 @@ final class Instantiator
     {
         $r = new \ReflectionClass($class);
         if ($r->isAbstract()) {
-            throw new AbstractClassException(sprintf('Cannot initialize abstract class: %s', $class));
+            throw new AbstractClassException($class);
         }
 
         $constructor = $r->getConstructor();

--- a/tests/Util/InstantiatorTest.php
+++ b/tests/Util/InstantiatorTest.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Tests\Util;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Exception\AbstractClassException;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\AbstractEntity;
+use Sonata\AdminBundle\Tests\Fixtures\Entity\Bar;
 use Sonata\AdminBundle\Util\Instantiator;
 
 /**
@@ -26,6 +27,12 @@ final class InstantiatorTest extends TestCase
     public function testAbstractClassThrowsException(): void
     {
         $this->expectException(AbstractClassException::class);
+
         Instantiator::instantiate(AbstractEntity::class);
+    }
+
+    public function testNotAbstractClassDoesntThrowsException(): void
+    {
+        static::assertInstanceOf(Bar::class, Instantiator::instantiate(Bar::class));
     }
 }

--- a/tests/Util/InstantiatorTest.php
+++ b/tests/Util/InstantiatorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Util;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Exception\AbstractClassException;
+use Sonata\AdminBundle\Tests\Fixtures\Entity\AbstractEntity;
+use Sonata\AdminBundle\Util\Instantiator;
+
+/**
+ * @author Morgan Abraham <morgan@geekimo.me>
+ */
+final class InstantiatorTest extends TestCase
+{
+    public function testAbstractClassThrowsException(): void
+    {
+        $this->expectException(AbstractClassException::class);
+        Instantiator::instantiate(AbstractEntity::class);
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Handle Abstract class of mapped entities in autocompletion

<!-- Describe your Pull Request content here -->
This PR aims to add mapped entities handling for `ModelAutocompleteType` when definition's subject is an abstract entity.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is the current stable release.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #7822 .

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Support for abstract class subject in `RetrieveAutocompleteItemsAction`.
```
