### PR TITLE
ChoiceFieldMaskType inside CollectionType does not work - bugfix

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -500,6 +500,7 @@ file that was distributed with this source code.
                         defaultFieldId = '#sonata-ba-field-container-{{ main_form_name }}-' + field;
                     }
 
+                    // Some fields are rendered by form_widget (no container)
                     if (jQuery(defaultFieldId).length === 0) {
                         defaultFieldId = '#{{ main_form_name }}_' + field;
                     }

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -497,7 +497,11 @@ file that was distributed with this source code.
 
                     // Some fields may be named with a dash (like keys of immutable array form type)
                     if (jQuery(defaultFieldId).length === 0) {
-                        return '#sonata-ba-field-container-{{ main_form_name }}-' + field;
+                        defaultFieldId = '#sonata-ba-field-container-{{ main_form_name }}-' + field;
+                    }
+
+                    if (jQuery(defaultFieldId).length === 0) {
+                        defaultFieldId = '#{{ main_form_name }}_' + field;
                     }
 
                     return defaultFieldId;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This commit solves the problem with ChoiceFieldMaskType inside CollectionType.
A detailed description of the problem: https://github.com/sonata-project/SonataAdminBundle/issues/6847

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fixes ChoiceFieldMaskType behavior inside CollectionType
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
