### PR TITLE
Fix Symfony 6.1 deprecations

### DIFF
--- a/src/Command/ExplainAdminCommand.php
+++ b/src/Command/ExplainAdminCommand.php
@@ -24,8 +24,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class ExplainAdminCommand extends Command
 {
-    protected static $defaultName = 'sonata:admin:explain';
-
     private Pool $pool;
 
     /**
@@ -40,9 +38,10 @@ final class ExplainAdminCommand extends Command
 
     public function configure(): void
     {
-        $this->setDescription('Explain an admin service');
-
-        $this->addArgument('admin', InputArgument::REQUIRED, 'The admin service id');
+        $this
+            ->setName('sonata:admin:explain')
+            ->setDescription('Explain an admin service')
+            ->addArgument('admin', InputArgument::REQUIRED, 'The admin service id');
     }
 
     public function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/GenerateObjectAclCommand.php
+++ b/src/Command/GenerateObjectAclCommand.php
@@ -26,8 +26,6 @@ use Symfony\Component\Security\Acl\Domain\UserSecurityIdentity;
  */
 final class GenerateObjectAclCommand extends QuestionableCommand
 {
-    protected static $defaultName = 'sonata:admin:generate-object-acl';
-
     private string $userModelClass = '';
 
     private Pool $pool;
@@ -55,6 +53,7 @@ final class GenerateObjectAclCommand extends QuestionableCommand
     public function configure(): void
     {
         $this
+            ->setName('sonata:admin:generate-object-acl')
             ->setDescription('Install ACL for the objects of the Admin Classes.')
             ->addOption('object_owner', null, InputOption::VALUE_OPTIONAL, 'If set, the task will set the object owner for each admin.')
             ->addOption('user_model', null, InputOption::VALUE_OPTIONAL, 'Fully qualified class name <comment>App\Model\User</comment>. If not set, it will be asked the first time an object owner is set.')

--- a/src/Command/ListAdminCommand.php
+++ b/src/Command/ListAdminCommand.php
@@ -23,8 +23,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class ListAdminCommand extends Command
 {
-    protected static $defaultName = 'sonata:admin:list';
-
     private Pool $pool;
 
     /**
@@ -39,7 +37,9 @@ final class ListAdminCommand extends Command
 
     public function configure(): void
     {
-        $this->setDescription('List all admin services available');
+        $this
+            ->setName('sonata:admin:list')
+            ->setDescription('List all admin services available');
     }
 
     public function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Command/SetupAclCommand.php
+++ b/src/Command/SetupAclCommand.php
@@ -24,8 +24,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 final class SetupAclCommand extends Command
 {
-    protected static $defaultName = 'sonata:admin:setup-acl';
-
     private Pool $pool;
 
     private AdminAclManipulatorInterface $aclManipulator;
@@ -43,7 +41,9 @@ final class SetupAclCommand extends Command
 
     public function configure(): void
     {
-        $this->setDescription('Install ACL for Admin Classes');
+        $this
+            ->setName('sonata:admin:setup-acl')
+            ->setDescription('Install ACL for Admin Classes');
     }
 
     public function execute(InputInterface $input, OutputInterface $output): int

--- a/src/Resources/config/commands.php
+++ b/src/Resources/config/commands.php
@@ -24,26 +24,26 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->services()
 
         ->set('sonata.admin.command.explain', ExplainAdminCommand::class)
-            ->tag('console.command')
+            ->tag('console.command', ['command' => 'sonata:admin:explain'])
             ->args([
                 new ReferenceConfigurator('sonata.admin.pool'),
             ])
 
         ->set('sonata.admin.command.generate_object_acl', GenerateObjectAclCommand::class)
-            ->tag('console.command')
+            ->tag('console.command', ['command' => 'sonata:admin:generate-object-acl'])
             ->args([
                 new ReferenceConfigurator('sonata.admin.pool'),
                 [],
             ])
 
         ->set('sonata.admin.command.list', ListAdminCommand::class)
-            ->tag('console.command')
+            ->tag('console.command', ['command' => 'sonata:admin:list'])
             ->args([
                 new ReferenceConfigurator('sonata.admin.pool'),
             ])
 
         ->set('sonata.admin.command.setup_acl', SetupAclCommand::class)
-            ->tag('console.command')
+            ->tag('console.command', ['command' => 'sonata:admin:setup-acl'])
             ->args([
                 new ReferenceConfigurator('sonata.admin.pool'),
                 new ReferenceConfigurator('sonata.admin.manipulator.acl.admin'),

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -92,6 +92,7 @@ final class AppKernel extends Kernel
             'translator' => [
                 'default_path' => '%kernel.project_dir%/translations',
             ],
+            'http_method_override' => false,
         ];
 
         // TODO: Remove else case when dropping support of Symfony < 5.3


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This will keep [the command lazy loaded](https://symfony.com/doc/4.4/console/commands_as_services.html#lazy-loading) and prevents triggering deprecations when using [Symfony 6.1](https://github.com/symfony/symfony/blob/6.1/UPGRADE-6.1.md#console)

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Command deprecations using Symfony 6.1
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
