### PR TITLE
Added ExporterInterface usage instead of Exporter class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "sonata-project/block-bundle": "^4.11",
         "sonata-project/doctrine-extensions": "^1.8 || ^2.0",
-        "sonata-project/exporter": "^2.11 || ^3.0",
+        "sonata-project/exporter": "^2.14 || ^3.1.1",
         "sonata-project/form-extensions": "^1.15",
         "sonata-project/twig-extensions": "^1.4.1 || ^2.0",
         "symfony/asset": "^4.4 || ^5.4 || ^6.0",

--- a/src/Bridge/Exporter/AdminExporter.php
+++ b/src/Bridge/Exporter/AdminExporter.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Bridge\Exporter;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
-use Sonata\Exporter\Exporter;
+use Sonata\Exporter\ExporterInterface;
 
 /**
  * @author Grégoire Paris <postmaster@greg0ire.fr>
@@ -22,14 +22,14 @@ use Sonata\Exporter\Exporter;
 final class AdminExporter
 {
     /**
-     * @var Exporter service from the exporter bundle
+     * @var ExporterInterface service from the exporter bundle
      */
-    private Exporter $exporter;
+    private ExporterInterface $exporter;
 
     /**
-     * @param Exporter $exporter will be used to get global settings
+     * @param ExporterInterface $exporter will be used to get global settings
      */
-    public function __construct(Exporter $exporter)
+    public function __construct(ExporterInterface $exporter)
     {
         $this->exporter = $exporter;
     }

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -31,7 +31,7 @@ use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Sonata\AdminBundle\Util\AdminAclUserManagerInterface;
 use Sonata\AdminBundle\Util\AdminObjectAclData;
 use Sonata\AdminBundle\Util\AdminObjectAclManipulator;
-use Sonata\Exporter\Exporter;
+use Sonata\Exporter\ExporterInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormRenderer;
@@ -93,7 +93,7 @@ class CRUDController extends AbstractController
             'sonata.admin.audit.manager' => AuditManagerInterface::class,
             'sonata.admin.object.manipulator.acl.admin' => AdminObjectAclManipulator::class,
             'sonata.admin.request.fetcher' => AdminFetcherInterface::class,
-            'sonata.exporter.exporter' => '?'.Exporter::class,
+            'sonata.exporter.exporter' => '?'.ExporterInterface::class,
             'sonata.admin.admin_exporter' => '?'.AdminExporter::class,
             'sonata.admin.security.acl_user_manager' => '?'.AdminAclUserManagerInterface::class,
 
@@ -851,7 +851,7 @@ class CRUDController extends AbstractController
         $filename = $adminExporter->getExportFilename($this->admin, $format);
 
         $exporter = $this->container->get('sonata.exporter.exporter');
-        \assert($exporter instanceof Exporter);
+        \assert($exporter instanceof ExporterInterface);
 
         if (!\in_array($format, $allowedExportFormats, true)) {
             throw new \RuntimeException(sprintf(


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added usage of ExporterInterface instead of Exporter class.

### Changed
- Drop support sonata-project/exporter 2.x.
```
