### PR TITLE
Deprecate BCLabelTranslatorStrategy

### DIFF
--- a/UPGRADE-4.x.md
+++ b/UPGRADE-4.x.md
@@ -1,6 +1,14 @@
 UPGRADE 4.x
 ===========
 
+UPGRADE FROM 4.18 to 4.19
+=========================
+
+## BCLabelTranslatorStrategy
+
+The BCLabelTranslatorStrategy is deprecated. Please use another label translator strategy or
+implements your own directly in your project.
+
 UPGRADE FROM 4.13 to 4.14
 =========================
 

--- a/src/Resources/config/core.php
+++ b/src/Resources/config/core.php
@@ -92,6 +92,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
         // Services used to format the label, default is sonata.admin.label.strategy.noop
 
+        // NEXT_MAJOR: Remove this line.
         ->set('sonata.admin.label.strategy.bc', BCLabelTranslatorStrategy::class)
 
         ->set('sonata.admin.label.strategy.native', NativeLabelTranslatorStrategy::class)

--- a/src/Translator/BCLabelTranslatorStrategy.php
+++ b/src/Translator/BCLabelTranslatorStrategy.php
@@ -15,11 +15,21 @@ namespace Sonata\AdminBundle\Translator;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @deprecated since sonata-project/admin-bundle 4.x, will be removed in 5.0.
  */
 final class BCLabelTranslatorStrategy implements LabelTranslatorStrategyInterface
 {
     public function getLabel(string $label, string $context = '', string $type = ''): string
     {
+        @trigger_error(sprintf(
+            'The "%s" class is deprecated since sonata-project/admin-bundle version 4.x and will be'
+            .' removed in 5.0 version.',
+            self::class
+        ), \E_USER_DEPRECATED);
+
         if ('breadcrumb' === $context) {
             return sprintf('%s.%s_%s', $context, $type, strtolower($label));
         }

--- a/tests/Translator/BCLabelTranslatorStrategyTest.php
+++ b/tests/Translator/BCLabelTranslatorStrategyTest.php
@@ -16,6 +16,11 @@ namespace Sonata\AdminBundle\Tests\Translator;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Translator\BCLabelTranslatorStrategy;
 
+/**
+ * NEXT_MAJOR: Remove this class.
+ *
+ * @group legacy
+ */
 final class BCLabelTranslatorStrategyTest extends TestCase
 {
     public function testLabel(): void


### PR DESCRIPTION
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- BCLabelTranslatorStrategy
```