### PR TITLE
Increase width of datetime widget

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -305,7 +305,7 @@ file that was distributed with this source code.
             {{ form_errors(form.time) }}
 
             {% if form.date.vars.widget == 'single_text' %}
-                <div class="col-sm-2">
+                <div class="col-sm-6">
                     {{ form_widget(form.date) }}
                 </div>
             {% else %}
@@ -313,7 +313,7 @@ file that was distributed with this source code.
             {% endif %}
 
             {% if form.time.vars.widget == 'single_text' %}
-                <div class="col-sm-2">
+                <div class="col-sm-6">
                     {{ form_widget(form.time) }}
                 </div>
             {% else %}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Changed
- Increase `datetime_widget` width to 6 when using separated field inputs for date and time.
```

Given the following form type, the default width is far to small to display the date widget.

```php
            ->add('begin', DateTimeType::class, [
                'label'        => 'form.label_date_begin',
                'required'     => true,
                'row_attr'     => [
                    'class' => 'col-md-6',
                ],
                'date_widget'   => 'single_text',
                'time_widget'   => 'choice',
            ])
            ->add('end', DateTimeType::class, [
                'label'        => 'form.label_date_begin',
                'required'     => true,
                'row_attr'     => [
                    'class' => 'col-md-6',
                ],
                'date_widget'   => 'single_text',
                'time_widget'   => 'choice',
            ])
```