### PR TITLE
Support editable mode on FieldDescriptionInterface::TYPE_ENUM

### DIFF
--- a/src/Action/SetObjectFieldValueAction.php
+++ b/src/Action/SetObjectFieldValueAction.php
@@ -137,7 +137,7 @@ final class SetObjectFieldValueAction
                 $value = $dataTransformer->reverseTransform($value);
             }
 
-            if (null === $value && FieldDescriptionInterface::TYPE_CHOICE === $fieldDescription->getType()) {
+            if (null === $value && \in_array($fieldDescription->getType(), [FieldDescriptionInterface::TYPE_CHOICE, FieldDescriptionInterface::TYPE_ENUM], true)) {
                 return new JsonResponse(\sprintf(
                     'Edit failed, object with id "%s" not found in association "%s".',
                     $objectId,

--- a/src/Form/DataTransformer/BackedEnumTransformer.php
+++ b/src/Form/DataTransformer/BackedEnumTransformer.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Form\DataTransformer;
+
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+
+/**
+ * @phpstan-template T of \BackedEnum
+ * @phpstan-implements DataTransformerInterface<T, int|string>
+ */
+final class BackedEnumTransformer implements DataTransformerInterface
+{
+    /**
+     * @phpstan-param class-string<T> $className
+     */
+    public function __construct(
+        private string $className,
+    ) {
+    }
+
+    /**
+     * @param int|string|null $value
+     *
+     * @phpstan-return T|null
+     */
+    public function reverseTransform($value): ?\BackedEnum
+    {
+        if (null === $value || '' === $value) {
+            return null;
+        }
+
+        if (!\is_int($value) && !\is_string($value)) {
+            throw new TransformationFailedException(\sprintf('Could not transform value: expecting an int or string, got "%s".', get_debug_type($value)));
+        }
+
+        try {
+            return $this->className::from($value);
+        } catch (\ValueError|\TypeError) {
+            throw new TransformationFailedException(\sprintf('Could not transform value "%s".', $value));
+        }
+    }
+
+    /**
+     * @param \BackedEnum|null $value
+     *
+     * @phpstan-param T|null $value
+     */
+    public function transform($value): string|int|null
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        if (!$value instanceof \BackedEnum) {
+            throw new UnexpectedTypeException($value, \BackedEnum::class);
+        }
+
+        return $value->value;
+    }
+}

--- a/src/Form/DataTransformerResolver.php
+++ b/src/Form/DataTransformerResolver.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Form;
 
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
+use Sonata\AdminBundle\Form\DataTransformer\BackedEnumTransformer;
 use Sonata\AdminBundle\Form\DataTransformer\ModelToIdTransformer;
 use Sonata\AdminBundle\Model\ModelManagerInterface;
 use Symfony\Component\Form\DataTransformerInterface;
@@ -73,6 +74,18 @@ final class DataTransformerResolver implements DataTransformerResolverInterface
             );
 
             return $this->globalCustomTransformers[$fieldType];
+        }
+
+        if (FieldDescriptionInterface::TYPE_ENUM === $fieldType) {
+            $className = $fieldDescription->getOption('class');
+
+            if (
+                null !== $className
+                && \is_string($className)
+                && is_a($className, \BackedEnum::class, true)
+            ) {
+                return new BackedEnumTransformer($className);
+            }
         }
 
         // Handle entity choice association type, transforming the value into entity

--- a/src/Resources/views/CRUD/base_list_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_field.html.twig
@@ -61,6 +61,8 @@ file that was distributed with this source code.
                 {% set data_value = value|date('Y-m-d', options.timezone|default(null)) %}
             {% elseif field_description.type == constant('Sonata\\AdminBundle\\FieldDescription\\FieldDescriptionInterface::TYPE_BOOLEAN') and value is empty %}
                 {% set data_value = 0 %}
+            {% elseif field_description.type == constant('Sonata\\AdminBundle\\FieldDescription\\FieldDescriptionInterface::TYPE_ENUM') and value is not empty %}
+                {% set data_value = value.value %}
             {% elseif value is iterable %}
                 {% set data_value = value|json_encode %}
             {% else %}

--- a/src/Resources/views/CRUD/list_enum.html.twig
+++ b/src/Resources/views/CRUD/list_enum.html.twig
@@ -11,6 +11,21 @@ file that was distributed with this source code.
 
 {% extends get_admin_template('base_list_field', admin.code) %}
 
+{% set is_editable =
+    field_description.option('editable', false) and
+    admin.hasAccess('edit', object)
+%}
+{% set x_editable_type = field_description.type|sonata_xeditable_type %}
+
+{% block field_span_attributes %}
+    {% if is_editable and x_editable_type %}
+        {% apply spaceless %}
+            {{ parent() }}
+            data-source="{{ field_description|sonata_xeditable_choices|json_encode }}"
+        {% endapply %}
+    {% endif %}
+{% endblock %}
+
 {% block field %}
     {%- include '@SonataAdmin/CRUD/display_enum.html.twig' with {
         value: value,

--- a/src/Twig/XEditableRuntime.php
+++ b/src/Twig/XEditableRuntime.php
@@ -20,6 +20,7 @@ use Twig\Extension\RuntimeExtensionInterface;
 final class XEditableRuntime implements RuntimeExtensionInterface
 {
     public const FIELD_DESCRIPTION_MAPPING = [
+        FieldDescriptionInterface::TYPE_ENUM => 'select',
         FieldDescriptionInterface::TYPE_CHOICE => 'select',
         FieldDescriptionInterface::TYPE_BOOLEAN => 'select',
         FieldDescriptionInterface::TYPE_TEXTAREA => 'textarea',
@@ -81,6 +82,11 @@ final class XEditableRuntime implements RuntimeExtensionInterface
                     // the choice is already in the right format
                     $xEditableChoices[] = $text;
                     break;
+                }
+
+                if ($text instanceof \BackedEnum) {
+                    $value = $text->value;
+                    $text = $text->name;
                 }
 
                 if (\is_string($catalogue)) {

--- a/tests/Form/DataTransformer/BackedEnumTransformerTest.php
+++ b/tests/Form/DataTransformer/BackedEnumTransformerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sonata\AdminBundle\Tests\Form\DataTransformer;
+
+use PHPUnit\Framework\TestCase;
+use Sonata\AdminBundle\Form\DataTransformer\BackedEnumTransformer;
+use Sonata\AdminBundle\Tests\Fixtures\Enum\Suit;
+use Symfony\Component\Form\Exception\TransformationFailedException;
+use Symfony\Component\Form\Exception\UnexpectedTypeException;
+
+/**
+ * @requires PHP 8.1
+ */
+final class BackedEnumTransformerTest extends TestCase
+{
+    public function testReverseTransform(): void
+    {
+        $transformer = new BackedEnumTransformer(Suit::class);
+
+        static::assertNull($transformer->reverseTransform(null));
+        static::assertNull($transformer->reverseTransform(''));
+        static::assertSame(Suit::Hearts, $transformer->reverseTransform(Suit::Hearts->value));
+    }
+
+    public function testReverseTransformNotValidValue(): void
+    {
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('Could not transform value "not_valid_value".');
+
+        $transformer = new BackedEnumTransformer(Suit::class);
+        $transformer->reverseTransform('not_valid_value');
+    }
+
+    /**
+     * @psalm-suppress InvalidArgument
+     */
+    public function testReverseTransformNotScalar(): void
+    {
+        $this->expectException(TransformationFailedException::class);
+        $this->expectExceptionMessage('Could not transform value: expecting an int or string, got "stdClass".');
+
+        $transformer = new BackedEnumTransformer(Suit::class);
+        // @phpstan-ignore-next-line
+        $transformer->reverseTransform(new \stdClass());
+    }
+
+    public function testTransform(): void
+    {
+        $transformer = new BackedEnumTransformer(Suit::class);
+
+        static::assertNull($transformer->transform(null));
+        static::assertSame(Suit::Clubs->value, $transformer->transform(Suit::Clubs));
+    }
+
+    /**
+     * @psalm-suppress InvalidArgument
+     */
+    public function testTransformUnexpectedType(): void
+    {
+        $this->expectException(UnexpectedTypeException::class);
+        $this->expectExceptionMessage('Expected argument of type "BackedEnum", "stdClass" given');
+
+        $transformer = new BackedEnumTransformer(Suit::class);
+        // @phpstan-ignore-next-line
+        $transformer->transform(new \stdClass());
+    }
+}

--- a/tests/Twig/XEditableRuntimeTest.php
+++ b/tests/Twig/XEditableRuntimeTest.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Tests\Twig;
 
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
+use Sonata\AdminBundle\Tests\Fixtures\Enum\Suit;
 use Sonata\AdminBundle\Twig\XEditableRuntime;
 use Symfony\Component\Translation\Translator;
 
@@ -91,5 +92,20 @@ final class XEditableRuntimeTest extends TestCase
                 ['value' => 'Status2', 'text' => 'Alias2'],
             ],
         ];
+
+        // TODO: Remove the "if" check when dropping support of PHP < 8.1 and add the case to the list
+        if (\PHP_VERSION_ID >= 80100) {
+            yield 'enum cases' => [
+                [
+                    'required' => false,
+                    'multiple' => false,
+                    'choices' => [Suit::Hearts, Suit::Clubs],
+                ],
+                [
+                    ['value' => 'H', 'text' => 'Hearts'],
+                    ['value' => 'C', 'text' => 'Clubs'],
+                ],
+            ];
+        }
     }
 }


### PR DESCRIPTION
## Subject

```php
    protected function configureListFields(ListMapper $list): void
    {
        $list
            ->add('status', FieldDescriptionInterface::TYPE_ENUM, [
                'editable' => true,
                'class' => Status::class,
                'choices' => Status::cases(),
            ])
            ->add(ListMapper::NAME_ACTIONS, null, [
                ListMapper::TYPE_ACTIONS => [
                    'edit' => [],
                    'delete' => [],
                ],
            ])
        ;
    }
```

## Changelog

```markdown
### Added
- Support editable mode on `FieldDescriptionInterface::TYPE_ENUM`
```
