### PR TITLE
Fix phpstan and deprecate some modelManager methods

### DIFF
--- a/src/Form/DataTransformer/ModelsToArrayTransformer.php
+++ b/src/Form/DataTransformer/ModelsToArrayTransformer.php
@@ -15,9 +15,7 @@ namespace Sonata\AdminBundle\Form\DataTransformer;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
-use Sonata\AdminBundle\BCLayer\BCHelper;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
-use Sonata\AdminBundle\Model\ProxyResolverInterface;
 use Symfony\Component\Form\DataTransformerInterface;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
@@ -67,14 +65,9 @@ final class ModelsToArrayTransformer implements DataTransformerInterface
         foreach ($value as $model) {
             $identifier = $this->modelManager->getNormalizedIdentifier($model);
             if (null === $identifier) {
-                $class = $this->modelManager instanceof ProxyResolverInterface
-                    ? $this->modelManager->getRealClass($model)
-                    // NEXT_MAJOR: Change to `\get_class`
-                    : BCHelper::getClass($model);
-
                 throw new TransformationFailedException(sprintf(
                     'No identifier was found for the model "%s".',
-                    $class
+                    $this->class
                 ));
             }
 
@@ -115,14 +108,9 @@ final class ModelsToArrayTransformer implements DataTransformerInterface
         foreach ($queryResult as $model) {
             $identifier = $this->modelManager->getNormalizedIdentifier($model);
             if (null === $identifier) {
-                $class = $this->modelManager instanceof ProxyResolverInterface
-                    ? $this->modelManager->getRealClass($model)
-                    // NEXT_MAJOR: Change to `\get_class`
-                    : BCHelper::getClass($model);
-
                 throw new TransformationFailedException(sprintf(
                     'No identifier was found for the model "%s".',
-                    $class
+                    $this->class
                 ));
             }
 

--- a/src/Model/ModelManagerInterface.php
+++ b/src/Model/ModelManagerInterface.php
@@ -89,6 +89,8 @@ interface ModelManagerInterface
     public function createQuery(string $class): ProxyQueryInterface;
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * Get the identifiers of this model class.
      *
      * This returns an array to handle cases like a primary key that is
@@ -102,6 +104,8 @@ interface ModelManagerInterface
     public function getIdentifierValues(object $model): array;
 
     /**
+     * NEXT_MAJOR: Remove this method.
+     *
      * Get a list of the field names models of the specified fully qualified
      * class name used to store the identifier.
      *

--- a/tests/Form/ChoiceList/ModelChoiceLoaderTest.php
+++ b/tests/Form/ChoiceList/ModelChoiceLoaderTest.php
@@ -49,11 +49,11 @@ final class ModelChoiceLoaderTest extends TestCase
     public function testLoadFromEntityWithSamePropertyValues(): void
     {
         $fooA = new Foo();
-        $fooA->setBar(1);
+        $fooA->setBar('1');
         $fooA->setBaz('baz');
 
         $fooB = new Foo();
-        $fooB->setBar(2);
+        $fooB->setBar('2');
         $fooB->setBaz('baz');
 
         $this->modelManager->expects(static::once())
@@ -61,8 +61,8 @@ final class ModelChoiceLoaderTest extends TestCase
             ->willReturn([$fooA, $fooB]);
 
         $this->modelManager
-            ->method('getIdentifierValues')
-            ->willReturnCallback(static fn (Foo $foo): array => [$foo->getBar()]);
+            ->method('getNormalizedIdentifier')
+            ->willReturnCallback(static fn (Foo $foo): ?string => $foo->getBar());
 
         $modelChoiceLoader = new ModelChoiceLoader(
             $this->modelManager,

--- a/tests/Twig/Extension/RenderElementExtensionTest.php
+++ b/tests/Twig/Extension/RenderElementExtensionTest.php
@@ -1475,15 +1475,18 @@ final class RenderElementExtensionTest extends TestCase
         ];
 
         // TODO: Remove the "if" check when dropping support of PHP < 8.1 and add the case to the list
-        if (\PHP_VERSION_ID >= 80100) {
-            $elements[] = [
-                '<td class="sonata-ba-list-field sonata-ba-list-field-enum" objectId="12345"> Hearts </td>',
-                FieldDescriptionInterface::TYPE_ENUM,
-                Suit::Hearts,
-                [],
-            ];
+        if (\PHP_VERSION_ID < 80100) {
+            return $elements;
         }
 
+        $elements[] = [
+            '<td class="sonata-ba-list-field sonata-ba-list-field-enum" objectId="12345"> Hearts </td>',
+            FieldDescriptionInterface::TYPE_ENUM,
+            Suit::Hearts,
+            [],
+        ];
+
+        // @phpstan-ignore-next-line https://github.com/phpstan/phpstan/issues/7963
         return $elements;
     }
 
@@ -1991,15 +1994,18 @@ final class RenderElementExtensionTest extends TestCase
         ];
 
         // TODO: Remove the "if" check when dropping support of PHP < 8.1 and add the case to the list
-        if (\PHP_VERSION_ID >= 80100) {
-            $elements[] = [
-                '<th>Data</th> <td>Hearts</td>',
-                FieldDescriptionInterface::TYPE_ENUM,
-                Suit::Hearts,
-                [],
-            ];
+        if (\PHP_VERSION_ID < 80100) {
+            return $elements;
         }
 
+        $elements[] = [
+            '<th>Data</th> <td>Hearts</td>',
+            FieldDescriptionInterface::TYPE_ENUM,
+            Suit::Hearts,
+            [],
+        ];
+
+        // @phpstan-ignore-next-line https://github.com/phpstan/phpstan/issues/7963
         return $elements;
     }
 

--- a/tests/Twig/RenderElementRuntimeTest.php
+++ b/tests/Twig/RenderElementRuntimeTest.php
@@ -1471,15 +1471,18 @@ final class RenderElementRuntimeTest extends TestCase
         ];
 
         // TODO: Remove the "if" check when dropping support of PHP < 8.1 and add the case to the list
-        if (\PHP_VERSION_ID >= 80100) {
-            $elements[] = [
-                '<td class="sonata-ba-list-field sonata-ba-list-field-enum" objectId="12345"> Hearts </td>',
-                FieldDescriptionInterface::TYPE_ENUM,
-                Suit::Hearts,
-                [],
-            ];
+        if (\PHP_VERSION_ID < 80100) {
+            return $elements;
         }
 
+        $elements[] = [
+            '<td class="sonata-ba-list-field sonata-ba-list-field-enum" objectId="12345"> Hearts </td>',
+            FieldDescriptionInterface::TYPE_ENUM,
+            Suit::Hearts,
+            [],
+        ];
+
+        // @phpstan-ignore-next-line https://github.com/phpstan/phpstan/issues/7963
         return $elements;
     }
 


### PR DESCRIPTION
## Subject

I wanted to fix the phpstan issues:
- For too big array we can't really do things, it's a phpstan simplification.
- For the ModelToIdPropertyTransformer, it's the `current` call which can return false.
  - Looking at the method getIdentifierValues, it's "weird" to use only the current value. If the entity has multiple identifier values, it won't work in the transform method. If you look at the find implementation, they explode the id https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/4.x/src/Model/ModelManager.php#L152, so we should implode all the identifier instead. And that's the job of the NormalizedIdentifier https://github.com/sonata-project/SonataDoctrineORMAdminBundle/blob/4.x/src/Model/ModelManager.php#L293
  - Some of the exception thrown are looking for the class of the model. Seems like we can access it from the constructor instead using the modelManager. Solving https://github.com/sonata-project/SonataAdminBundle/pull/7906#pullrequestreview-1072274435
  - getIdentifierValues and getIdentifierFieldNames are not used in SonataAdmin, so they don't need to be in the modelManager interface. Less is better.

Also, we should prefer to use Symfony/Form exception in dataTransformers.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Deprecated
- `ModelManager::getIdentifierValues`
- `ModelManager::getIdentifierFieldNames`

### Fixed
- ModelToIdPropertyTransformer now supports composite identifiers
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
