### PR TITLE
Add default actions translation for list view

### DIFF
--- a/src/Resources/translations/SonataAdminBundle.ar.xliff
+++ b/src/Resources/translations/SonataAdminBundle.ar.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>لائحة العمليات</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>لائحة العمليات</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>ميزة الجافا معطلة في متصفح الشبكة لديك. بعض الميزات لن تعمل بشكل صحيح.</target>

--- a/src/Resources/translations/SonataAdminBundle.bg.xliff
+++ b/src/Resources/translations/SonataAdminBundle.bg.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Действия</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Действия</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Ползването на джаваскрипт в браузъра е изключено. Някои функционалности няма да работят както трябва.</target>

--- a/src/Resources/translations/SonataAdminBundle.bs.xliff
+++ b/src/Resources/translations/SonataAdminBundle.bs.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Akcije</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Akcije</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Javascript je onemogućen u Vašem internet pretraživaču. Neke funkcije neće raditi ispravno.</target>

--- a/src/Resources/translations/SonataAdminBundle.ca.xliff
+++ b/src/Resources/translations/SonataAdminBundle.ca.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Accions</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Accions</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Javascript està deshabilitat al teu navegador. Algunes característiques no funcionaran correctament.</target>

--- a/src/Resources/translations/SonataAdminBundle.cs.xliff
+++ b/src/Resources/translations/SonataAdminBundle.cs.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Akce</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Akce</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Javascript je zakázán ve vašem webovém prohlížeči. Některé funkce nebudou pracovat správně.</target>

--- a/src/Resources/translations/SonataAdminBundle.de.xliff
+++ b/src/Resources/translations/SonataAdminBundle.de.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Aktionen</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Aktionen</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Javascript ist in ihrem Browser deaktiviert. Einige Funktionen werden nicht korrekt funktionieren.</target>

--- a/src/Resources/translations/SonataAdminBundle.en.xliff
+++ b/src/Resources/translations/SonataAdminBundle.en.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Actions</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Actions</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Javascript is disabled in your web browser. Some features will not work properly.</target>

--- a/src/Resources/translations/SonataAdminBundle.es.xliff
+++ b/src/Resources/translations/SonataAdminBundle.es.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Acciones</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Acciones</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Javascript esta deshabilitado en tu navegador. Algunas características no funcionarán correctamente.</target>

--- a/src/Resources/translations/SonataAdminBundle.eu.xliff
+++ b/src/Resources/translations/SonataAdminBundle.eu.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Ekintzak</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Ekintzak</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Javascript desgaituta dago zure arakatzailean. Ezaugarri batzuk ez dira ondo funtzionatuko.</target>

--- a/src/Resources/translations/SonataAdminBundle.fa.xliff
+++ b/src/Resources/translations/SonataAdminBundle.fa.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>عملیات</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>عملیات</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>جاوااسکریپت روی مرورگر شما فعال نیست و ممکن است بعضی از قابلیت‌ها به خوبی عمل نکنند.</target>

--- a/src/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/src/Resources/translations/SonataAdminBundle.fr.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Liste d'actions</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Liste d'actions</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Certaines fonctionnalités ne fonctionnent pas sans JavaScript. Merci de l'activer sur votre navigateur.</target>

--- a/src/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/src/Resources/translations/SonataAdminBundle.fr.xliff
@@ -444,7 +444,7 @@
       </trans-unit>
       <trans-unit id="link_actions">
         <source>link_actions</source>
-        <target>Liste d'actions</target>
+        <target>Actions</target>
       </trans-unit>
       <trans-unit id="list.label__actions">
         <source>list.label__actions</source>

--- a/src/Resources/translations/SonataAdminBundle.fr.xliff
+++ b/src/Resources/translations/SonataAdminBundle.fr.xliff
@@ -448,7 +448,7 @@
       </trans-unit>
       <trans-unit id="list.label__actions">
         <source>list.label__actions</source>
-        <target>Liste d'actions</target>
+        <target>Actions</target>
       </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>

--- a/src/Resources/translations/SonataAdminBundle.hr.xliff
+++ b/src/Resources/translations/SonataAdminBundle.hr.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Akcije</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Akcije</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Vaš internet preglednik ne podržava JavaScript. Neke mogućnosti neće raditi ispravno.</target>

--- a/src/Resources/translations/SonataAdminBundle.hu.xliff
+++ b/src/Resources/translations/SonataAdminBundle.hu.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Műveletek</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Műveletek</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>A böngészőben a Javascript le van tiltva, emiatt néhány funkció nem fog megfelelően működni.</target>

--- a/src/Resources/translations/SonataAdminBundle.it.xliff
+++ b/src/Resources/translations/SonataAdminBundle.it.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Azioni</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Azioni</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Javascript è disattivato nel tuo browser. Alcune funzioni non funzioneranno correttamente.</target>

--- a/src/Resources/translations/SonataAdminBundle.ja.xliff
+++ b/src/Resources/translations/SonataAdminBundle.ja.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>操作</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>操作</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>JavaScriptが無効になっています。機能の一部が利用できません。</target>

--- a/src/Resources/translations/SonataAdminBundle.lb.xliff
+++ b/src/Resources/translations/SonataAdminBundle.lb.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Aktiounen</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Aktiounen</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>JavaScript ass an dengem Browser deaktivéiert. Eng Rei Funktioune wäerten net korrekt funktionéieren.</target>

--- a/src/Resources/translations/SonataAdminBundle.lt.xliff
+++ b/src/Resources/translations/SonataAdminBundle.lt.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Veiksmai</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Veiksmai</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Javascript scenarijus jūsų interneto naršyklėje neleidžiamas. Kai kurios funkcijos neveiks tinkamai.</target>

--- a/src/Resources/translations/SonataAdminBundle.lv.xliff
+++ b/src/Resources/translations/SonataAdminBundle.lv.xliff
@@ -448,6 +448,10 @@
         <source>link_actions</source>
         <target>Darbības</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Darbības</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Javascript ir izslēgts Jūsu pārlūkprogrammā. Dažas funkcijas var nedarboties pareizi.</target>

--- a/src/Resources/translations/SonataAdminBundle.nl.xliff
+++ b/src/Resources/translations/SonataAdminBundle.nl.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Acties</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Acties</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Javascript is uitgeschakeld in uw browser. Sommige functies zullen niet goed werken.</target>

--- a/src/Resources/translations/SonataAdminBundle.no.xliff
+++ b/src/Resources/translations/SonataAdminBundle.no.xliff
@@ -447,6 +447,10 @@
         <source>link_actions</source>
         <target>Handlinger</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Handlinger</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Javascript er skrudd av i din nettleser. Noen funksjoner vil ikke virke.</target>

--- a/src/Resources/translations/SonataAdminBundle.pl.xliff
+++ b/src/Resources/translations/SonataAdminBundle.pl.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Akcje</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Akcje</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Twoja przeglądarka ma wyłączoną obsługę JavaScript. Niektóre funkcje mogą nie działać poprawnie.</target>

--- a/src/Resources/translations/SonataAdminBundle.pt.xliff
+++ b/src/Resources/translations/SonataAdminBundle.pt.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Ações</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Ações</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>

--- a/src/Resources/translations/SonataAdminBundle.pt_BR.xliff
+++ b/src/Resources/translations/SonataAdminBundle.pt_BR.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Ações</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Ações</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Javascript está desativado no seu navegador. Algumas recursos não funcionarão corretamente.</target>

--- a/src/Resources/translations/SonataAdminBundle.ro.xliff
+++ b/src/Resources/translations/SonataAdminBundle.ro.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Acțiuni</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Acțiuni</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Javascript este dezactivat în browser-ul dvs. Unele funcții nu vor funcționa corect.</target>

--- a/src/Resources/translations/SonataAdminBundle.ru.xliff
+++ b/src/Resources/translations/SonataAdminBundle.ru.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Действия</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Действия</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>В вашем браузере отключен Javascipt. Некоторые функции сайта будут недоступны.</target>

--- a/src/Resources/translations/SonataAdminBundle.sk.xliff
+++ b/src/Resources/translations/SonataAdminBundle.sk.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Akcie</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Akcie</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Javascript je zakázaný vo vašom webovom prehliadači. Niektoré funkcie nebudú pracovať správne.</target>

--- a/src/Resources/translations/SonataAdminBundle.sl.xliff
+++ b/src/Resources/translations/SonataAdminBundle.sl.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Dejanja</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Dejanja</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>JavaScript je v vašem brskalniku onemogočen. Nekatere lastnosti ne bodo ustrezno delovale.</target>

--- a/src/Resources/translations/SonataAdminBundle.sr_Cyrl.xliff
+++ b/src/Resources/translations/SonataAdminBundle.sr_Cyrl.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Акције</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Акције</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Javascript је онемогућен у Вашем интернет претраживачу. Неке функције неће радити исправно.</target>

--- a/src/Resources/translations/SonataAdminBundle.sr_Latn.xliff
+++ b/src/Resources/translations/SonataAdminBundle.sr_Latn.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Akcije</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Akcije</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Javascript je onemogućen u Vašem internet pretraživaču. Neke funkcije neće raditi ispravno.</target>

--- a/src/Resources/translations/SonataAdminBundle.sv_SE.xliff
+++ b/src/Resources/translations/SonataAdminBundle.sv_SE.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Åtgärder</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Åtgärder</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Javascript är avaktiverat i din webbläsare. Vissa funktioner fungerar inte korrekt.</target>

--- a/src/Resources/translations/SonataAdminBundle.tr.xliff
+++ b/src/Resources/translations/SonataAdminBundle.tr.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>İşlemler</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>İşlemler</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Tarayıcınızda Javascript devre dışı. Bazı özellikler doğru çalışmayabilir.</target>

--- a/src/Resources/translations/SonataAdminBundle.uk.xliff
+++ b/src/Resources/translations/SonataAdminBundle.uk.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>Дії</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>Дії</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>Javascript вимкнений у вашому браузері. Деякі функції не будуть працювати належним чином.</target>

--- a/src/Resources/translations/SonataAdminBundle.zh_CN.xliff
+++ b/src/Resources/translations/SonataAdminBundle.zh_CN.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>其他功能</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>其他功能</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>你的浏览器并不支持Javascript，所以有些功能不能正常使用</target>

--- a/src/Resources/translations/SonataAdminBundle.zh_HK.xliff
+++ b/src/Resources/translations/SonataAdminBundle.zh_HK.xliff
@@ -446,6 +446,10 @@
         <source>link_actions</source>
         <target>操作</target>
       </trans-unit>
+      <trans-unit id="list.label__actions">
+        <source>list.label__actions</source>
+        <target>操作</target>
+      </trans-unit>
       <trans-unit id="noscript_warning">
         <source>noscript_warning</source>
         <target>由於你的瀏覽器已將 Javascript 關閉，某些功能或不能正常運作。</target>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix missing default translation for actions label on list view.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
