### PR TITLE
Allow ChildAdmin for Unidirectional References

### DIFF
--- a/docs/reference/child_admin.rst
+++ b/docs/reference/child_admin.rst
@@ -23,6 +23,8 @@ its parent:
         App\Admin\PlaylistAdmin:
             calls:
                 - [addChild, ['@App\Admin\VideoAdmin', 'playlist']]
+                # Or `[addChild, ['@App\Admin\VideoAdmin']]` if there is no
+                # field to access the Playlist from the Video entity
 
     .. code-block:: xml
 

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1259,7 +1259,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $this->filterFieldDescriptions;
     }
 
-    final public function addChild(AdminInterface $child, ?string $field): void
+    final public function addChild(AdminInterface $child, ?string $field = null): void
     {
         $parentAdmin = $this;
         while ($parentAdmin->isChild() && $parentAdmin->getCode() !== $child->getCode()) {
@@ -1302,7 +1302,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $this->getChildren()[$code];
     }
 
-    final public function setParent(AdminInterface $parent, ?string $parentAssociationMapping): void
+    final public function setParent(AdminInterface $parent, ?string $parentAssociationMapping = null): void
     {
         $this->parent = $parent;
         $this->parentAssociationMapping[$parent->getCode()] = $parentAssociationMapping;

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1259,6 +1259,9 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $this->filterFieldDescriptions;
     }
 
+    /**
+     * @psalm-suppress PossiblyNullArgument Will be solved in NEXT_MAJOR
+     */
     final public function addChild(AdminInterface $child, ?string $field = null): void
     {
         $parentAdmin = $this;
@@ -1276,6 +1279,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
 
         $this->children[$child->getCode()] = $child;
 
+        // @phpstan-ignore-next-line Will be solved in NEXT_MAJOR
         $child->setParent($this, $field);
     }
 

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -255,7 +255,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
     private array $cacheIsGranted = [];
 
     /**
-     * @var array<string, string>
+     * @var array<string, string|null>
      */
     private array $parentAssociationMapping = [];
 
@@ -1259,7 +1259,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $this->filterFieldDescriptions;
     }
 
-    final public function addChild(AdminInterface $child, string $field): void
+    final public function addChild(AdminInterface $child, ?string $field): void
     {
         $parentAdmin = $this;
         while ($parentAdmin->isChild() && $parentAdmin->getCode() !== $child->getCode()) {
@@ -1302,7 +1302,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         return $this->getChildren()[$code];
     }
 
-    final public function setParent(AdminInterface $parent, string $parentAssociationMapping): void
+    final public function setParent(AdminInterface $parent, ?string $parentAssociationMapping): void
     {
         $this->parent = $parent;
         $this->parentAssociationMapping[$parent->getCode()] = $parentAssociationMapping;

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -295,6 +295,8 @@ interface AdminInterface extends TaggedAdminInterface, AccessRegistryInterface, 
     public function getParent(): self;
 
     /**
+     * NEXT_MAJOR: Change to ?string $parentAssociationMapping.
+     *
      * @param AdminInterface<object> $parent
      */
     public function setParent(self $parent, string $parentAssociationMapping): void;

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -302,7 +302,7 @@ interface AdminInterface extends TaggedAdminInterface, AccessRegistryInterface, 
     public function setParent(self $parent, string $parentAssociationMapping): void;
 
     /**
-     * Returns true if the Admin class has an Parent Admin defined.
+     * Returns true if the Admin class has a Parent Admin defined.
      */
     public function isChild(): bool;
 

--- a/src/Admin/AdminInterface.php
+++ b/src/Admin/AdminInterface.php
@@ -295,7 +295,7 @@ interface AdminInterface extends TaggedAdminInterface, AccessRegistryInterface, 
     public function getParent(): self;
 
     /**
-     * NEXT_MAJOR: Change to ?string $parentAssociationMapping.
+     * NEXT_MAJOR: Change to ?string $parentAssociationMapping = null.
      *
      * @param AdminInterface<object> $parent
      */

--- a/src/Admin/ParentAdminInterface.php
+++ b/src/Admin/ParentAdminInterface.php
@@ -23,7 +23,7 @@ namespace Sonata\AdminBundle\Admin;
 interface ParentAdminInterface
 {
     /**
-     * NEXT_MAJOR: Change to ?string $field
+     * NEXT_MAJOR: Change to ?string $field.
      *
      * add an Admin child to the current one.
      *

--- a/src/Admin/ParentAdminInterface.php
+++ b/src/Admin/ParentAdminInterface.php
@@ -23,7 +23,7 @@ namespace Sonata\AdminBundle\Admin;
 interface ParentAdminInterface
 {
     /**
-     * NEXT_MAJOR: Change to ?string $field.
+     * NEXT_MAJOR: Change to ?string $field = null.
      *
      * add an Admin child to the current one.
      *

--- a/src/Admin/ParentAdminInterface.php
+++ b/src/Admin/ParentAdminInterface.php
@@ -23,6 +23,8 @@ namespace Sonata\AdminBundle\Admin;
 interface ParentAdminInterface
 {
     /**
+     * NEXT_MAJOR: Change to ?string $field
+     *
      * add an Admin child to the current one.
      *
      * @param AdminInterface<object> $child

--- a/tests/App/Admin/BazAdmin.php
+++ b/tests/App/Admin/BazAdmin.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\App\Admin;
+
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Show\ShowMapper;
+use Sonata\AdminBundle\Tests\App\Model\Baz;
+
+/**
+ * @phpstan-extends AbstractAdmin<Baz>
+ */
+class BazAdmin extends AbstractAdmin
+{
+    protected function createNewInstance(): object
+    {
+        return new Baz('test_id');
+    }
+
+    protected function configureListFields(ListMapper $list): void
+    {
+        $list->add('id');
+    }
+
+    protected function configureFormFields(FormMapper $form): void
+    {
+    }
+
+    protected function configureShowFields(ShowMapper $show): void
+    {
+        $show->add('id');
+    }
+}

--- a/tests/App/Model/Bar.php
+++ b/tests/App/Model/Bar.php
@@ -25,6 +25,7 @@ final class Bar implements EntityInterface
     {
         $this->id = $id;
         $this->foo = $foo;
+        $this->baz = $baz;
     }
 
     public function getId(): string

--- a/tests/App/Model/Baz.php
+++ b/tests/App/Model/Baz.php
@@ -13,32 +13,17 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Tests\App\Model;
 
-final class Bar implements EntityInterface
+final class Baz implements EntityInterface
 {
     private string $id;
 
-    private ?Foo $foo = null;
-
-    private ?Baz $baz = null;
-
-    public function __construct(string $id, ?Foo $foo = null, ?Baz $baz = null)
+    public function __construct(string $id)
     {
         $this->id = $id;
-        $this->foo = $foo;
     }
 
     public function getId(): string
     {
         return $this->id;
-    }
-
-    public function getFoo(): ?Foo
-    {
-        return $this->foo;
-    }
-
-    public function getBaz(): ?Baz
-    {
-        return $this->baz;
     }
 }

--- a/tests/App/Model/BazRepository.php
+++ b/tests/App/Model/BazRepository.php
@@ -14,29 +14,29 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Tests\App\Model;
 
 /**
- * @phpstan-implements RepositoryInterface<Bar>
+ * @phpstan-implements RepositoryInterface<Baz>
  */
-final class BarRepository implements RepositoryInterface
+final class BazRepository implements RepositoryInterface
 {
     /**
-     * @var Bar[]
+     * @var Baz[]
      */
     private array $elements;
 
-    public function __construct(FooRepository $fooRepository, BazRepository $bazRepository)
+    public function __construct()
     {
         $this->elements = [
-            'test_id' => new Bar('test_id', $fooRepository->byId('test_id'), $bazRepository->byId('test_id')),
+            'test_id' => new Baz('test_id'),
         ];
     }
 
-    public function byId(string $id): ?Bar
+    public function byId(string $id): ?Baz
     {
         return $this->elements[$id] ?? null;
     }
 
     /**
-     * @return Bar[]
+     * @return Baz[]
      */
     public function all(): array
     {

--- a/tests/App/config/services.yml
+++ b/tests/App/config/services.yml
@@ -99,7 +99,7 @@ services:
         tags:
             - {name: sonata.admin, model_class: Sonata\AdminBundle\Tests\App\Model\Bar, manager_type: test, model_manager: sonata.admin.manager.bar, label: Bar}
         calls:
-            - [ addChild, [ '@sonata_baz_admin', ~ ]]
+            - [addChild, [ '@sonata_baz_admin']]
 
     Sonata\AdminBundle\Tests\App\Admin\Extension\CustomAdminExtension:
         tags:

--- a/tests/App/config/services.yml
+++ b/tests/App/config/services.yml
@@ -25,6 +25,13 @@ services:
         tags:
             - {name: sonata.admin.manager}
 
+    sonata.admin.manager.baz:
+        class: Sonata\AdminBundle\Tests\App\Model\ModelManager
+        arguments:
+            - '@Sonata\AdminBundle\Tests\App\Model\BazRepository'
+        tags:
+            - {name: sonata.admin.manager}
+
     sonata.admin.builder.test_form:
         class: Sonata\AdminBundle\Tests\App\Builder\FormContractor
         arguments:
@@ -41,6 +48,7 @@ services:
         class: Sonata\AdminBundle\Tests\App\Datagrid\Pager
         arguments:
             - '@Sonata\AdminBundle\Tests\App\Model\FooRepository'
+            - '@Sonata\AdminBundle\Tests\App\Model\BazRepository'
 
     sonata.admin.builder.test_datagrid:
         class: Sonata\AdminBundle\Tests\App\Builder\DatagridBuilder
@@ -81,10 +89,17 @@ services:
         tags:
             - {name: sonata.admin, model_class: Sonata\AdminBundle\Tests\App\Model\Translated, manager_type: test, group: 'group_label', label: 'admin_label'}
 
+    sonata_baz_admin:
+        class: Sonata\AdminBundle\Tests\App\Admin\BazAdmin
+        tags:
+            - {name: sonata.admin, model_class: Sonata\AdminBundle\Tests\App\Model\Baz, manager_type: test, model_manager: sonata.admin.manager.baz, label: Baz}
+
     sonata_bar_admin:
         class: Sonata\AdminBundle\Tests\App\Admin\BarAdmin
         tags:
             - {name: sonata.admin, model_class: Sonata\AdminBundle\Tests\App\Model\Bar, manager_type: test, model_manager: sonata.admin.manager.bar, label: Bar}
+        calls:
+            - [ addChild, [ '@sonata_baz_admin', ~ ]]
 
     Sonata\AdminBundle\Tests\App\Admin\Extension\CustomAdminExtension:
         tags:

--- a/tests/App/config/services.yml
+++ b/tests/App/config/services.yml
@@ -99,7 +99,7 @@ services:
         tags:
             - {name: sonata.admin, model_class: Sonata\AdminBundle\Tests\App\Model\Bar, manager_type: test, model_manager: sonata.admin.manager.bar, label: Bar}
         calls:
-            - [addChild, [ '@sonata_baz_admin']]
+            - [addChild, ['@sonata_baz_admin']]
 
     Sonata\AdminBundle\Tests\App\Admin\Extension\CustomAdminExtension:
         tags:

--- a/tests/Functional/Controller/CRUDControllerTest.php
+++ b/tests/Functional/Controller/CRUDControllerTest.php
@@ -140,6 +140,7 @@ final class CRUDControllerTest extends WebTestCase
             ['/admin/tests/app/foo-with-custom-controller/test_id/show'],
             ['/admin/tests/app/foo-with-custom-controller/test_id/edit'],
             ['/admin/tests/app/foo/test_id/bar/list'],
+            ['/admin/tests/app/bar/test_id/baz/list'],
         ];
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Closes #7857.

Changing the typehint in the AbstractAdmin is BC.
But for the interface we'll have to wait next major (or should we consider the BC-break now @jordisala1991  ?)

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Allow ChildAdmin for Unidirectional References
```