### PR TITLE
Fix `label_catalogue` configuration node deprecation message

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -413,7 +413,7 @@ final class Configuration implements ConfigurationInterface
                                         ->setDeprecated(
                                             'sonata-project/admin-bundle',
                                             '4.9',
-                                            'The "default_label_catalogue" node is deprecated, use "default_translation_domain" instead.'
+                                            'The "label_catalogue" node is deprecated, use "translation_domain" instead.'
                                         )
                                     ->end()
                                     ->scalarNode('icon')->end()


### PR DESCRIPTION
## Subject

This PR fixes the faulty (copy-paste mistake) `label_catalogue` configuration node deprecation message. It confused me, because I searched my project for the use of `default_label_catalogue` but could not find anything. It seemed I have been using 
`label_catalogue` in my project, which triggered the deprecation message.

Apparently the has been a small copy-paste mistake of
https://github.com/sonata-project/SonataAdminBundle/blob/939707cff48a3a49388ac5cb1d28e46c00effa15/src/DependencyInjection/Configuration.php#L327-L335

I am targeting the 4.x branch, because it is a patch fix and it is backwards compatible.

## Changelog

```markdown
### Fixed
- `label_catalogue` configuration node deprecation message
```
