### PR TITLE
Avoid to perform sorting on transient model properties

### DIFF
--- a/src/Datagrid/ListMapper.php
+++ b/src/Datagrid/ListMapper.php
@@ -142,6 +142,16 @@ final class ListMapper implements MapperInterface
             $fieldDescriptionOptions
         );
 
+        $targetModel = $fieldDescription->getTargetModel();
+
+        if (true === ($fieldDescriptionOptions['sortable'] ?? false) && null !== $targetModel) {
+            // @todo: Find a better approach than `getExportFields()`.
+            $fields = $fieldDescription->getAdmin()->getModelManager()->getExportFields($targetModel);
+            if (!\in_array($fieldDescription->getSortFieldMapping()['fieldName'], $fields, true)) {
+                $fieldDescription->setOption('sortable', false);
+            }
+        }
+
         if (null === $fieldDescription->getLabel()) {
             $fieldDescription->setOption(
                 'label',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

Reproducer:
```php
// src/Entity/User.php

public function getFullname(): string
{
    return $this->firstname.' '.$this->lastname;
}
```
```php
// src/Admin/UserSettingsAdmin.php

$listMapper->add('user', null, [
    'associated_property' => 'fullname',
]);
```

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Attempting to sort on a transient property at `ListMapper`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
## To do
- [ ] Check how to replace the call to `ModelManagerInterface::getExportFields()`;
- [ ] Check if an exception must be thrown on specific configuration options;
- [ ] Update the tests;
- [ ] Update the documentation.
