### PR TITLE
Allow translations in "enum" values

### DIFF
--- a/docs/reference/field_types.rst
+++ b/docs/reference/field_types.rst
@@ -194,6 +194,19 @@ The ``FieldDescriptionInterface::TYPE_CHOICE`` field type also supports multiple
 
     The default delimiter is a comma ``,``.
 
+``FieldDescriptionInterface::TYPE_ENUM``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can use the following options:
+
+======================================  ==============================================================
+Option                                  Description
+======================================  ==============================================================
+**use_value**                           Determines if the field must show the value or the case' name.
+                                        ``false`` by default.
+**enum_translation_domain**             Translation domain.
+======================================  ==============================================================
+
 ``FieldDescriptionInterface::TYPE_URL``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/Resources/views/CRUD/display_enum.html.twig
+++ b/src/Resources/views/CRUD/display_enum.html.twig
@@ -10,9 +10,13 @@ file that was distributed with this source code.
 #}
 
 {%- apply spaceless %}
-    {%- if value is null -%}
-        &nbsp;
-    {%- else -%}
-        {{ value.name }}
-    {%- endif -%}
+    {% set value = use_value|default(false) ? value.value : value.name %}
+
+    {% if translation_domain|default(null) is null %}
+        {% set value = value %}
+    {% else %}
+        {% set value = value|trans({}, translation_domain) %}
+    {% endif %}
+
+    {{ value }}
 {% endapply -%}

--- a/src/Resources/views/CRUD/list_enum.html.twig
+++ b/src/Resources/views/CRUD/list_enum.html.twig
@@ -12,5 +12,9 @@ file that was distributed with this source code.
 {% extends get_admin_template('base_list_field', admin.code) %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_enum.html.twig' with { value: value } only -%}
+    {%- include '@SonataAdmin/CRUD/display_enum.html.twig' with {
+        value: value,
+        use_value: field_description.option('use_value', false),
+        translation_domain: field_description.option('enum_translation_domain', null),
+    } only -%}
 {% endblock %}

--- a/src/Resources/views/CRUD/show_enum.html.twig
+++ b/src/Resources/views/CRUD/show_enum.html.twig
@@ -12,5 +12,9 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_show_field.html.twig' %}
 
 {% block field %}
-    {%- include '@SonataAdmin/CRUD/display_enum.html.twig' with { value: value } only -%}
+    {%- include '@SonataAdmin/CRUD/display_enum.html.twig' with {
+        value: value,
+        use_value: field_description.option('use_value', false),
+        translation_domain: field_description.option('enum_translation_domain', null),
+    } only -%}
 {% endblock %}

--- a/tests/Twig/Extension/RenderElementExtensionTest.php
+++ b/tests/Twig/Extension/RenderElementExtensionTest.php
@@ -1488,6 +1488,24 @@ final class RenderElementExtensionTest extends TestCase
             [],
         ];
 
+        $elements[] = [
+            '<td class="sonata-ba-list-field sonata-ba-list-field-enum" objectId="12345"> Clubs </td>',
+            FieldDescriptionInterface::TYPE_ENUM,
+            Suit::Clubs,
+            [
+                'use_value' => false,
+            ],
+        ];
+
+        $elements[] = [
+            '<td class="sonata-ba-list-field sonata-ba-list-field-enum" objectId="12345"> C </td>',
+            FieldDescriptionInterface::TYPE_ENUM,
+            Suit::Clubs,
+            [
+                'use_value' => true,
+            ],
+        ];
+
         return $elements;
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this change respects BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Added
- "enum_translation_domain" and "use_value" options for fields of type `FieldDescriptionInterface::TYPE_ENUM`.
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->

## To do

- [x] Update the tests;
- [x] Update the documentation;
- [x] Allow to display the enum value instead of the case (similar to what we have for `FieldDescriptionInterface::TYPE_CHOICE`).
