### PR TITLE
Fix add item on collection named the same in nested form

### DIFF
--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -100,7 +100,10 @@ class AdminHelper
             $formData = $admin->getRequest()->get($formBuilder->getName(), []);
             \assert(\is_array($formData));
 
-            if (\array_key_exists($childFormBuilder->getName(), $formData)) {
+            if (
+                \array_key_exists($childFormBuilder->getName(), $formData)
+                && is_iterable($formData[$childFormBuilder->getName()])
+            ) {
                 $formData = $admin->getRequest()->get($formBuilder->getName(), []);
                 \assert(\is_array($formData));
 
@@ -121,15 +124,19 @@ class AdminHelper
         $form->setData($subject);
         $form->handleRequest($admin->getRequest());
 
+        $childFieldDescription = null !== $childFormBuilder
+            ? $childFormBuilder->getOption('sonata_field_description')
+            : null;
+
         if (
             null !== $childFormBuilder
-            && $childFormBuilder->getOption('sonata_field_description') instanceof FieldDescriptionInterface
-            && $admin->hasFormFieldDescription($childFormBuilder->getOption('sonata_field_description')->getName())
+            && $childFieldDescription instanceof FieldDescriptionInterface
+            && $childFieldDescription->hasAdmin()
+            && $childFieldDescription->getAdmin() === $admin
+            && $admin->hasFormFieldDescription($childFieldDescription->getName())
         ) {
             // retrieve the FieldDescription
-            $fieldDescription = $admin->getFormFieldDescription(
-                $childFormBuilder->getOption('sonata_field_description')->getName()
-            );
+            $fieldDescription = $admin->getFormFieldDescription($childFieldDescription->getName());
 
             try {
                 $value = $fieldDescription->getValue($form->getData());

--- a/tests/Admin/AdminHelperTest.php
+++ b/tests/Admin/AdminHelperTest.php
@@ -143,7 +143,7 @@ final class AdminHelperTest extends TestCase
 
         $associationMapping = [
             'fieldName' => 'bar',
-            'targetEntity' => Foo::class,
+            'targetEntity' => Bar::class,
             'sourceEntity' => Foo::class,
             'isOwningSide' => false,
         ];

--- a/tests/Admin/AdminHelperTest.php
+++ b/tests/Admin/AdminHelperTest.php
@@ -148,26 +148,22 @@ final class AdminHelperTest extends TestCase
             'isOwningSide' => false,
         ];
 
-        $fieldDescription = $this->createStub(FieldDescriptionInterface::class);
+        $fieldDescription = $this->createMock(FieldDescriptionInterface::class);
         $fieldDescription->method('getName')->willReturn('bar');
         $fieldDescription->method('getAssociationAdmin')->willReturn($associationAdmin);
         $fieldDescription->method('getAssociationMapping')->willReturn($associationMapping);
         $fieldDescription->method('getParentAssociationMappings')->willReturn([]);
+        $fieldDescription->method('hasAdmin')->willReturn(true);
+        $fieldDescription->method('getAdmin')->willReturn($admin);
 
-        $admin
-            ->method('getFormFieldDescription')
-            ->willReturn($fieldDescription);
+        $admin->method('hasFormFieldDescription')->with('bar')->willReturn(true);
+        $admin->method('getFormFieldDescription')->with('bar')->willReturn($fieldDescription);
 
         $associationAdmin
             ->method('getFormFieldDescriptions')
             ->willReturn([
                 'bar' => $fieldDescription,
             ]);
-
-        $admin
-            ->method('hasFormFieldDescription')
-            ->with($associationMapping['fieldName'])
-            ->willReturn(true);
 
         $request = new Request([], [
             'test' => [


### PR DESCRIPTION
## Subject

This PR fixes the observed problem when adding a new item to a nested form's collection whose name is the same as one of the parent fields. 
 
I am targeting this branch, because the problem is oberved on this one.

Closes #7955

## Changelog

```markdown
### Fixed
- Fix `appendFormFieldElement` on nested collection named the same as one of the parent fields 
```