### PR TITLE
Fix Doctrine link recipe_lock_protection.rst

### DIFF
--- a/docs/cookbook/recipe_lock_protection.rst
+++ b/docs/cookbook/recipe_lock_protection.rst
@@ -67,7 +67,7 @@ Using XML:
         </entity>
     </doctrine-mapping>
 
-For more information about this visit the `Doctrine docs <https://www.doctrine-project.org/projects/doctrine-orm/en/2.7/reference/transactions-and-concurrency.html#optimistic-locking>`_
+For more information about this visit the `Doctrine docs <https://www.doctrine-project.org/projects/doctrine-orm/en/latest/reference/transactions-and-concurrency.html#optimistic-locking>`_
 
 .. note::
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Fixed Doctrine link.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because there is a wrong Doctrine link in the documentation.

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->
