### PR TITLE
Rely on filter methods rather than option

### DIFF
--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -322,6 +322,7 @@ final class Datagrid implements DatagridInterface
         }
 
         foreach ($this->getFilters() as $filter) {
+            // NEXT_MAJOR: Keep the if part.
             if (method_exists($filter, 'getFormOptions')) {
                 $type = FilterDataType::class;
 

--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -322,10 +322,30 @@ final class Datagrid implements DatagridInterface
         }
 
         foreach ($this->getFilters() as $filter) {
-            // NEXT_MAJOR: Keep the if part.
             if (method_exists($filter, 'getFormOptions')) {
                 $type = FilterDataType::class;
-                $options = $filter->getFormOptions();
+
+                // NEXT_MAJOR: Keep the if part.
+                if (method_exists($filter, 'getLabelTranslationParameters')) {
+                    $labelTranslationParameters = $filter->getLabelTranslationParameters();
+                } else {
+                    @trigger_error(
+                        'Not implementing "getLabelTranslationParameters()" is deprecated since sonata-project/admin-bundle 4.30'
+                        .' and will throw an error in 5.0.',
+                        \E_USER_DEPRECATED
+                    );
+
+                    $labelTranslationParameters = $filter->getOption('label_translation_parameters');
+                }
+
+                $defaultFormOptions = [
+                    'label' => $filter->getLabel(),
+                    'label_translation_parameters' => $labelTranslationParameters,
+                    'translation_domain' => $filter->getTranslationDomain(),
+                    'field_type' => $filter->getFieldType(),
+                    'field_options' => $filter->getFieldOptions(),
+                ];
+                $options = array_merge($defaultFormOptions, $filter->getFormOptions());
             } else {
                 @trigger_error(
                     'Not implementing "getFormOptions()" is deprecated since sonata-project/admin-bundle 4.15'

--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -248,6 +248,24 @@ abstract class Filter implements FilterInterface, ChainableFilterInterface
         ];
     }
 
+    final public function showFilter(): ?bool
+    {
+        return $this->getOption('show_filter');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    final public function getLabelTranslationParameters(): array
+    {
+        return $this->getOption('label_translation_parameters');
+    }
+
+    final public function withAdvancedFilter(): bool
+    {
+        return $this->getOption('advanced_filter');
+    }
+
     final protected function setActive(bool $active): void
     {
         $this->active = $active;

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -20,6 +20,9 @@ use Sonata\AdminBundle\Filter\Model\FilterData;
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
  * @method array getFormOptions();
+ * @method bool|null showFilter();
+ * @method array getLabelTranslationParameters();
+ * @method bool withAdvancedFilter();
  */
 interface FilterInterface
 {

--- a/src/Resources/views/Block/block_search_result.html.twig
+++ b/src/Resources/views/Block/block_search_result.html.twig
@@ -45,10 +45,10 @@ file that was distributed with this source code.
                 <div class="matches">
                     {% for name, filter in filters %}
                         <a class="label label-primary" href="{{ admin.generateUrl('list', {'filter': {(filter.formName): {'value': term}}}) }}">
-                            {% if filter.option('translation_domain') is same as(false) %}
-                                {{ filter.option('label') }}
+                            {% if filter.translationDomain is same as(false) %}
+                                {{ filter.label }}
                             {% else %}
-                                {{ filter.option('label')|trans({}, filter.option('translation_domain', admin.translationDomain)) }}
+                                {{ filter.label|trans({}, filter.translationDomain ?? admin.translationDomain) }}
                             {% endif %}
                         </a>
                     {% endfor %}

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -256,7 +256,8 @@ file that was distributed with this source code.
 {% endblock %}
 
 {% block list_filters_actions %}
-    {% set displayableFilters = admin.datagrid.filters|filter(filter => filter.option('show_filter') is not same as (false)) %}
+    {# NEXT_MAJOR: Remove |default(filter.option('show_filter')) #}
+    {% set displayableFilters = admin.datagrid.filters|filter(filter => filter.showFilter|default(filter.option('show_filter')) is not same as (false)) %}
     {%- if displayableFilters|length %}
         <ul class="nav navbar-nav navbar-right">
 
@@ -270,14 +271,17 @@ file that was distributed with this source code.
 
                 <ul class="dropdown-menu dropdown-menu-scrollable" role="menu">
                     {% for filter in displayableFilters %}
-                        {% set filterDisplayed = filter.isActive() or filter.option('show_filter') is same as (true) %}
+                        {# NEXT_MAJOR: Remove |default(filter.option('show_filter')) #}
+                        {% set filterDisplayed = filter.isActive() or filter.showFilter|default(filter.option('show_filter')) is same as (true) %}
                         <li>
                             <a href="#" class="sonata-toggle-filter sonata-ba-action" filter-target="filter-{{ admin.uniqid }}-{{ filter.name }}" filter-container="filter-container-{{ admin.uniqid() }}">
                                 <i class="far {{ filterDisplayed ? 'fa-check-square' : 'fa-square' }}"></i>
                                 {% if filter.label is not same as(false) %}
                                     {% if filter.translationDomain is same as(false) %}
                                         {{ filter.label }}
-                                    {% else %}
+                                    {% elseif filter.labelTranslationParameters is defined %}
+                                        {{ filter.label|trans(filter.labelTranslationParameters, filter.translationDomain ?? admin.translationDomain) }}
+                                    {% else %} {# NEXT_MAJOR: remove the else part and change elseif to else #}
                                         {{ filter.label|trans(filter.option('label_translation_parameters', {}), filter.translationDomain ?? admin.translationDomain) }}
                                     {% endif %}
                                 {% endif %}
@@ -310,7 +314,8 @@ file that was distributed with this source code.
                             <div class="col-sm-9">
                                 {% set withAdvancedFilter = false %}
                                 {% for filter in admin.datagrid.filters %}
-                                    {% set filterDisplayed = filter.isActive() or filter.option('show_filter') is same as (true) %}
+                                    {# NEXT_MAJOR: Remove |default(filter.option('show_filter')) #}
+                                    {% set filterDisplayed = filter.isActive() or filter.showFilter|default(filter.option('show_filter')) is same as (true) %}
                                     {% set filterCanBeDisplayed = filter.option('show_filter') is not same as(false) %}
                                     <div class="form-group {% block sonata_list_filter_group_class %}{% endblock %}" id="filter-{{ admin.uniqid }}-{{ filter.name }}" sonata-filter="{{ filterCanBeDisplayed ? 'true' : 'false' }}" style="display: {% if filterDisplayed %}block{% else %}none{% endif %}">
                                         {% if filter.label is not same as(false) %}
@@ -343,7 +348,8 @@ file that was distributed with this source code.
                                         {% endif %}
                                     </div>
 
-                                    {% if filter.option('advanced_filter') %}
+                                    {# NEXT_MAJOR: Remove |default(filter.option('advanced_filter')) #}
+                                    {% if filter.withAdvancedFilter|default(filter.option('advanced_filter')) %}
                                         {% set withAdvancedFilter = true %}
                                     {% endif %}
                                 {% endfor %}

--- a/tests/Datagrid/DatagridTest.php
+++ b/tests/Datagrid/DatagridTest.php
@@ -25,6 +25,7 @@ use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 use Sonata\AdminBundle\Filter\FilterInterface;
 use Sonata\AdminBundle\Form\Type\Filter\FilterDataType;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilder;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -318,7 +319,7 @@ final class DatagridTest extends TestCase
     public function testBuildPager(): void
     {
         $filter1 = $this->getMockBuilder(FilterInterface::class)
-            ->addMethods(['getFormOptions'])
+            ->addMethods(['getFormOptions', 'getLabelTranslationParameters'])
             ->getMockForAbstractClass();
         $filter1->expects(static::once())
             ->method('getName')
@@ -330,13 +331,16 @@ final class DatagridTest extends TestCase
             ->method('isActive')
             ->willReturn(false);
         $filter1
+            ->method('getFieldType')
+            ->willReturn(TextType::class);
+        $filter1
             ->method('getFormOptions')
             ->willReturn(['operator_options' => ['help' => 'baz1']]);
 
         $this->datagrid->addFilter($filter1);
 
         $filter2 = $this->getMockBuilder(FilterInterface::class)
-            ->addMethods(['getFormOptions'])
+            ->addMethods(['getFormOptions', 'getLabelTranslationParameters'])
             ->getMockForAbstractClass();
         $filter2->expects(static::once())
             ->method('getName')
@@ -347,6 +351,9 @@ final class DatagridTest extends TestCase
         $filter2
             ->method('isActive')
             ->willReturn(true);
+        $filter2
+            ->method('getFieldType')
+            ->willReturn(TextType::class);
         $filter2
             ->method('getFormOptions')
             ->willReturn(['operator_options' => ['help' => 'baz2']]);
@@ -374,12 +381,13 @@ final class DatagridTest extends TestCase
         $this->datagrid->setValue('fooFormName', $type, $value);
 
         $filter = $this->getMockBuilder(FilterInterface::class)
-            ->addMethods(['getFormOptions'])
+            ->addMethods(['getFormOptions', 'getLabelTranslationParameters'])
             ->getMockForAbstractClass();
         $filter->expects(static::once())->method('getName')->willReturn('foo');
         $filter->method('getFormName')->willReturn('fooFormName');
         $filter->method('isActive')->willReturn(false);
         $filter->method('getFormOptions')->willReturn(['operator_options' => ['help' => 'baz2']]);
+        $filter->method('getFieldType')->willReturn(TextType::class);
         $filter->expects(static::exactly($applyCallNumber))->method('apply');
 
         $this->datagrid->addFilter($filter);
@@ -430,7 +438,7 @@ final class DatagridTest extends TestCase
     public function testBuildPagerWithException(): void
     {
         $filter = $this->getMockBuilder(FilterInterface::class)
-            ->addMethods(['getFormOptions'])
+            ->addMethods(['getFormOptions', 'getLabelTranslationParameters'])
             ->getMockForAbstractClass();
         $filter->expects(static::once())
             ->method('getName')
@@ -443,6 +451,9 @@ final class DatagridTest extends TestCase
         $filter
             ->method('isActive')
             ->willReturn(false);
+        $filter
+            ->method('getFieldType')
+            ->willReturn(TextType::class);
         $filter
             ->method('getFormOptions')
             ->willReturn(['operator_options' => ['help' => 'baz']]);
@@ -475,7 +486,7 @@ final class DatagridTest extends TestCase
         $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, [DatagridInterface::SORT_BY => $sortBy]);
 
         $filter = $this->getMockBuilder(FilterInterface::class)
-            ->addMethods(['getFormOptions'])
+            ->addMethods(['getFormOptions', 'getLabelTranslationParameters'])
             ->getMockForAbstractClass();
         $filter->expects(static::once())
             ->method('getName')
@@ -486,6 +497,9 @@ final class DatagridTest extends TestCase
         $filter
             ->method('isActive')
             ->willReturn(false);
+        $filter
+            ->method('getFieldType')
+            ->willReturn(TextType::class);
         $filter
             ->method('getFormOptions')
             ->willReturn(['operator_options' => ['help' => 'baz']]);
@@ -526,7 +540,7 @@ final class DatagridTest extends TestCase
         $this->datagrid = new Datagrid($this->query, $this->columns, $this->pager, $this->formBuilder, [DatagridInterface::SORT_BY => $sortBy, DatagridInterface::PAGE => $page, DatagridInterface::PER_PAGE => $perPage]);
 
         $filter = $this->getMockBuilder(FilterInterface::class)
-            ->addMethods(['getFormOptions'])
+            ->addMethods(['getFormOptions', 'getLabelTranslationParameters'])
             ->getMockForAbstractClass();
         $filter->expects(static::once())
             ->method('getName')
@@ -537,6 +551,9 @@ final class DatagridTest extends TestCase
         $filter
             ->method('isActive')
             ->willReturn(false);
+        $filter
+            ->method('getFieldType')
+            ->willReturn(TextType::class);
         $filter
             ->method('getFormOptions')
             ->willReturn(['operator_options' => ['help' => 'baz']]);


### PR DESCRIPTION
## Subject

1) We should rely on filter methods rather than options.
2) a lot of filter options could be set by default instead asking for them in persistence bundle

Fix https://github.com/sonata-project/SonataDoctrineORMAdminBundle/issues/1779

## Changelog

```markdown
### Fixed
- `label_translation_parameters` option usage


### Deprecated
- Not implementing `FilterInterface::showFilter`
- Not implementing `FilterInterface::getLabelTranslationParameters`
- Not implementing `FilterInterface::withAdvancedFilter`
```