### PR TITLE
Improve error handling in Ajax

### DIFF
--- a/UPGRADE-4.x.md
+++ b/UPGRADE-4.x.md
@@ -6,6 +6,9 @@ UPGRADE FROM 4.x to 4.x
 
 ## Form errors retrieved via ajax calls
 
+This change will most likely not affect you since normally the admin is not used
+directly as an api for create or edit objects.
+
 Previously ajax form errors that happen on creation / edit of an admin object
 were outputted as a custom json that didn't had the information about which field
 had the error. This was a problem because the form was not able to highlight the

--- a/UPGRADE-4.x.md
+++ b/UPGRADE-4.x.md
@@ -1,6 +1,50 @@
 UPGRADE 4.x
 ===========
 
+UPGRADE FROM 4.x to 4.x
+=======================
+
+## Form errors retrieved via ajax calls
+
+Previously ajax form errors that happen on creation / edit of an admin object
+were outputted as a custom json that didn't had the information about which field
+had the error. This was a problem because the form was not able to highlight the
+field with the error.
+
+Now the ajax form errors are outputted with the standard Symfony json format for
+validation errors.
+
+To be able to output errors with that new format, you will also need to have
+`symfony/serializer` installed.
+
+Before:
+
+```json
+    {
+        "result":"error",
+        "errors": [
+            "Form error message"
+        ]
+    }
+```
+
+After:
+
+```json
+    {
+        "type":"https://symfony.com/errors/validation",
+        "title":"Validation Failed",
+        "detail":"name: Form error message",
+        "violations": [
+            {
+                "propertyPath":"name",
+                "title":"Form error message",
+                "parameters":[]
+            }
+        ]
+    }
+```
+
 UPGRADE FROM 4.18 to 4.19
 =========================
 

--- a/composer.json
+++ b/composer.json
@@ -91,8 +91,8 @@
         "vimeo/psalm": "^4.9.2"
     },
     "suggest": {
-        "twig/extra-bundle": "Auto configures the Twig Intl extension",
-        "symfony/serializer": "To render errors coming from form validation on ajax calls"
+        "symfony/serializer": "To render errors coming from form validation on ajax calls",
+        "twig/extra-bundle": "Auto configures the Twig Intl extension"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -86,11 +86,13 @@
         "symfony/filesystem": "^4.4 || ^5.4 || ^6.0",
         "symfony/maker-bundle": "^1.25",
         "symfony/phpunit-bridge": "^6.1",
+        "symfony/serializer": "^4.4 || ^5.4 || ^6.0",
         "symfony/yaml": "^4.4 || ^5.4 || ^6.0",
         "vimeo/psalm": "^4.9.2"
     },
     "suggest": {
-        "twig/extra-bundle": "Auto configures the Twig Intl extension"
+        "twig/extra-bundle": "Auto configures the Twig Intl extension",
+        "symfony/serializer": "To render errors coming from form validation on ajax calls"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
         "psalm/plugin-phpunit": "^0.17",
         "psalm/plugin-symfony": "^3.0",
         "psr/event-dispatcher": "^1.0",
-        "rector/rector": "^0.13",
+        "rector/rector": "^0.14",
         "symfony/browser-kit": "^4.4 || ^5.4 || ^6.0",
         "symfony/css-selector": "^4.4 || ^5.4 || ^6.0",
         "symfony/filesystem": "^4.4 || ^5.4 || ^6.0",

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1376,7 +1376,7 @@ class CRUDController extends AbstractController
 
             $fieldName = $formName . '_' . $name . $fieldName;
 
-            if (!in_array($fieldName, $errors)) {
+            if (!isset($errors[$fieldName])) {
                 $errors[$fieldName] = [];
             }
 

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1360,8 +1360,27 @@ class CRUDController extends AbstractController
         }
 
         $errors = [];
-        foreach ($form->getErrors(true) as $error) {
-            $errors[] = $error->getMessage();
+        $formName = $form->getName();
+
+        foreach ($form->getErrors(true) as $formError) {
+            $origin = $formError->getOrigin();
+
+            $fieldName = $origin->getName();
+            $name = '';
+
+            while ($origin = $origin->getParent()) {
+                if ($formName !== $origin->getName()) {
+                    $name = $origin->getName() . '_' . $name;
+                }
+            }
+
+            $fieldName = $formName . '_' . $name . $fieldName;
+
+            if (!in_array($fieldName, $errors)) {
+                $errors[$fieldName] = [];
+            }
+
+            $errors[$fieldName][] = $formError->getMessage();
         }
 
         return $this->renderJson([

--- a/src/Form/FormErrorIteratorToConstraintViolationList.php
+++ b/src/Form/FormErrorIteratorToConstraintViolationList.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Form;
+
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormErrorIterator;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+/**
+ * @author Jordi Sala <jordism91@gmail.com>
+ */
+final class FormErrorIteratorToConstraintViolationList
+{
+    /**
+     * @param FormErrorIterator<FormError> $errors
+     */
+    public static function transform(FormErrorIterator $errors): ConstraintViolationListInterface
+    {
+        $closure = \Closure::bind(static function (ConstraintViolation $violation, string $newPropertyPath): ConstraintViolation {
+            /**
+             * @psalm-suppress InaccessibleProperty
+             */
+            $violation->propertyPath = $newPropertyPath;
+
+            return $violation;
+        }, null, ConstraintViolation::class);
+
+        $list = new ConstraintViolationList();
+
+        foreach ($errors as $error) {
+            $origin = $error->getOrigin();
+            $cause = $error->getCause();
+
+            if (null === $origin || !$cause instanceof ConstraintViolation) {
+                continue;
+            }
+
+            /**
+             * @psalm-suppress PossiblyInvalidFunctionCall
+             */
+            $list->add($closure($cause, self::buildName($origin)));
+        }
+
+        return $list;
+    }
+
+    private static function buildName(FormInterface $form): string
+    {
+        $parent = $form->getParent();
+
+        if (null === $parent) {
+            return $form->getName();
+        }
+
+        return self::buildName($parent).'['.$form->getName().']';
+    }
+}

--- a/src/Form/FormErrorIteratorToConstraintViolationList.php
+++ b/src/Form/FormErrorIteratorToConstraintViolationList.php
@@ -31,10 +31,11 @@ final class FormErrorIteratorToConstraintViolationList
      */
     public static function transform(FormErrorIterator $errors): ConstraintViolationListInterface
     {
+        $form = $errors->getForm();
         $list = new ConstraintViolationList();
 
         foreach ($errors as $error) {
-            $violation = static::buildViolation($error);
+            $violation = static::buildViolation($error, $form);
 
             if (null === $violation) {
                 continue;
@@ -46,12 +47,11 @@ final class FormErrorIteratorToConstraintViolationList
         return $list;
     }
 
-    private static function buildViolation(FormError $error): ?ConstraintViolationInterface
+    private static function buildViolation(FormError $error, FormInterface $form): ?ConstraintViolationInterface
     {
-        $origin = $error->getOrigin();
         $cause = $error->getCause();
 
-        if (null === $origin || !$cause instanceof ConstraintViolationInterface) {
+        if (!$cause instanceof ConstraintViolationInterface) {
             return null;
         }
 
@@ -60,7 +60,7 @@ final class FormErrorIteratorToConstraintViolationList
             $cause->getMessageTemplate(),
             $cause->getParameters(),
             $cause->getRoot(),
-            self::buildName($origin),
+            self::buildName($error->getOrigin() ?? $form),
             $cause->getInvalidValue(),
             $cause->getPlural(),
             $cause->getCode(),

--- a/tests/Form/FormErrorIteratorToConstraintViolationListTest.php
+++ b/tests/Form/FormErrorIteratorToConstraintViolationListTest.php
@@ -40,7 +40,7 @@ final class FormErrorIteratorToConstraintViolationListTest extends TestCase
     }
 
     /**
-     * @phpstan-return iterable<array{int, FormErrorIterator<FormError>}>
+     * @phpstan-return iterable<array{int, FormErrorIterator}>
      */
     public function provideFormErrorIterators(): iterable
     {

--- a/tests/Form/FormErrorIteratorToConstraintViolationListTest.php
+++ b/tests/Form/FormErrorIteratorToConstraintViolationListTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Form;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Form\FormErrorIteratorToConstraintViolationList;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormErrorIterator;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+/**
+ * @author Jordi Sala <jordism91@gmail.com>
+ */
+final class FormErrorIteratorToConstraintViolationListTest extends TestCase
+{
+    /**
+     * @param FormErrorIterator<FormError> $formErrors
+     *
+     * @dataProvider provideFormErrorIterators
+     */
+    public function testTransform(int $expectedCount, FormErrorIterator $formErrors): void
+    {
+        $violationList = FormErrorIteratorToConstraintViolationList::transform($formErrors);
+
+        static::assertInstanceOf(ConstraintViolationList::class, $violationList);
+        static::assertCount($expectedCount, $violationList);
+    }
+
+    /**
+     * @phpstan-return iterable<array-key, array{int, FormErrorIterator<FormError>}>
+     */
+    public function provideFormErrorIterators(): iterable
+    {
+        $form = $this->createStub(FormInterface::class);
+
+        yield [0, new FormErrorIterator($form, [])];
+
+        yield [0, new FormErrorIterator($form, [
+            new FormError('error'),
+        ])];
+
+        yield [1, new FormErrorIterator($form, [
+            new FormError(
+                'error',
+                null,
+                [],
+                null,
+                new ConstraintViolation('error', null, [], $form, 'path', 'invalid value')
+            ),
+        ])];
+    }
+}

--- a/tests/Form/FormErrorIteratorToConstraintViolationListTest.php
+++ b/tests/Form/FormErrorIteratorToConstraintViolationListTest.php
@@ -40,11 +40,12 @@ final class FormErrorIteratorToConstraintViolationListTest extends TestCase
     }
 
     /**
-     * @phpstan-return iterable<array-key, array{int, FormErrorIterator<FormError>}>
+     * @phpstan-return iterable<array{int, FormErrorIterator<FormError>}>
      */
     public function provideFormErrorIterators(): iterable
     {
         $form = $this->createStub(FormInterface::class);
+        $form->method('getName')->willReturn('name');
 
         yield [0, new FormErrorIterator($form, [])];
 

--- a/tests/Form/FormErrorIteratorToConstraintViolationListTest.php
+++ b/tests/Form/FormErrorIteratorToConstraintViolationListTest.php
@@ -40,7 +40,8 @@ final class FormErrorIteratorToConstraintViolationListTest extends TestCase
     }
 
     /**
-     * @phpstan-return iterable<array{int, FormErrorIterator}>
+     * @psalm-return iterable<array{int, FormErrorIterator<FormError|FormErrorIterator>}>
+     * @phpstan-return iterable<array{int, FormErrorIterator<FormError>}>
      */
     public function provideFormErrorIterators(): iterable
     {

--- a/tests/Form/FormErrorIteratorToConstraintViolationListTest.php
+++ b/tests/Form/FormErrorIteratorToConstraintViolationListTest.php
@@ -40,8 +40,8 @@ final class FormErrorIteratorToConstraintViolationListTest extends TestCase
     }
 
     /**
-     * @psalm-return iterable<array{int, FormErrorIterator<FormError|FormErrorIterator>}>
      * @phpstan-return iterable<array{int, FormErrorIterator<FormError>}>
+     * @psalm-return iterable<array{int, FormErrorIterator<FormError|FormErrorIterator>}>
      */
     public function provideFormErrorIterators(): iterable
     {

--- a/tests/Maker/AdminMakerTest.php
+++ b/tests/Maker/AdminMakerTest.php
@@ -23,7 +23,6 @@ use Symfony\Bundle\MakerBundle\FileManager;
 use Symfony\Bundle\MakerBundle\Generator;
 use Symfony\Bundle\MakerBundle\Util\AutoloaderUtil;
 use Symfony\Bundle\MakerBundle\Util\MakerFileLinkFormatter;
-use Symfony\Bundle\MakerBundle\Util\PhpCompatUtil;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputDefinition;
@@ -113,8 +112,7 @@ final class AdminMakerTest extends TestCase
 
         $this->generator = new Generator(
             $fileManager,
-            'Sonata\AdminBundle\Tests',
-            new PhpCompatUtil($fileManager)
+            'Sonata\AdminBundle\Tests'
         );
         $maker->generate($this->input, $this->io, $this->generator);
     }

--- a/tests/Twig/Extension/RenderElementExtensionTest.php
+++ b/tests/Twig/Extension/RenderElementExtensionTest.php
@@ -1486,7 +1486,6 @@ final class RenderElementExtensionTest extends TestCase
             [],
         ];
 
-        // @phpstan-ignore-next-line https://github.com/phpstan/phpstan/issues/7963
         return $elements;
     }
 
@@ -2005,7 +2004,6 @@ final class RenderElementExtensionTest extends TestCase
             [],
         ];
 
-        // @phpstan-ignore-next-line https://github.com/phpstan/phpstan/issues/7963
         return $elements;
     }
 

--- a/tests/Twig/RenderElementRuntimeTest.php
+++ b/tests/Twig/RenderElementRuntimeTest.php
@@ -1482,7 +1482,6 @@ final class RenderElementRuntimeTest extends TestCase
             [],
         ];
 
-        // @phpstan-ignore-next-line https://github.com/phpstan/phpstan/issues/7963
         return $elements;
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because error output for ajax calls is kinda broken atm and it is needed for page bundle.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- [BC break] Change json error output for ajax calls to create or edit admin endpoints.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
