### PR TITLE
Fix response_item_callback option

### DIFF
--- a/src/Form/Type/ModelAutocompleteType.php
+++ b/src/Form/Type/ModelAutocompleteType.php
@@ -43,6 +43,7 @@ final class ModelAutocompleteType extends AbstractType
 
         $builder->setAttribute('property', $options['property']);
         $builder->setAttribute('callback', $options['callback']);
+        $builder->setAttribute('response_item_callback', $options['response_item_callback']);
         $builder->setAttribute('minimum_input_length', $options['minimum_input_length']);
         $builder->setAttribute('items_per_page', $options['items_per_page']);
         $builder->setAttribute('req_param_name_page_number', $options['req_param_name_page_number']);


### PR DESCRIPTION
## Subject

The ModelAutocompleteType supports customizing of the autocomplete response. This functionality doesn't work, because this parameter was skipped in the form type **buildForm** function.
This PR fixes 'response_item_callback' parameter and make this option work again.

I am targeting this branch, because it is broken in this branch.

Closes #8008.

## Changelog

```markdown

### Fixed

- Fix response_item_callback option for `ModelAutocompleteType` form field.
```
