### PR TITLE
Fix an issue that exception is thrown when the admin code is different from its service id

### DIFF
--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -94,9 +94,11 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
                 // ));
             }
 
-            $adminServices[$id] = new Reference($id);
-
             foreach ($tags as $attributes) {
+                $code = $attributes['code'] ?? $id;
+
+                $adminServices[$code] = new Reference($id);
+
                 $definition = $container->getDefinition($id);
                 $parentDefinition = null;
 
@@ -127,7 +129,7 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
                     array_merge($parentDefinition->getArguments(), $definition->getArguments()) :
                     $definition->getArguments();
 
-                $admins[] = $id;
+                $admins[] = $code;
 
                 // NEXT_MAJOR: Remove the fallback to $arguments[1].
                 $modelClass = $attributes['model_class'] ?? $arguments[1];
@@ -191,7 +193,7 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
                 }
 
                 $groupDefaults[$resolvedGroupName]['items'][] = [
-                    'admin' => $id,
+                    'admin' => $code,
                     'label' => $attributes['label'] ?? '', // NEXT_MAJOR: Remove this line.
                     'route' => '', // NEXT_MAJOR: Remove this line.
                     'route_params' => [],


### PR DESCRIPTION
## Fix an issue that exception is thrown when the admin code is different from its service id

As title. Please refer to [here](https://github.com/sonata-project/SonataAdminBundle/issues/7820#issuecomment-1269298812) and [here](https://github.com/sonata-project/SonataAdminBundle/issues/7820#issuecomment-1269455882) for details.

I am targeting the 4.x branch, because it doesn't break bc.

## Changelog

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix an issue that exception is thrown when the admin code is different from its service id.
```
