### PR TITLE
Fix incorrect model class to service lookup array

### DIFF
--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -81,7 +81,7 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
                 // NEXT_MAJOR: Remove deprecation error with the exception below.
                 @trigger_error(sprintf(
                     'Found multiple sonata.admin tags in service %s. Tagging a service with sonata.admin more
-                    than once is not supported, and will result in a RuntimeException removed in 5.0.',
+                    than once is not supported, and will result in a RuntimeException in 5.0.',
                     $id
                 ), \E_USER_DEPRECATED);
 

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -113,7 +113,7 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
                     // - if it's not used, the old syntax is used, so we still need to
 
                     $this->replaceDefaultArguments([
-                        0 => $id,
+                        0 => $code,
                         2 => $defaultController,
                     ], $definition, $parentDefinition);
                 }
@@ -144,13 +144,13 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
                             'The class %s has two admins %s and %s with the "default" attribute set to true. Only one is allowed.',
                             $modelClass,
                             $classes[$modelClass][Pool::DEFAULT_ADMIN_KEY],
-                            $id
+                            $code
                         ));
                     }
 
-                    $classes[$modelClass][Pool::DEFAULT_ADMIN_KEY] = $id;
+                    $classes[$modelClass][Pool::DEFAULT_ADMIN_KEY] = $code;
                 } else {
-                    $classes[$modelClass][] = $id;
+                    $classes[$modelClass][] = $code;
                 }
 
                 $showInDashboard = (bool) (isset($attributes['show_in_dashboard']) ? $parameterBag->resolveValue($attributes['show_in_dashboard']) : true);

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -649,7 +649,13 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
             ->register('sonata_foo_admin')
             ->setClass(CustomAdmin::class)
             ->setPublic(true)
-            ->addTag('sonata.admin', ['model_class' => PostEntity::class, 'code' => 'sonata_bar_admin', 'controller' => 'sonata.admin.controller.crud', 'group' => 'sonata_group_one', 'manager_type' => 'test']);
+            ->addTag('sonata.admin', ['model_class' => FooEntity::class, 'code' => 'sonata_bar_admin', 'controller' => 'sonata.admin.controller.crud', 'group' => 'sonata_group_one', 'manager_type' => 'test']);
+
+        $this->container
+            ->register('sonata_baz_admin')
+            ->setClass(CustomAdmin::class)
+            ->setPublic(true)
+            ->addTag('sonata.admin', ['model_class' => BazEntity::class, 'default' => true, 'code' => 'sonata_qux_admin', 'controller' => 'sonata.admin.controller.crud', 'group' => 'sonata_group_one', 'manager_type' => 'test']);
 
         $config = $this->getConfig();
         $config['options']['sort_admins'] = true;
@@ -664,10 +670,26 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
 
         $pool = $this->container->get('sonata.admin.pool');
         static::assertInstanceOf(Pool::class, $pool);
+
         $serviceCodes = $pool->getAdminServiceCodes();
 
         static::assertContains('sonata_bar_admin', $serviceCodes);
         static::assertNotContains('sonata_foo_admin', $serviceCodes);
+
+        static::assertContains('sonata_qux_admin', $serviceCodes);
+        static::assertNotContains('sonata_baz_admin', $serviceCodes);
+
+        $classes = $pool->getAdminClasses();
+
+        static::assertArrayHasKey(FooEntity::class, $classes);
+        static::assertCount(1, $classes[FooEntity::class]);
+        static::assertArrayHasKey(0, $classes[FooEntity::class]);
+        static::assertSame('sonata_bar_admin', $classes[FooEntity::class][0]);
+
+        static::assertArrayHasKey(BazEntity::class, $classes);
+        static::assertCount(1, $classes[BazEntity::class]);
+        static::assertArrayHasKey(Pool::DEFAULT_ADMIN_KEY, $classes[BazEntity::class]);
+        static::assertSame('sonata_qux_admin', $classes[BazEntity::class][Pool::DEFAULT_ADMIN_KEY]);
     }
 
     /**
@@ -851,5 +873,11 @@ class PostEntity
 {
 }
 class ArticleEntity
+{
+}
+class FooEntity
+{
+}
+class BazEntity
 {
 }


### PR DESCRIPTION
## Fix incorrect model class to service lookup array

This patch mainly fixes the problem about the service id is incorrectly used when constructing the model class to service lookup array. The service code should be used instead.

In addition, this PR also modifies the first constructor parameter replacement from service ID to admin code in "legacy mode", and fix a typo in the deprecation message.

I am targeting this branch 4.x, because it doesn't break BC and is a follow up to #7940.

Closes #7951.

## Changelog

```markdown
### Fixed
- Fix an issue that an exception will be thrown by `Pool::getAdminByClass()` when the admin code is different from its service id.
- Fix a typo in the deprecation message which is triggered when multiple `sonata.admin` tags are found in the same service definition.
```