### PR TITLE
Remove deprecation using Symfony 6.2

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -4,6 +4,8 @@
         <directory name="src"/>
         <directory name="tests"/>
         <ignoreFiles>
+            <!-- see https://github.com/vimeo/psalm/issues/5338 -->
+            <file name="src/ArgumentResolver/CompatibleValueResolverInterface.php"/>
             <directory name="src/Resources/skeleton"/>
             <directory name="vendor"/>
         </ignoreFiles>

--- a/src/ArgumentResolver/AdminValueResolver.php
+++ b/src/ArgumentResolver/AdminValueResolver.php
@@ -16,10 +16,9 @@ namespace Sonata\AdminBundle\ArgumentResolver;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Request\AdminFetcherInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
-final class AdminValueResolver implements ArgumentValueResolverInterface
+final class AdminValueResolver implements CompatibleValueResolverInterface
 {
     private AdminFetcherInterface $adminFetcher;
 
@@ -28,6 +27,7 @@ final class AdminValueResolver implements ArgumentValueResolverInterface
         $this->adminFetcher = $adminFetcher;
     }
 
+    // TODO: Deprecate this method when dropping support of Symfony < 6.2
     public function supports(Request $request, ArgumentMetadata $argument): bool
     {
         $type = $argument->getType();
@@ -54,6 +54,22 @@ final class AdminValueResolver implements ArgumentValueResolverInterface
      */
     public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
-        yield $this->adminFetcher->get($request);
+        $type = $argument->getType();
+
+        if (null === $type) {
+            return [];
+        }
+
+        if (AdminInterface::class !== $type && !is_subclass_of($type, AdminInterface::class)) {
+            return [];
+        }
+
+        try {
+            $admin = $this->adminFetcher->get($request);
+        } catch (\InvalidArgumentException $exception) {
+            return [];
+        }
+
+        return is_a($admin, $type) ? [$admin] : [];
     }
 }

--- a/src/ArgumentResolver/CompatibleValueResolverInterface.php
+++ b/src/ArgumentResolver/CompatibleValueResolverInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\ArgumentResolver;
+
+use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\Controller\ValueResolverInterface;
+
+// TODO: Remove this interface when dropping support of Symfony < 6.2 and replace its usage with ValueResolverInterface
+if (interface_exists(ValueResolverInterface::class)) {
+    /** @internal */
+    interface CompatibleValueResolverInterface extends ValueResolverInterface
+    {
+    }
+} else {
+    /** @internal */
+    interface CompatibleValueResolverInterface extends ArgumentValueResolverInterface
+    {
+    }
+}

--- a/src/ArgumentResolver/ProxyQueryResolver.php
+++ b/src/ArgumentResolver/ProxyQueryResolver.php
@@ -15,11 +15,11 @@ namespace Sonata\AdminBundle\ArgumentResolver;
 
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
 use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
-final class ProxyQueryResolver implements ArgumentValueResolverInterface
+final class ProxyQueryResolver implements CompatibleValueResolverInterface
 {
+    // TODO: Deprecate this method when dropping support of Symfony < 6.2
     public function supports(Request $request, ArgumentMetadata $argument): bool
     {
         $type = $argument->getType();
@@ -46,12 +46,22 @@ final class ProxyQueryResolver implements ArgumentValueResolverInterface
      */
     public function resolve(Request $request, ArgumentMetadata $argument): iterable
     {
+        $type = $argument->getType();
+
+        if (null === $type) {
+            return [];
+        }
+
+        if (ProxyQueryInterface::class !== $type && !is_subclass_of($type, ProxyQueryInterface::class)) {
+            return [];
+        }
+
         foreach ($request->attributes as $attribute) {
             if ($attribute instanceof ProxyQueryInterface) {
-                yield $attribute;
-
-                break;
+                return [$attribute];
             }
         }
+
+        return [];
     }
 }

--- a/tests/ArgumentResolver/AdminValueResolverTest.php
+++ b/tests/ArgumentResolver/AdminValueResolverTest.php
@@ -26,108 +26,110 @@ use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
 
 final class AdminValueResolverTest extends TestCase
 {
-    private PostAdmin $admin;
-
-    private AdminValueResolver $adminValueResolver;
-
-    protected function setUp(): void
+    /**
+     * @dataProvider provideInvalidData
+     */
+    public function testWithInvalidData(Request $request, ArgumentMetadata $argumentMetadata): void
     {
-        $this->admin = new PostAdmin();
-        $this->admin->setCode('sonata.admin.post');
+        $admin = new PostAdmin();
+        $admin->setCode('sonata.admin.post');
 
         $container = new Container();
-        $container->set('sonata.admin.post', $this->admin);
+        $container->set('sonata.admin.post', $admin);
 
         $adminFetcher = new AdminFetcher(new Pool($container, ['sonata.admin.post']));
+        $adminValueResolver = new AdminValueResolver($adminFetcher);
 
-        $this->adminValueResolver = new AdminValueResolver($adminFetcher);
-    }
-
-    /**
-     * @dataProvider supportDataProvider
-     */
-    public function testSupports(bool $expectedSupport, Request $request, ArgumentMetadata $argumentMetadata): void
-    {
-        static::assertSame($expectedSupport, $this->adminValueResolver->supports($request, $argumentMetadata));
-    }
-
-    /**
-     * @phpstan-return iterable<array-key, array{bool, Request, ArgumentMetadata}>
-     */
-    public function supportDataProvider(): iterable
-    {
-        yield 'Object must implement AdminInterface' => [
-            false,
-            new Request(),
-            new ArgumentMetadata('_sonata_admin', self::class, false, false, null),
-        ];
-
-        yield 'Admin code must be passed' => [
-            false,
-            Request::create('/'),
-            new ArgumentMetadata('_sonata_admin', PostAdmin::class, false, false, null),
-        ];
-
-        $request = Request::create('/');
-        $request->attributes->set('_sonata_admin', 'non_existing');
-
-        yield 'Admin code must exist' => [
-            false,
-            $request,
-            new ArgumentMetadata('_sonata_admin', PostAdmin::class, false, false, null),
-        ];
-
-        $request = new Request();
-        $request->attributes->set('_sonata_admin', 'non_existing');
-
-        yield 'Admin fetched must be of the type specified in the action' => [
-            false,
-            $request,
-            new ArgumentMetadata('_sonata_admin', CommentAdmin::class, false, false, null),
-        ];
-
-        $request = new Request();
-        $request->attributes->set('_sonata_admin', 'sonata.admin.post');
-
-        yield 'Admin class is valid' => [
-            true,
-            $request,
-            new ArgumentMetadata('_sonata_admin', PostAdmin::class, false, false, null),
-        ];
-
-        yield 'Admin can fetch by interface' => [
-            true,
-            $request,
-            new ArgumentMetadata('_sonata_admin', AdminInterface::class, false, false, null),
-        ];
-    }
-
-    public function testResolveAdmin(): void
-    {
-        $request = new Request();
-        $request->attributes->set('_sonata_admin', 'sonata.admin.post');
-
-        $argument = new ArgumentMetadata('_sonata_admin', PostAdmin::class, false, false, null);
-
-        static::assertTrue($this->adminValueResolver->supports($request, $argument));
+        static::assertFalse($adminValueResolver->supports($request, $argumentMetadata));
         static::assertSame(
-            [$this->admin],
-            $this->iterableToArray($this->adminValueResolver->resolve($request, $argument))
+            [],
+            $adminValueResolver->resolve($request, $argumentMetadata)
         );
     }
 
     /**
-     * @phpstan-template T
-     * @phpstan-param iterable<T> $iterable
-     * @phpstan-return array<T>
+     * @phpstan-return iterable<array-key, array{Request, ArgumentMetadata}>
      */
-    private function iterableToArray(iterable $iterable): array
+    public function provideInvalidData(): iterable
     {
-        $array = [];
-        foreach ($iterable as $admin) {
-            $array[] = $admin;
-        }
+        yield 'Object with no type' => [
+            static::createRequest(),
+            static::createArgumentMetadata('_sonata_admin'),
+        ];
 
-        return $array;
+        yield 'Object must implement AdminInterface' => [
+            static::createRequest(),
+            static::createArgumentMetadata('_sonata_admin', self::class),
+        ];
+
+        yield 'Admin code must be passed' => [
+            static::createRequest(),
+            static::createArgumentMetadata('_sonata_admin', PostAdmin::class),
+        ];
+
+        yield 'Admin code must exist' => [
+            static::createRequest(['_sonata_admin' => 'non_existing']),
+            static::createArgumentMetadata('_sonata_admin', PostAdmin::class),
+        ];
+
+        yield 'Admin fetched must be of the type specified in the action' => [
+            static::createRequest(['_sonata_admin' => 'sonata.admin.post']),
+            static::createArgumentMetadata('_sonata_admin', CommentAdmin::class),
+        ];
+    }
+
+    public function testResolvesAdminClass(): void
+    {
+        $admin = new PostAdmin();
+        $admin->setCode('sonata.admin.post');
+
+        $container = new Container();
+        $container->set('sonata.admin.post', $admin);
+
+        $adminFetcher = new AdminFetcher(new Pool($container, ['sonata.admin.post']));
+        $adminValueResolver = new AdminValueResolver($adminFetcher);
+
+        $request = static::createRequest(['_sonata_admin' => 'sonata.admin.post']);
+        $argumentMetadata = static::createArgumentMetadata('_sonata_admin', PostAdmin::class);
+
+        static::assertTrue($adminValueResolver->supports($request, $argumentMetadata));
+        static::assertSame(
+            [$admin],
+            $adminValueResolver->resolve($request, $argumentMetadata)
+        );
+    }
+
+    public function testResolvesAdminInterface(): void
+    {
+        $admin = new PostAdmin();
+        $admin->setCode('sonata.admin.post');
+
+        $container = new Container();
+        $container->set('sonata.admin.post', $admin);
+
+        $adminFetcher = new AdminFetcher(new Pool($container, ['sonata.admin.post']));
+        $adminValueResolver = new AdminValueResolver($adminFetcher);
+
+        $request = static::createRequest(['_sonata_admin' => 'sonata.admin.post']);
+        $argumentMetadata = static::createArgumentMetadata('_sonata_admin', AdminInterface::class);
+
+        static::assertTrue($adminValueResolver->supports($request, $argumentMetadata));
+        static::assertSame(
+            [$admin],
+            $adminValueResolver->resolve($request, $argumentMetadata)
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $attributes
+     */
+    private static function createRequest(array $attributes = []): Request
+    {
+        return new Request([], [], $attributes);
+    }
+
+    private static function createArgumentMetadata(string $name, ?string $type = null): ArgumentMetadata
+    {
+        return new ArgumentMetadata($name, $type, false, false, null);
     }
 }


### PR DESCRIPTION
[`ArgumentValueResolverInterface` is deprecated since Symfony 6.2 in favor of `ValueResolverInterface`](https://github.com/symfony/symfony/blob/92481baae9f1ffd77f520aaad1fcdef07fafb3a2/UPGRADE-6.2.md#httpkernel). 

The easy solution I've seen is to create a `CompatibleValueResolverInterface` interface that in case `ValueResolverInterface` exists, it extends from it, otherwise from the deprecated `ArgumentValueResolverInterface`.

It's technically BC break since we're changing interfaces, but I don't think user should use these classes directly.

I've refactored the tests a bit so all cases are executed by the `supports()` method (only available in `ArgumentValueResolverInterface`) and the `resolve` method (available in `ArgumentValueResolverInterface` and `ValueResolverInterface`) so it should be easier to remove the `supports` method in a future.

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC-ish

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Value resolver deprecations using Symfony 6.2
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
