### PR TITLE
Remove doctrine annotations as dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,6 @@
         "twig/twig": "^2.12.1 || ^3.0"
     },
     "require-dev": {
-        "doctrine/annotations": "^1.7",
         "friendsofphp/php-cs-fixer": "^3.4",
         "matthiasnoback/symfony-config-test": "^4.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.2",


### PR DESCRIPTION
We don't use doctrine annotations here, and it is blocking the install of latest php-cs-fixer versions. (3.15 is released with support for php 8.2)