### PR TITLE
Allow to use symfony/expression in security attributes

### DIFF
--- a/src/Security/Handler/RoleSecurityHandler.php
+++ b/src/Security/Handler/RoleSecurityHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Security\Handler;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Symfony\Component\ExpressionLanguage\Expression;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundException;
 
@@ -76,7 +77,7 @@ final class RoleSecurityHandler implements SecurityHandlerInterface
         $useAll = false;
         foreach ($attributes as $pos => $attribute) {
             // If the attribute is not already a ROLE_ we generate the related role.
-            if (0 !== strpos($attribute, 'ROLE_')) {
+            if (is_string($attribute) && 0 !== strpos($attribute, 'ROLE_')) {
                 $attributes[$pos] = sprintf($this->getBaseRole($admin), $attribute);
                 // All the admin related role are available when you have the `_ALL` role.
                 $useAll = true;
@@ -114,7 +115,7 @@ final class RoleSecurityHandler implements SecurityHandlerInterface
     }
 
     /**
-     * @param string[] $attributes
+     * @param array<string|Expression> $attributes
      */
     private function isAnyGranted(array $attributes, ?object $subject = null): bool
     {

--- a/src/Security/Handler/SecurityHandlerInterface.php
+++ b/src/Security/Handler/SecurityHandlerInterface.php
@@ -22,7 +22,7 @@ use Symfony\Component\ExpressionLanguage\Expression;
 interface SecurityHandlerInterface
 {
     /**
-     * NEXT_MAJOR: Restrict $attributes typehint to string and rename it $attribute.
+     * NEXT_MAJOR: Restrict $attributes typehint to string|Expression and rename it $attribute.
      *
      * @param AdminInterface<object> $admin
      * @param string|Expression|array<string|Expression>        $attributes

--- a/src/Security/Handler/SecurityHandlerInterface.php
+++ b/src/Security/Handler/SecurityHandlerInterface.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Security\Handler;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Symfony\Component\ExpressionLanguage\Expression;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -24,7 +25,7 @@ interface SecurityHandlerInterface
      * NEXT_MAJOR: Restrict $attributes typehint to string and rename it $attribute.
      *
      * @param AdminInterface<object> $admin
-     * @param string|string[]        $attributes
+     * @param string|Expression|array<string|Expression>        $attributes
      */
     public function isGranted(AdminInterface $admin, $attributes, ?object $object = null): bool;
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
Allow to use symfony expressions in security attributes.

As of symfony 4.4 (https://symfony.com/doc/4.4/security/expressions.html) it is possible to use expressions (not only strings) for attributes. 

I am targeting this branch, because i think that is a small bc break but if you think that it needs to go into 5.x i can rebase it.

I did not add tests or documentation because I want to see if there is interest in this PR, if yes i will provide tests and documentation. 


## Changelog
```markdown

### Changed
- Security attributes can be string or symfony expression language expressions
```

## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.

