### PR TITLE
Do not throw an exception when parent association mapping is missing

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1464,7 +1464,7 @@ class CRUDController extends AbstractController
 
         $parentAssociationMapping = $this->admin->getParentAssociationMapping();
         if (null === $parentAssociationMapping) {
-            throw new \RuntimeException('The admin has no parent association mapping.');
+            return;
         }
 
         $propertyAccessor = PropertyAccess::createPropertyAccessor();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it's a bugfix.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

<!-- Closes #{put_issue_number_here}. -->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Child admins not related directly to a parent now handle show, edit and delete actions correctly.
```
