### PR TITLE
admin value resolver accept generat AdminInterface type

### DIFF
--- a/docs/cookbook/recipe_decouple_crud_controller.rst
+++ b/docs/cookbook/recipe_decouple_crud_controller.rst
@@ -27,6 +27,29 @@ You can add your Admin as parameter of the action::
         }
     }
 
+Or if you have a reusable action for **all** admin::
+
+    // src/Controller/CarAdminController.php
+
+    namespace App\Controller;
+
+    use Sonata\AdminBundle\Admin\AdminInterface;
+    use Symfony\Component\HttpFoundation\RedirectResponse;
+
+    final class CloneAdminController
+    {
+        public function clone(AdminInterface $admin, Request $request)
+        {
+            $object = $admin->getSubject();
+
+            // ...
+
+            $request->getSession()->getFlashBag()->add('sonata_flash_success', 'Cloned successfully');
+
+            return new RedirectResponse($admin->generateUrl('list'));
+        }
+    }
+
 Or you can use ``AdminFetcherInterface`` service to fetch the admin from the request, in this example we transformed
 the controller to make it Invokable::
 

--- a/src/ArgumentResolver/AdminValueResolver.php
+++ b/src/ArgumentResolver/AdminValueResolver.php
@@ -31,7 +31,12 @@ final class AdminValueResolver implements ArgumentValueResolverInterface
     public function supports(Request $request, ArgumentMetadata $argument): bool
     {
         $type = $argument->getType();
-        if (null === $type || !is_subclass_of($type, AdminInterface::class)) {
+
+        if (null === $type) {
+            return false;
+        }
+
+        if (AdminInterface::class !== $type && !is_subclass_of($type, AdminInterface::class)) {
             return false;
         }
 

--- a/tests/ArgumentResolver/AdminValueResolverTest.php
+++ b/tests/ArgumentResolver/AdminValueResolverTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\ArgumentResolver;
 
 use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\ArgumentResolver\AdminValueResolver;
 use Sonata\AdminBundle\Request\AdminFetcher;
@@ -92,6 +93,12 @@ final class AdminValueResolverTest extends TestCase
             true,
             $request,
             new ArgumentMetadata('_sonata_admin', PostAdmin::class, false, false, null),
+        ];
+
+        yield 'Admin can fetch by interface' => [
+            true,
+            $request,
+            new ArgumentMetadata('_sonata_admin', AdminInterface::class, false, false, null),
         ];
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

I am targeting this branch, because the bug is present in this branch.

Closes #7846.

## Changelog



<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed
AdminValueResolver does support generic AdminInterface type.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
