### PR TITLE
Bugfix/issue 8168 fix batch consistency

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -525,15 +525,17 @@ class CRUDController extends AbstractController
             }
         }
 
-        if (\count($idx) > 0) {
-            $this->admin->getModelManager()->addIdentifiersToQuery($this->admin->getClass(), $query, $idx);
-        } elseif (!$allElements) {
-            $this->addFlash(
-                'sonata_flash_info',
-                $this->trans('flash_batch_no_elements_processed', [], 'SonataAdminBundle')
-            );
+        if (!$allElements) {
+            if (\count($idx) > 0) {
+                $this->admin->getModelManager()->addIdentifiersToQuery($this->admin->getClass(), $query, $idx);
+            } else {
+                $this->addFlash(
+                    'sonata_flash_info',
+                    $this->trans('flash_batch_no_elements_processed', [], 'SonataAdminBundle')
+                );
 
-            return $this->redirectToList();
+                return $this->redirectToList();
+            }
         }
 
         return \call_user_func($batchActionExecutable, $query, $forwardedRequest);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
Subject
Fix Inconsistent Batch Selection Behavior

<!-- Describe your Pull Request content here -->
This PR addresses an inconsistency observed when both the all_elements and individual list rows are selected simultaneously before executing a batch action. The changes ensure that all_elements has priority over individual indices, leading to more predictable outcomes for batch operations.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are backwards compatible and do not introduce any breaking changes.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->
Closes #8168.

## Changelog

```markdown
### Fixed
- Batch consistency
```