### PR TITLE
Fix getLabelTranslationParameters

### DIFF
--- a/src/Filter/Filter.php
+++ b/src/Filter/Filter.php
@@ -258,7 +258,7 @@ abstract class Filter implements FilterInterface, ChainableFilterInterface
      */
     final public function getLabelTranslationParameters(): array
     {
-        return $this->getOption('label_translation_parameters');
+        return $this->getOption('label_translation_parameters', []);
     }
 
     final public function withAdvancedFilter(): bool

--- a/tests/Filter/FilterTest.php
+++ b/tests/Filter/FilterTest.php
@@ -27,6 +27,8 @@ final class FilterTest extends TestCase
         static::assertSame(TextType::class, $filter->getFieldType());
         static::assertSame([], $filter->getFieldOptions());
         static::assertNull($filter->getLabel());
+        static::assertNull($filter->getTranslationDomain());
+        static::assertSame([], $filter->getLabelTranslationParameters());
 
         $options = [
             'label' => 'foo',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

## Changelog

```markdown
### Fixed
- `Filter::getLabelTranslationParameters` implementation
```