### PR TITLE
Support Symfony's `TranslatableInterface` in enum fields

### DIFF
--- a/docs/reference/field_types.rst
+++ b/docs/reference/field_types.rst
@@ -221,7 +221,7 @@ Option                                  Description
     This provides full compatibility with symfony's
     `EnumType <https://symfony.com/doc/current/reference/forms/types/enum.html>`_ form type:
 
-    .. code-block:: php
+    ::
 
         protected function configureListFields(ListMapper $list): void
         {

--- a/docs/reference/field_types.rst
+++ b/docs/reference/field_types.rst
@@ -16,7 +16,7 @@ Fieldtype                                           Description
 ``FieldDescriptionInterface::TYPE_DATETIME``        display a formatted date and time. Accepts the options ``format`` and ``timezone``
 ``FieldDescriptionInterface::TYPE_STRING``          display a text
 ``FieldDescriptionInterface::TYPE_EMAIL``           display a mailto link. Accepts the options ``as_string``, ``subject`` and ``body``
-``FieldDescriptionInterface::TYPE_ENUM``            display the name of a backed enum
+``FieldDescriptionInterface::TYPE_ENUM``            display an enum
 ``FieldDescriptionInterface::TYPE_TEXTAREA``        display a textarea
 ``FieldDescriptionInterface::TYPE_TRANS``           translate the value with a provided ``value_translation_domain`` and ``format`` (sprintf format) option
 ``FieldDescriptionInterface::TYPE_FLOAT``           display a number
@@ -199,13 +199,61 @@ The ``FieldDescriptionInterface::TYPE_CHOICE`` field type also supports multiple
 
 You can use the following options:
 
-======================================  ==============================================================
+======================================  ========================================================================
 Option                                  Description
-======================================  ==============================================================
+======================================  ========================================================================
 **use_value**                           Determines if the field must show the value or the case' name.
                                         ``false`` by default.
-**enum_translation_domain**             Translation domain.
-======================================  ==============================================================
+
+                                        *Ignored if the enum implements Symfony's* ``TranslatableInterface`` *.*
+**enum_translation_domain**             | Translation domain. If set, the enum value or case' name will be send
+                                          to the translator.
+                                        | ``{{ value|trans({}, translation_domain) }}``
+
+                                        *Ignored if the enum implements Symfony's* ``TranslatableInterface`` *.*
+======================================  ========================================================================
+
+.. note::
+
+    If the enum implements Symfony's ``TranslatableInterface`` the options above will be ignored and the enum's
+    ``trans()`` method will be used instead to display the enum.
+
+    This provides full compatibility with symfony's
+    `EnumType <https://symfony.com/doc/current/reference/forms/types/enum.html>`_ form type:
+
+    .. code-block:: php
+
+        protected function configureListFields(ListMapper $list): void
+        {
+            $list
+                // Sonata Admin will select the `FieldDescriptionInterface::TYPE_ENUM`
+                // field type automatically. If the enum implements `TranslatableInterface`,
+                // the `trans()` method will be used to render its value.
+                ->add('saluation')
+            ;
+        }
+
+        protected function configureFormFields(FormMapper $form): void
+        {
+            $form
+                // Symfony's EnumType form field will automatically detect the usage of
+                // the `TranslatableInterface` and use the enum's `trans()` method to
+                // render the choice labels.
+                ->add('salutation', EnumType::class, [
+                    'class' => Salutation::class,
+                ])
+            ;
+        }
+
+        protected function configureShowFields(ShowMapper $show): void
+        {
+            $show
+                // Again, Sonata Admin will select the `FieldDescriptionInterface::TYPE_ENUM`
+                // field type automatically. If the enum implements `TranslatableInterface`,
+                // the `trans()` method will be used to render its value.
+                ->add('salutation')
+            ;
+        }
 
 ``FieldDescriptionInterface::TYPE_URL``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/Resources/views/CRUD/display_enum.html.twig
+++ b/src/Resources/views/CRUD/display_enum.html.twig
@@ -12,6 +12,9 @@ file that was distributed with this source code.
 {%- apply spaceless %}
     {% if value is null %}
         &nbsp;
+    {% elseif value.trans is defined %}
+        {# Enum implements TranslatableInterface and therefore has direct control over how it should be displayed. #}
+        {{ value|trans }}
     {% else %}
         {% set value = use_value|default(false) ? value.value : value.name %}
 

--- a/tests/Fixtures/Enum/TranslatableSuit.php
+++ b/tests/Fixtures/Enum/TranslatableSuit.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Fixtures\Enum;
+
+use Symfony\Contracts\Translation\TranslatableInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+enum TranslatableSuit: string implements TranslatableInterface
+{
+    case Hearts = 'hearts';
+    case Diamonds = 'diamonds';
+    case Clubs = 'clubs';
+    case Spades = 'spades';
+
+    #[\Override]
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
+    {
+        return $translator->trans(
+            id: 'enum.suit.'.$this->value,
+            domain: 'render-element-extension-test',
+            locale: $locale,
+        );
+    }
+}

--- a/tests/Fixtures/Resources/translations/render-element-extension-test.en.yaml
+++ b/tests/Fixtures/Resources/translations/render-element-extension-test.en.yaml
@@ -1,2 +1,8 @@
 D: '[trans]D[/trans]'
 Diamonds: '[trans]Diamonds[/trans]'
+enum:
+    suit:
+        hearts: '[trans]enum.suit.hearts[/trans]'
+        diamonds: '[trans]enum.suit.diamonds[/trans]'
+        clubs: '[trans]enum.suit.clubs[/trans]'
+        spades: '[trans]enum.suit.spades[/trans]'

--- a/tests/Fixtures/Resources/translations/render-element-extension-test.en.yaml
+++ b/tests/Fixtures/Resources/translations/render-element-extension-test.en.yaml
@@ -1,0 +1,2 @@
+D: '[trans]D[/trans]'
+Diamonds: '[trans]Diamonds[/trans]'

--- a/tests/Twig/Extension/RenderElementExtensionTest.php
+++ b/tests/Twig/Extension/RenderElementExtensionTest.php
@@ -22,6 +22,7 @@ use Sonata\AdminBundle\Templating\MutableTemplateRegistryInterface;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Sonata\AdminBundle\Tests\Fixtures\Entity\FooToString;
 use Sonata\AdminBundle\Tests\Fixtures\Enum\Suit;
+use Sonata\AdminBundle\Tests\Fixtures\Enum\TranslatableSuit;
 use Sonata\AdminBundle\Tests\Fixtures\StubFilesystemLoader;
 use Sonata\AdminBundle\Twig\Extension\RenderElementExtension;
 use Sonata\AdminBundle\Twig\Extension\XEditableExtension;
@@ -1576,6 +1577,24 @@ final class RenderElementExtensionTest extends TestCase
             [
                 'use_value' => true,
                 'enum_translation_domain' => 'render-element-extension-test',
+            ],
+        ];
+
+        $elements[] = [
+            '<td class="sonata-ba-list-field sonata-ba-list-field-enum" objectId="12345"> [trans]enum.suit.hearts[/trans] </td>',
+            FieldDescriptionInterface::TYPE_ENUM,
+            TranslatableSuit::Hearts,
+            [],
+        ];
+
+        $elements[] = [
+            '<td class="sonata-ba-list-field sonata-ba-list-field-enum" objectId="12345"> [trans]enum.suit.spades[/trans] </td>',
+            FieldDescriptionInterface::TYPE_ENUM,
+            TranslatableSuit::Spades,
+            [
+                // These values are ignored if the enum implements the TranslatableInterface
+                'use_value' => false,
+                'enum_translation_domain' => 'doesnt-exist',
             ],
         ];
 

--- a/tests/Twig/Extension/RenderElementExtensionTest.php
+++ b/tests/Twig/Extension/RenderElementExtensionTest.php
@@ -36,6 +36,7 @@ use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Loader\XmlFileLoader;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Translation\Loader\XliffFileLoader;
+use Symfony\Component\Translation\Loader\YamlFileLoader;
 use Symfony\Component\Translation\Translator;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
@@ -79,11 +80,18 @@ final class RenderElementExtensionTest extends TestCase
         // translation extension
         $translator = new Translator('en');
         $translator->addLoader('xlf', new XliffFileLoader());
+        $translator->addLoader('yaml', new YamlFileLoader());
         $translator->addResource(
             'xlf',
             \sprintf('%s/../../../src/Resources/translations/SonataAdminBundle.en.xliff', __DIR__),
             'en',
             'SonataAdminBundle'
+        );
+        $translator->addResource(
+            'yaml',
+            \sprintf('%s/../../Fixtures/Resources/translations/render-element-extension-test.en.yaml', __DIR__),
+            'en',
+            'render-element-extension-test',
         );
 
         $this->translator = $translator;
@@ -1548,6 +1556,26 @@ final class RenderElementExtensionTest extends TestCase
             Suit::Clubs,
             [
                 'use_value' => true,
+            ],
+        ];
+
+        $elements[] = [
+            '<td class="sonata-ba-list-field sonata-ba-list-field-enum" objectId="12345"> [trans]Diamonds[/trans] </td>',
+            FieldDescriptionInterface::TYPE_ENUM,
+            Suit::Diamonds,
+            [
+                'use_value' => false,
+                'enum_translation_domain' => 'render-element-extension-test',
+            ],
+        ];
+
+        $elements[] = [
+            '<td class="sonata-ba-list-field sonata-ba-list-field-enum" objectId="12345"> [trans]D[/trans] </td>',
+            FieldDescriptionInterface::TYPE_ENUM,
+            Suit::Diamonds,
+            [
+                'use_value' => true,
+                'enum_translation_domain' => 'render-element-extension-test',
             ],
         ];
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Support Symfony's `TranslatableInterface` in enum fields

<!-- Describe your Pull Request content here -->
Fixes the translation of enums implementing Symfony's `TranslatableInterface`.

Right now there is a discrepancy between how the Symfony `EnumType` form type translates enums and how Sonata Admin translates them. The `EnumType` uses the enum case's name by default for the choice labels. If you need anything else, your enum has to implement the `TranslatableInterface` and a `trans()` method like in the third example on the docs page: https://symfony.com/doc/current/reference/forms/types/enum.html#example-usage

However the `FieldDescriptionInterface::TYPE_ENUM` field type completely ignores this and instead implements the options `use_value` and `enum_translation_domain`, which severely limits how the enum can be translated. I for example often use the format `enum.[ENUM_SHORT_NAME].[ENUM_VALUE]` which is not possible with the current implementation.

With this PR, the `FieldDescriptionInterface::TYPE_ENUM` field type will use the enum's `trans()` method if available to translate the enum and therefore use the same logic, Symfony's `EnumType` uses.

With this PR, using enums is as easy as:

```php
enum Salutation implements TranslatableInterface
{
    /* case ... = ...; */

    public function trans(TranslatorInterface $translator, ?string $locale = null): string
    {
        // Implement your custom enum translation logic here
        return $translator->trans('enum.saluation.'.$this->value, locale: $locale);
    }
}
```

```php
protected function configureListFields(ListMapper $list): void
{
    $list
        ->add('saluation')
    ;
}

protected function configureFormFields(FormMapper $form): void
{
    $form
        ->add('salutation', EnumType::class, [
            'class' => Salutation::class,
        ])
    ;
}

protected function configureShowFields(ShowMapper $show): void
{
    $show
        ->add('salutation')
    ;
}
```

I also added tests for the previous translation method, as there were none.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting the 4.x branch, because people using enums with the `TranslatableInterface` currently can not use the enum field type anyway, as it would use the wrong translation, so there should be no backwards compatible issues here.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Changed
- Enums implementing Symfony's `TranslatableInterface` are now correctly translated by the `FieldDescriptionInterface::TYPE_ENUM` field type
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->