### PR TITLE
Fix issue 6904 by removing the subclass parameter from model auto complete

### DIFF
--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -114,11 +114,6 @@ file that was distributed with this source code.
                                     '_sonata_admin': '{{ admin_code|e('js') }}',
                                 {% endif %}
 
-                                 // subclass
-                                {% if app.request.query.get('subclass') %}
-                                    'subclass': '{{ app.request.query.get('subclass') }}',
-                                {% endif %}
-
                                 {% if context == 'filter' %}
                                     'field':  '{{ full_name|replace({'filter[': '', '][value]': '', '__':'.'}) }}',
                                     '_context': 'filter'

--- a/tests/App/Admin/FooAdmin.php
+++ b/tests/App/Admin/FooAdmin.php
@@ -19,8 +19,10 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
 use Sonata\AdminBundle\Form\Type\TemplateType;
 use Sonata\AdminBundle\Show\ShowMapper;
+use Sonata\AdminBundle\Tests\App\Model\Bar;
 use Sonata\AdminBundle\Tests\App\Model\Foo;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
@@ -51,7 +53,18 @@ class FooAdmin extends AbstractAdmin
             ->add('customField', TemplateType::class, [
                 'template' => 'foo/custom_field.html.twig',
                 'parameters' => ['number' => 42],
-            ]);
+            ])
+            ->add(
+                'referenced',
+                ModelAutocompleteType::class,
+                [
+                    'class' => Bar::class,
+                    'property' => ['name', 'title'],
+                ],
+                [
+                    'admin_code' => 'sonata_bar_admin',
+                ]
+            );
     }
 
     protected function configureShowFields(ShowMapper $show): void

--- a/tests/App/Model/Foo.php
+++ b/tests/App/Model/Foo.php
@@ -24,6 +24,8 @@ final class Foo implements EntityInterface
      */
     private array $elements;
 
+    private ?Bar $referenced;
+
     /**
      * @param string[] $elements
      */
@@ -32,6 +34,7 @@ final class Foo implements EntityInterface
         $this->id = $id;
         $this->name = $name;
         $this->elements = $elements;
+        $this->referenced = null;
     }
 
     public function getId(): string
@@ -42,6 +45,11 @@ final class Foo implements EntityInterface
     public function getName(): string
     {
         return $this->name;
+    }
+
+    public function getReferenced(): ?Bar
+    {
+        return $this->referenced;
     }
 
     /**

--- a/tests/Functional/Controller/CRUDControllerTest.php
+++ b/tests/Functional/Controller/CRUDControllerTest.php
@@ -48,6 +48,24 @@ final class CRUDControllerTest extends WebTestCase
         );
     }
 
+    /**
+     * https://github.com/sonata-project/SonataAdminBundle/issues/6904.
+     */
+    public function testCreateModelAutoCompleteNotPassingSubclassParameter(): void
+    {
+        $subclass = uniqid('subclass');
+        $client = static::createClient();
+        $crawler = $client->request(Request::METHOD_GET, '/admin/tests/app/foo/create?subclass='.$subclass);
+
+        static::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        static::assertStringNotContainsString(
+            $subclass,
+            $crawler->filter('div[id$=_referenced]')->text(),
+            'The subclass parameter must no be present in referenced model auto complete ajax call'
+        );
+    }
+
     public function testShow(): void
     {
         $client = static::createClient();


### PR DESCRIPTION
…
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because the bug was introduce here.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6904.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
Model Auto Complete failing in create flow of admin with subclasses
```
