### PR TITLE
Add version suffix to assets to force cache break

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -616,7 +616,7 @@ final class Configuration implements ConfigurationInterface
                     ->children()
                         ->arrayNode('stylesheets')
                             ->defaultValue([
-                                'bundles/sonataadmin/app.css',
+                                'bundles/sonataadmin/app.css?v=4.36',
                                 'bundles/sonataform/app.css',
                             ])
                             ->prototype('scalar')->end()
@@ -633,7 +633,7 @@ final class Configuration implements ConfigurationInterface
                         ->end()
                         ->arrayNode('javascripts')
                             ->defaultValue([
-                                'bundles/sonataadmin/app.js',
+                                'bundles/sonataadmin/app.js?v=4.36',
                                 'bundles/sonataform/app.js',
                             ])
                             ->prototype('scalar')->end()

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -90,7 +90,7 @@ final class SonataAdminExtension extends Extension
         $javascript = $this->buildJavascripts($config);
 
         $config['assets']['stylesheets'][] = \sprintf(
-            'bundles/sonataadmin/admin-lte-skins/%s.min.css',
+            'bundles/sonataadmin/admin-lte-skins/%s.min.css?v=4.36',
             $config['options']['skin']
         );
         $stylesheet = $this->buildStylesheets($config);

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -68,14 +68,14 @@ file that was distributed with this source code.
             {# localize moment #}
             {% set localeForMoment = canonicalize_locale_for_moment() %}
             {% if localeForMoment %}
-                <script src="{{ asset('bundles/sonataform/moment-locale/' ~ localeForMoment ~ '.js') }}"></script>
+                <script src="{{ asset('bundles/sonataform/moment-locale/' ~ localeForMoment ~ '.js?v=2.0') }}"></script>
             {% endif %}
 
             {# localize select2 #}
             {% if sonata_config.getOption('use_select2') %}
                 {% set localeForSelect2 = canonicalize_locale_for_select2() %}
                 {% if localeForSelect2 %}
-                    <script src="{{ asset('bundles/sonataadmin/select2-locale/' ~ localeForSelect2 ~ '.js') }}"></script>
+                    <script src="{{ asset('bundles/sonataadmin/select2-locale/' ~ localeForSelect2 ~ '.js?v=4.36') }}"></script>
                 {% endif %}
             {% endif %}
         {% endblock %}

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -134,8 +134,8 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
     {
         $this->container->setParameter('kernel.bundles', []);
         $removeStylesheets = [
-            'bundles/sonataadmin/app.css',
-            'bundles/sonataadmin/admin-lte-skins/skin-black.min.css',
+            'bundles/sonataadmin/app.css?v=4.36',
+            'bundles/sonataadmin/admin-lte-skins/skin-black.min.css?v=4.36',
         ];
         $this->load([
             'assets' => [
@@ -179,7 +179,7 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
     {
         $this->container->setParameter('kernel.bundles', []);
         $removeJavascripts = [
-            'bundles/sonataadmin/app.js',
+            'bundles/sonataadmin/app.js?v=4.36',
         ];
         $this->load([
             'assets' => [
@@ -205,11 +205,11 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
         $extraStylesheets = ['foo/bar.css', 'bar/quux.css'];
         $extraJavascripts = ['foo/bar.js', 'bar/quux.js'];
         $removeStylesheets = [
-            'bundles/sonataadmin/app.css',
-            'bundles/sonataadmin/admin-lte-skins/skin-black.min.css',
+            'bundles/sonataadmin/app.css?v=4.36',
+            'bundles/sonataadmin/admin-lte-skins/skin-black.min.css?v=4.36',
         ];
         $removeJavascripts = [
-            'bundles/sonataadmin/app.js',
+            'bundles/sonataadmin/app.js?v=4.36',
         ];
         $this->load([
             'assets' => [
@@ -399,7 +399,7 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
 
         $defaultStylesheets = $this->defaultConfiguration['assets']['stylesheets'];
         $defaultStylesheets[] = \sprintf(
-            'bundles/sonataadmin/admin-lte-skins/%s.min.css',
+            'bundles/sonataadmin/admin-lte-skins/%s.min.css?v=4.36',
             $skin
         );
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because this is a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #8275 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Add version suffix to assets to force cache break
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
