### PR TITLE
Autocomplete attr support

### DIFF
--- a/docs/reference/form_types.rst
+++ b/docs/reference/form_types.rst
@@ -483,6 +483,18 @@ The available options are:
           }
       }
 
+``attr``
+  An array of arbitrary attributes which will be rendered inside the select tag::
+
+      $form
+          ->add('category', ModelAutocompleteType::class, [
+              'property' => 'title',
+              'attr' => [
+                    'data-my-custom-variable' => 'my-custom-value',
+              ],
+          ])
+      ;
+
 Sonata\\AdminBundle\\Form\\Type\\ChoiceFieldMaskType
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -70,7 +70,6 @@ file that was distributed with this source code.
                 placeholder: '{{ placeholder ?: allowClearPlaceholder }}', // allowClear needs placeholder to work properly
                 allowClear: {{ required ? 'false' : 'true' }},
                 enable: {{ disabled ? 'false' : 'true' }},
-                readonly: {{ attr.read_only|default(false) ? 'true' : 'false' }},
                 minimumInputLength: {{ minimum_input_length }},
                 theme: 'bootstrap',
                 width: function() {

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -10,9 +10,9 @@ file that was distributed with this source code.
 #}
 {% apply spaceless %}
     <select id="{{ id }}_autocomplete_input" data-sonata-select2="false"
-        {%- if read_only|default(false) %} readonly="readonly"{% endif -%}
         {%- if disabled %} disabled="disabled"{% endif %}
         {%- if multiple %} multiple="multiple"{% endif %}
+        {%- for attribute, value in attr %} {{ attribute }}="{{ value }}" {% endfor -%}
     >
         {%- for idx, val in value|filter((val, idx) => idx~'' != '_labels') -%}
             <option value="{{ val }}" selected>{{ value['_labels'][idx] }}</option>

--- a/tests/Translator/Extractor/AdminExtractorTest.php
+++ b/tests/Translator/Extractor/AdminExtractorTest.php
@@ -32,7 +32,7 @@ final class AdminExtractorTest extends TestCase
     /**
      * @var AdminInterface<object>&MockObject
      */
-    private AdminInterface$fooAdmin;
+    private AdminInterface $fooAdmin;
 
     /**
      * @var AdminInterface<object>&MockObject


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because Sonata 4 does not support the attr option in ModelAutocompleteType

Sonata3 ModelAutocompleteType rendered the passed attr options into the autocomplete template allowing for custom data attributes etc. This was removed here: https://github.com/sonata-project/SonataAdminBundle/commit/8f4d4667852ed109f30dd58f727ba177f005f710 which I think was simply overlooked

Moreover Select2 v4 no longer supports readonly, see: https://github.com/select2/select2/blob/4.0.13/CHANGELOG.md

## Changelog

```markdown

### Added
- Autocomplete attr support for select2

```