### PR TITLE
Deprecate FormMapper::create

### DIFF
--- a/src/Form/FormMapper.php
+++ b/src/Form/FormMapper.php
@@ -186,11 +186,19 @@ final class FormMapper extends BaseGroupedMapper implements BlockFormMapper
     }
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * @param class-string<FormTypeInterface>|null $type
      * @param array<string, mixed>                 $options
      */
     public function create(string $name, ?string $type = null, array $options = []): FormBuilderInterface
     {
+        @trigger_error(sprintf(
+            'The "%s()" method is deprecated since sonata-project/admin-bundle version 4.x and will be'
+            .' removed in 5.0 version.',
+            __METHOD__
+        ), \E_USER_DEPRECATED);
+
         return $this->formBuilder->create($name, $type, $options);
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because BC.

Related to the deprecation introduce in SonataBlock

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- FormMapper::create()
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
