### PR TITLE
Enable security information mapping for RoleSecurityHandler

### DIFF
--- a/src/Security/Handler/RoleSecurityHandler.php
+++ b/src/Security/Handler/RoleSecurityHandler.php
@@ -71,17 +71,8 @@ final class RoleSecurityHandler implements SecurityHandlerInterface
             $attributes = [$attributes];
         }
 
-        // NEXT_MAJOR: Change the foreach to a single check.
-        $useAll = false;
-        foreach ($attributes as $pos => $attribute) {
-            // If the attribute is not already a ROLE_ we generate the related role.
-            if (\is_string($attribute) && !str_starts_with($attribute, 'ROLE_')) {
-                $attributes[$pos] = sprintf($this->getBaseRole($admin), $attribute);
-                // All the admin related role are available when you have the `_ALL` role.
-                $useAll = true;
-            }
-        }
-
+        $useAll = $this->hasOnlyAdminRoles($attributes);
+        $attributes = $this->mapAttributes($attributes, $admin);
         $allRole = sprintf($this->getBaseRole($admin), 'ALL');
 
         try {
@@ -124,5 +115,40 @@ final class RoleSecurityHandler implements SecurityHandlerInterface
         }
 
         return false;
+    }
+
+    /**
+     * @param array<string|Expression> $attributes
+     */
+    private function hasOnlyAdminRoles(mixed $attributes): bool
+    {
+        // NEXT_MAJOR: Change the foreach to a single check.
+        foreach ($attributes as $attribute) {
+            // If the attribute is not already a ROLE_ we generate the related role.
+            if (\is_string($attribute) && !str_starts_with($attribute, 'ROLE_')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<string|Expression> $attributes
+     * @param AdminInterface<object>   $admin
+     *
+     * @return array<string|Expression>
+     */
+    private function mapAttributes(mixed $attributes, AdminInterface $admin): array
+    {
+        // NEXT_MAJOR: Change the foreach to a single check.
+        foreach ($attributes as $pos => $attribute) {
+            // If the attribute is not already a ROLE_ we generate the related role.
+            if (\is_string($attribute) && !str_starts_with($attribute, 'ROLE_')) {
+                $attributes[$pos] = sprintf($this->getBaseRole($admin), $attribute);
+            }
+        }
+
+        return $attributes;
     }
 }

--- a/src/Security/Handler/RoleSecurityHandler.php
+++ b/src/Security/Handler/RoleSecurityHandler.php
@@ -120,7 +120,7 @@ final class RoleSecurityHandler implements SecurityHandlerInterface
     /**
      * @param array<string|Expression> $attributes
      */
-    private function hasOnlyAdminRoles(mixed $attributes): bool
+    private function hasOnlyAdminRoles(array $attributes): bool
     {
         // NEXT_MAJOR: Change the foreach to a single check.
         foreach ($attributes as $attribute) {
@@ -139,16 +139,28 @@ final class RoleSecurityHandler implements SecurityHandlerInterface
      *
      * @return array<string|Expression>
      */
-    private function mapAttributes(mixed $attributes, AdminInterface $admin): array
+    private function mapAttributes(array $attributes, AdminInterface $admin): array
     {
-        // NEXT_MAJOR: Change the foreach to a single check.
-        foreach ($attributes as $pos => $attribute) {
-            // If the attribute is not already a ROLE_ we generate the related role.
-            if (\is_string($attribute) && !str_starts_with($attribute, 'ROLE_')) {
-                $attributes[$pos] = sprintf($this->getBaseRole($admin), $attribute);
+        $mappedAttributes = [];
+
+        foreach ($attributes as $attribute) {
+            if (!\is_string($attribute) || str_starts_with($attribute, 'ROLE_')) {
+                $mappedAttributes[] = $attribute;
+
+                continue;
+            }
+
+            $baseRole = $this->getBaseRole($admin);
+
+            $mappedAttributes[] = sprintf($baseRole, $attribute);
+
+            foreach ($admin->getSecurityInformation() as $role => $permissions) {
+                if (\in_array($attribute, $permissions, true)) {
+                    $mappedAttributes[] = sprintf($baseRole, $role);
+                }
             }
         }
 
-        return $attributes;
+        return array_unique($mappedAttributes);
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject



<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this feature is BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Finally provide #4925 feature

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Added
-  Enable security information mapping for `RoleSecurityHandler`
```

If you want to combine multiple permissions, you can now use the `sonata.admin.security.handler.role` for this.

```yaml
sonata_admin:
    security:
        handler:    sonata.admin.security.handler.role

        information:
            VIEWER:    [VIEW, LIST, EXPORT]
            EDITOR:    [EDIT, LIST, CREATE]
            ADMIN:     [OPERATOR, MASTER]
```

If you have a user with a `ROLE_ACME_ADMIN_VIEWER` permission, the security handler will work if your admin asks for VIEW, LIST or EXPORTER grants.

The changes are BC, because if will also work if you have no special information mapping.