### PR TITLE
Add Picker Option to Form Filter to change default field_type

### DIFF
--- a/src/Form/Type/Filter/DateRangeType.php
+++ b/src/Form/Type/Filter/DateRangeType.php
@@ -14,9 +14,11 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Form\Type\Filter;
 
 use Sonata\AdminBundle\Form\Type\Operator\DateRangeOperatorType;
+use Sonata\Form\Type\DateRangePickerType;
 use Sonata\Form\Type\DateRangeType as FormDateRangeType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -38,7 +40,10 @@ final class DateRangeType extends AbstractType
     {
         $resolver->setDefaults([
             'operator_type' => DateRangeOperatorType::class,
-            'field_type' => FormDateRangeType::class,
+            'field_type' => function (Options $options) {
+                return $options['picker'] ? DateRangePickerType::class : FormDateRangeType::class;
+            },
+            'picker' => false,
             'field_options' => [
                 'field_options' => [
                     'format' => DateType::HTML5_FORMAT,

--- a/src/Form/Type/Filter/DateTimeRangeType.php
+++ b/src/Form/Type/Filter/DateTimeRangeType.php
@@ -14,9 +14,11 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Form\Type\Filter;
 
 use Sonata\AdminBundle\Form\Type\Operator\DateRangeOperatorType;
+use Sonata\Form\Type\DateTimeRangePickerType;
 use Sonata\Form\Type\DateTimeRangeType as FormDateTimeRangeType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -38,7 +40,10 @@ final class DateTimeRangeType extends AbstractType
     {
         $resolver->setDefaults([
             'operator_type' => DateRangeOperatorType::class,
-            'field_type' => FormDateTimeRangeType::class,
+            'field_type' => function (Options $options) {
+                return $options['picker'] ? DateTimeRangePickerType::class : FormDateTimeRangeType::class;
+            },
+            'picker' => false,
             'field_options' => [
                 'field_options' => ['date_format' => DateTimeType::HTML5_FORMAT],
             ],

--- a/src/Form/Type/Filter/DateTimeType.php
+++ b/src/Form/Type/Filter/DateTimeType.php
@@ -14,9 +14,10 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Form\Type\Filter;
 
 use Sonata\AdminBundle\Form\Type\Operator\DateOperatorType;
+use Sonata\Form\Type\DateTimePickerType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType as FormDateTimeType;
-use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -38,8 +39,11 @@ final class DateTimeType extends AbstractType
     {
         $resolver->setDefaults([
             'operator_type' => DateOperatorType::class,
-            'field_type' => FormDateTimeType::class,
-            'field_options' => ['date_format' => DateType::HTML5_FORMAT],
+            'field_type' => function (Options $options) {
+                return $options['picker'] ? DateTimePickerType::class : FormDateTimeType::class;
+            },
+            'picker' => false,
+            'field_options' => ['date_format' => FormDateTimeType::HTML5_FORMAT],
         ]);
     }
 }

--- a/src/Form/Type/Filter/DateType.php
+++ b/src/Form/Type/Filter/DateType.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Form\Type\Filter;
 
 use Sonata\AdminBundle\Form\Type\Operator\DateOperatorType;
+use Sonata\Form\Type\DatePickerType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateType as FormDateType;
+use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -37,7 +39,10 @@ final class DateType extends AbstractType
     {
         $resolver->setDefaults([
             'operator_type' => DateOperatorType::class,
-            'field_type' => FormDateType::class,
+            'field_type' => function (Options $options) {
+                return $options['picker'] ? DatePickerType::class : FormDateType::class;
+            },
+            'picker' => false,
             'field_options' => ['format' => FormDateType::HTML5_FORMAT],
         ]);
     }

--- a/tests/Form/Type/Filter/DateRangeTypeTest.php
+++ b/tests/Form/Type/Filter/DateRangeTypeTest.php
@@ -14,6 +14,12 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Form\Type\Filter;
 
 use Sonata\AdminBundle\Form\Type\Filter\DateRangeType;
+use Sonata\AdminBundle\Form\Type\Operator\DateRangeOperatorType;
+use Sonata\Form\Type\DateRangePickerType;
+use Sonata\Form\Type\DateRangeType as FormDateRangeType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class DateRangeTypeTest extends BaseTypeTest
 {
@@ -27,6 +33,45 @@ final class DateRangeTypeTest extends BaseTypeTest
         static::assertFalse($view->children['value']->vars['required']);
     }
 
+    public function testGetDefaultOptions(): void
+    {
+        $type = new DateRangeType();
+
+        $optionsResolver = new OptionsResolver();
+
+        $type->configureOptions($optionsResolver);
+
+        $options = $optionsResolver->resolve();
+
+        $expected = [
+            'operator_type' => DateRangeOperatorType::class,
+            'picker' => false,
+            'field_options' => ['field_options' => ['format' => DateType::HTML5_FORMAT]],
+            'field_type' => FormDateRangeType::class,
+        ];
+        static::assertSame($expected, $options);
+    }
+
+    public function testGetPickerDefaultOptions(): void
+    {
+        $type = new DateRangeType();
+
+        $optionsResolver = new OptionsResolver();
+
+        $type->configureOptions($optionsResolver);
+
+        $options = $optionsResolver->resolve([
+            'picker' => true
+        ]);
+
+        $expected = [
+            'operator_type' => DateRangeOperatorType::class,
+            'field_options' => ['field_options' => ['format' => DateType::HTML5_FORMAT]],
+            'picker' => true,
+            'field_type' => DateRangePickerType::class,
+        ];
+        static::assertSame($expected, $options);
+    }
     protected function getTestedType(): string
     {
         return DateRangeType::class;

--- a/tests/Form/Type/Filter/DateTimeRangeTypeTest.php
+++ b/tests/Form/Type/Filter/DateTimeRangeTypeTest.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Tests\Form\Type\Filter;
 
 use Sonata\AdminBundle\Form\Type\Filter\DateTimeRangeType;
 use Sonata\AdminBundle\Form\Type\Operator\DateRangeOperatorType;
+use Sonata\Form\Type\DateTimeRangePickerType;
 use Sonata\Form\Type\DateTimeRangeType as FormDateTimeRangeType;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -43,8 +44,30 @@ final class DateTimeRangeTypeTest extends BaseTypeTest
 
         $expected = [
             'operator_type' => DateRangeOperatorType::class,
-            'field_type' => FormDateTimeRangeType::class,
+            'picker' => false,
             'field_options' => ['field_options' => ['date_format' => DateTimeType::HTML5_FORMAT]],
+            'field_type' => FormDateTimeRangeType::class,
+        ];
+        static::assertSame($expected, $options);
+    }
+
+    public function testGetPickerDefaultOptions(): void
+    {
+        $type = new DateTimeRangeType();
+
+        $optionsResolver = new OptionsResolver();
+
+        $type->configureOptions($optionsResolver);
+
+        $options = $optionsResolver->resolve([
+            'picker' => true
+        ]);
+
+        $expected = [
+            'operator_type' => DateRangeOperatorType::class,
+            'field_options' => ['field_options' => ['date_format' => DateTimeType::HTML5_FORMAT]],
+            'picker' => true,
+            'field_type' => DateTimeRangePickerType::class,
         ];
         static::assertSame($expected, $options);
     }

--- a/tests/Form/Type/Filter/DateTimeTypeTest.php
+++ b/tests/Form/Type/Filter/DateTimeTypeTest.php
@@ -14,6 +14,10 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Form\Type\Filter;
 
 use Sonata\AdminBundle\Form\Type\Filter\DateTimeType;
+use Sonata\AdminBundle\Form\Type\Operator\DateOperatorType;
+use Sonata\Form\Type\DateTimePickerType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType as FormDateTimeType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class DateTimeTypeTest extends BaseTypeTest
 {
@@ -25,6 +29,46 @@ final class DateTimeTypeTest extends BaseTypeTest
 
         static::assertFalse($view->children['type']->vars['required']);
         static::assertFalse($view->children['value']->vars['required']);
+    }
+
+    public function testGetDefaultOptions(): void
+    {
+        $type = new DateTimeType();
+
+        $optionsResolver = new OptionsResolver();
+
+        $type->configureOptions($optionsResolver);
+
+        $options = $optionsResolver->resolve();
+
+        $expected = [
+            'operator_type' => DateOperatorType::class,
+            'picker' => false,
+            'field_options' => ['date_format' => FormDateTimeType::HTML5_FORMAT],
+            'field_type' => FormDateTimeType::class,
+        ];
+        static::assertSame($expected, $options);
+    }
+
+    public function testGetPickerDefaultOptions(): void
+    {
+        $type = new DateTimeType();
+
+        $optionsResolver = new OptionsResolver();
+
+        $type->configureOptions($optionsResolver);
+
+        $options = $optionsResolver->resolve([
+            'picker' => true
+        ]);
+
+        $expected = [
+            'operator_type' => DateOperatorType::class,
+            'field_options' => ['date_format' => FormDateTimeType::HTML5_FORMAT],
+            'picker' => true,
+            'field_type' => DateTimePickerType::class,
+        ];
+        static::assertSame($expected, $options);
     }
 
     protected function getTestedType(): string

--- a/tests/Form/Type/Filter/DateTypeTest.php
+++ b/tests/Form/Type/Filter/DateTypeTest.php
@@ -14,6 +14,10 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\Form\Type\Filter;
 
 use Sonata\AdminBundle\Form\Type\Filter\DateType;
+use Sonata\AdminBundle\Form\Type\Operator\DateOperatorType;
+use Sonata\Form\Type\DatePickerType;
+use Symfony\Component\Form\Extension\Core\Type\DateType as FormDateType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class DateTypeTest extends BaseTypeTest
 {
@@ -25,6 +29,46 @@ final class DateTypeTest extends BaseTypeTest
 
         static::assertFalse($view->children['type']->vars['required']);
         static::assertFalse($view->children['value']->vars['required']);
+    }
+
+    public function testGetDefaultOptions(): void
+    {
+        $type = new DateType();
+
+        $optionsResolver = new OptionsResolver();
+
+        $type->configureOptions($optionsResolver);
+
+        $options = $optionsResolver->resolve();
+
+        $expected = [
+            'operator_type' => DateOperatorType::class,
+            'picker' => false,
+            'field_options' => ['format' => FormDateType::HTML5_FORMAT],
+            'field_type' => FormDateType::class,
+        ];
+        static::assertSame($expected, $options);
+    }
+
+    public function testGetPickerDefaultOptions(): void
+    {
+        $type = new DateType();
+
+        $optionsResolver = new OptionsResolver();
+
+        $type->configureOptions($optionsResolver);
+
+        $options = $optionsResolver->resolve([
+            'picker' => true
+        ]);
+
+        $expected = [
+            'operator_type' => DateOperatorType::class,
+            'field_options' => ['format' => FormDateType::HTML5_FORMAT],
+            'picker' => true,
+            'field_type' => DatePickerType::class,
+        ];
+        static::assertSame($expected, $options);
     }
 
     protected function getTestedType(): string


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it should be BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

It is needed to make this one cleaner: https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/1662 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added picker option to Form Filter to change default field_type.

### Changed

### Deprecated

### Removed

### Fixed
- Filter DateTimeType used wrong date_format

### Security
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [x] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
