### PR TITLE
remove deprecated spaceless filter usages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "symfony/twig-bundle": "^6.4 || ^7.1",
         "symfony/validator": "^6.4 || ^7.1",
         "twig/string-extra": "^3.0",
-        "twig/twig": "^3.0"
+        "twig/twig": "^3.15"
     },
     "require-dev": {
         "doctrine/persistence": "^3.0",

--- a/src/Resources/views/Block/block_admin_preview.html.twig
+++ b/src/Resources/views/Block/block_admin_preview.html.twig
@@ -43,20 +43,18 @@ file that was distributed with this source code.
                                     {% if field_description.name == constant('Sonata\\AdminBundle\\Datagrid\\ListMapper::NAME_SELECT') %}
                                         <th class="sonata-ba-list-field-header sonata-ba-list-field-header-select"></th>
                                     {% else %}
-                                        {% apply spaceless %}
-                                            <th class="sonata-ba-list-field-header-{{ field_description.type}} {% if field_description.option('header_class') is not null %} {{ field_description.option('header_class') }}{% endif %}"{% if field_description.option('header_style') is not null %} style="{{ field_description.option('header_style') }}"{% endif %}>
-                                                {% if field_description.option('label_icon') %}
-                                                    <span class="sonata-ba-list-field-header-label-icon">
+                                        <th class="sonata-ba-list-field-header-{{ field_description.type}} {% if field_description.option('header_class') is not null %} {{ field_description.option('header_class') }}{% endif %}"{% if field_description.option('header_style') is not null %} style="{{ field_description.option('header_style') }}"{% endif %}>
+                                            {% if field_description.option('label_icon') %}
+                                                <span class="sonata-ba-list-field-header-label-icon">
                                                         {{ field_description.option('label_icon')|parse_icon }}
                                                     </span>
-                                                {% endif %}
-                                                {% if field_description.translationDomain is same as(false) %}
-                                                    {{ field_description.label }}
-                                                {% else %}
-                                                    {{ field_description.label|trans({}, field_description.translationDomain) }}
-                                                {% endif %}
-                                            </th>
-                                        {% endapply %}
+                                            {% endif %}
+                                            {% if field_description.translationDomain is same as(false) %}
+                                                {{ field_description.label }}
+                                            {% else %}
+                                                {{ field_description.label|trans({}, field_description.translationDomain) }}
+                                            {% endif %}
+                                        </th>
                                     {% endif %}
                                 {% endfor %}
                             </tr>

--- a/src/Resources/views/Breadcrumb/breadcrumb.html.twig
+++ b/src/Resources/views/Breadcrumb/breadcrumb.html.twig
@@ -1,4 +1,3 @@
-{% apply spaceless %}
 {% for menu in items %}
     {%- set translation_domain = menu.extra('translation_domain', 'messages') -%}
     {# We use method accessor instead of ".label" since `menu` implements `ArrayAccess` and could have a property called "label". #}
@@ -25,4 +24,3 @@
         <li class="active"><span>{{ label|u.truncate(100, '...') }}</span></li>
     {% endif %}
 {% endfor %}
-{% endapply %}

--- a/src/Resources/views/CRUD/action_buttons.html.twig
+++ b/src/Resources/views/CRUD/action_buttons.html.twig
@@ -8,10 +8,8 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% apply spaceless %}
-    {% for item in admin.getActionButtons(action, (object is defined) ? object : null ) %}
-        {% if item.template is defined %}
-            {% include item.template %}
-        {% endif %}
-    {% endfor %}
-{% endapply %}
+{% for item in admin.getActionButtons(action, (object is defined) ? object : null ) %}
+    {% if item.template is defined %}
+        {%- include item.template -%}
+    {% endif %}
+{% endfor %}

--- a/src/Resources/views/CRUD/base_array_macro.html.twig
+++ b/src/Resources/views/CRUD/base_array_macro.html.twig
@@ -16,73 +16,71 @@ file that was distributed with this source code.
         'value_translation_domain': false,
         'display': 'both'
     }|merge(options) %}
-    {%- apply spaceless -%}
-        {%- from _self import render_array -%}
+    {%- from _self import render_array -%}
 
+    {%- if not options.inline -%}
+        <ul>
+    {%- else -%}
+        [
+    {%- endif -%}
+
+    {%- for key, val in value -%}
         {%- if not options.inline -%}
-            <ul>
-        {%- else -%}
-            [
+            <li>
         {%- endif -%}
 
-        {%- for key, val in value -%}
-            {%- if not options.inline -%}
-                <li>
-            {%- endif -%}
-
-            {%- if options.display in ['both', 'keys'] -%}
-                {%- if options.key_translation_domain is same as(false) -%}
-                    {{- key -}}
-                {%- else -%}
-                    {%- if options.key_translation_domain is same as(true) -%}
-                        {%- set key_translation_domain = options.default_translation_domain -%}
-                    {%- elseif options.key_translation_domain is same as(null) -%}
-                        {%- set key_translation_domain = null -%}
-                    {%- else -%}
-                        {%- set key_translation_domain = options.key_translation_domain -%}
-                    {%- endif -%}
-
-                    {{- key|trans({}, key_translation_domain) -}}
-                {%- endif -%}
-            {%- endif -%}
-
-            {%- if options.display == 'both' -%}
-                &nbsp;=>&nbsp;
-            {%- endif -%}
-
-            {%- if val is iterable -%}
-                {{ render_array(val, options) }}
+        {%- if options.display in ['both', 'keys'] -%}
+            {%- if options.key_translation_domain is same as(false) -%}
+                {{- key -}}
             {%- else -%}
-                {%- if options.display in ['both', 'values'] -%}
-                    {%- if options.value_translation_domain is same as(false) -%}
-                        {{ val }}
-                    {%- else -%}
-                        {%- if options.value_translation_domain is same as(true) -%}
-                            {%- set value_translation_domain = options.default_translation_domain -%}
-                        {%- elseif options.value_translation_domain is same as(null) -%}
-                            {%- set value_translation_domain = null -%}
-                        {%- else -%}
-                            {%- set value_translation_domain = options.value_translation_domain -%}
-                        {%- endif -%}
+                {%- if options.key_translation_domain is same as(true) -%}
+                    {%- set key_translation_domain = options.default_translation_domain -%}
+                {%- elseif options.key_translation_domain is same as(null) -%}
+                    {%- set key_translation_domain = null -%}
+                {%- else -%}
+                    {%- set key_translation_domain = options.key_translation_domain -%}
+                {%- endif -%}
 
-                        {{- val|trans({}, value_translation_domain) -}}
+                {{- key|trans({}, key_translation_domain) -}}
+            {%- endif -%}
+        {%- endif -%}
+
+        {%- if options.display == 'both' -%}
+            &nbsp;=>&nbsp;
+        {%- endif -%}
+
+        {%- if val is iterable -%}
+            {{ render_array(val, options) }}
+        {%- else -%}
+            {%- if options.display in ['both', 'values'] -%}
+                {%- if options.value_translation_domain is same as(false) -%}
+                    {{ val }}
+                {%- else -%}
+                    {%- if options.value_translation_domain is same as(true) -%}
+                        {%- set value_translation_domain = options.default_translation_domain -%}
+                    {%- elseif options.value_translation_domain is same as(null) -%}
+                        {%- set value_translation_domain = null -%}
+                    {%- else -%}
+                        {%- set value_translation_domain = options.value_translation_domain -%}
                     {%- endif -%}
+
+                    {{- val|trans({}, value_translation_domain) -}}
                 {%- endif -%}
             {%- endif -%}
-
-            {%- if not options.inline -%}
-                </li>
-            {%- endif -%}
-
-            {%- if options.inline == true and not loop.last -%}
-                ,
-            {% endif -%}
-        {%- endfor -%}
+        {%- endif -%}
 
         {%- if not options.inline -%}
-            </ul>
-        {%- else -%}
-            ]
+            </li>
         {%- endif -%}
-    {%- endapply -%}
+
+        {%- if options.inline == true and not loop.last -%}
+            ,
+        {% endif -%}
+    {%- endfor -%}
+
+    {%- if not options.inline -%}
+        </ul>
+    {%- else -%}
+        ]
+    {%- endif -%}
 {% endmacro %}

--- a/src/Resources/views/CRUD/base_list.html.twig
+++ b/src/Resources/views/CRUD/base_list.html.twig
@@ -78,26 +78,24 @@ file that was distributed with this source code.
                                                 {% set sort_by              = current ? admin.datagrid.values[constant('Sonata\\AdminBundle\\Datagrid\\DatagridInterface::SORT_ORDER')] : field_description.option(constant('Sonata\\AdminBundle\\Datagrid\\DatagridInterface::SORT_ORDER'), sort_parameters.filter[constant('Sonata\\AdminBundle\\Datagrid\\DatagridInterface::SORT_ORDER')]) %}
                                             {% endif %}
 
-                                            {% apply spaceless %}
-                                                <th class="sonata-ba-list-field-header-{{ field_description.type }}{% if sortable %} sonata-ba-list-field-header-order-{{ sort_by|lower }} {{ sort_active_class }}{% endif %}{% if field_description.option('header_class') %} {{ field_description.option('header_class') }}{% endif %}"{% if field_description.option('header_style') %} style="{{ field_description.option('header_style') }}"{% endif %}>
-                                                    {% if sortable %}
-                                                        <a href="{{ admin.generateUrl(action|default('list'), sort_parameters|merge({_list_mode: admin.getListMode()})) }}">
+                                            <th class="sonata-ba-list-field-header-{{ field_description.type }}{% if sortable %} sonata-ba-list-field-header-order-{{ sort_by|lower }} {{ sort_active_class }}{% endif %}{% if field_description.option('header_class') %} {{ field_description.option('header_class') }}{% endif %}"{% if field_description.option('header_style') %} style="{{ field_description.option('header_style') }}"{% endif %}>
+                                                {% if sortable %}
+                                                    <a href="{{ admin.generateUrl(action|default('list'), sort_parameters|merge({_list_mode: admin.getListMode()})) }}">
+                                                {% endif %}
+                                                {% if field_description.getOption('label_icon') %}
+                                                    <span class="sonata-ba-list-field-header-label-icon">
+                                                        {{ field_description.getOption('label_icon')|parse_icon }}
+                                                    </span>
+                                                {% endif %}
+                                                {% if field_description.label is not same as(false) %}
+                                                    {% if field_description.translationDomain is same as(false) %}
+                                                        {{ field_description.label }}
+                                                    {% else %}
+                                                        {{ field_description.label|trans({}, field_description.translationDomain) }}
                                                     {% endif %}
-                                                    {% if field_description.getOption('label_icon') %}
-                                                        <span class="sonata-ba-list-field-header-label-icon">
-                                                            {{ field_description.getOption('label_icon')|parse_icon }}
-                                                        </span>
-                                                    {% endif %}
-                                                    {% if field_description.label is not same as(false) %}
-                                                        {% if field_description.translationDomain is same as(false) %}
-                                                            {{ field_description.label }}
-                                                        {% else %}
-                                                            {{ field_description.label|trans({}, field_description.translationDomain) }}
-                                                        {% endif %}
-                                                    {% endif %}
-                                                    {% if sortable %}</a>{% endif %}
-                                                </th>
-                                            {% endapply %}
+                                                {% endif %}
+                                                {% if sortable %}</a>{% endif %}
+                                            </th>
                                         {% endif %}
                                     {% endfor %}
                                 </tr>

--- a/src/Resources/views/CRUD/base_list_field.html.twig
+++ b/src/Resources/views/CRUD/base_list_field.html.twig
@@ -20,17 +20,15 @@ file that was distributed with this source code.
     %}
         <a class="sonata-link-identifier" href="{{ admin.generateObjectUrl(route_name, object, route_parameters) }}">
             {%- block field %}
-                {% apply spaceless %}
-                    {% if field_description.option('collapse') is not null %}
-                        {% set collapse = field_description.option('collapse') %}
-                        <div class="sonata-readmore"
-                              data-readmore-height="{{ collapse.height|default(40) }}"
-                              data-readmore-more="{{ collapse.more|default('read_more')|trans({}, 'SonataAdminBundle') }}"
-                              data-readmore-less="{{ collapse.less|default('read_less')|trans({}, 'SonataAdminBundle') }}">{{ value }}</div>
-                    {% else %}
-                        {{ value }}
-                    {% endif %}
-                {% endapply %}
+                {% if field_description.option('collapse') is not null %}
+                    {% set collapse = field_description.option('collapse') %}
+                    <div class="sonata-readmore"
+                          data-readmore-height="{{ collapse.height|default(40) }}"
+                          data-readmore-more="{{ collapse.more|default('read_more')|trans({}, 'SonataAdminBundle') }}"
+                          data-readmore-less="{{ collapse.less|default('read_less')|trans({}, 'SonataAdminBundle') }}">{{ value }}</div>
+                {% else %}
+                    {{ value }}
+                {% endif %}
             {% endblock -%}
         </a>
     {% else %}

--- a/src/Resources/views/CRUD/base_show_compare.html.twig
+++ b/src/Resources/views/CRUD/base_show_compare.html.twig
@@ -12,11 +12,9 @@ file that was distributed with this source code.
 {% extends '@SonataAdmin/CRUD/base_show.html.twig' %}
 
 {%- block show_field -%}
-    {% apply spaceless %}
-        <tr class="sonata-ba-view-container history-audit-compare">
-            {% if elements[show_field_name] is defined %}
-                {{ elements[show_field_name]|render_view_element_compare(object, object_compare) }}
-            {% endif %}
-        </tr>
-    {% endapply %}
+    <tr class="sonata-ba-view-container history-audit-compare">
+        {% if elements[show_field_name] is defined %}
+            {{ elements[show_field_name]|render_view_element_compare(object, object_compare) }}
+        {% endif %}
+    </tr>
 {%- endblock -%}

--- a/src/Resources/views/CRUD/base_show_field.html.twig
+++ b/src/Resources/views/CRUD/base_show_field.html.twig
@@ -11,43 +11,37 @@ file that was distributed with this source code.
 
 <th{% if(is_diff|default(false)) %} class="diff"{% endif %}>
     {%- block name -%}
-        {% apply spaceless %}
-            {% if field_description.label is not same as(false) %}
-                {% if field_description.translationDomain is same as(false) %}
-                    {{ field_description.label }}
-                {% else %}
-                    {{ field_description.label|trans({}, field_description.translationDomain) }}
-                {% endif %}
-            {% endif %}
-        {% endapply %}
+        {%- if field_description.label is not same as(false) -%}
+            {%- if field_description.translationDomain is same as(false) -%}
+                {{ field_description.label }}
+            {%- else -%}
+                {{ field_description.label|trans({}, field_description.translationDomain) }}
+            {%- endif -%}
+        {%- endif -%}
     {%- endblock -%}
 </th>
 <td>
     {%- block field -%}
-        {% apply spaceless %}
-            {% set collapse = field_description.option('collapse') %}
-            {% if collapse %}
-                <div class="sonata-readmore"
-                      data-readmore-height="{{ collapse.height|default(40) }}"
-                      data-readmore-more="{{ collapse.more|default('read_more')|trans({}, 'SonataAdminBundle') }}"
-                      data-readmore-less="{{ collapse.less|default('read_less')|trans({}, 'SonataAdminBundle') }}">
-                    {% block field_value %}
-                        {% if field_description.option('safe', false) %}{{ value|raw }}{% else %}{{ value|default('')|nl2br }}{% endif %}
-                    {% endblock %}
-                </div>
-            {% else %}
-                {{ block('field_value') }}
-            {% endif %}
-        {% endapply %}
+        {% set collapse = field_description.option('collapse') %}
+        {%- if collapse -%}
+            <div class="sonata-readmore"
+                  data-readmore-height="{{ collapse.height|default(40) }}"
+                  data-readmore-more="{{ collapse.more|default('read_more')|trans({}, 'SonataAdminBundle') }}"
+                  data-readmore-less="{{ collapse.less|default('read_less')|trans({}, 'SonataAdminBundle') }}">
+                {%- block field_value -%}
+                    {% if field_description.option('safe', false) %}{{ value|raw }}{% else %}{{ value|default('')|nl2br }}{% endif %}
+                {%- endblock -%}
+            </div>
+        {%- else -%}
+            {{- block('field_value') -}}
+        {%- endif -%}
     {%- endblock -%}
 </td>
 
 {%- block field_compare -%}
-    {% apply spaceless %}
-        {% if value_compare is defined %}
-            {% set value = value_compare %}
-            {% set object = object_compare %}
-            <td>{{ block('field') }}</td>
-        {% endif %}
-    {% endapply %}
+    {%- if value_compare is defined -%}
+        {% set value = value_compare %}
+        {% set object = object_compare %}
+        <td>{{- block('field') -}}</td>
+    {%- endif -%}
 {%- endblock -%}

--- a/src/Resources/views/CRUD/display_boolean.html.twig
+++ b/src/Resources/views/CRUD/display_boolean.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{%- apply spaceless %}
+{%- apply trim|raw %}
     {% if value %}
         {% set text = 'label_type_yes'|trans({}, 'SonataAdminBundle') %}
     {% else %}

--- a/src/Resources/views/CRUD/display_choice.html.twig
+++ b/src/Resources/views/CRUD/display_choice.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{%- apply spaceless %}
+{%- apply trim|raw %}
     {% set choices = choices|default([]) %}
     {% if multiple|default(false) and value is iterable %}
 

--- a/src/Resources/views/CRUD/display_currency.html.twig
+++ b/src/Resources/views/CRUD/display_currency.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{%- apply spaceless %}
+{%- apply trim|raw %}
     {%- if value is null -%}
         &nbsp;
     {%- else -%}

--- a/src/Resources/views/CRUD/display_date.html.twig
+++ b/src/Resources/views/CRUD/display_date.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{%- apply spaceless %}
+{%- apply trim|raw %}
     {%- if value is empty -%}
         &nbsp;
     {%- else -%}

--- a/src/Resources/views/CRUD/display_datetime.html.twig
+++ b/src/Resources/views/CRUD/display_datetime.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{%- apply spaceless %}
+{%- apply trim|raw %}
     {%- if value is empty -%}
         &nbsp;
     {%- else -%}

--- a/src/Resources/views/CRUD/display_email.html.twig
+++ b/src/Resources/views/CRUD/display_email.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{%- apply spaceless %}
+{%- apply trim|raw %}
     {%- if value is empty -%}
         &nbsp;
     {%- elseif as_string|default(false) -%}

--- a/src/Resources/views/CRUD/display_enum.html.twig
+++ b/src/Resources/views/CRUD/display_enum.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{%- apply spaceless %}
+{%- apply trim|raw %}
     {% if value is null %}
         &nbsp;
     {% elseif value.trans is defined %}

--- a/src/Resources/views/CRUD/display_html.html.twig
+++ b/src/Resources/views/CRUD/display_html.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{%- apply spaceless %}
+{%- apply trim|raw %}
     {%- if value is empty -%}
         &nbsp;
     {% else %}

--- a/src/Resources/views/CRUD/display_percent.html.twig
+++ b/src/Resources/views/CRUD/display_percent.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{%- apply spaceless %}
+{%- apply trim|raw %}
     {%- if value is null -%}
         &nbsp;
     {%- else -%}

--- a/src/Resources/views/CRUD/display_time.html.twig
+++ b/src/Resources/views/CRUD/display_time.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{%- apply spaceless %}
+{%- apply trim|raw %}
     {%- if value is empty -%}
         &nbsp;
     {%- else -%}

--- a/src/Resources/views/CRUD/display_trans.html.twig
+++ b/src/Resources/views/CRUD/display_trans.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{%- apply spaceless %}
+{%- apply trim|raw %}
     {% set value = value_format|default('%s')|format(value)|trans({}, translation_domain|default('messages')) %}
 
     {% if safe|default(false) %}

--- a/src/Resources/views/CRUD/display_url.html.twig
+++ b/src/Resources/views/CRUD/display_url.html.twig
@@ -9,7 +9,7 @@ file that was distributed with this source code.
 
 #}
 
-{%- apply spaceless %}
+{%- apply trim|raw %}
     {% if value is empty %}
         &nbsp;
     {% else %}

--- a/src/Resources/views/CRUD/list_boolean.html.twig
+++ b/src/Resources/views/CRUD/list_boolean.html.twig
@@ -16,10 +16,8 @@ file that was distributed with this source code.
 
 {% block field_span_attributes %}
     {% if is_editable and x_editable_type %}
-        {% apply spaceless %}
-            {{ parent() }}
-            data-source="[{value: 0, text: '{%- trans from 'SonataAdminBundle' %}label_type_no{% endtrans -%}'},{value: 1, text: '{%- trans from 'SonataAdminBundle' %}label_type_yes{% endtrans -%}'}]"
-        {% endapply %}
+        {{ parent() }}
+        data-source="[{value: 0, text: '{%- trans from 'SonataAdminBundle' %}label_type_no{% endtrans -%}'},{value: 1, text: '{%- trans from 'SonataAdminBundle' %}label_type_yes{% endtrans -%}'}]"
     {% endif %}
 {% endblock %}
 

--- a/src/Resources/views/CRUD/list_choice.html.twig
+++ b/src/Resources/views/CRUD/list_choice.html.twig
@@ -19,10 +19,8 @@ file that was distributed with this source code.
 
 {% block field_span_attributes %}
     {% if is_editable and x_editable_type %}
-        {% apply spaceless %}
-            {{ parent() }}
-            data-source="{{ field_description|sonata_xeditable_choices|json_encode }}"
-        {% endapply %}
+        {{ parent() }}
+        data-source="{{ field_description|sonata_xeditable_choices|json_encode }}"
     {% endif %}
 {% endblock %}
 

--- a/src/Resources/views/CRUD/list_enum.html.twig
+++ b/src/Resources/views/CRUD/list_enum.html.twig
@@ -19,10 +19,8 @@ file that was distributed with this source code.
 
 {% block field_span_attributes %}
     {% if is_editable and x_editable_type %}
-        {% apply spaceless %}
-            {{ parent() }}
-            data-source="{{ field_description|sonata_xeditable_choices|json_encode }}"
-        {% endapply %}
+        {{ parent() }}
+        data-source="{{ field_description|sonata_xeditable_choices|json_encode }}"
     {% endif %}
 {% endblock %}
 

--- a/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
+++ b/src/Resources/views/Form/Type/sonata_type_model_autocomplete.html.twig
@@ -8,259 +8,257 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 
 #}
-{% apply spaceless %}
-    <select id="{{ id }}_autocomplete_input" data-sonata-select2="false"
-        {%- if disabled %} disabled="disabled"{% endif %}
-        {%- if multiple %} multiple="multiple"{% endif %}
-        {%- for attribute, value in attr %} {{ attribute }}="{{ value }}" {% endfor -%}
-    >
+<select id="{{ id }}_autocomplete_input" data-sonata-select2="false"
+    {%- if disabled %} disabled="disabled"{% endif %}
+    {%- if multiple %} multiple="multiple"{% endif %}
+    {%- for attribute, value in attr %} {{ attribute }}="{{ value }}" {% endfor -%}
+>
+    {%- for idx, val in value|filter((val, idx) => idx~'' != '_labels') -%}
+        <option value="{{ val }}" selected>{{ value['_labels'][idx] }}</option>
+    {%- endfor -%}
+</select>
+
+<div id="{{ id }}_hidden_inputs_wrap">
+    {% if multiple -%}
         {%- for idx, val in value|filter((val, idx) => idx~'' != '_labels') -%}
-            <option value="{{ val }}" selected>{{ value['_labels'][idx] }}</option>
+            <input type="hidden" name="{{ full_name }}[]" {%- if disabled %} disabled="disabled"{% endif %} value="{{ val }}">
         {%- endfor -%}
-    </select>
+    {% else -%}
+        <input type="hidden" name="{{ full_name }}" {%- if disabled %} disabled="disabled"{% endif %} value="{{ value[0]|default('') }}">
+    {% endif -%}
+</div>
 
-    <div id="{{ id }}_hidden_inputs_wrap">
-        {% if multiple -%}
-            {%- for idx, val in value|filter((val, idx) => idx~'' != '_labels') -%}
-                <input type="hidden" name="{{ full_name }}[]" {%- if disabled %} disabled="disabled"{% endif %} value="{{ val }}">
-            {%- endfor -%}
-        {% else -%}
-            <input type="hidden" name="{{ full_name }}" {%- if disabled %} disabled="disabled"{% endif %} value="{{ value[0]|default('') }}">
-        {% endif -%}
+{% if sonata_admin.field_description and sonata_admin.field_description.hasAssociationAdmin %}
+    <div id="field_actions_{{ id }}" class="field-actions">
+        {% set display_btn_add = sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasRoute('create')
+                                 and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
+        {% if display_btn_add %}
+            <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create',
+                         sonata_admin.field_description.getOption('link_parameters', {}))
+                      }}"
+                onclick="return start_field_dialog_form_add_{{ id }}(this);"
+                class="btn btn-success btn-sm sonata-ba-action"
+                {# NEXT_MAJOR: Remove the fallback on null and on btn_catalogue #}
+                title="{{
+                    btn_translation_domain|default(null) is same as(false)
+                    ? btn_add
+                    : btn_add|trans({}, btn_translation_domain|default(btn_catalogue))
+                }}"
+                >
+                <i class="fas fa-plus-circle"></i>
+                {# NEXT_MAJOR: Remove the fallback on null and on btn_catalogue #}
+                {{
+                    btn_translation_domain|default(null) is same as(false)
+                    ? btn_add
+                    : btn_add|trans({}, btn_translation_domain|default(btn_catalogue))
+                }}
+            </a>
+            {% include '@SonataAdmin/CRUD/Association/edit_modal.html.twig' %}
+            {% include '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
+        {% endif %}
     </div>
+{% endif %}
 
-    {% if sonata_admin.field_description and sonata_admin.field_description.hasAssociationAdmin %}
-        <div id="field_actions_{{ id }}" class="field-actions">
-            {% set display_btn_add = sonata_admin.edit != 'admin' and sonata_admin.field_description.associationadmin.hasRoute('create')
-                                     and sonata_admin.field_description.associationadmin.isGranted('CREATE') and btn_add %}
-            {% if display_btn_add %}
-                <a  href="{{ sonata_admin.field_description.associationadmin.generateUrl('create',
-                             sonata_admin.field_description.getOption('link_parameters', {}))
-                          }}"
-                    onclick="return start_field_dialog_form_add_{{ id }}(this);"
-                    class="btn btn-success btn-sm sonata-ba-action"
-                    {# NEXT_MAJOR: Remove the fallback on null and on btn_catalogue #}
-                    title="{{
-                        btn_translation_domain|default(null) is same as(false)
-                        ? btn_add
-                        : btn_add|trans({}, btn_translation_domain|default(btn_catalogue))
-                    }}"
-                    >
-                    <i class="fas fa-plus-circle"></i>
-                    {# NEXT_MAJOR: Remove the fallback on null and on btn_catalogue #}
-                    {{
-                        btn_translation_domain|default(null) is same as(false)
-                        ? btn_add
-                        : btn_add|trans({}, btn_translation_domain|default(btn_catalogue))
-                    }}
-                </a>
-                {% include '@SonataAdmin/CRUD/Association/edit_modal.html.twig' %}
-                {% include '@SonataAdmin/CRUD/Association/edit_many_script.html.twig' %}
-            {% endif %}
-        </div>
-    {% endif %}
+<script>
+    {% autoescape 'js' %}
+    jQuery(function ($) {
+        var autocompleteInput = $('#{{ id }}_autocomplete_input');
 
-    <script>
-        {% autoescape 'js' %}
-        jQuery(function ($) {
-            var autocompleteInput = $('#{{ id }}_autocomplete_input');
-
-            var select2Options = {
-                {%- set allowClearPlaceholder = (not multiple and not required) ? ' ' : '' -%}
-                placeholder: '{{ placeholder ?: allowClearPlaceholder }}', // allowClear needs placeholder to work properly
-                allowClear: {{ required ? 'false' : 'true' }},
-                enable: {{ disabled ? 'false' : 'true' }},
-                minimumInputLength: {{ minimum_input_length }},
-                theme: 'bootstrap',
-                width: function() {
-                    return Admin.get_select2_width(jQuery(this));
+        var select2Options = {
+            {%- set allowClearPlaceholder = (not multiple and not required) ? ' ' : '' -%}
+            placeholder: '{{ placeholder ?: allowClearPlaceholder }}', // allowClear needs placeholder to work properly
+            allowClear: {{ required ? 'false' : 'true' }},
+            enable: {{ disabled ? 'false' : 'true' }},
+            minimumInputLength: {{ minimum_input_length }},
+            theme: 'bootstrap',
+            width: function() {
+                return Admin.get_select2_width(jQuery(this));
+            },
+            language: "{{ canonicalize_locale_for_select2() }}",
+            dropdownAutoWidth: {{ dropdown_auto_width ? 'true' : 'false' }},
+            containerCssClass: '{{ container_css_class ~ ' form-control' }}',
+            dropdownCssClass: '{{ dropdown_css_class }}',
+            dropdownParent: autocompleteInput.parents('.modal').length > 0 ? autocompleteInput.parents('.modal') : $(document.body),
+            ajax: {
+                url:  '{{ url ?: path(route.name, route.parameters|default([])) }}',
+                dataType: 'json',
+                delay: {{ delay == 100 and quiet_millis != 100 ? quiet_millis : delay }}, // NEXT_MAJOR: Replace by `{{ delay }}` instead.
+                cache: {{ cache ? 'true' : 'false' }},
+                processResults: function (data, params) {
+                    return {
+                        results: data.items,
+                        pagination: {
+                            more: data.more
+                        }
+                    };
                 },
-                language: "{{ canonicalize_locale_for_select2() }}",
-                dropdownAutoWidth: {{ dropdown_auto_width ? 'true' : 'false' }},
-                containerCssClass: '{{ container_css_class ~ ' form-control' }}',
-                dropdownCssClass: '{{ dropdown_css_class }}',
-                dropdownParent: autocompleteInput.parents('.modal').length > 0 ? autocompleteInput.parents('.modal') : $(document.body),
-                ajax: {
-                    url:  '{{ url ?: path(route.name, route.parameters|default([])) }}',
-                    dataType: 'json',
-                    delay: {{ delay == 100 and quiet_millis != 100 ? quiet_millis : delay }}, // NEXT_MAJOR: Replace by `{{ delay }}` instead.
-                    cache: {{ cache ? 'true' : 'false' }},
-                    processResults: function (data, params) {
-                        return {
-                            results: data.items,
-                            pagination: {
-                                more: data.more
-                            }
-                        };
-                    },
-                    data: function (params) {
-                        {% block sonata_type_model_autocomplete_ajax_request_parameters %}
-                        return {
-                                //search term
-                                '{{ req_param_name_search }}': params.term,
+                data: function (params) {
+                    {% block sonata_type_model_autocomplete_ajax_request_parameters %}
+                    return {
+                            //search term
+                            '{{ req_param_name_search }}': params.term,
 
-                                // page size
-                                '{{ req_param_name_items_per_page }}': {{ items_per_page }},
+                            // page size
+                            '{{ req_param_name_items_per_page }}': {{ items_per_page }},
 
-                                // page number
-                                '{{ req_param_name_page_number }}': (params.page !== 'undefined' ? params.page : 1),
+                            // page number
+                            '{{ req_param_name_page_number }}': (params.page !== 'undefined' ? params.page : 1),
 
-                                // admin
-                                {% if sonata_admin.admin %}
-                                    'uniqid': '{{ sonata_admin.admin.uniqid }}',
-                                    '_sonata_admin': '{{ sonata_admin.admin.baseCodeRoute|e('js') }}',
-                                {% elseif admin_code %}
-                                    '_sonata_admin': '{{ admin_code|e('js') }}',
-                                {% endif %}
+                            // admin
+                            {% if sonata_admin.admin %}
+                                'uniqid': '{{ sonata_admin.admin.uniqid }}',
+                                '_sonata_admin': '{{ sonata_admin.admin.baseCodeRoute|e('js') }}',
+                            {% elseif admin_code %}
+                                '_sonata_admin': '{{ admin_code|e('js') }}',
+                            {% endif %}
 
-                                {% if context == 'filter' %}
-                                    'field':  '{{ full_name|replace({'filter[': '', '][value]': '', '__':'.'}) }}',
-                                    '_context': 'filter'
-                                {% else %}
-                                    'field':  '{{ name }}'
-                                {% endif %}
+                            {% if context == 'filter' %}
+                                'field':  '{{ full_name|replace({'filter[': '', '][value]': '', '__':'.'}) }}',
+                                '_context': 'filter'
+                            {% else %}
+                                'field':  '{{ name }}'
+                            {% endif %}
 
-                                // other parameters
-                                {% if req_params is not empty %},
-                                    {%- for key, value in req_params -%}
-                                        '{{- key -}}': '{{- value -}}'
-                                        {%- if not loop.last -%}, {% endif -%}
-                                    {%- endfor -%}
-                                {% endif %}
-                        };
-                        {% endblock %}
-                    },
+                            // other parameters
+                            {% if req_params is not empty %},
+                                {%- for key, value in req_params -%}
+                                    '{{- key -}}': '{{- value -}}'
+                                    {%- if not loop.last -%}, {% endif -%}
+                                {%- endfor -%}
+                            {% endif %}
+                    };
+                    {% endblock %}
                 },
-                escapeMarkup: function (m) { return m; }, // we do not want to escape markup since we are displaying html in results
-                templateResult: function (item) {
-                    // When selecting a new result, the label is undefined and the correct property is text
-                    if (typeof item.label === 'undefined') {
-                        item.label = item.text;
+            },
+            escapeMarkup: function (m) { return m; }, // we do not want to escape markup since we are displaying html in results
+            templateResult: function (item) {
+                // When selecting a new result, the label is undefined and the correct property is text
+                if (typeof item.label === 'undefined') {
+                    item.label = item.text;
+                }
+
+                return {% block sonata_type_model_autocomplete_dropdown_item_format -%}
+                    {% if safe_label|default(false) %}
+                        '<div class="{{ dropdown_item_css_class }}">'+item.label+'<\/div>'
+                    {% else %}
+                        jQuery('<div class="{{ dropdown_item_css_class }}">').text(item.label).prop('outerHTML')
+                    {% endif %}
+                {%- endblock %}; // format of one dropdown item
+            },
+            templateSelection: function (item) {
+                // The searching... placeholder appears as text
+                if (typeof item.label === 'undefined') {
+                    item.label = item.text;
+                }
+
+                return {% block sonata_type_model_autocomplete_selection_format -%}
+                    {% if safe_label|default(false) %}
+                        item.label
+                    {% else %}
+                        jQuery('<div>').text(item.label).prop('innerHTML')
+                    {% endif %}
+                {%- endblock %}; // format selected item '<b>'+item.label+'</b>';
+            },
+        };
+
+        autocompleteInput.select2(select2Options);
+
+        autocompleteInput.on('select2:select select2:unselect', function(e) {
+            if (e.type === 'select2:select') {
+                e.added = e.params.data;
+            }
+            if (e.type === 'select2:unselect') {
+                e.removed = e.params.data;
+            }
+
+            // console.log('change '+JSON.stringify({val:e.val, added:e.added, removed:e.removed}));
+
+            // remove input
+            if (undefined !== e.removed && null !== e.removed) {
+                var removedItems = e.removed;
+
+                {% if multiple %}
+                    if(!$.isArray(removedItems)) {
+                        removedItems = [removedItems];
                     }
 
-                    return {% block sonata_type_model_autocomplete_dropdown_item_format -%}
-                        {% if safe_label|default(false) %}
-                            '<div class="{{ dropdown_item_css_class }}">'+item.label+'<\/div>'
-                        {% else %}
-                            jQuery('<div class="{{ dropdown_item_css_class }}">').text(item.label).prop('outerHTML')
-                        {% endif %}
-                    {%- endblock %}; // format of one dropdown item
-                },
-                templateSelection: function (item) {
-                    // The searching... placeholder appears as text
-                    if (typeof item.label === 'undefined') {
-                        item.label = item.text;
+                    var length = removedItems.length;
+                    for (var i = 0; i < length; i++) {
+                        el = removedItems[i];
+                        $('#{{ id }}_hidden_inputs_wrap input:hidden[value="'+el.id+'"]').remove();
+                    }
+                {%- else -%}
+                    $('#{{ id }}_hidden_inputs_wrap input:hidden').val('');
+                {%- endif %}
+            }
+
+            // add new input
+            var el = null;
+            if (undefined !== e.added) {
+
+                var addedItems = e.added;
+
+                {% if multiple %}
+                    if(!$.isArray(addedItems)) {
+                        addedItems = [addedItems];
                     }
 
-                    return {% block sonata_type_model_autocomplete_selection_format -%}
-                        {% if safe_label|default(false) %}
-                            item.label
-                        {% else %}
-                            jQuery('<div>').text(item.label).prop('innerHTML')
-                        {% endif %}
-                    {%- endblock %}; // format selected item '<b>'+item.label+'</b>';
-                },
-            };
-
-            autocompleteInput.select2(select2Options);
-
-            autocompleteInput.on('select2:select select2:unselect', function(e) {
-                if (e.type === 'select2:select') {
-                    e.added = e.params.data;
-                }
-                if (e.type === 'select2:unselect') {
-                    e.removed = e.params.data;
-                }
-
-                // console.log('change '+JSON.stringify({val:e.val, added:e.added, removed:e.removed}));
-
-                // remove input
-                if (undefined !== e.removed && null !== e.removed) {
-                    var removedItems = e.removed;
-
-                    {% if multiple %}
-                        if(!$.isArray(removedItems)) {
-                            removedItems = [removedItems];
-                        }
-
-                        var length = removedItems.length;
-                        for (var i = 0; i < length; i++) {
-                            el = removedItems[i];
-                            $('#{{ id }}_hidden_inputs_wrap input:hidden[value="'+el.id+'"]').remove();
-                        }
-                    {%- else -%}
-                        $('#{{ id }}_hidden_inputs_wrap input:hidden').val('');
-                    {%- endif %}
-                }
-
-                // add new input
-                var el = null;
-                if (undefined !== e.added) {
-
-                    var addedItems = e.added;
-
-                    {% if multiple %}
-                        if(!$.isArray(addedItems)) {
-                            addedItems = [addedItems];
-                        }
-
-                        var length = addedItems.length;
-                        for (var i = 0; i < length; i++) {
-                            el = addedItems[i];
-                            $('#{{ id }}_hidden_inputs_wrap').append('<input type="hidden" name="{{ full_name }}[]" value="'+el.id+'" />');
-                        }
-                    {%- else -%}
-                        $('#{{ id }}_hidden_inputs_wrap input:hidden').val(addedItems.id);
-                    {%- endif %}
-                }
-            });
-
-            // remove unneeded autocomplete text input before form submit
-            autocompleteInput.closest('form').submit(function()
-            {
-                autocompleteInput.remove();
-                return true;
-            });
-
-            // Automatically select the created record after closing the popup window
-            {% if sonata_admin.field_description
-                and sonata_admin.field_description.hasAssociationAdmin
-                and btn_add
-                and sonata_admin.field_description.associationadmin.hasRoute('create')
-                and sonata_admin.field_description.associationadmin.hasAccess('create') %}
-
-                {% set create_url = sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) %}
-
-                $(document).ajaxSuccess(function(event, xhr, settings) {
-                  if(typeof xhr.responseJSON != 'undefined') {
-                      if ('{{ create_url }}'.indexOf(settings.url) !== -1 && typeof xhr.responseJSON != 'string' && xhr.responseJSON.result == 'ok') {
-                        var item = new Option(
-                          new DOMParser().parseFromString(xhr.responseJSON.objectName, "text/html").documentElement.textContent,
-                          xhr.responseJSON.objectId,
-                          true, true
-                          );
-
-                        // append to Select2
-                        autocompleteInput.append(item).trigger('change');
-
-                        // manually trigger the `select2:select` event
-                        autocompleteInput.trigger({
-                            type: 'select2:select',
-                            params: {
-                                data: autocompleteInput.select2('data')
-                            }
-                        });
-
-                        {% if multiple %}
-                          $('#{{ id }}_hidden_inputs_wrap').append('<input type="hidden" name="{{ full_name }}[]" value="'+xhr.responseJSON.objectId+'" />');
-                        {% else %}
-                          $('#{{ id }}_hidden_inputs_wrap').html('<input type="hidden" name="{{ full_name }}" value="'+xhr.responseJSON.objectId+'" />');
-                        {% endif %}
-                      }
-                  }
-                });
-            {% endif %}
+                    var length = addedItems.length;
+                    for (var i = 0; i < length; i++) {
+                        el = addedItems[i];
+                        $('#{{ id }}_hidden_inputs_wrap').append('<input type="hidden" name="{{ full_name }}[]" value="'+el.id+'" />');
+                    }
+                {%- else -%}
+                    $('#{{ id }}_hidden_inputs_wrap input:hidden').val(addedItems.id);
+                {%- endif %}
+            }
         });
-        {% endautoescape %}
-    </script>
-{% endapply %}
+
+        // remove unneeded autocomplete text input before form submit
+        autocompleteInput.closest('form').submit(function()
+        {
+            autocompleteInput.remove();
+            return true;
+        });
+
+        // Automatically select the created record after closing the popup window
+        {% if sonata_admin.field_description
+            and sonata_admin.field_description.hasAssociationAdmin
+            and btn_add
+            and sonata_admin.field_description.associationadmin.hasRoute('create')
+            and sonata_admin.field_description.associationadmin.hasAccess('create') %}
+
+            {% set create_url = sonata_admin.field_description.associationadmin.generateUrl('create', sonata_admin.field_description.getOption('link_parameters', {})) %}
+
+            $(document).ajaxSuccess(function(event, xhr, settings) {
+              if(typeof xhr.responseJSON != 'undefined') {
+                  if ('{{ create_url }}'.indexOf(settings.url) !== -1 && typeof xhr.responseJSON != 'string' && xhr.responseJSON.result == 'ok') {
+                    var item = new Option(
+                      new DOMParser().parseFromString(xhr.responseJSON.objectName, "text/html").documentElement.textContent,
+                      xhr.responseJSON.objectId,
+                      true, true
+                      );
+
+                    // append to Select2
+                    autocompleteInput.append(item).trigger('change');
+
+                    // manually trigger the `select2:select` event
+                    autocompleteInput.trigger({
+                        type: 'select2:select',
+                        params: {
+                            data: autocompleteInput.select2('data')
+                        }
+                    });
+
+                    {% if multiple %}
+                      $('#{{ id }}_hidden_inputs_wrap').append('<input type="hidden" name="{{ full_name }}[]" value="'+xhr.responseJSON.objectId+'" />');
+                    {% else %}
+                      $('#{{ id }}_hidden_inputs_wrap').html('<input type="hidden" name="{{ full_name }}" value="'+xhr.responseJSON.objectId+'" />');
+                    {% endif %}
+                  }
+              }
+            });
+        {% endif %}
+    });
+    {% endautoescape %}
+</script>

--- a/src/Resources/views/Form/filter_admin_fields.html.twig
+++ b/src/Resources/views/Form/filter_admin_fields.html.twig
@@ -31,61 +31,57 @@ file that was distributed with this source code.
 {% endblock form_widget_simple %}
 
 {% block choice_widget_expanded %}
-    {% apply spaceless %}
-        {% set label_attr = label_attr|merge({'class': (label_attr.class|default(''))}) %}
-        {% set label_attr = label_attr|merge({'class': (label_attr.class ~ ' ' ~ (widget_type is defined and widget_type != '' ? (multiple ? 'checkbox' : 'radio') ~ '-' ~ widget_type : ''))}) %}
-        {% if expanded %}
-            {% set attr = attr|merge({'class': attr.class|default('')}) %}
-            <div {{ block('widget_container_attributes') }}>
+    {% set label_attr = label_attr|merge({'class': (label_attr.class|default(''))}) %}
+    {% set label_attr = label_attr|merge({'class': (label_attr.class ~ ' ' ~ (widget_type is defined and widget_type != '' ? (multiple ? 'checkbox' : 'radio') ~ '-' ~ widget_type : ''))}) %}
+    {% if expanded %}
+        {% set attr = attr|merge({'class': attr.class|default('')}) %}
+        <div {{ block('widget_container_attributes') }}>
+    {% endif %}
+    {% for child in form %}
+        {% if widget_type is defined and widget_type != 'inline' %}
+            <div class="{{ multiple ? 'checkbox' : 'radio' }}">
         {% endif %}
-        {% for child in form %}
-            {% if widget_type is defined and widget_type != 'inline' %}
-                <div class="{{ multiple ? 'checkbox' : 'radio' }}">
-            {% endif %}
-            <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
-            {{ form_widget(child, {'attr': {'class': attr.widget_class|default('')}}) }}
-            {{ child.vars.label|trans({}, translation_domain) }}
-            </label>
-            {% if widget_type is defined and widget_type != 'inline' %}
-                </div>
-            {% endif %}
-        {% endfor %}
-        {% if block('form_message') is defined %}
-            {{ block('form_message') }}
-        {% endif %}
-        {% if expanded %}
+        <label{% for attrname, attrvalue in label_attr %} {{ attrname }}="{{ attrvalue }}"{% endfor %}>
+        {{ form_widget(child, {'attr': {'class': attr.widget_class|default('')}}) }}
+        {{ child.vars.label|trans({}, translation_domain) }}
+        </label>
+        {% if widget_type is defined and widget_type != 'inline' %}
             </div>
         {% endif %}
-    {% endapply %}
+    {% endfor %}
+    {% if block('form_message') is defined %}
+        {{ block('form_message') }}
+    {% endif %}
+    {% if expanded %}
+        </div>
+    {% endif %}
 {% endblock choice_widget_expanded %}
 
 {% block checkbox_widget %}
-    {% apply spaceless %}
-        {% if label is not same as(false) and label is empty %}
-            {% set label = name|humanize %}
-        {% endif %}
-        {% if form.parent != null and 'choice' not in form.parent.vars.block_prefixes %}
-            <div class="checkbox">
-        {% endif %}
+    {% if label is not same as(false) and label is empty %}
+        {% set label = name|humanize %}
+    {% endif %}
+    {% if form.parent != null and 'choice' not in form.parent.vars.block_prefixes %}
+        <div class="checkbox">
+    {% endif %}
 
-        {% if form.parent != null and 'choice' not in form.parent.vars.block_prefixes and label_render is defined %}
-            <label class="{% if inline is defined and inline %}checkbox-inline{% endif %}">
-        {% endif %}
+    {% if form.parent != null and 'choice' not in form.parent.vars.block_prefixes and label_render is defined %}
+        <label class="{% if inline is defined and inline %}checkbox-inline{% endif %}">
+    {% endif %}
 
-        <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %}/>
-        {% if form.parent != null and 'choice' not in form.parent.vars.block_prefixes %}
-            {% if label_render is defined and widget_checkbox_label in ['both', 'widget'] %}
-                {{ label|trans({}, translation_domain) }}
-                </label>
-            {% endif %}
+    <input type="checkbox" {{ block('widget_attributes') }}{% if value is defined %} value="{{ value }}"{% endif %}{% if checked %} checked="checked"{% endif %}/>
+    {% if form.parent != null and 'choice' not in form.parent.vars.block_prefixes %}
+        {% if label_render is defined and widget_checkbox_label in ['both', 'widget'] %}
+            {{ label|trans({}, translation_domain) }}
+            </label>
         {% endif %}
-        {% if form.parent != null and 'choice' not in form.parent.vars.block_prefixes %}
-            </div>
-            {% if block('form_message') is defined %}
-                {{ block('form_message') }}
-            {% endif %}
+    {% endif %}
+    {% if form.parent != null and 'choice' not in form.parent.vars.block_prefixes %}
+        </div>
+        {% if block('form_message') is defined %}
+            {{ block('form_message') }}
         {% endif %}
-    {% endapply %}
+    {% endif %}
 {% endblock checkbox_widget %}
 
 {% block sonata_type_model_autocomplete_widget %}

--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -66,13 +66,11 @@ file that was distributed with this source code.
 {%- endblock money_widget %}
 
 {% block percent_widget %}
-    {% apply spaceless %}
-        {% set type = type|default('text') %}
-        <div class="input-group">
-            {{ block('form_widget_simple') }}
-            <span class="input-group-addon">%</span>
-        </div>
-    {% endapply %}
+    {% set type = type|default('text') %}
+    <div class="input-group">
+        {{ block('form_widget_simple') }}
+        <span class="input-group-addon">%</span>
+    </div>
 {% endblock percent_widget %}
 
 {% block checkbox_widget -%}
@@ -99,7 +97,6 @@ file that was distributed with this source code.
 
 {# Labels #}
 {% block form_label %}
-{% apply spaceless %}
     {% if label is not same as(false) and sonata_admin.options['form_type'] == 'horizontal' %}
         {% set label_class = 'col-sm-3' %}
     {% endif %}
@@ -137,7 +134,6 @@ file that was distributed with this source code.
             {%- endif -%}
         </label>
     {% endif %}
-{% endapply %}
 {% endblock form_label %}
 
 {% block checkbox_label -%}
@@ -179,7 +175,6 @@ file that was distributed with this source code.
 {% endblock checkbox_radio_label %}
 
 {% block choice_widget_expanded %}
-{% apply spaceless %}
     {% set attr = attr|merge({'class': attr.class|default('') ~ ' list-unstyled'}) %}
     <ul {{ block('widget_container_attributes') }}>
     {% for child in form %}
@@ -192,11 +187,9 @@ file that was distributed with this source code.
         </li>
     {% endfor %}
     </ul>
-{% endapply %}
 {% endblock choice_widget_expanded %}
 
 {% block choice_widget_collapsed %}
-{% apply spaceless %}
     {% if required and placeholder is defined and placeholder is none %}
         {% set required = false %}
     {% elseif required and empty_value is defined and empty_value_in_choices is defined and empty_value is none and not empty_value_in_choices and not multiple %}
@@ -243,11 +236,9 @@ file that was distributed with this source code.
             {{ block('choice_widget_options') }}
         </select>
     {% endif %}
-{% endapply %}
 {% endblock choice_widget_collapsed %}
 
 {% block date_widget %}
-{% apply spaceless %}
     {% if widget == 'single_text' %}
         {{ block('form_widget_simple') }}
     {% else %}
@@ -263,11 +254,9 @@ file that was distributed with this source code.
             })|raw }}
         </div>
     {% endif %}
-{% endapply %}
 {% endblock date_widget %}
 
 {% block time_widget %}
-{% apply spaceless %}
     {% if widget == 'single_text' %}
         {{ block('form_widget_simple') }}
     {% else %}
@@ -291,11 +280,9 @@ file that was distributed with this source code.
             {% endif %}
         </div>
     {% endif %}
-{% endapply %}
 {% endblock time_widget %}
 
 {% block datetime_widget %}
-{% apply spaceless %}
     {% if widget == 'single_text' %}
         {{ block('form_widget_simple') }}
     {% else %}
@@ -321,7 +308,6 @@ file that was distributed with this source code.
             {% endif %}
         </div>
     {% endif %}
-{% endapply %}
 {% endblock datetime_widget %}
 
 {% block form_row %}
@@ -385,7 +371,6 @@ file that was distributed with this source code.
 {%- endblock radio_row %}
 
 {% block sonata_type_native_collection_widget_row %}
-{% apply spaceless %}
     <div class="sonata-collection-row">
         {% if allow_delete %}
             <div class="row">
@@ -402,11 +387,9 @@ file that was distributed with this source code.
             </div>
         {% endif %}
     </div>
-{% endapply %}
 {% endblock sonata_type_native_collection_widget_row %}
 
 {% block sonata_type_native_collection_widget %}
-{% apply spaceless %}
     {% if prototype is defined %}
         {% set child = prototype %}
         {% set allow_delete_backup = allow_delete %}
@@ -424,45 +407,40 @@ file that was distributed with this source code.
             <div><a href="#" class="btn btn-link sonata-collection-add"><i class="fas fa-plus-circle" aria-hidden="true"></i></a></div>
         {% endif %}
     </div>
-{% endapply %}
 {% endblock sonata_type_native_collection_widget %}
 
 {% block sonata_type_immutable_array_widget %}
-    {% apply spaceless %}
-        <div {{ block('widget_container_attributes') }}>
-            {{ form_errors(form) }}
+    <div {{ block('widget_container_attributes') }}>
+        {{ form_errors(form) }}
 
-            {% for key, child in form %}
-                {{ block('sonata_type_immutable_array_widget_row') }}
-            {% endfor %}
+        {% for key, child in form %}
+            {{ block('sonata_type_immutable_array_widget_row') }}
+        {% endfor %}
 
-            {{ form_rest(form) }}
-        </div>
-    {% endapply %}
+        {{ form_rest(form) }}
+    </div>
 {% endblock sonata_type_immutable_array_widget %}
 
 {% block sonata_type_immutable_array_widget_row %}
-    {% apply spaceless %}
-        <div class="form-group{% if child.vars.errors|length > 0 %} has-error{% endif %}" id="sonata-ba-field-container-{{ id }}-{{ key }}">
+    <div class="form-group{% if child.vars.errors|length > 0 %} has-error{% endif %}" id="sonata-ba-field-container-{{ id }}-{{ key }}">
 
-            {{ form_label(child) }}
+        {{ form_label(child) }}
 
-            {% set div_class = "" %}
-            {% if sonata_admin.options['form_type'] == 'horizontal' %}
-                {% set div_class = 'col-sm-9' %}
-            {% endif %}
+        {% set div_class = "" %}
+        {% if sonata_admin.options['form_type'] == 'horizontal' %}
+            {% set div_class = 'col-sm-9' %}
+        {% endif %}
 
-            <div class="{{ div_class }} sonata-ba-field sonata-ba-field-{{ sonata_admin.edit }}-{{ sonata_admin.inline }}{% if child.vars.errors|length > 0 %} sonata-ba-field-error{% endif %}">
-                {{ form_widget(child, {'horizontal': false, 'horizontal_input_wrapper_class': ''}) }} {# {'horizontal': false, 'horizontal_input_wrapper_class': ''} needed to avoid MopaBootstrapBundle messing with the DOM #}
-            </div>
-
-            {% if child.vars.errors|length > 0 %}
-                <div class="help-block sonata-ba-field-error-messages">
-                    {{ form_errors(child) }}
-                </div>
-            {% endif %}
+        <div class="{{ div_class }} sonata-ba-field sonata-ba-field-{{ sonata_admin.edit }}-{{ sonata_admin.inline }}{% if child.vars.errors|length > 0 %} sonata-ba-field-error{% endif %}">
+            {{ form_widget(child, {'horizontal': false, 'horizontal_input_wrapper_class': ''}) }} {# {'horizontal': false, 'horizontal_input_wrapper_class': ''} needed to avoid MopaBootstrapBundle messing with the DOM #}
         </div>
-    {% endapply %}
+
+        {% if child.vars.errors|length > 0 %}
+            <div class="help-block sonata-ba-field-error-messages">
+                {{ form_errors(child) }}
+            </div>
+        {% endif %}
+    </div>
 {% endblock %}
 
 {% block sonata_type_model_autocomplete_widget %}

--- a/src/Resources/views/Menu/sonata_menu.html.twig
+++ b/src/Resources/views/Menu/sonata_menu.html.twig
@@ -21,47 +21,41 @@
 {% endblock %}
 
 {% block linkElement %}
-    {% apply spaceless %}
-        {# NEXT_MAJOR: Remove the label_catalogue fallback #}
-        {%- set translation_domain = item.extra('translation_domain', item.extra('label_catalogue', 'messages')) -%}
-        {%- if item.extra('on_top') is defined and not item.extra('on_top') -%}
-            {%- set icon = item.extra('icon')|default(item.level > 1 ? 'fa fa-angle-double-right' : '')|parse_icon -%}
-        {%- else -%}
-            {%- set icon = item.extra('icon')|parse_icon -%}
-        {%- endif -%}
-        {%- set is_link = true -%}
-        {{ parent() }}
-    {% endapply %}
+    {# NEXT_MAJOR: Remove the label_catalogue fallback #}
+    {%- set translation_domain = item.extra('translation_domain', item.extra('label_catalogue', 'messages')) -%}
+    {%- if item.extra('on_top') is defined and not item.extra('on_top') -%}
+        {%- set icon = item.extra('icon')|default(item.level > 1 ? 'fa fa-angle-double-right' : '')|parse_icon -%}
+    {%- else -%}
+        {%- set icon = item.extra('icon')|parse_icon -%}
+    {%- endif -%}
+    {%- set is_link = true -%}
+    {{ parent() }}
 {% endblock %}
 
 {% block spanElement %}
-    {% apply spaceless %}
-        <a href="#">
-            {# NEXT_MAJOR: Remove the label_catalogue fallback #}
-            {%- set translation_domain = item.extra('translation_domain', item.extra('label_catalogue', 'messages')) -%}
-            {%- set icon = item.extra('icon')|default('')|parse_icon -%}
-            {{ icon|raw }}
-            {{ parent() }}
-            {%- if item.extra('keep_open') is not defined or not item.extra('keep_open') -%}
-                <span class="pull-right-container"><i class="fas pull-right fa-angle-left"></i></span>
-            {%- endif -%}
-        </a>
-    {% endapply %}
+    <a href="#">
+        {# NEXT_MAJOR: Remove the label_catalogue fallback #}
+        {%- set translation_domain = item.extra('translation_domain', item.extra('label_catalogue', 'messages')) -%}
+        {%- set icon = item.extra('icon')|default('')|parse_icon -%}
+        {{ icon|raw }}
+        {{ parent() }}
+        {%- if item.extra('keep_open') is not defined or not item.extra('keep_open') -%}
+            <span class="pull-right-container"><i class="fas pull-right fa-angle-left"></i></span>
+        {%- endif -%}
+    </a>
 {% endblock %}
 
 {% block label %}
-    {% apply spaceless %}
-        {%- if is_link|default(false) -%}
-            {{ icon|default('')|parse_icon }}
-        {%- endif -%}
-        {# We use method accessor instead of ".label" since `item` implements `ArrayAccess` and could have a property called "label". #}
-        {%- set item_label = item.getLabel() -%}
-        {%- if options.allow_safe_labels and item.extra('safe_label', false) -%}
-            {{ item_label|raw }}
-        {%- else -%}
-            {# NEXT_MAJOR: Remove the label_catalogue fallback #}
-            {%- set translation_domain = item.extra('translation_domain', item.extra('label_catalogue', 'messages')) -%}
-            {{ item_label|trans(item.extra('label_translation_parameters', {}), translation_domain) }}
-        {%- endif -%}
-    {% endapply %}
+    {%- if is_link|default(false) -%}
+        {{ icon|default('')|parse_icon }}
+    {%- endif -%}
+    {# We use method accessor instead of ".label" since `item` implements `ArrayAccess` and could have a property called "label". #}
+    {%- set item_label = item.getLabel() -%}
+    {%- if options.allow_safe_labels and item.extra('safe_label', false) -%}
+        {{ item_label|raw }}
+    {%- else -%}
+        {# NEXT_MAJOR: Remove the label_catalogue fallback #}
+        {%- set translation_domain = item.extra('translation_domain', item.extra('label_catalogue', 'messages')) -%}
+        {{ item_label|trans(item.extra('label_translation_parameters', {}), translation_domain) }}
+    {%- endif -%}
 {% endblock %}

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -119,16 +119,14 @@ file that was distributed with this source code.
                     </noscript>
                 {% endblock %}
                 {% block logo %}
-                    {% apply spaceless %}
-                        <a class="logo" href="{{ path('sonata_admin_dashboard') }}">
-                            {% if 'icon' == sonata_config.getOption('logo_content') or 'all' == sonata_config.getOption('logo_content') %}
-                                <img src="{{ asset(sonata_config.logo) }}" alt="{{ sonata_config.title }}">
-                            {% endif %}
-                            {% if 'text' == sonata_config.getOption('logo_content') or 'all' == sonata_config.getOption('logo_content') %}
-                                <span>{{ sonata_config.title }}</span>
-                            {% endif %}
-                        </a>
-                    {% endapply %}
+                    <a class="logo" href="{{ path('sonata_admin_dashboard') }}">
+                        {% if 'icon' == sonata_config.getOption('logo_content') or 'all' == sonata_config.getOption('logo_content') %}
+                            <img src="{{ asset(sonata_config.logo) }}" alt="{{ sonata_config.title }}">
+                        {% endif %}
+                        {% if 'text' == sonata_config.getOption('logo_content') or 'all' == sonata_config.getOption('logo_content') %}
+                            <span>{{ sonata_config.title }}</span>
+                        {% endif %}
+                    </a>
                 {% endblock %}
                 {% block sonata_nav %}
                     <nav class="navbar navbar-static-top">
@@ -160,7 +158,7 @@ file that was distributed with this source code.
                                 <ul class="nav navbar-nav">
                                     {% block sonata_top_nav_menu_add_block %}
                                         {% set addBlock = include(get_global_template('add_block')) %}
-                                        {% if addBlock|spaceless is not empty %}
+                                        {% if addBlock|trim is not empty %}
                                             <li class="dropdown">
                                                 <a class="dropdown-toggle" data-toggle="dropdown" href="#">
                                                     <i class="fas fa-plus-square fa-fw" aria-hidden="true"></i> <i class="fas fa-caret-down" aria-hidden="true"></i>
@@ -172,7 +170,7 @@ file that was distributed with this source code.
                                     {% if app.user %}
                                         {% block sonata_top_nav_menu_user_block %}
                                             {% set userBlock = include(get_global_template('user_block')) %}
-                                            {% if userBlock|spaceless is not empty %}
+                                            {% if userBlock|trim is not empty %}
                                                 <li class="dropdown user-menu">
                                                     <a class="dropdown-toggle" data-toggle="dropdown" href="#">
                                                         <i class="fas fa-user fa-fw" aria-hidden="true"></i> <i class="fas fa-caret-down" aria-hidden="true"></i>

--- a/tests/Twig/BreadcrumbsRuntimeTest.php
+++ b/tests/Twig/BreadcrumbsRuntimeTest.php
@@ -157,6 +157,6 @@ final class BreadcrumbsRuntimeTest extends TestCase
 
     private function removeExtraWhitespace(string $string): string
     {
-        return trim(preg_replace('/\s+/', ' ', $string) ?? '');
+        return trim(preg_replace('/\s+/', ' ', preg_replace('/>\s+</', '><', $string) ?? '') ?? '');
     }
 }

--- a/tests/Twig/Extension/BreadcrumbsExtensionTest.php
+++ b/tests/Twig/Extension/BreadcrumbsExtensionTest.php
@@ -169,6 +169,6 @@ final class BreadcrumbsExtensionTest extends TestCase
 
     private function removeExtraWhitespace(string $string): string
     {
-        return trim(preg_replace('/\s+/', ' ', $string) ?? '');
+        return trim(preg_replace('/\s+/', ' ', preg_replace('/>\s+</', '><', $string) ?? '') ?? '');
     }
 }

--- a/tests/Twig/Extension/RenderElementExtensionTest.php
+++ b/tests/Twig/Extension/RenderElementExtensionTest.php
@@ -2164,7 +2164,7 @@ final class RenderElementExtensionTest extends TestCase
 
     private function removeExtraWhitespace(string $string): string
     {
-        return trim(preg_replace('/\s+/', ' ', $string) ?? '');
+        return trim(preg_replace('/\s+/', ' ', preg_replace('/>\s+</', '><', $string) ?? '') ?? '');
     }
 
     private function registerRequiredTwigExtensions(): void

--- a/tests/Twig/RenderElementRuntimeTest.php
+++ b/tests/Twig/RenderElementRuntimeTest.php
@@ -2041,7 +2041,7 @@ final class RenderElementRuntimeTest extends TestCase
 
     private function removeExtraWhitespace(string $string): string
     {
-        return trim(preg_replace('/\s+/', ' ', $string) ?? '');
+        return trim(preg_replace('/\s+/', ' ', preg_replace('/>\s+</', '><', $string) ?? '') ?? '');
     }
 
     private function registerRequiredTwigExtensions(): void


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its BC.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes https://github.com/sonata-project/SonataAdminBundle/issues/8214

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- deprecated usages of `spaceless` twig filter

```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
