### PR TITLE
Allow to disable icheck and to be able to use still choice field mask

### DIFF
--- a/docs/cookbook/recipe_icheck.rst
+++ b/docs/cookbook/recipe_icheck.rst
@@ -44,7 +44,7 @@ set data attribute ``data-sonata-icheck = "false"`` to this form element::
 
     You have to use false as string! ``"false"``!
 
-When using ``Sonata\AdminBundle\Form\Type\ChoiceFieldMaskType`` (or other types that inherit from it, such as )
+When using ``Sonata\AdminBundle\Form\Type\ChoiceFieldMaskType`` (or other types that inherit from it)
 with the ``expanded``: ``true`` option (that renders the form type with checkboxes or radio buttons),
 it is necessary to set the ``data-sonata-icheck`` attribute on its choice elements::
 

--- a/docs/cookbook/recipe_icheck.rst
+++ b/docs/cookbook/recipe_icheck.rst
@@ -43,3 +43,30 @@ set data attribute ``data-sonata-icheck = "false"`` to this form element::
 .. note::
 
     You have to use false as string! ``"false"``!
+
+When using ``Sonata\AdminBundle\Form\Type\ChoiceFieldMaskType`` (or other types that inherit from it, such as )
+with the ``expanded``: ``true`` option (that renders the form type with checkboxes or radio buttons),
+it is necessary to set the ``data-sonata-icheck`` attribute on its choice elements::
+
+    use Sonata\AdminBundle\Form\FormMapper;
+    use Sonata\AdminBundle\Form\Type\ModelType;
+    use Sonata\AdminBundle\Form\Type\ChoiceFieldMaskType;
+
+    protected function configureFormFields(FormMapper $form): void
+    {
+        $form
+            ->add('category', ChoiceFieldMaskType::class, [
+                'expanded' => true,
+                'placeholder_attr' => [
+                    // the placeholder (if any) needs also the data-sonata-icheck attr too since is rendered as
+                    // checkbox or radio button
+                    'data-sonata-icheck' => 'false'
+                ],
+                'choice_attr' => [
+                    'val1' => ['data-sonata-icheck' => 'false'],
+                    'val2' => ['data-sonata-icheck' => 'false'],
+                    // ...
+                ],
+            ])
+        ;
+    }

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -475,20 +475,21 @@ file that was distributed with this source code.
     {% set main_form_name = id|slice(0, (id|length - name|length)-1) %}
     {% if expanded %}
         {% set js_selector = '#' ~ main_form_name ~ '_' ~ name ~ ' input' %}
-        {% set js_event = 'ifChecked' %}
+        {% set js_events = ['change', 'ifChecked'] %}
     {% else %}
         {% set js_selector = '#' ~ main_form_name ~ '_' ~ name %}
-        {% set js_event = 'change' %}
+        {% set js_events = ['change'] %}
     {% endif %}
     <script>
         jQuery(document).ready(function() {
             var allFields = {{ all_fields|json_encode|raw }},
                 map = {{ map|json_encode|raw }},
                 showMaskChoiceEl = jQuery("{{ js_selector }}");
-
-            showMaskChoiceEl.on("{{ js_event }}", function () {
-                choice_field_mask_show(jQuery(this).val());
-            });
+                {% for js_event in js_events %}
+                    showMaskChoiceEl.on("{{ js_event }}", function () {
+                        choice_field_mask_show(jQuery(this).val());
+                    });
+                {% endfor %}
 
             function choice_field_mask_show(val) {
                 var controlGroupIdFunc = function (field) {


### PR DESCRIPTION
## Subject

Allows to disable `icheck` and to be able to use still choice field mask with the expanded option

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because is backward compatible.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataAdminBundle/issues/8104

## Changelog

```markdown
### Added
- Allow to disable `icheck` and to be able to use still choice field mask with the expanded option
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
