### PR TITLE
Allow a null limit for findRevisionHistory in next major

### DIFF
--- a/src/Model/AuditReaderInterface.php
+++ b/src/Model/AuditReaderInterface.php
@@ -30,6 +30,8 @@ interface AuditReaderInterface
     public function find(string $className, $id, $revisionId): ?object;
 
     /**
+     * NEXT_MAJOR: Change the default limit value to `null` and change the native type to `?int`.
+     *
      * @return Revision[]
      *
      * @phpstan-param class-string<T> $className


### PR DESCRIPTION
Pedantic since it's only a NEXT_MAJOR comment

This will be consistent with the fact that our AuditReader
https://github.com/sonata-project/EntityAuditBundle/blob/723b3bece17bc4e2897c7a487aa758f392568150/src/AuditReader.php#L338-L349
- supports a null limit
- will use null as default value in next major.