### PR TITLE
Fix clashing global twig variable

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -994,10 +994,7 @@ class CRUDController extends AbstractController
      */
     final public function setTwigGlobals(Request $request): void
     {
-        $twig = $this->container->get('twig');
-        \assert($twig instanceof Environment);
-
-        $twig->addGlobal('admin', $this->admin);
+        $this->setTwigGlobal('admin', $this->admin);
 
         if ($this->isXmlHttpRequest($request)) {
             $baseTemplate = $this->templateRegistry->getTemplate('ajax');
@@ -1005,7 +1002,7 @@ class CRUDController extends AbstractController
             $baseTemplate = $this->templateRegistry->getTemplate('layout');
         }
 
-        $twig->addGlobal('base_template', $baseTemplate);
+        $this->setTwigGlobal('base_template', $baseTemplate);
     }
 
     /**
@@ -1540,6 +1537,18 @@ class CRUDController extends AbstractController
                 $parentAdmin->toString($parentAdminObject),
                 $this->admin->toString($object)
             ));
+        }
+    }
+
+    private function setTwigGlobal(string $name, mixed $value): void
+    {
+        $twig = $this->container->get('twig');
+        \assert($twig instanceof Environment);
+
+        try {
+            $twig->addGlobal($name, $value);
+        } catch (\LogicException) {
+            // Variable already set
         }
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This PR fixes the problem, when the global variables have already been set:
```
Unable to add global "admin" as the runtime or the extensions have already been initialized.
```
<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a hotfix of #8125 

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Fix clashing global twig variables (admin, base_template) if already set
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
