### PR TITLE
AbstractAdmin getPersistentParameters return type

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1461,7 +1461,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
             $parameters = $extension->configurePersistentParameters($this, $parameters);
         }
 
-        return $parameters;
+        return $parameters ?? [];
     }
 
     final public function getPersistentParameter(string $name, $default = null)


### PR DESCRIPTION
## Subject

Return null in some cases, does not match return type. Throws an error.


## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Changed
- Changed AbstractAdmin::getPersistentParameters() to have a fallback empty array return.
```