### PR TITLE
Drop doctrine/inflector for symfony/string

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "ext-json": "*",
         "doctrine/collections": "^1.6 || ^2.0",
         "doctrine/common": "^3.0",
-        "doctrine/inflector": "^2.0",
         "knplabs/knp-menu": "^3.1",
         "knplabs/knp-menu-bundle": "^3.0",
         "psr/container": "^1.0 || ^2.0",

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Controller;
 
-use Doctrine\Inflector\InflectorFactory;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Sonata\AdminBundle\Admin\AdminInterface;
@@ -53,6 +52,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
+use Symfony\Component\String\UnicodeString;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 
@@ -446,7 +446,7 @@ class CRUDController extends AbstractController
             throw new \RuntimeException('The action is not defined');
         }
 
-        $camelizedAction = InflectorFactory::create()->build()->classify($action);
+        $camelizedAction = (new UnicodeString($action))->camel()->title(true)->toString();
 
         try {
             $batchActionExecutable = $this->getBatchActionExecutable($action);
@@ -1491,7 +1491,7 @@ class CRUDController extends AbstractController
         $controller = $batchActions[$action]['controller'] ?? sprintf(
             '%s::%s',
             $this->admin->getBaseControllerName(),
-            sprintf('batchAction%s', InflectorFactory::create()->build()->classify($action))
+            sprintf('batchAction%s', (new UnicodeString($action))->camel()->title(true)->toString())
         );
 
         // This will throw an exception when called so we know if it's possible or not to call the controller.

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\DependencyInjection\Compiler;
 
-use Doctrine\Inflector\InflectorFactory;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Datagrid\Pager;
 use Sonata\AdminBundle\DependencyInjection\Admin\TaggedAdminInterface;
@@ -25,6 +24,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\String\UnicodeString;
 
 /**
  * Add all dependencies to the Admin class, this avoids writing too many lines
@@ -546,6 +546,6 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
 
     private function generateSetterMethodName(string $key): string
     {
-        return 'set'.InflectorFactory::create()->build()->classify($key);
+        return 'set'.(new UnicodeString($key))->camel()->title(true)->toString();
     }
 }


### PR DESCRIPTION

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is Bc

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Changed
- Use `symfony/string` instead of `doctrine/inflector` to convert words from snake_case to camelCase.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
