### PR TITLE
fix(form): Error messages displayed twice with form type "sonata_type_native_collection" or "sonata_type_immutable_array" when "error_bubbling" sets to false

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -415,7 +415,6 @@ file that was distributed with this source code.
         {% set allow_delete = allow_delete_backup %}
     {% endif %}
     <div {{ block('widget_container_attributes') }}>
-        {{ form_errors(form) }}
         {% for child in form %}
             {{ block('sonata_type_native_collection_widget_row') }}
         {% endfor %}
@@ -430,7 +429,6 @@ file that was distributed with this source code.
 {% block sonata_type_immutable_array_widget %}
     {% apply spaceless %}
         <div {{ block('widget_container_attributes') }}>
-            {{ form_errors(form) }}
 
             {% for key, child in form %}
                 {{ block('sonata_type_immutable_array_widget_row') }}


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

fix error messages displayed twice with form type "sonata_type_native_collection" or "sonata_type_immutable_array" when "error_bubbling" sets to false

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it's a fix.


Closes #2761

## Step To Reproduce
- Add an array property on an entity
- Add `Count` constraints with `min=2`
- On the Admin of this entity add `Sonata\AdminBundle\Form\Type\CollectionType` or  `Sonata\Form\Type\ImmutableArrayType` field targeting this new property.
- Add `'error_bubbling' => false` form option on this field
- Go to the creation form of this entity and try to submit.


## Screenshot
<img width="719" alt="Screenshot 2024-08-29 at 16 37 40" src="https://github.com/user-attachments/assets/68202e01-e0fc-4bac-83af-caa498cde3cd">

## Changelog

```markdown
### Fixed
- Error messages displayed twice with form type `sonata_type_native_collection` or `sonata_type_immutable_array` when `error_bubbling` sets to `false` #2761
```

