### PR TITLE
#8106: ModelList btn_delete bug when hit Enter key

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -646,6 +646,7 @@ file that was distributed with this source code.
                     <button
                         onclick="return remove_selected_element_{{ id }}(this);"
                         class="btn btn-danger btn-sm sonata-ba-action"
+                        type="button"
                         {# NEXT_MAJOR: Remove the fallback on null and on btn_catalogue #}
                         title="{{
                             btn_translation_domain|default(null) is same as(false)


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
Fix bug ModelList btn_delete when hit Enter key

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it's a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{8106}.

## Changelog

```markdown
### Fixed
Add missing type button on ModelList form widget
```

