### PR TITLE
fix: DI Extension deprecated since Symfony 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
         "psalm/plugin-phpunit": "^0.18",
         "psalm/plugin-symfony": "^5.0",
         "psr/event-dispatcher": "^1.0",
-        "rector/rector": "^0.19",
+        "rector/rector": "^1.1",
         "symfony/browser-kit": "^5.4 || ^6.2 || ^7.0",
         "symfony/css-selector": "^5.4 || ^6.2 || ^7.0",
         "symfony/filesystem": "^5.4 || ^6.2 || ^7.0",

--- a/src/DependencyInjection/AbstractSonataAdminExtension.php
+++ b/src/DependencyInjection/AbstractSonataAdminExtension.php
@@ -16,7 +16,7 @@ namespace Sonata\AdminBundle\DependencyInjection;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -20,6 +20,7 @@ use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Sonata\AdminBundle\Util\AdminAclUserManagerInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType as SymfonyChoiceType;
@@ -29,7 +30,6 @@ use Symfony\Component\Form\Extension\Core\Type\EmailType as SymfonyEmailType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType as SymfonyIntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType as SymfonyTextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType as SymfonyTextType;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Since Symfony 7.1:

> The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "Sonata\AdminBundle\DependencyInjection\SonataAdminExtension".

Related Symfony PR: https://github.com/symfony/symfony/pull/53801

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because these changes are BC.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Symfony 7.1 deprecation about `Symfony\Component\HttpKernel\DependencyInjection\Extension` usage
```

Other bundles like SonataBlockExtension, SonataFormExtension, etc. have the same deprecation, will take care of them if this proposed fix is ok for you.