### PR TITLE
Fix loading new item list after adding new created element on sortable collections

### DIFF
--- a/src/Form/Extension/ChoiceTypeExtension.php
+++ b/src/Form/Extension/ChoiceTypeExtension.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Form\Extension;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
 use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormTypeInterface;

--- a/src/Form/Extension/ChoiceTypeExtension.php
+++ b/src/Form/Extension/ChoiceTypeExtension.php
@@ -27,6 +27,25 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  */
 final class ChoiceTypeExtension extends AbstractTypeExtension
 {
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        if ($options['multiple'] && (true === ($options['sortable'] ?? false))) {
+            $builder->addEventListener(FormEvents::PRE_SUBMIT, static function (FormEvent $event) use ($options) {
+                /** @var PreSubmitEvent $event */
+                $form = $event->getForm();
+                $data = $event->getData();
+
+                if (!is_array($data) || count($data) !== 1) {
+                    return;
+                }
+
+                if (str_contains($data[0], ',')) {
+                    $event->setData(explode(',', $data[0]));
+                }
+            },1);
+        }
+    }
+    
     public function configureOptions(OptionsResolver $resolver): void
     {
         $optionalOptions = ['sortable'];

--- a/src/Form/Extension/ChoiceTypeExtension.php
+++ b/src/Form/Extension/ChoiceTypeExtension.php
@@ -45,7 +45,7 @@ final class ChoiceTypeExtension extends AbstractTypeExtension
                 if (str_contains($data[0], ',')) {
                     $event->setData(explode(',', $data[0]));
                 }
-            },1);
+            }, 1);
         }
     }
     

--- a/src/Form/Extension/ChoiceTypeExtension.php
+++ b/src/Form/Extension/ChoiceTypeExtension.php
@@ -15,6 +15,8 @@ namespace Sonata\AdminBundle\Form\Extension;
 
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvents;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\Form\FormView;

--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -329,17 +329,24 @@ This code manages the many-to-[one|many] association field popup
                             data: {_xml_http_request: true },
                             dataType: 'html',
                             type: 'POST',
-                            success: function(html) {
+                            success: function(html) { 
                                 jQuery('#field_container_{{ id }}').replaceWith(html);
                                 var newElement = jQuery('#{{ id }} [value="' + data.objectId + '"]');
-                                if (newElement.is("input")) {
-                                    newElement.attr('checked', 'checked');
+
+                                if (newElement.length) {
+                                    if (newElement.is("input")) {
+                                        newElement.attr('checked', 'checked');
+                                    } else {
+                                        newElement.attr('selected', 'selected');
+                                    }
                                 } else {
-                                    newElement.attr('selected', 'selected');
+                                    var selections = jQuery('#{{ id }}').val().split(',');
+                                    selections.push(data.objectId);
+                                    jQuery('#{{ id }}').val(selections.filter((val) => val.length > 0).join(','));
                                 }
 
                                 jQuery('#field_container_{{ id }}').trigger('sonata-admin-append-form-element');
-                            }
+                            } 
                         });
 
                     {% endif %}


### PR DESCRIPTION
## Subject

This Pull request closes two issues related to sortable collections as described in #8201


I am targeting this branch, because this patches an existing issue.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #8201

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Assert new created items on sortable collections are added in javascript correctly after creation in modal
- Avoid clearing selections when loading new choice list after reating a new model in sortable collections

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
