### PR TITLE
Avoid error when no model managers are available

### DIFF
--- a/src/DependencyInjection/Compiler/ModelManagerCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ModelManagerCompilerPass.php
@@ -48,12 +48,10 @@ final class ModelManagerCompilerPass implements CompilerPassInterface
             $availableManagers[$id] = $definition;
         }
 
-        $bundles = $container->getParameter('kernel.bundles');
-        \assert(\is_array($bundles));
+        if ($container->hasDefinition('sonata.admin.maker')) {
+            $adminMaker = $container->getDefinition('sonata.admin.maker');
 
-        if (isset($bundles['MakerBundle'])) {
-            $adminMakerDefinition = $container->getDefinition('sonata.admin.maker');
-            $adminMakerDefinition->replaceArgument(1, $availableManagers);
+            $adminMaker->replaceArgument(1, $availableManagers);
         }
     }
 }

--- a/src/DependencyInjection/Compiler/ModelManagerCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ModelManagerCompilerPass.php
@@ -48,14 +48,12 @@ final class ModelManagerCompilerPass implements CompilerPassInterface
             $availableManagers[$id] = $definition;
         }
 
-        if ([] !== $availableManagers) {
-            $bundles = $container->getParameter('kernel.bundles');
-            \assert(\is_array($bundles));
+        $bundles = $container->getParameter('kernel.bundles');
+        \assert(\is_array($bundles));
 
-            if (isset($bundles['MakerBundle'])) {
-                $adminMakerDefinition = $container->getDefinition('sonata.admin.maker');
-                $adminMakerDefinition->replaceArgument(1, $availableManagers);
-            }
+        if (isset($bundles['MakerBundle'])) {
+            $adminMakerDefinition = $container->getDefinition('sonata.admin.maker');
+            $adminMakerDefinition->replaceArgument(1, $availableManagers);
         }
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

When there are no model managers, you can end up with an error because of an undefined abstract argument on a service.
This PR fixes that error.

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataAdminBundle/issues/8081.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Installing SonataAdminBundle without any persistence does not throw missing abstract argument definition
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
