### PR TITLE
Deprecate getRenderSettings and lot of types

### DIFF
--- a/UPGRADE-4.x.md
+++ b/UPGRADE-4.x.md
@@ -1,6 +1,39 @@
 UPGRADE 4.x
 ===========
 
+UPGRADE FROM 4.x to 4.x
+=======================
+
+## FilterInterface
+
+Not implementing `getFormOptions()` is deprecated, it will replace the `getRenderSettings()`
+in next major. If you have an implementation this way:
+```php
+public function getRenderSettings(): array
+{
+    return [DefaultType::class, [
+        'operator_type' => $this->getOption('operator_type'),
+        'operator_options' => $this->getOption('operator_options'),
+        'field_type' => $this->getFieldType(),
+        'field_options' => $this->getFieldOptions(),
+        'label' => $this->getLabel(),
+    ]];
+}
+```
+You can implement the `getFormOptions()` method this way:
+```php
+public function getFormOptions(): array
+{
+    return [
+        'operator_type' => $this->getOption('operator_type'),
+        'operator_options' => $this->getOption('operator_options'),
+        'field_type' => $this->getFieldType(),
+        'field_options' => $this->getFieldOptions(),
+        'label' => $this->getLabel(),
+    ];
+}
+```
+
 UPGRADE FROM 4.12.0 to 4.13.0
 =============================
 
@@ -8,7 +41,6 @@ UPGRADE FROM 4.12.0 to 4.13.0
 
 Deprecate `batchAction%sIsRelevant` hook. You must handle the specific logic in your
 batch action controller directly.
-
 
 UPGRADE FROM 4.11.1 to 4.12.0
 =============================

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
         "phpstan/phpstan-strict-rules": "^1.0",
         "phpstan/phpstan-symfony": "^1.0",
         "phpunit/phpunit": "^9.5",
-        "psalm/plugin-phpunit": "^0.16",
+        "psalm/plugin-phpunit": "^0.17",
         "psalm/plugin-symfony": "^3.0",
         "psr/event-dispatcher": "^1.0",
         "rector/rector": "^0.12",

--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -356,7 +356,7 @@ final class Datagrid implements DatagridInterface
             } else {
                 @trigger_error(
                     'Not implementing "getFormOptions()" is deprecated since sonata-project/admin-bundle 4.x'
-                    .' and will throws an error  in 5.0.',
+                    .' and will throw an error in 5.0.',
                     \E_USER_DEPRECATED
                 );
 

--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Datagrid;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionCollection;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 use Sonata\AdminBundle\Filter\FilterInterface;
+use Sonata\AdminBundle\Form\Type\Filter\FilterDataType;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
@@ -348,7 +349,19 @@ final class Datagrid implements DatagridInterface
         }
 
         foreach ($this->getFilters() as $filter) {
-            [$type, $options] = $filter->getRenderSettings();
+            // NEXT_MAJOR: Keep the if part.
+            if (method_exists($filter, 'getFormOptions')) { // @phpstan-ignore-line
+                $type = FilterDataType::class;
+                $options = $filter->getFormOptions();
+            } else {
+                @trigger_error(
+                    'Not implementing "getFormOptions()" is deprecated since sonata-project/admin-bundle 4.x'
+                    .' and will throws an error  in 5.0.',
+                    \E_USER_DEPRECATED
+                );
+
+                [$type, $options] = $filter->getRenderSettings();
+            }
 
             $this->formBuilder->add($filter->getFormName(), $type, $options);
         }

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Filter;
 
+use Sonata\AdminBundle\Form\Type\Filter\FilterDataType;
 use Sonata\AdminBundle\Search\ChainableFilterInterface;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
@@ -224,6 +225,25 @@ abstract class Filter implements FilterInterface, ChainableFilterInterface
     final public function hasPreviousFilter(): bool
     {
         return null !== $this->previousFilter;
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
+    public function getRenderSettings(): array
+    {
+        // @phpstan-ignore-next-line
+        if (!method_exists($this, 'getFormOptions')) {
+            throw new \BadMethodCallException('You MUST implements `getFormOptions()`.');
+        }
+
+        /** @var array<string, mixed> $formOptions */
+        $formOptions = $this->getFormOptions();
+
+        return [
+            FilterDataType::class,
+            $formOptions,
+        ];
     }
 
     final protected function setActive(bool $active): void

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -234,7 +234,7 @@ abstract class Filter implements FilterInterface, ChainableFilterInterface
     {
         // @phpstan-ignore-next-line
         if (!method_exists($this, 'getFormOptions')) {
-            throw new \BadMethodCallException('You MUST implements `getFormOptions()`.');
+            throw new \BadMethodCallException('You MUST implement `getFormOptions()`.');
         }
 
         /** @var array<string, mixed> $formOptions */

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -18,6 +18,8 @@ use Sonata\AdminBundle\Filter\Model\FilterData;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * @method array  getFormOptions();
  */
 interface FilterInterface
 {
@@ -121,6 +123,10 @@ interface FilterInterface
     public function getFieldType(): string;
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
+     * @deprecated since sonata-project/admin-bundle version 4.x use getFormType() and getFormOptions() instead.
+     *
      * Returns the main widget used to render the filter.
      *
      * @return array{string, array<string, mixed>}

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -19,7 +19,7 @@ use Sonata\AdminBundle\Filter\Model\FilterData;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
- * @method array  getFormOptions();
+ * @method array getFormOptions();
  */
 interface FilterInterface
 {
@@ -125,7 +125,7 @@ interface FilterInterface
     /**
      * NEXT_MAJOR: Remove this method.
      *
-     * @deprecated since sonata-project/admin-bundle version 4.x use getFormType() and getFormOptions() instead.
+     * @deprecated since sonata-project/admin-bundle version 4.x use getFormOptions() instead.
      *
      * Returns the main widget used to render the filter.
      *

--- a/src/Form/Type/Filter/ChoiceType.php
+++ b/src/Form/Type/Filter/ChoiceType.php
@@ -20,6 +20,10 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * NEXT_MAJOR: Remove this form.
+ *
+ * @deprecated since sonata-project/admin-bundle version 4.x use the FilterDataType instead
  */
 final class ChoiceType extends AbstractType
 {

--- a/src/Form/Type/Filter/DateRangeType.php
+++ b/src/Form/Type/Filter/DateRangeType.php
@@ -21,6 +21,10 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * NEXT_MAJOR: Remove this form.
+ *
+ * @deprecated since sonata-project/admin-bundle version 4.x use the FilterDataType instead
  */
 final class DateRangeType extends AbstractType
 {

--- a/src/Form/Type/Filter/DateTimeRangeType.php
+++ b/src/Form/Type/Filter/DateTimeRangeType.php
@@ -21,6 +21,10 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * NEXT_MAJOR: Remove this form.
+ *
+ * @deprecated since sonata-project/admin-bundle version 4.x use the FilterDataType instead
  */
 final class DateTimeRangeType extends AbstractType
 {

--- a/src/Form/Type/Filter/DateTimeType.php
+++ b/src/Form/Type/Filter/DateTimeType.php
@@ -21,6 +21,10 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * NEXT_MAJOR: Remove this form.
+ *
+ * @deprecated since sonata-project/admin-bundle version 4.x use the FilterDataType instead
  */
 final class DateTimeType extends AbstractType
 {

--- a/src/Form/Type/Filter/DateType.php
+++ b/src/Form/Type/Filter/DateType.php
@@ -20,6 +20,10 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * NEXT_MAJOR: Remove this form.
+ *
+ * @deprecated since sonata-project/admin-bundle version 4.x use the FilterDataType instead
  */
 final class DateType extends AbstractType
 {

--- a/src/Form/Type/Filter/DefaultType.php
+++ b/src/Form/Type/Filter/DefaultType.php
@@ -20,6 +20,10 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * NEXT_MAJOR: Remove this form.
+ *
+ * @deprecated since sonata-project/admin-bundle version 4.x use the FilterDataType instead
  */
 final class DefaultType extends AbstractType
 {

--- a/src/Form/Type/Filter/FilterDataType.php
+++ b/src/Form/Type/Filter/FilterDataType.php
@@ -15,6 +15,8 @@ namespace Sonata\AdminBundle\Form\Type\Filter;
 
 use Sonata\AdminBundle\Form\DataTransformer\FilterDataTransformer;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -42,11 +44,12 @@ final class FilterDataType extends AbstractType
     public function configureOptions(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
+            'operator_type' => HiddenType::class,
             'operator_options' => [],
+            'field_type' => TextType::class,
             'field_options' => [],
         ]);
         $resolver
-            ->setRequired(['operator_type', 'field_type'])
             ->setAllowedTypes('operator_type', 'string')
             ->setAllowedTypes('field_type', 'string')
             ->setAllowedTypes('operator_options', 'array')

--- a/src/Form/Type/Filter/NumberType.php
+++ b/src/Form/Type/Filter/NumberType.php
@@ -20,6 +20,10 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * NEXT_MAJOR: Remove this form.
+ *
+ * @deprecated since sonata-project/admin-bundle version 4.x use the FilterDataType instead
  */
 final class NumberType extends AbstractType
 {

--- a/tests/Datagrid/DatagridTest.php
+++ b/tests/Datagrid/DatagridTest.php
@@ -315,7 +315,9 @@ final class DatagridTest extends TestCase
 
     public function testBuildPager(): void
     {
-        $filter1 = $this->createMock(FilterInterface::class);
+        $filter1 = $this->getMockBuilder(FilterInterface::class)
+            ->addMethods(['getFormOptions'])
+            ->getMockForAbstractClass();
         $filter1->expects(static::once())
             ->method('getName')
             ->willReturn('foo');
@@ -326,12 +328,14 @@ final class DatagridTest extends TestCase
             ->method('isActive')
             ->willReturn(false);
         $filter1
-            ->method('getRenderSettings')
-            ->willReturn([DefaultType::class, ['operator_options' => ['help' => 'baz1']]]);
+            ->method('getFormOptions')
+            ->willReturn(['operator_options' => ['help' => 'baz1']]);
 
         $this->datagrid->addFilter($filter1);
 
-        $filter2 = $this->createMock(FilterInterface::class);
+        $filter2 = $this->getMockBuilder(FilterInterface::class)
+            ->addMethods(['getFormOptions'])
+            ->getMockForAbstractClass();
         $filter2->expects(static::once())
             ->method('getName')
             ->willReturn('bar');
@@ -342,8 +346,8 @@ final class DatagridTest extends TestCase
             ->method('isActive')
             ->willReturn(true);
         $filter2
-            ->method('getRenderSettings')
-            ->willReturn([DefaultType::class, ['operator_options' => ['help' => 'baz2']]]);
+            ->method('getFormOptions')
+            ->willReturn(['operator_options' => ['help' => 'baz2']]);
 
         $this->datagrid->addFilter($filter2);
 
@@ -364,6 +368,31 @@ final class DatagridTest extends TestCase
      * @dataProvider applyFilterDataProvider
      */
     public function testApplyFilter(?string $type, ?string $value, int $applyCallNumber): void
+    {
+        $this->datagrid->setValue('fooFormName', $type, $value);
+
+        $filter = $this->getMockBuilder(FilterInterface::class)
+            ->addMethods(['getFormOptions'])
+            ->getMockForAbstractClass();
+        $filter->expects(static::once())->method('getName')->willReturn('foo');
+        $filter->method('getFormName')->willReturn('fooFormName');
+        $filter->method('isActive')->willReturn(false);
+        $filter->method('getFormOptions')->willReturn(['operator_options' => ['help' => 'baz2']]);
+        $filter->expects(static::exactly($applyCallNumber))->method('apply');
+
+        $this->datagrid->addFilter($filter);
+
+        $this->datagrid->buildPager();
+    }
+
+    /**
+     * NEXT_MAJOR: Remove this test.
+     *
+     * @group legacy
+     *
+     * @dataProvider applyFilterDataProvider
+     */
+    public function testLegacyApplyFilter(?string $type, ?string $value, int $applyCallNumber): void
     {
         $this->datagrid->setValue('fooFormName', $type, $value);
 
@@ -398,7 +427,9 @@ final class DatagridTest extends TestCase
 
     public function testBuildPagerWithException(): void
     {
-        $filter = $this->createMock(FilterInterface::class);
+        $filter = $this->getMockBuilder(FilterInterface::class)
+            ->addMethods(['getFormOptions'])
+            ->getMockForAbstractClass();
         $filter->expects(static::once())
             ->method('getName')
             ->willReturn('foo');
@@ -411,8 +442,8 @@ final class DatagridTest extends TestCase
             ->method('isActive')
             ->willReturn(false);
         $filter
-            ->method('getRenderSettings')
-            ->willReturn([DefaultType::class, ['operator_options' => ['help' => 'baz']]]);
+            ->method('getFormOptions')
+            ->willReturn(['operator_options' => ['help' => 'baz']]);
 
         $this->datagrid->addFilter($filter);
 
@@ -441,7 +472,9 @@ final class DatagridTest extends TestCase
 
         $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, [DatagridInterface::SORT_BY => $sortBy]);
 
-        $filter = $this->createMock(FilterInterface::class);
+        $filter = $this->getMockBuilder(FilterInterface::class)
+            ->addMethods(['getFormOptions'])
+            ->getMockForAbstractClass();
         $filter->expects(static::once())
             ->method('getName')
             ->willReturn('foo');
@@ -452,8 +485,8 @@ final class DatagridTest extends TestCase
             ->method('isActive')
             ->willReturn(false);
         $filter
-            ->method('getRenderSettings')
-            ->willReturn([DefaultType::class, ['operator_options' => ['help' => 'baz']]]);
+            ->method('getFormOptions')
+            ->willReturn(['operator_options' => ['help' => 'baz']]);
 
         $this->datagrid->addFilter($filter);
 
@@ -491,7 +524,9 @@ final class DatagridTest extends TestCase
 
         $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, [DatagridInterface::SORT_BY => $sortBy, DatagridInterface::PAGE => $page, DatagridInterface::PER_PAGE => $perPage]);
 
-        $filter = $this->createMock(FilterInterface::class);
+        $filter = $this->getMockBuilder(FilterInterface::class)
+            ->addMethods(['getFormOptions'])
+            ->getMockForAbstractClass();
         $filter->expects(static::once())
             ->method('getName')
             ->willReturn('foo');
@@ -502,8 +537,8 @@ final class DatagridTest extends TestCase
             ->method('isActive')
             ->willReturn(false);
         $filter
-            ->method('getRenderSettings')
-            ->willReturn([DefaultType::class, ['operator_options' => ['help' => 'baz']]]);
+            ->method('getFormOptions')
+            ->willReturn(['operator_options' => ['help' => 'baz']]);
 
         $this->datagrid->addFilter($filter);
 

--- a/tests/Fixtures/Filter/BarFilter.php
+++ b/tests/Fixtures/Filter/BarFilter.php
@@ -29,10 +29,21 @@ final class BarFilter extends Filter
         return ['bar' => 'bar'];
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function getRenderSettings(): array
     {
         return [DefaultType::class, [
             'label' => 'label',
         ]];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getFormOptions(): array
+    {
+        return ['label' => 'label'];
     }
 }

--- a/tests/Fixtures/Filter/FooFilter.php
+++ b/tests/Fixtures/Filter/FooFilter.php
@@ -35,8 +35,19 @@ final class FooFilter extends Filter
         ];
     }
 
+    /**
+     * NEXT_MAJOR: Remove this method.
+     */
     public function getRenderSettings(): array
     {
         return ['string', []];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getFormOptions(): array
+    {
+        return [];
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Related to the issue https://github.com/sonata-project/SonataAdminBundle/pull/7839#issuecomment-1143483090

The options from the different formTypes in the Form/Type/Filter folder are overridden by the options passed in the `getRenderSettings` method of the FilterInterface. So there is no real interest in having different FilterType. We should just provide the FilterDataType and then all the filters would configure which options are passed to it.

This is supposed to be BC.
In order to use the new logic with a FilterDataType, you have to implements the `getFormOptions()` method

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Support for a FilterInterface::getFormOptions method.

### Deprecated
- FilterInterface::getRenderSettigns
- All the `Sonata\AdminBundle\Form\Type\Filter\*Type` except the FilterDataType.
```