### PR TITLE
Allow specifying custom role name prefix for the role security handler

### DIFF
--- a/src/DependencyInjection/Compiler/RoleSecurityCompilerPass.php
+++ b/src/DependencyInjection/Compiler/RoleSecurityCompilerPass.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RoleSecurityCompilerPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->has('sonata.admin.security.handler.role')) {
+            return;
+        }
+
+        $roleHandlerDefinition = $container->getDefinition('sonata.admin.security.handler.role');
+
+        foreach ($container->findTaggedServiceIds('sonata.admin.role_security') as $id => $tags) {
+            foreach ($tags as $attributes) {
+                if (isset($attributes['role_prefix'])) {
+                    $roleHandlerDefinition->addMethodCall('setCustomRolePrefix', [
+                        $id,
+                        $attributes['role_prefix']
+                    ]);
+                }
+            }
+        }
+    }
+}

--- a/src/DependencyInjection/Compiler/RoleSecurityCompilerPass.php
+++ b/src/DependencyInjection/Compiler/RoleSecurityCompilerPass.php
@@ -25,14 +25,25 @@ class RoleSecurityCompilerPass implements CompilerPassInterface
         }
 
         $roleHandlerDefinition = $container->getDefinition('sonata.admin.security.handler.role');
+        $prefixes = [];
 
         foreach ($container->findTaggedServiceIds('sonata.admin.role_security') as $id => $tags) {
             foreach ($tags as $attributes) {
                 if (isset($attributes['role_prefix'])) {
+                    $rolePrefix = $attributes['role_prefix'];
+                    \assert(\is_string($rolePrefix));
+
+                    if (isset($prefixes[$id])) {
+                        throw new \RuntimeException(sprintf('Unable to set role prefix for %s to "%s", because
+                it has already been assigned with role prefix "%s".', $id, $rolePrefix, $prefixes[$id]));
+                    }
+
                     $roleHandlerDefinition->addMethodCall('setCustomRolePrefix', [
                         $id,
-                        $attributes['role_prefix']
+                        $rolePrefix,
                     ]);
+
+                    $prefixes[$id] = $rolePrefix;
                 }
             }
         }

--- a/src/Security/Handler/RoleSecurityHandler.php
+++ b/src/Security/Handler/RoleSecurityHandler.php
@@ -104,7 +104,7 @@ final class RoleSecurityHandler implements SecurityHandlerInterface
     public function getBaseRole(AdminInterface $admin): string
     {
         if (isset($this->customRolePrefixes[$admin->getCode()])) {
-            return $this->customRolePrefixes[$admin->getCode()] . '_%s';
+            return $this->customRolePrefixes[$admin->getCode()].'_%s';
         }
 
         return sprintf('ROLE_%s_%%s', str_replace('.', '_', strtoupper($admin->getCode())));

--- a/src/Security/Handler/RoleSecurityHandler.php
+++ b/src/Security/Handler/RoleSecurityHandler.php
@@ -28,6 +28,11 @@ final class RoleSecurityHandler implements SecurityHandlerInterface
     /**
      * @var string[]
      */
+    private array $customRolePrefixes = [];
+
+    /**
+     * @var string[]
+     */
     private array $superAdminRoles = [];
 
     /**
@@ -98,6 +103,10 @@ final class RoleSecurityHandler implements SecurityHandlerInterface
 
     public function getBaseRole(AdminInterface $admin): string
     {
+        if (isset($this->customRolePrefixes[$admin->getCode()])) {
+            return $this->customRolePrefixes[$admin->getCode()] . '_%s';
+        }
+
         return sprintf('ROLE_%s_%%s', str_replace('.', '_', strtoupper($admin->getCode())));
     }
 
@@ -112,6 +121,11 @@ final class RoleSecurityHandler implements SecurityHandlerInterface
 
     public function deleteObjectSecurity(AdminInterface $admin, object $object): void
     {
+    }
+
+    public function setCustomRolePrefix(string $id, string $prefix): void
+    {
+        $this->customRolePrefixes[$id] = $prefix;
     }
 
     /**

--- a/src/SonataAdminBundle.php
+++ b/src/SonataAdminBundle.php
@@ -23,6 +23,7 @@ use Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\GlobalVariablesCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ModelManagerCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ObjectAclManipulatorCompilerPass;
+use Sonata\AdminBundle\DependencyInjection\Compiler\RoleSecurityCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\Compiler\TwigStringExtensionCompilerPass;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -43,5 +44,6 @@ final class SonataAdminBundle extends Bundle
         $container->addCompilerPass(new AdminMakerCompilerPass());
         $container->addCompilerPass(new AddAuditReadersCompilerPass());
         $container->addCompilerPass(new AdminAddInitializeCallCompilerPass(), PassConfig::TYPE_BEFORE_REMOVING, -100);
+        $container->addCompilerPass(new RoleSecurityCompilerPass());
     }
 }

--- a/tests/DependencyInjection/Compiler/RoleSecurityCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/RoleSecurityCompilerPassTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Sonata\AdminBundle\DependencyInjection\Compiler\RoleSecurityCompilerPass;
+use Sonata\AdminBundle\Security\Handler\RoleSecurityHandler;
+use Sonata\AdminBundle\Tests\App\Admin\FooAdmin;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class RoleSecurityCompilerPassTest extends AbstractCompilerPassTestCase
+{
+    public function testCustomRolePrefixTagging(): void
+    {
+        $roleSecurityHandlerDefinition = new Definition(RoleSecurityHandler::class);
+        $this->container->setDefinition('sonata.admin.security.handler.role', $roleSecurityHandlerDefinition);
+
+        $definition = new Definition(FooAdmin::class);
+        $definition->addTag('sonata.admin.role_security', [
+            'role_prefix' => 'ROLE_BAZ',
+        ]);
+        $this->container->setDefinition('admin.foo', $definition);
+        $this->compile();
+
+        self::assertContainerBuilderHasServiceDefinitionWithTag('admin.foo', 'sonata.admin.role_security', [
+            'role_prefix' => 'ROLE_BAZ',
+        ]);
+
+        self::assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'sonata.admin.security.handler.role',
+            'setCustomRolePrefix',
+            ['admin.foo', 'ROLE_BAZ']
+        );
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new RoleSecurityCompilerPass());
+    }
+}

--- a/tests/DependencyInjection/Compiler/RoleSecurityCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/RoleSecurityCompilerPassTest.php
@@ -45,6 +45,29 @@ class RoleSecurityCompilerPassTest extends AbstractCompilerPassTestCase
         );
     }
 
+    public function testRepeatedCustomRolePrefixTagging(): void
+    {
+        $roleSecurityHandlerDefinition = new Definition(RoleSecurityHandler::class);
+        $this->container->setDefinition('sonata.admin.security.handler.role', $roleSecurityHandlerDefinition);
+
+        $definition = new Definition(FooAdmin::class);
+        $definition->addTag('sonata.admin.role_security', [
+            'role_prefix' => 'ROLE_BAZ',
+        ]);
+        $definition->addTag('sonata.admin.role_security', [
+            'role_prefix' => 'ROLE_BAR',
+        ]);
+        $this->container->setDefinition('admin.foo', $definition);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Unable to set role prefix for admin.foo to "ROLE_BAR", because
+                it has already been assigned with role prefix "ROLE_BAZ".'
+        );
+
+        $this->compile();
+    }
+
     protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new RoleSecurityCompilerPass());

--- a/tests/Security/Handler/RoleSecurityHandlerTest.php
+++ b/tests/Security/Handler/RoleSecurityHandlerTest.php
@@ -239,6 +239,20 @@ final class RoleSecurityHandlerTest extends TestCase
         static::assertSame([], $handler->buildSecurityInformation($this->getSonataAdminObject()));
     }
 
+    public function testCustomRolePrefix(): void
+    {
+        $handler = new RoleSecurityHandler($this->authorizationChecker, 'ROLE_SUPER_ADMIN');
+
+        $this->admin
+            ->method('getCode')
+            ->willReturn('foo.bar');
+
+        static::assertSame('ROLE_FOO_BAR_%s', $handler->getBaseRole($this->admin));
+
+        $handler->setCustomRolePrefix($this->admin->getCode(), 'ROLE_ADMIN_BAR');
+        static::assertSame('ROLE_ADMIN_BAR_%s', $handler->getBaseRole($this->admin));
+    }
+
     /**
      * @param string|string[] $superAdminRoles
      */


### PR DESCRIPTION
## Allow specifying custom role name prefix for the role security handler

Similar to [my previous pull request](https://github.com/sonata-project/SonataAdminBundle/pull/7937#issue-1397592093), this pull request aims to resolve one of the shortcomings I saw when attempt to migrate the admin registrations from YAML service definitions to `#[AutoConfigure]` attributes, which is the weird looking role names when using the `RoleSecurityHandler` because the class doesn't expect FQCN when generating the base role name, thus producing role names like `ROLE_APP\ADMIN\POSTADMIN_LIST`.

[My comment in #7820](https://github.com/sonata-project/SonataAdminBundle/issues/7820#issuecomment-1263517942) suggests modifying `RoleSecurityHandler::getBaseName()` with additional string processing logic if the `code` matches the admin class' FQCN, so that the resultant role name in the above example will become `ROLE_APP_ADMIN_POST_ADMIN_LIST`. However, I have two worries about the suggestion:
1. There could be developers relying on these strange looking role names in the security definitions. Changing that behavior may break BC, so I am not confident to target the change to 4.x.
2. `preg_replace` isn't a light operation; I am not sure how frequent the `RoleSecurityHandler::getBaseName()` method will be called.

Therefore, I think whether to (and how to) beautify the FQCN role name can be left for further discussion. Instead, this pull request adds the ability for developers to specify their custom role name prefix for admin classes through the service tag when `RoleSecurityHandler` is used to determine user access rights.

The prefix can be specified through the service definition, e.g. in YAML:

```yaml
    admin.post:
        class: App\Admin\PostAdmin
        tags:
            - { name: sonata.admin.role_security, role_prefix: 'ROLE_ADMIN_POST' }
```

Or, through a PHP attribute:

```php
#[Autoconfigure(
    tags: [
        ['name' => 'sonata.admin',...],
        ['name' => 'sonata.admin.role_security', 'role_prefix' => 'ROLE_ADMIN_POST',]
    ],
)]
final class PostAdmin extends AbstractAdmin
```

A custom role prefix is also benefitial to those who are migrating from service definitions with YAML/XML/PHP, so developers aren't forced to modify `security.yaml` to use the new role names because of the changed service ids.

I am targeting the 4.x branch, because it should not break bc.

```markdown
### Added

- Added a new tag `sonata.admin.role_security` which allows specifying custom role prefix when using `RoleSecurityHandler` (`sonata.admin.security.handler.role`) in service definitions.
```
