### PR TITLE
Improve error message for non existent admin declaration

### DIFF
--- a/src/DependencyInjection/Compiler/AdminSearchCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AdminSearchCompilerPass.php
@@ -39,8 +39,6 @@ final class AdminSearchCompilerPass implements CompilerPassInterface
         $adminSearch = [];
 
         foreach ($container->findTaggedServiceIds(TaggedAdminInterface::ADMIN_TAG) as $id => $tags) {
-            $this->validateAdminClass($container, $id);
-
             foreach ($tags as $attributes) {
                 $globalSearch = $this->getGlobalSearchValue($attributes, $id);
                 if (null === $globalSearch) {
@@ -54,30 +52,6 @@ final class AdminSearchCompilerPass implements CompilerPassInterface
 
         $searchHandlerDefinition = $container->getDefinition('sonata.admin.search.handler');
         $searchHandlerDefinition->addMethodCall('configureAdminSearch', [$adminSearch]);
-    }
-
-    /**
-     * @throws LogicException if the class in the given service definition is not
-     *                        a subclass of `AdminInterface`
-     */
-    private function validateAdminClass(ContainerBuilder $container, string $id): void
-    {
-        $definition = $container->getDefinition($id);
-
-        // Trim possible parameter delimiters ("%") from the class name.
-        $adminClass = trim($definition->getClass() ?? '', '%');
-        if (!class_exists($adminClass) && $container->hasParameter($adminClass)) {
-            $adminClass = $container->getParameter($adminClass);
-            \assert(\is_string($adminClass));
-        }
-
-        if (!is_subclass_of($adminClass, AdminInterface::class)) {
-            throw new LogicException(sprintf(
-                'Service "%s" must implement `%s`.',
-                $id,
-                AdminInterface::class
-            ));
-        }
     }
 
     /**

--- a/src/DependencyInjection/Compiler/AdminSearchCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AdminSearchCompilerPass.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\DependencyInjection\Compiler;
 
-use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\DependencyInjection\Admin\TaggedAdminInterface;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;


### PR DESCRIPTION

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #7969.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Improve message when the admin class declared on the container does not exist.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
