### PR TITLE
Add support of "priority" attribute in service tag definitions

### DIFF
--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -192,12 +192,14 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
                     ];
                 }
 
+                $groupDefaults[$resolvedGroupName]['priority'] = max($groupDefaults[$resolvedGroupName]['priority'] ?? 0, $attributes['priority'] ?? 0);
                 $groupDefaults[$resolvedGroupName]['items'][] = [
                     'admin' => $code,
                     'label' => $attributes['label'] ?? '', // NEXT_MAJOR: Remove this line.
                     'route' => '', // NEXT_MAJOR: Remove this line.
                     'route_params' => [],
                     'route_absolute' => false,
+                    'priority' => $attributes['priority'] ?? 0,
                 ];
 
                 if (isset($groupDefaults[$resolvedGroupName]['on_top']) && $groupDefaults[$resolvedGroupName]['on_top']
@@ -214,6 +216,8 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
         \assert(\is_array($dashboardGroupsSettings));
         $sortAdmins = $container->getParameter('sonata.admin.configuration.sort_admins');
         \assert(\is_bool($sortAdmins));
+
+        $sortAdminsByPriority = true;
 
         if ([] !== $dashboardGroupsSettings) {
             $groups = $dashboardGroupsSettings;
@@ -237,6 +241,8 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
                 if (!isset($group['items']) || [] === $group['items']) {
                     $groups[$resolvedGroupName]['items'] = $groupDefaults[$resolvedGroupName]['items'];
+                } else {
+                    $sortAdminsByPriority = false;
                 }
 
                 if (!isset($group['label']) || '' === $group['label']) {
@@ -299,8 +305,23 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
              */
             ksort($groups);
             array_walk($groups, $elementSort);
+
+            $sortAdminsByPriority = false;
         } else {
             $groups = $groupDefaults;
+
+            uasort($groups, static fn (array $a, array $b): int => ($b['priority'] ?? 0) <=> ($a['priority'] ?? 0));
+        }
+
+        if ($sortAdminsByPriority) {
+            $elementSort = static function (array &$element): void {
+                usort(
+                    $element['items'],
+                    static fn (array $a, array $b): int => ($b['priority'] ?? 0) <=> ($a['priority'] ?? 0)
+                );
+            };
+
+            array_walk($groups, $elementSort);
         }
 
         $pool->replaceArgument(0, ServiceLocatorTagPass::register($container, $adminServices));


### PR DESCRIPTION
## Add support of "priority" attribute in service tag definitions

As written in [a comment of issue #7820 by myself](https://github.com/sonata-project/SonataAdminBundle/issues/7820#issuecomment-1263517942), I faced a few shortcomings when attempting to migrate my admin class service definitions in YAML to attributes. In short, they are:

1. the inability to customize the appearance order of the admins and groups, and
2. weird looking role names when using the `RoleSecurityHandler` because the class doesn't expect FQCN when generating the base role name.

This pull request attempts to solve the first issue. After merging this should work correctly:

```php
#[Autoconfigure(
    tags: [
        [
            'name' => 'sonata.admin',
            'group' => 'group 1',
            'priority' => 100,
        ],
        [
            'name' => 'sonata.admin',
            'group' => 'group 2',
            'priority' => 200,
        ]
    ],
)]
```

A larger value implies a higher priority, thus will appear earlier.

The priority attribute will also affects admin group ordering; the maximum priority for each group will be taken into account when sorting. In the above example, group 2 will appear before group 1 if the priority of other classes are below 200.

I am targeting the 4.x branch, because it doesn't break bc. By default the priority will be 0, there should be no change to item order after sorting.

## Changelog

```markdown
### Added
- Allow manually reorder tagged admin services using the `priority` attribute.
```