### PR TITLE
Fix group mapper remove method

### DIFF
--- a/src/Mapper/BaseGroupedMapper.php
+++ b/src/Mapper/BaseGroupedMapper.php
@@ -268,8 +268,8 @@ abstract class BaseGroupedMapper implements MapperInterface
         }
 
         if (isset($groups[$group])) {
-            foreach ($groups[$group]['fields'] as $field) {
-                $this->remove($field);
+            foreach ($groups[$group]['fields'] as $fieldKey => $field) {
+                $this->remove((string) $fieldKey);
             }
         }
         unset($groups[$group]);
@@ -302,8 +302,8 @@ abstract class BaseGroupedMapper implements MapperInterface
 
         foreach ($tabs[$tab]['groups'] as $group) {
             if (isset($groups[$group])) {
-                foreach ($groups[$group]['fields'] as $field) {
-                    $this->remove($field);
+                foreach ($groups[$group]['fields'] as $fieldKey => $field) {
+                    $this->remove((string) $fieldKey);
                 }
             }
 

--- a/tests/Fixtures/Mapper/AbstractDummyGroupedMapper.php
+++ b/tests/Fixtures/Mapper/AbstractDummyGroupedMapper.php
@@ -29,6 +29,13 @@ abstract class AbstractDummyGroupedMapper extends BaseGroupedMapper
     ) {
     }
 
+    public function add(string $fieldName, ?string $name = null): self
+    {
+        $this->addFieldToCurrentGroup($fieldName, $name);
+
+        return $this;
+    }
+
     /**
      * @return AdminInterface<object>
      */

--- a/tests/Mapper/BaseGroupedMapperTest.php
+++ b/tests/Mapper/BaseGroupedMapperTest.php
@@ -28,7 +28,7 @@ use Symfony\Component\DependencyInjection\Container;
 final class BaseGroupedMapperTest extends TestCase
 {
     /**
-     * @var BaseGroupedMapper<object>&MockObject
+     * @var AbstractDummyGroupedMapper<object>&MockObject
      */
     protected $baseGroupedMapper;
 
@@ -117,6 +117,50 @@ final class BaseGroupedMapperTest extends TestCase
         static::assertCount(0, $this->groups);
         static::assertSame($this->baseGroupedMapper, $this->baseGroupedMapper->with('fooTab', ['tab' => true]));
         static::assertCount(1, $this->tabs);
+        static::assertCount(0, $this->groups);
+    }
+
+    public function testRemoveGroup(): void
+    {
+        static::assertCount(0, $this->tabs);
+        static::assertCount(0, $this->groups);
+
+        $this->baseGroupedMapper
+            ->tab('fooTab1')
+            ->with('fooGroup1')
+            ->add('field1', 'name1')
+            ->end()
+            ->end();
+
+        static::assertCount(1, $this->tabs);
+        static::assertCount(1, $this->groups);
+
+        $this->baseGroupedMapper->expects(self::once())->method('remove')->with('field1');
+        $this->baseGroupedMapper->removeGroup('fooGroup1', 'fooTab1');
+
+        static::assertCount(1, $this->tabs);
+        static::assertCount(0, $this->groups);
+    }
+
+    public function testRemoveTab(): void
+    {
+        static::assertCount(0, $this->tabs);
+        static::assertCount(0, $this->groups);
+
+        $this->baseGroupedMapper
+            ->tab('fooTab1')
+            ->with('fooGroup1')
+            ->add('field1', 'name1')
+            ->end()
+            ->end();
+
+        static::assertCount(1, $this->tabs);
+        static::assertCount(1, $this->groups);
+
+        $this->baseGroupedMapper->expects(self::once())->method('remove')->with('field1');
+        $this->baseGroupedMapper->removeTab('fooTab1');
+
+        static::assertCount(0, $this->tabs);
         static::assertCount(0, $this->groups);
     }
 

--- a/tests/Mapper/BaseGroupedMapperTest.php
+++ b/tests/Mapper/BaseGroupedMapperTest.php
@@ -17,7 +17,6 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\Pool;
-use Sonata\AdminBundle\Mapper\BaseGroupedMapper;
 use Sonata\AdminBundle\Tests\Fixtures\Mapper\AbstractDummyGroupedMapper;
 use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
 use Symfony\Component\DependencyInjection\Container;
@@ -28,7 +27,7 @@ use Symfony\Component\DependencyInjection\Container;
 final class BaseGroupedMapperTest extends TestCase
 {
     /**
-     * @var AbstractDummyGroupedMapper<object>&MockObject
+     * @var AbstractDummyGroupedMapper&MockObject
      */
     protected $baseGroupedMapper;
 
@@ -135,7 +134,7 @@ final class BaseGroupedMapperTest extends TestCase
         static::assertCount(1, $this->tabs);
         static::assertCount(1, $this->groups);
 
-        $this->baseGroupedMapper->expects(self::once())->method('remove')->with('field1');
+        $this->baseGroupedMapper->expects(static::once())->method('remove')->with('field1');
         $this->baseGroupedMapper->removeGroup('fooGroup1', 'fooTab1');
 
         static::assertCount(1, $this->tabs);
@@ -157,7 +156,7 @@ final class BaseGroupedMapperTest extends TestCase
         static::assertCount(1, $this->tabs);
         static::assertCount(1, $this->groups);
 
-        $this->baseGroupedMapper->expects(self::once())->method('remove')->with('field1');
+        $this->baseGroupedMapper->expects(static::once())->method('remove')->with('field1');
         $this->baseGroupedMapper->removeTab('fooTab1');
 
         static::assertCount(0, $this->tabs);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

## Changelog

```markdown
### Fixed
- `GroupMapper::removeTab` and `GroupMapper::removeGroup`
```