### PR TITLE
Enhancement: Introduces `PagerInterface::isDeterministic` (refs #8164)

### DIFF
--- a/src/Datagrid/Pager.php
+++ b/src/Datagrid/Pager.php
@@ -189,6 +189,14 @@ abstract class Pager implements PagerInterface
         return $this->query;
     }
 
+    /**
+     * Returns whether `countResults()` is the exact number of results or only a lower bound.
+     */
+    public function isDeterministic(): bool
+    {
+        return true;
+    }
+
     final protected function setLastPage(int $page): void
     {
         $this->lastPage = $page;

--- a/src/Datagrid/PagerInterface.php
+++ b/src/Datagrid/PagerInterface.php
@@ -16,6 +16,8 @@ namespace Sonata\AdminBundle\Datagrid;
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
+ * @method bool isDeterministic()
+ *
  * @phpstan-template T of ProxyQueryInterface
  */
 interface PagerInterface
@@ -99,4 +101,7 @@ interface PagerInterface
      * Returns the maximum number of page numbers.
      */
     public function getMaxPageLinks(): int;
+
+    // NEXT_MAJOR: Uncomment this method and remove the `@method` annotation above.
+    // public function isDeterministic(): bool;
 }

--- a/src/Datagrid/SimplePager.php
+++ b/src/Datagrid/SimplePager.php
@@ -121,4 +121,12 @@ final class SimplePager extends Pager
     {
         return $this->threshold;
     }
+
+    public function isDeterministic(): bool
+    {
+        // The pager only fetches a limited window of results ahead, so `countResults()`
+        // is a lower bound as long as there are further pages. Once we reached the last
+        // page the window was not saturated and the count is exact.
+        return $this->isLastPage();
+    }
 }

--- a/src/Resources/config/twig.php
+++ b/src/Resources/config/twig.php
@@ -19,6 +19,7 @@ use Sonata\AdminBundle\Twig\Extension\BreadcrumbsExtension;
 use Sonata\AdminBundle\Twig\Extension\CanonicalizeExtension;
 use Sonata\AdminBundle\Twig\Extension\GroupExtension;
 use Sonata\AdminBundle\Twig\Extension\IconExtension;
+use Sonata\AdminBundle\Twig\Extension\PagerExtension;
 use Sonata\AdminBundle\Twig\Extension\RenderElementExtension;
 use Sonata\AdminBundle\Twig\Extension\SecurityExtension;
 use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
@@ -26,6 +27,7 @@ use Sonata\AdminBundle\Twig\Extension\TemplateRegistryExtension;
 use Sonata\AdminBundle\Twig\Extension\XEditableExtension;
 use Sonata\AdminBundle\Twig\GroupRuntime;
 use Sonata\AdminBundle\Twig\IconRuntime;
+use Sonata\AdminBundle\Twig\PagerRuntime;
 use Sonata\AdminBundle\Twig\RenderElementRuntime;
 use Sonata\AdminBundle\Twig\SecurityRuntime;
 use Sonata\AdminBundle\Twig\SonataAdminRuntime;
@@ -111,6 +113,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ])
 
         ->set('sonata.admin.twig.icon_runtime', IconRuntime::class)
+            ->tag('twig.runtime')
+
+        ->set('sonata.admin.twig.pager_extension', PagerExtension::class)
+            ->tag('twig.extension')
+
+        ->set('sonata.admin.twig.pager_runtime', PagerRuntime::class)
             ->tag('twig.runtime')
 
         // NEXT_MAJOR: Remove the `args()` call.

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -184,7 +184,7 @@ file that was distributed with this source code.
                                             <label class="checkbox" for="{{ admin.uniqid }}_all_elements">
                                                 <input type="checkbox" name="all_elements" id="{{ admin.uniqid }}_all_elements">
                                                 {{ 'all_elements'|trans({}, 'SonataAdminBundle') }}
-                                                ({{ admin.datagrid.pager.countResults() }})
+                                                ({{ admin.datagrid.pager.countResults() }}{% if not sonata_pager_deterministic(admin.datagrid.pager) %}+{% endif %})
                                             </label>
 
                                             <select name="action" style="width: auto; height: auto" class="form-control">

--- a/src/Twig/Extension/PagerExtension.php
+++ b/src/Twig/Extension/PagerExtension.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Twig\Extension;
+
+use Sonata\AdminBundle\Twig\PagerRuntime;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class PagerExtension extends AbstractExtension
+{
+    /**
+     * @return TwigFunction[]
+     */
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('sonata_pager_deterministic', [PagerRuntime::class, 'isDeterministic']),
+        ];
+    }
+}

--- a/src/Twig/PagerRuntime.php
+++ b/src/Twig/PagerRuntime.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Twig;
+
+use Sonata\AdminBundle\Datagrid\PagerInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Twig\Extension\RuntimeExtensionInterface;
+
+final class PagerRuntime implements RuntimeExtensionInterface
+{
+    /**
+     * Returns whether the pager knows the exact number of results.
+     *
+     * @param PagerInterface<ProxyQueryInterface<object>> $pager
+     */
+    public function isDeterministic(PagerInterface $pager): bool
+    {
+        // NEXT_MAJOR: Remove the method_exists check and always call `$pager->isDeterministic()`.
+        // @phpstan-ignore-next-line
+        if (!method_exists($pager, 'isDeterministic')) {
+            return true;
+        }
+
+        return $pager->isDeterministic();
+    }
+}

--- a/tests/Datagrid/PagerTest.php
+++ b/tests/Datagrid/PagerTest.php
@@ -166,6 +166,11 @@ final class PagerTest extends TestCase
         static::assertFalse($this->pager->isLastPage());
     }
 
+    public function testIsDeterministic(): void
+    {
+        static::assertTrue($this->pager->isDeterministic());
+    }
+
     public function testGetLinks(): void
     {
         static::assertSame([], $this->pager->getLinks());

--- a/tests/Datagrid/SimplePagerTest.php
+++ b/tests/Datagrid/SimplePagerTest.php
@@ -63,6 +63,7 @@ final class SimplePagerTest extends TestCase
 
         // We're not knowing exactly the result number, at least 13 (the result found)
         static::assertSame(13, $this->pager->countResults());
+        static::assertFalse($this->pager->isDeterministic());
     }
 
     public function testInitOffset(): void
@@ -113,6 +114,7 @@ final class SimplePagerTest extends TestCase
 
         // We're knowing exactly the result number: 10 (first page) + 9 (this page)
         static::assertSame(19, $this->pager->countResults());
+        static::assertTrue($this->pager->isDeterministic());
     }
 
     public function testNoPagesPerConfig(): void
@@ -152,6 +154,7 @@ final class SimplePagerTest extends TestCase
         $this->pager->init();
         static::assertSame(1, $this->pager->getLastPage());
         static::assertSame(0, $this->pager->countResults());
+        static::assertTrue($this->pager->isDeterministic());
     }
 
     public function testInitNoQuery(): void

--- a/tests/Twig/Extension/PagerExtensionTest.php
+++ b/tests/Twig/Extension/PagerExtensionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Twig\Extension;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Twig\Extension\PagerExtension;
+
+final class PagerExtensionTest extends TestCase
+{
+    public function testExposesTheDeterministicFunction(): void
+    {
+        $functionNames = array_map(
+            static fn ($function): string => $function->getName(),
+            (new PagerExtension())->getFunctions(),
+        );
+
+        static::assertContains('sonata_pager_deterministic', $functionNames);
+    }
+}

--- a/tests/Twig/PagerRuntimeTest.php
+++ b/tests/Twig/PagerRuntimeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Twig;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Datagrid\Pager;
+use Sonata\AdminBundle\Datagrid\PagerInterface;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+use Sonata\AdminBundle\Twig\PagerRuntime;
+
+final class PagerRuntimeTest extends TestCase
+{
+    public function testIsDeterministicReturnsTrueWhenPagerIsDeterministic(): void
+    {
+        static::assertTrue((new PagerRuntime())->isDeterministic($this->createPager(true)));
+    }
+
+    public function testIsDeterministicReturnsFalseWhenPagerIsNotDeterministic(): void
+    {
+        static::assertFalse((new PagerRuntime())->isDeterministic($this->createPager(false)));
+    }
+
+    /**
+     * BC layer: a pager implemented before `isDeterministic()` was introduced is
+     * considered deterministic.
+     */
+    public function testIsDeterministicReturnsTrueWhenMethodIsMissing(): void
+    {
+        $pager = $this->createMock(PagerInterface::class);
+
+        static::assertFalse(method_exists($pager, 'isDeterministic'));
+        static::assertTrue((new PagerRuntime())->isDeterministic($pager));
+    }
+
+    /**
+     * @return Pager<ProxyQueryInterface<object>>&MockObject
+     */
+    private function createPager(bool $deterministic): Pager
+    {
+        /** @var Pager<ProxyQueryInterface<object>>&MockObject $pager */
+        $pager = $this->createMock(Pager::class);
+        $pager->method('isDeterministic')->willReturn($deterministic);
+
+        return $pager;
+    }
+}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
This is my suggestion to indicate an enduser that the list doesn't know how many elements ("all elements") will be affected by now. I decided to use a universal `+` sign to indicate it.

Default behavior: 

![image](https://github.com/user-attachments/assets/5284844f-44be-45a1-b23e-ee2351a762bc)

Behavior `SimplePager`:

![image](https://github.com/user-attachments/assets/da334001-3689-407c-931b-72366260829f)

I'm not sure if I should add this to `abstract Pager` class without finalizing it. I rather suggest to implement `abstract function isDeterministic` and force any implementation of Pager to set it. WDYT? As this is not BC, I didn't choose this path  (any custom implementation might be broken after a patch/minor update). 

This refs #8164 but does not finally closes it. I'll update the way `SimplePager` count results using thresholds in a separate MR. Together they will solve #8164.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it's BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Refs #8164

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Added
- Introduces `PagerInterface::isDeterministic` to render yet unknown result count in `SimplePager` properly
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
