### PR TITLE
Fix handle exception in #7761

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1130,7 +1130,7 @@ class CRUDController extends AbstractController
         }
         $this->getLogger()->error($exception->getMessage(), $context);
 
-        return null;
+        return $exception->getMessage();
     }
 
     /**
@@ -1154,7 +1154,7 @@ class CRUDController extends AbstractController
         }
         $this->getLogger()->error($exception->getMessage(), $context);
 
-        return null;
+        return $exception->getMessage();
     }
 
     /**


### PR DESCRIPTION
Return error message from handleModelManagerThrowable

## Subject
In #7761 was introduced ability to return custom error message when something goes wrong on persist/update/delete actions with ORM. But it always return null instead of message.

I am targeting this branch, because fix bug in current stable branch.

## Changelog

### Changed
```markdown
- CrudController::handleModelManagerThrowable can now return a custom error message to display in the flashbag instead of the generic one from Sonata
```
