### PR TITLE
Fix batch action proxy query parameter name requirement

### DIFF
--- a/src/ArgumentResolver/ProxyQueryResolver.php
+++ b/src/ArgumentResolver/ProxyQueryResolver.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\ArgumentResolver;
+
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+
+final class ProxyQueryResolver implements ArgumentValueResolverInterface
+{
+    public function supports(Request $request, ArgumentMetadata $argument): bool
+    {
+        $type = $argument->getType();
+
+        if (null === $type) {
+            return false;
+        }
+
+        if (ProxyQueryInterface::class !== $type && !is_subclass_of($type, ProxyQueryInterface::class)) {
+            return false;
+        }
+
+        foreach ($request->attributes as $attribute) {
+            if ($attribute instanceof ProxyQueryInterface) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return iterable<ProxyQueryInterface>
+     */
+    public function resolve(Request $request, ArgumentMetadata $argument): iterable
+    {
+        foreach ($request->attributes as $attribute) {
+            if ($attribute instanceof ProxyQueryInterface) {
+                yield $attribute;
+
+                break;
+            }
+        }
+    }
+}

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -358,7 +358,7 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
             );
 
         // NEXT_MAJOR: Uncomment the exception instead of the deprecation.
-            // throw new InvalidArgumentException(sprintf('Missing tag information "model_class" on service "%s".', $serviceId));
+        // throw new InvalidArgumentException(sprintf('Missing tag information "model_class" on service "%s".', $serviceId));
         } else {
             $methodCalls[] = ['setModelClass', [$modelClass]];
 

--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -18,6 +18,7 @@ use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
 use Sonata\AdminBundle\Admin\Extension\LockExtension;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\ArgumentResolver\AdminValueResolver;
+use Sonata\AdminBundle\ArgumentResolver\ProxyQueryResolver;
 use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\AdminBundle\Event\AdminEventExtension;
 use Sonata\AdminBundle\Filter\FilterFactory;
@@ -158,5 +159,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->args([
                 new ReferenceConfigurator('sonata.admin.request.fetcher'),
             ])
+            ->tag('controller.argument_value_resolver')
+
+        ->set('sonata.admin.argument_resolver.proxy_query', ProxyQueryResolver::class)
             ->tag('controller.argument_value_resolver');
 };

--- a/src/Util/AdminAclManipulator.php
+++ b/src/Util/AdminAclManipulator.php
@@ -62,7 +62,7 @@ final class AdminAclManipulator implements AdminAclManipulatorInterface
         if ($configResult) {
             $securityHandler->updateAcl($acl);
         } else {
-            $output->writeln(sprintf('   - %s , no roles and permissions found', ($newAcl ? 'skip' : 'removed')));
+            $output->writeln(sprintf('   - %s , no roles and permissions found', $newAcl ? 'skip' : 'removed'));
             $securityHandler->deleteAcl($objectIdentity);
         }
     }

--- a/tests/App/Admin/FooAdmin.php
+++ b/tests/App/Admin/FooAdmin.php
@@ -24,6 +24,7 @@ use Sonata\AdminBundle\Form\Type\TemplateType;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\AdminBundle\Tests\App\Model\Bar;
 use Sonata\AdminBundle\Tests\App\Model\Foo;
+use Sonata\AdminBundle\Tests\Fixtures\Controller\BatchOtherController;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 
 /**
@@ -76,5 +77,18 @@ class FooAdmin extends AbstractAdmin
     {
         // Check conflict between `MenuItemInterface::getLabel()` method and menu item with a child with the key `label`
         $menu->addChild('label')->addChild('label');
+    }
+
+    protected function configureBatchActions(array $actions): array
+    {
+        $actions = parent::configureBatchActions($actions);
+
+        $actions['other'] = [
+            'label' => 'Other',
+            'ask_confirmation' => false,
+            'controller' => BatchOtherController::class.'::batchAction',
+        ];
+
+        return $actions;
     }
 }

--- a/tests/App/Datagrid/ProxyQuery.php
+++ b/tests/App/Datagrid/ProxyQuery.php
@@ -44,6 +44,10 @@ final class ProxyQuery implements ProxyQueryInterface
 
     public function setFirstResult(?int $firstResult): ProxyQueryInterface
     {
+        if (null === $firstResult) {
+            return $this;
+        }
+
         throw new \BadMethodCallException('Not implemented.');
     }
 
@@ -54,6 +58,10 @@ final class ProxyQuery implements ProxyQueryInterface
 
     public function setMaxResults(?int $maxResults): ProxyQueryInterface
     {
+        if (null === $maxResults) {
+            return $this;
+        }
+
         throw new \BadMethodCallException('Not implemented.');
     }
 

--- a/tests/ArgumentResolver/ProxyQueryResolverTest.php
+++ b/tests/ArgumentResolver/ProxyQueryResolverTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\ArgumentResolver;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\ArgumentResolver\ProxyQueryResolver;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+
+final class ProxyQueryResolverTest extends TestCase
+{
+    private ProxyQueryResolver $proxyQueryResolver;
+
+    protected function setUp(): void
+    {
+        $this->proxyQueryResolver = new ProxyQueryResolver();
+    }
+
+    public function testConstruct(): void
+    {
+        static::assertInstanceOf(
+            ArgumentValueResolverInterface::class,
+            $this->proxyQueryResolver
+        );
+    }
+
+    /**
+     * @dataProvider supportDataProvider
+     */
+    public function testSupports(bool $expectedSupport, Request $request, ArgumentMetadata $argumentMetadata): void
+    {
+        static::assertSame($expectedSupport, $this->proxyQueryResolver->supports($request, $argumentMetadata));
+    }
+
+    /**
+     * @phpstan-return iterable<array-key, array{bool, Request, ArgumentMetadata}>
+     */
+    public function supportDataProvider(): iterable
+    {
+        yield 'No ProxyQuery object in the request' => [
+            false,
+            new Request(),
+            new ArgumentMetadata('query', ProxyQueryInterface::class, false, false, null),
+        ];
+
+        yield 'Not looking for a query argument' => [
+            false,
+            new Request([], [], ['query' => static::createMock(ProxyQueryInterface::class)]),
+            new ArgumentMetadata('query', \stdClass::class, false, false, null),
+        ];
+
+        yield 'ProxyQuery attributes under query name' => [
+            true,
+            new Request([], [], ['query' => static::createMock(ProxyQueryInterface::class)]),
+            new ArgumentMetadata('query', ProxyQueryInterface::class, false, false, null),
+        ];
+
+        yield 'ProxyQuery attributes under any names' => [
+            true,
+            new Request([], [], ['query' => static::createMock(ProxyQueryInterface::class)]),
+            new ArgumentMetadata(uniqid('parameter'), ProxyQueryInterface::class, false, false, null),
+        ];
+    }
+
+    public function testResolve(): void
+    {
+        $request = new Request();
+        $request->attributes->set('query', $proxy = static::createMock(ProxyQueryInterface::class));
+
+        $argument = new ArgumentMetadata('query', ProxyQueryInterface::class, false, false, null);
+
+        static::assertTrue($this->proxyQueryResolver->supports($request, $argument));
+
+        static::assertSame(
+            [$proxy],
+            $this->iterableToArray($this->proxyQueryResolver->resolve($request, $argument))
+        );
+    }
+
+    /**
+     * @phpstan-template T
+     * @phpstan-param iterable<T> $iterable
+     * @phpstan-return array<T>
+     */
+    private function iterableToArray(iterable $iterable): array
+    {
+        $array = [];
+        foreach ($iterable as $admin) {
+            $array[] = $admin;
+        }
+
+        return $array;
+    }
+}

--- a/tests/Fixtures/Controller/BatchOtherController.php
+++ b/tests/Fixtures/Controller/BatchOtherController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Controller;
+
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Symfony\Component\HttpFoundation\Response;
+
+final class BatchOtherController
+{
+    public function batchAction(ProxyQueryInterface $aCustomNameForTheProxyQuery): Response
+    {
+        return new Response('Other Controller');
+    }
+}

--- a/tests/Functional/Controller/CRUDControllerTest.php
+++ b/tests/Functional/Controller/CRUDControllerTest.php
@@ -17,7 +17,6 @@ use Sonata\AdminBundle\Tests\App\AppKernel;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 final class CRUDControllerTest extends WebTestCase
 {

--- a/tests/Functional/Controller/CRUDControllerTest.php
+++ b/tests/Functional/Controller/CRUDControllerTest.php
@@ -17,6 +17,7 @@ use Sonata\AdminBundle\Tests\App\AppKernel;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
 final class CRUDControllerTest extends WebTestCase
 {
@@ -99,6 +100,29 @@ final class CRUDControllerTest extends WebTestCase
         $client->request(Request::METHOD_GET, $url);
 
         static::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+    }
+
+    public function testBatchAction(): void
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request(Request::METHOD_GET, '/admin/tests/app/foo/list');
+
+        static::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+
+        $csrfToken = $crawler->selectButton('OK')->form()->getValues()['_sonata_csrf_token'];
+
+        $client->request(
+            Request::METHOD_POST,
+            '/admin/tests/app/foo/batch',
+            [
+                'data' => json_encode(['action' => 'other', 'all_elements' => true]),
+                '_sonata_csrf_token' => $csrfToken,
+            ]
+        );
+
+        static::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        static::assertSame('Other Controller', $client->getResponse()->getContent());
     }
 
     /**


### PR DESCRIPTION
## Subject

I am targeting this branch, because the BC break was introduce in this branch.

Closes #7869 .

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
 - Batch action ProxyQueryInterface parameter don't have to be named $query anymore.
```