### PR TITLE
improved the AdminMaker using services input option if set as default

### DIFF
--- a/src/Maker/AdminMaker.php
+++ b/src/Maker/AdminMaker.php
@@ -158,7 +158,7 @@ final class AdminMaker extends AbstractMaker
             $path = sprintf('%s/config/', $this->projectDirectory);
             $servicesFile = $io->ask(
                 'The services YAML configuration file',
-                is_file($path.'admin.yaml') ? 'admin.yaml' : 'services.yaml',
+                $input->getOption('services') ?? (is_file($path.'admin.yaml') ? 'admin.yaml' : 'services.yaml'),
                 [Validators::class, 'validateServicesFile']
             );
             $id = $io->ask(


### PR DESCRIPTION
## Subject

Improved the AdminMaker to use the input option "services" if it's set.

I am targeting this branch, because this is a patch.

Closes #7897.

## Changelog

```markdown
### Fixed
- AdminMaker service option
```