### PR TITLE
`AbstractAdmin::setSubject()` should use `getModelClass()` instead of `getClass()`

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -1056,12 +1056,12 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
 
     final public function setSubject(?object $subject): void
     {
-        if (null !== $subject && !is_a($subject, $this->getClass(), true)) {
+        if (null !== $subject && !is_a($subject, $this->getModelClass(), true)) {
             throw new \LogicException(sprintf(
                 'Admin "%s" does not allow this subject: %s, use the one register with this admin class %s',
                 static::class,
                 \get_class($subject),
-                $this->getClass()
+                $this->getModelClass()
             ));
         }
 

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -64,6 +64,7 @@ use Sonata\AdminBundle\Tests\Fixtures\Admin\TagWithoutPostAdmin;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\BlogPost;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Comment;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\CommentVote;
+use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\NewsPost;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Post;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\PostCategory;
 use Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity\Tag;
@@ -1729,6 +1730,34 @@ final class AdminTest extends TestCase
         static::assertTrue($admin->hasSubject());
         static::assertSame($model, $admin->getSubject());
         static::assertSame($model, $admin->getSubject()); // model manager must be used only once
+    }
+
+    public function testSetSubject(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $admin = new PostAdmin();
+        $admin->setModelClass(Post::class);
+
+        $admin->setSubject(new BlogPost());
+        $admin->setSubject(new NewsPost());
+        $admin->setSubject(new Post());
+        $admin->setSubject(null);
+    }
+
+    public function testSetSubjectNotAllowed(): void
+    {
+        $admin = new PostAdmin();
+        $admin->setModelClass(Post::class);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Admin "%s" does not allow this subject: %s, use the one register with this admin class %s',
+            PostAdmin::class,
+            Comment::class,
+            Post::class
+        ));
+        $admin->setSubject(new Comment());
     }
 
     public function testGetSubjectWithParentDescription(): void

--- a/tests/Fixtures/Bundle/Entity/NewsPost.php
+++ b/tests/Fixtures/Bundle/Entity/NewsPost.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Bundle\Entity;
+
+final class NewsPost extends Post
+{
+}


### PR DESCRIPTION
## Subject

Made `AbstractAdmin::setSubject()` use `getModelClass()` instead of `getClass()` to check is the subject is allowed.

`getClass()` would check the class of the current subject. So setting the subject with an instance of a parent class when the current subject is of a child class, this would fail before.

I am targeting this branch, because this is backwards compatible.

Closes #7944.

## Changelog

```markdown
### Changed
- Made `AbstractAdmin::setSubject()` use `getModelClass()` instead of `getClass()` to check is the subject is allowed
```
