### PR TITLE
Remove outdated checks php 8.0 in tests

### DIFF
--- a/tests/Form/DataTransformer/BackedEnumTransformerTest.php
+++ b/tests/Form/DataTransformer/BackedEnumTransformerTest.php
@@ -19,9 +19,6 @@ use Sonata\AdminBundle\Tests\Fixtures\Enum\Suit;
 use Symfony\Component\Form\Exception\TransformationFailedException;
 use Symfony\Component\Form\Exception\UnexpectedTypeException;
 
-/**
- * @requires PHP 8.1
- */
 final class BackedEnumTransformerTest extends TestCase
 {
     public function testReverseTransform(): void

--- a/tests/Twig/Extension/RenderElementExtensionTest.php
+++ b/tests/Twig/Extension/RenderElementExtensionTest.php
@@ -1523,11 +1523,6 @@ final class RenderElementExtensionTest extends TestCase
             ],
         ];
 
-        // TODO: Remove the "if" check when dropping support of PHP < 8.1 and add the case to the list
-        if (\PHP_VERSION_ID < 80100) {
-            return $elements;
-        }
-
         $elements[] = [
             '<td class="sonata-ba-list-field sonata-ba-list-field-enum" objectId="12345"> &nbsp; </td>',
             FieldDescriptionInterface::TYPE_ENUM,
@@ -2102,11 +2097,6 @@ final class RenderElementExtensionTest extends TestCase
                 ],
             ],
         ];
-
-        // TODO: Remove the "if" check when dropping support of PHP < 8.1 and add the case to the list
-        if (\PHP_VERSION_ID < 80100) {
-            return $elements;
-        }
 
         $elements[] = [
             '<th>Data</th> <td>Hearts</td>',

--- a/tests/Twig/RenderElementRuntimeTest.php
+++ b/tests/Twig/RenderElementRuntimeTest.php
@@ -1473,11 +1473,6 @@ final class RenderElementRuntimeTest extends TestCase
             ],
         ];
 
-        // TODO: Remove the "if" check when dropping support of PHP < 8.1 and add the case to the list
-        if (\PHP_VERSION_ID < 80100) {
-            return $elements;
-        }
-
         $elements[] = [
             '<td class="sonata-ba-list-field sonata-ba-list-field-enum" objectId="12345"> Hearts </td>',
             FieldDescriptionInterface::TYPE_ENUM,

--- a/tests/Twig/XEditableRuntimeTest.php
+++ b/tests/Twig/XEditableRuntimeTest.php
@@ -93,19 +93,16 @@ final class XEditableRuntimeTest extends TestCase
             ],
         ];
 
-        // TODO: Remove the "if" check when dropping support of PHP < 8.1 and add the case to the list
-        if (\PHP_VERSION_ID >= 80100) {
-            yield 'enum cases' => [
-                [
-                    'required' => false,
-                    'multiple' => false,
-                    'choices' => [Suit::Hearts, Suit::Clubs],
-                ],
-                [
-                    ['value' => 'H', 'text' => 'Hearts'],
-                    ['value' => 'C', 'text' => 'Clubs'],
-                ],
-            ];
-        }
+        yield 'enum cases' => [
+            [
+                'required' => false,
+                'multiple' => false,
+                'choices' => [Suit::Hearts, Suit::Clubs],
+            ],
+            [
+                ['value' => 'H', 'text' => 'Hearts'],
+                ['value' => 'C', 'text' => 'Clubs'],
+            ],
+        ];
     }
 }


### PR DESCRIPTION
## Subject

Now min version 8.1, lets remove outdated checks 

## Changelog
