### PR TITLE
Allow AdminExtractor to be used for abstract admins

### DIFF
--- a/src/Translator/Extractor/AdminExtractor.php
+++ b/src/Translator/Extractor/AdminExtractor.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Translator\Extractor;
 
+use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\BreadcrumbsBuilderInterface;
 use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Translator\LabelTranslatorStrategyInterface;
@@ -70,6 +71,10 @@ final class AdminExtractor implements ExtractorInterface, LabelTranslatorStrateg
         foreach ($this->adminPool->getAdminServiceCodes() as $code) {
             $admin = $this->adminPool->getInstance($code);
 
+            if (!$this->isValidAdmin($admin)) {
+                continue;
+            }
+
             $this->labelStrategy = $admin->getLabelTranslatorStrategy();
             $this->domain = $admin->getTranslationDomain();
 
@@ -79,6 +84,7 @@ final class AdminExtractor implements ExtractorInterface, LabelTranslatorStrateg
             }
 
             $admin->setLabelTranslatorStrategy($this);
+
             $admin->setSubject($admin->getNewInstance());
 
             foreach (self::PUBLIC_ADMIN_METHODS as $method) {
@@ -116,5 +122,19 @@ final class AdminExtractor implements ExtractorInterface, LabelTranslatorStrateg
         $this->catalogue->set($label, $this->prefix.$label, $this->domain);
 
         return $label;
+    }
+
+    /**
+     * @param AdminInterface<object> $admin
+     */
+    private function isValidAdmin(AdminInterface $admin): bool
+    {
+        $class = $admin->getClass();
+
+        if (!class_exists($class)) {
+            return false;
+        }
+
+        return !(new \ReflectionClass($class))->isAbstract();
     }
 }

--- a/tests/Translator/Extractor/AdminExtractorTest.php
+++ b/tests/Translator/Extractor/AdminExtractorTest.php
@@ -51,8 +51,14 @@ final class AdminExtractorTest extends TestCase
 
         $this->fooAdmin->method('getShow')->willReturn(new FieldDescriptionCollection());
         $this->fooAdmin->method('getList')->willReturn(new FieldDescriptionCollection());
+        $this->fooAdmin
+            ->method('getClass')
+            ->willReturn(\stdClass::class);
         $this->barAdmin->method('getShow')->willReturn(new FieldDescriptionCollection());
         $this->barAdmin->method('getList')->willReturn(new FieldDescriptionCollection());
+        $this->barAdmin
+            ->method('getClass')
+            ->willReturn(\stdClass::class);
 
         $container = new Container();
         $container->set('foo_admin', $this->fooAdmin);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a bugfix.

Found some errors when using `console debug:translation` when using [admins without a subject](https://docs.sonata-project.org/projects/SonataAdminBundle/en/4.x/cookbook/recipe_custom_action/#custom-action-without-entity) or abstract classes.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Allow AdminExtractor to be used for abstract admins
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
