### PR TITLE
Replace calls to deprecated method Pool::getAdminServiceIds with Pool::getAdminServiceCodes

### DIFF
--- a/src/Command/GenerateObjectAclCommand.php
+++ b/src/Command/GenerateObjectAclCommand.php
@@ -96,9 +96,9 @@ final class GenerateObjectAclCommand extends QuestionableCommand
             return 1;
         }
 
-        foreach ($this->pool->getAdminServiceIds() as $id) {
+        foreach ($this->pool->getAdminServiceCodes() as $code) {
             try {
-                $admin = $this->pool->getInstance($id);
+                $admin = $this->pool->getInstance($code);
             } catch (\Exception $e) {
                 $output->writeln('<error>Warning : The admin class cannot be initiated from the command line</error>');
                 $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));
@@ -106,7 +106,7 @@ final class GenerateObjectAclCommand extends QuestionableCommand
                 continue;
             }
 
-            if ($input->getOption('step') && !$this->askConfirmation($input, $output, sprintf("<question>Generate ACLs for the object instances handled by \"%s\"?</question>\n", $id), 'no')) {
+            if ($input->getOption('step') && !$this->askConfirmation($input, $output, sprintf("<question>Generate ACLs for the object instances handled by \"%s\"?</question>\n", $code), 'no')) {
                 continue;
             }
 

--- a/src/Command/ListAdminCommand.php
+++ b/src/Command/ListAdminCommand.php
@@ -53,11 +53,11 @@ final class ListAdminCommand extends Command
     public function execute(InputInterface $input, OutputInterface $output): int
     {
         $output->writeln('<info>Admin services:</info>');
-        foreach ($this->pool->getAdminServiceIds() as $id) {
-            $instance = $this->pool->getInstance($id);
+        foreach ($this->pool->getAdminServiceCodes() as $code) {
+            $instance = $this->pool->getInstance($code);
             $output->writeln(sprintf(
                 '  <info>%-40s</info> %-60s',
-                $id,
+                $code,
                 $instance->getClass()
             ));
         }

--- a/src/Command/SetupAclCommand.php
+++ b/src/Command/SetupAclCommand.php
@@ -58,9 +58,9 @@ final class SetupAclCommand extends Command
     {
         $output->writeln('Starting ACL AdminBundle configuration');
 
-        foreach ($this->pool->getAdminServiceIds() as $id) {
+        foreach ($this->pool->getAdminServiceCodes() as $code) {
             try {
-                $admin = $this->pool->getInstance($id);
+                $admin = $this->pool->getInstance($code);
             } catch (\Exception $e) {
                 $output->writeln('<error>Warning : The admin class cannot be initiated from the command line</error>');
                 $output->writeln(sprintf('<error>%s</error>', $e->getMessage()));

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1220,9 +1220,9 @@ class CRUDController extends AbstractController
         $pool = $this->container->get('sonata.admin.pool');
         \assert($pool instanceof Pool);
 
-        foreach ($pool->getAdminServiceIds() as $id) {
+        foreach ($pool->getAdminServiceCodes() as $code) {
             try {
-                $admin = $pool->getInstance($id);
+                $admin = $pool->getInstance($code);
             } catch (\Exception $e) {
                 continue;
             }

--- a/src/Route/AdminPoolLoader.php
+++ b/src/Route/AdminPoolLoader.php
@@ -58,8 +58,8 @@ final class AdminPoolLoader extends Loader
     public function load($resource, $type = null): SymfonyRouteCollection
     {
         $collection = new SymfonyRouteCollection();
-        foreach ($this->pool->getAdminServiceIds() as $id) {
-            $admin = $this->pool->getInstance($id);
+        foreach ($this->pool->getAdminServiceCodes() as $code) {
+            $admin = $this->pool->getInstance($code);
 
             foreach ($admin->getRoutes()->getElements() as $route) {
                 $name = $route->getDefault('_sonata_name');

--- a/src/Route/RoutesCacheWarmUp.php
+++ b/src/Route/RoutesCacheWarmUp.php
@@ -45,8 +45,8 @@ final class RoutesCacheWarmUp implements CacheWarmerInterface
      */
     public function warmUp($cacheDir): array
     {
-        foreach ($this->pool->getAdminServiceIds() as $id) {
-            $this->cache->load($this->pool->getInstance($id));
+        foreach ($this->pool->getAdminServiceCodes() as $code) {
+            $this->cache->load($this->pool->getInstance($code));
         }
 
         return [];

--- a/src/Translator/Extractor/AdminExtractor.php
+++ b/src/Translator/Extractor/AdminExtractor.php
@@ -71,8 +71,8 @@ final class AdminExtractor implements ExtractorInterface, LabelTranslatorStrateg
             $catalogue->set($name, $this->prefix.$name, $group['translation_domain']);
         }
 
-        foreach ($this->adminPool->getAdminServiceIds() as $id) {
-            $admin = $this->adminPool->getInstance($id);
+        foreach ($this->adminPool->getAdminServiceCodes() as $code) {
+            $admin = $this->adminPool->getInstance($code);
 
             $this->labelStrategy = $admin->getLabelTranslatorStrategy();
             $this->domain = $admin->getTranslationDomain();

--- a/tests/Admin/PoolTest.php
+++ b/tests/Admin/PoolTest.php
@@ -426,10 +426,10 @@ final class PoolTest extends TestCase
         static::assertSame($groups, $pool->getAdminGroups());
     }
 
-    public function testGetAdminServiceIds(): void
+    public function testGetAdminServiceCodes(): void
     {
         $pool = new Pool($this->container, ['sonata.user.admin.group1', 'sonata.user.admin.group2', 'sonata.user.admin.group3']);
-        static::assertSame(['sonata.user.admin.group1', 'sonata.user.admin.group2', 'sonata.user.admin.group3'], $pool->getAdminServiceIds());
+        static::assertSame(['sonata.user.admin.group1', 'sonata.user.admin.group2', 'sonata.user.admin.group3'], $pool->getAdminServiceCodes());
     }
 
     /**

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -593,7 +593,7 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
 
         $pool = $this->container->get('sonata.admin.pool');
         static::assertInstanceOf(Pool::class, $pool);
-        $serviceCodes = $pool->getAdminServiceIds();
+        $serviceCodes = $pool->getAdminServiceCodes();
 
         static::assertContains('sonata_bar_admin', $serviceCodes);
         static::assertNotContains('sonata_foo_admin', $serviceCodes);

--- a/tests/Translator/Extractor/AdminExtractorTest.php
+++ b/tests/Translator/Extractor/AdminExtractorTest.php
@@ -119,7 +119,7 @@ final class AdminExtractorTest extends TestCase
 
     public function testExtractCallsBreadcrumbs(): void
     {
-        $numberOfAdmins = \count($this->pool->getAdminServiceIds());
+        $numberOfAdmins = \count($this->pool->getAdminServiceCodes());
         $numberOfActionsToCheck = 6;
 
         $this->breadcrumbsBuilder->expects(static::exactly($numberOfAdmins * $numberOfActionsToCheck))


### PR DESCRIPTION
## Replace calls to deprecated method Pool::getAdminServiceIds with Pool::getAdminServiceCodes (and rationalize corresponding array element variable names)

I am targeting the 4.x branch, because it doesn't break bc.

I suppose this is an internal change so a changelog entry isn't needed?

Thank you!