### PR TITLE
Shows a deprecation message when user applies sonata.admin tag to the same service more than once

### DIFF
--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -77,6 +77,23 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
         ];
 
         foreach ($container->findTaggedServiceIds(TaggedAdminInterface::ADMIN_TAG) as $id => $tags) {
+            if (\count($tags) > 1) {
+                // NEXT_MAJOR: Remove deprecation error with the exception below.
+                @trigger_error(sprintf(
+                    'Found multiple sonata.admin tags in service %s. Tagging a service with sonata.admin more
+                    than once is not supported, and will result in a RuntimeException removed in 5.0.',
+                    $id
+                ), \E_USER_DEPRECATED);
+
+                // NEXT_MAJOR: Enable this exception.
+                // throw new \RuntimeException(sprintf(
+                //    'Found multiple sonata.admin tags in service %s. Tagging a service with sonata.admin more
+                //    than once is not supported. Consider defining multiple services with different sonata.admin tag
+                //    parameters if this is really needed.',
+                //    $id
+                // ));
+            }
+
             $adminServices[$id] = new Reference($id);
 
             foreach ($tags as $attributes) {

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -570,6 +570,32 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
     }
 
     /**
+     * NEXT_MAJOR: Enable this test.
+     */
+    // public function testTaggingAdminClassMoreThanOnce(): void
+    // {
+    //    $this->setUpContainer();
+    //
+    //    $this->container
+    //        ->register('sonata_foo_admin')
+    //        ->setClass(CustomAdmin::class)
+    //        ->setPublic(true)
+    //        ->addTag('sonata.admin', ['model_class' => PostEntity::class, 'code' => 'sonata_post_admin', 'controller' => 'sonata.admin.controller.crud', 'group' => 'sonata_group_one', 'manager_type' => 'test'])
+    //        ->addTag('sonata.admin', ['model_class' => ArticleEntity::class, 'code' => 'sonata_article_admin', 'controller' => 'sonata.admin.controller.crud', 'group' => 'sonata_group_two', 'manager_type' => 'test']);
+    //
+    //    $this->extension->load([$this->getConfig()], $this->container);
+    //
+    //    $this->expectException(\RuntimeException::class);
+    //    $this->expectExceptionMessage(
+    //        'Found multiple sonata.admin tags in service sonata_foo_admin. Tagging a service with sonata.admin more
+    //                than once is not supported. Consider defining multiple services with different sonata.admin tag
+    //                parameters if this is really needed.'
+    //    );
+    //
+    //    $this->compile();
+    // }
+
+    /**
      * @return array<string, mixed>
      *
      * @phpstan-return array{


### PR DESCRIPTION
## Shows a deprecation message when user applies sonata.admin tag to the same service more than once

Again, the modifications of this pull request following the discussions in #7820 ([1](https://github.com/sonata-project/SonataAdminBundle/issues/7820#issuecomment-1269789042), [2](https://github.com/sonata-project/SonataAdminBundle/issues/7820#issuecomment-1269904454), [3](https://github.com/sonata-project/SonataAdminBundle/issues/7820#issuecomment-1270060397), [4](https://github.com/sonata-project/SonataAdminBundle/issues/7820#issuecomment-1270303732)). Currently, Sonata Admin will do nothing when user tags `sonata.admin` more than once for the same service id. Which means the following definition will not throw an error:

```yaml
services:
    App\Admin\FooOrBarAdmin:
        tags:
            - { name: sonata.admin, code: app.admin.foo, model_class: App\Entity\Foo, manager_type: orm, label_translator_strategy: sonata.admin.label.strategy.underscore, group: 'group_one' }
            - { name: sonata.admin, code: app.admin.bar, model_class: App\Entity\Bar, manager_type: orm, label_translator_strategy: sonata.admin.label.strategy.underscore, group: 'group_two' }
```

However, this will not work as intended, because during the service compilation stage, methods calls that set the admin code, model class, controller, manager type etc. are done against the actual service, i.e. the `App\Admin\FooOrBarAdmin` instance in the service container. As a result, only one of the attributes in the `sonata.admin` tag will be applied, regardless of which admin code is accessed. This also bring confusion when user injects `App\Admin\FooOrBarAdmin` to other classes through autowiring. This pull request makes it clear that definitions like this is not allowed.

I am targeting the 4.x branch, because in this pull request, a deprecation warning will be triggered when multiple `sonata.admin` tags are detected, so this shouldn't break bc. In 5.x an exception should be thrown instead.

## Changelog

```markdown
### Deprecated
- Applying the service tag `sonata.admin` to a service more than once is deprecated. This is not meant to be supported and will not work as intended, as only one of the tag attributes will be applied to the service.
```