### PR TITLE
Do not try to check access for created object

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -579,7 +579,6 @@ class CRUDController extends AbstractController
                 /** @phpstan-var T $submittedObject */
                 $submittedObject = $form->getData();
                 $this->admin->setSubject($submittedObject);
-                $this->admin->checkAccess('create', $submittedObject);
 
                 try {
                     $newObject = $this->admin->create($submittedObject);

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -2071,7 +2071,7 @@ final class CRUDControllerTest extends TestCase
     {
         $object = new \stdClass();
 
-        $this->admin->expects(static::exactly(2))
+        $this->admin->expects(static::once())
             ->method('checkAccess')
             ->willReturnCallback(static function (string $name, ?object $objectIn = null) use ($object): void {
                 if ('edit' === $name) {
@@ -2147,56 +2147,6 @@ final class CRUDControllerTest extends TestCase
         static::assertSame('stdClass_edit', $response->getTargetUrl());
     }
 
-    public function testCreateActionAccessDenied2(): void
-    {
-        $this->expectException(AccessDeniedException::class);
-
-        $object = new \stdClass();
-
-        $this->admin
-            ->method('checkAccess')
-            ->willReturnCallback(static function (string $name, ?object $object = null): void {
-                if ('create' !== $name) {
-                    throw new AccessDeniedException();
-                }
-                if (null === $object) {
-                    return;
-                }
-
-                throw new AccessDeniedException();
-            });
-
-        $this->admin->expects(static::once())
-            ->method('getNewInstance')
-            ->willReturn($object);
-
-        $form = $this->createMock(Form::class);
-
-        $this->admin
-            ->method('getClass')
-            ->willReturn(\stdClass::class);
-
-        $this->admin->expects(static::once())
-            ->method('getForm')
-            ->willReturn($form);
-
-        $form->expects(static::once())
-            ->method('isSubmitted')
-            ->willReturn(true);
-
-        $form->expects(static::once())
-            ->method('getData')
-            ->willReturn($object);
-
-        $form->expects(static::once())
-            ->method('isValid')
-            ->willReturn(true);
-
-        $this->request->setMethod(Request::METHOD_POST);
-
-        $this->controller->createAction($this->request);
-    }
-
     /**
      * @dataProvider getToStringValues
      */
@@ -2266,7 +2216,7 @@ final class CRUDControllerTest extends TestCase
      */
     public function testCreateActionWithModelManagerException(string $expectedToStringValue, string $toStringValue): void
     {
-        $this->admin->expects(static::exactly(2))
+        $this->admin->expects(static::once())
             ->method('checkAccess')
             ->with(static::equalTo('create'));
 
@@ -2335,7 +2285,7 @@ final class CRUDControllerTest extends TestCase
     {
         $object = new \stdClass();
 
-        $this->admin->expects(static::exactly(2))
+        $this->admin->expects(static::once())
             ->method('checkAccess')
             ->willReturnCallback(static function (string $name, ?object $objectIn = null) use ($object): void {
                 if ('create' !== $name) {


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Related to https://github.com/sonata-project/SonataAdminBundle/pull/7875#issuecomment-1189470683

It makes no sens to try to check that a user can access to the object he just created ; and if it fails it throws a 403.
It's the purpose of the form validation instead.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Do not try to check access for created object
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
