### PR TITLE
Fix ChoiceFieldMaskType inside CollectionType with inline table setting

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -505,12 +505,24 @@ file that was distributed with this source code.
                         defaultFieldId = '#{{ main_form_name }}_' + field;
                     }
 
+                    // catch select2 fields with inline: table option
+                    if (jQuery(defaultFieldId).length === 0) {
+                        defaultFieldId = '#{{ main_form_name }}_' + field + '_autocomplete_input';
+                    }
+
                     return defaultFieldId;
                 };
 
                 jQuery.each(allFields, function (i, field) {
                     var fieldContainer = controlGroupIdFunc(field);
                     jQuery(fieldContainer).hide();
+                    {% if form.parent.vars.sonata_admin.inline == 'table' %}
+                        var td = jQuery(fieldContainer).parent();
+                        var columnIndex = td.index();
+                        var headerTh = $("table thead tr th:eq(" + columnIndex + ")");
+                        td.hide();
+                        headerTh.hide();
+                    {% endif %}
                     jQuery(fieldContainer).find('[required="required"]').attr('data-required', 'required').removeAttr("required");
                 });
 
@@ -518,6 +530,13 @@ file that was distributed with this source code.
                     jQuery.each(map[val], function (i, field) {
                         var fieldContainer = controlGroupIdFunc(field);
                         jQuery(fieldContainer).show();
+                        {% if form.parent.vars.sonata_admin.inline == 'table' %}
+                            var td = jQuery(fieldContainer).parent();
+                            var columnIndex = td.index();
+                            var headerTh = $("table thead tr th:eq(" + columnIndex + ")");
+                            td.show();
+                            headerTh.show();
+                        {% endif %}
                         jQuery(fieldContainer).find('[data-required="required"]').attr("required", "required");
                     });
                 }


### PR DESCRIPTION
Fix ChoiceFieldMaskType inside CollectionType with inline table setting on parent field

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #6847 & #4911.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Logic to handle show / hide column of table html element

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
