### PR TITLE
Replace HttpException with BadRequestHttpException in CSRF validation

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -1319,7 +1319,7 @@ class CRUDController extends AbstractController
         \assert($tokenManager instanceof CsrfTokenManagerInterface);
 
         if (!$tokenManager->isTokenValid(new CsrfToken($intention, $token))) {
-            throw new HttpException(Response::HTTP_BAD_REQUEST, 'The csrf token is not valid, CSRF attack?');
+            throw new BadRequestHttpException('The csrf token is not valid, CSRF attack?');
         }
     }
 


### PR DESCRIPTION
Substitute HttpException with BadRequestHttpException to more accurately indicate a bad request (HTTP 400) error during CSRF token validation.

## Subject

This PR refactors the CSRF token validation in the `validateCsrfToken` method by replacing `HttpException` with `BadRequestHttpException`. This change improves clarity by accurately indicating an HTTP 400 error when an invalid CSRF token is detected.

I am targeting this branch because the change is backward compatible and addresses an improvement in error semantics without breaking any existing functionality.

## Changelog

```markdown
### Changed
- Replaced the commented-out `HttpException` with `BadRequestHttpException` in the `validateCsrfToken` method to properly reflect an HTTP 400 error for invalid CSRF tokens
```