### PR TITLE
:bug: Fix label & method countResults to display good things with simple pager

### DIFF
--- a/src/Datagrid/PagerInterface.php
+++ b/src/Datagrid/PagerInterface.php
@@ -81,6 +81,8 @@ interface PagerInterface
 
     public function countResults(): int;
 
+    public function displayCountResults(bool $rendering = true): int|string;
+
     /**
      * Returns an array of page numbers to use in pagination links.
      *

--- a/src/Datagrid/SimplePager.php
+++ b/src/Datagrid/SimplePager.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Datagrid;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Sonata\AdminBundle\Util\TraversableToCollection;
+use Traversable;
 
 /**
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
@@ -44,16 +45,35 @@ final class SimplePager extends Pager
      * If set to 3 the pager will generate links to the next three pages
      * etc.
      */
-    public function __construct(
-        int $maxPerPage = 10,
-        private int $threshold = 1
-    ) {
+    public function __construct(int $maxPerPage = 10, private int $threshold = 1)
+    {
         parent::__construct($maxPerPage);
     }
 
     public function countResults(): int
     {
         return ($this->getPage() - 1) * $this->getMaxPerPage() + ($this->thresholdCount ?? 0);
+    }
+
+    public function displayCountResults(bool $rendering = true): int|string
+    {
+        $countResults = $this->countResults() > $this->getMaxPerPage()
+            ? $this->getMaxPerPage()
+            : $this->countResults();
+
+        if ($this->getPage() > 1) {
+            $countResults = $this->countResults();
+        }
+
+        if ($this->getLastPage() === $this->getPage()) {
+            $rendering = false;
+        }
+
+        if (!$rendering) {
+            return $countResults;
+        }
+
+        return sprintf('%s+', $countResults);
     }
 
     public function getCurrentPageResults(): iterable

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -186,7 +186,7 @@ file that was distributed with this source code.
                                             <label class="checkbox" for="{{ admin.uniqid }}_all_elements">
                                                 <input type="checkbox" name="all_elements" id="{{ admin.uniqid }}_all_elements">
                                                 {{ 'all_elements'|trans({}, 'SonataAdminBundle') }}
-                                                ({{ admin.datagrid.pager.countResults() }})
+                                                ({{ admin.datagrid.pager.displayCountResults() }})
                                             </label>
 
                                             <select name="action" style="width: auto; height: auto" class="form-control">

--- a/src/Resources/views/Pager/simple_pager_results.html.twig
+++ b/src/Resources/views/Pager/simple_pager_results.html.twig
@@ -15,7 +15,8 @@ file that was distributed with this source code.
     {% if admin.datagrid.pager.lastPage != admin.datagrid.pager.page %}
         {{ 'list_results_count_prefix'|trans({}, 'SonataAdminBundle') }}
     {% endif %}
-    {% trans with {'%count%': admin.datagrid.pager.countResults()} from 'SonataAdminBundle' %}list_results_count{% endtrans %}
+    {% set rendering_count_results = false %}
+    {% trans with {'%count%': admin.datagrid.pager.displayCountResults(rendering_count_results)} from 'SonataAdminBundle' %}list_results_count{% endtrans %}
     &nbsp;-&nbsp;
 {% endblock %}
 

--- a/tests/App/Datagrid/Pager.php
+++ b/tests/App/Datagrid/Pager.php
@@ -106,6 +106,11 @@ final class Pager implements PagerInterface
         return 1;
     }
 
+    public function displayCountResults(bool $rendering = true): int|string
+    {
+        return 1;
+    }
+
     public function getLinks(?int $nbLinks = null): array
     {
         return [];

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -37,7 +37,7 @@ final class PagerTest extends TestCase
             true,
             true,
             true,
-            ['countResults']
+            ['countResults', 'displayCountResults']
         );
     }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Using SimplePager renders wrong statement on batch actions. 
For example: selecting 50 elements (on a table containing >1000 elements) the batch action checkbox "all_elements" would result in "all elements (51)".

Now with this PR, the display will change. A second basic query will be used to count the total number of results. 
Using the example above, this would give: "all elements (1000)".

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #8164.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Added
- `SimplePager::getTotalResults()` This method actually calculates the number of lines.

### Changed
- `SimplePager::countResults()` The "countResults" method now returns the true total number of lines ;
- `SimplePager::init()` The "init" method also calculates the total number of lines.

### Deprecated

### Removed

### Fixed

### Security
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
