### PR TITLE
Display violation errors on xhr request for non-input fields

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -388,6 +388,11 @@ This code manages the many-to-[one|many] association field popup
                         const field = event.currentTarget.querySelector(`[name="${violation.propertyPath}"]`);
 
                         if (!field) {
+                            content += '<div class="alert alert-danger alert-dismissable">'
+                                + '<button type="button" class="close" data-dismiss="alert" aria-hidden="true">×</button>'
+                                + violation.title
+                                + '</div>';
+
                             return;
                         }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
When you validate a form with errors on non-input fields that are displayed in a modal such as `ModelListType`, errors are not displayed.
I noticed that the current javascript only display errors for input with a name.
For all other types of input, the error is silenced.

Exemple of the admin in a modal : 
<img width="1440" alt="Screenshot 2023-03-22 at 18 49 45" src="https://user-images.githubusercontent.com/520893/226993662-c375e5fc-4bd9-40bf-8078-8a81f6d04141.png">

Exemple of the admin NOT in a modal : 
<img width="1245" alt="Screenshot 2023-03-22 at 18 55 46" src="https://user-images.githubusercontent.com/520893/226995154-683022c9-f308-4c84-89f8-13e5a55606fc.png">

This fix will show the errors at the top in an alert such as the one used for "Validation failed".

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it's a frontend patch and backwards compatible. 


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown

### Fixed

- Fix errors not being displayed in modal

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
