### PR TITLE
Bugfix: fixes empty sort_order

### DIFF
--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -270,11 +270,9 @@ final class Datagrid implements DatagridInterface
             $this->values[DatagridInterface::SORT_BY]->getSortFieldMapping()
         );
 
-        if (($this->values[DatagridInterface::SORT_ORDER] ?? null) === '') {
-            unset($this->values[DatagridInterface::SORT_ORDER]);
+        if (!isset(this->values[DatagridInterface::SORT_ORDER]) || '' === this->values[DatagridInterface::SORT_ORDER]) {
+             $this->values[DatagridInterface::SORT_ORDER] = 'ASC';
         }
-
-        $this->values[DatagridInterface::SORT_ORDER] ??= 'ASC';
         $this->query->setSortOrder($this->values[DatagridInterface::SORT_ORDER]);
     }
 

--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -270,6 +270,10 @@ final class Datagrid implements DatagridInterface
             $this->values[DatagridInterface::SORT_BY]->getSortFieldMapping()
         );
 
+        if (($this->values[DatagridInterface::SORT_ORDER] ?? null) === '') {
+            unset($this->values[DatagridInterface::SORT_ORDER]);
+        }
+
         $this->values[DatagridInterface::SORT_ORDER] ??= 'ASC';
         $this->query->setSortOrder($this->values[DatagridInterface::SORT_ORDER]);
     }

--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -270,7 +270,7 @@ final class Datagrid implements DatagridInterface
             $this->values[DatagridInterface::SORT_BY]->getSortFieldMapping()
         );
 
-        if (!isset(this->values[DatagridInterface::SORT_ORDER]) || '' === this->values[DatagridInterface::SORT_ORDER]) {
+        if (!isset($this->values[DatagridInterface::SORT_ORDER]) || '' === $this->values[DatagridInterface::SORT_ORDER]) {
              $this->values[DatagridInterface::SORT_ORDER] = 'ASC';
         }
         $this->query->setSortOrder($this->values[DatagridInterface::SORT_ORDER]);

--- a/src/Datagrid/Datagrid.php
+++ b/src/Datagrid/Datagrid.php
@@ -271,8 +271,9 @@ final class Datagrid implements DatagridInterface
         );
 
         if (!isset($this->values[DatagridInterface::SORT_ORDER]) || '' === $this->values[DatagridInterface::SORT_ORDER]) {
-             $this->values[DatagridInterface::SORT_ORDER] = 'ASC';
+            $this->values[DatagridInterface::SORT_ORDER] = 'ASC';
         }
+
         $this->query->setSortOrder($this->values[DatagridInterface::SORT_ORDER]);
     }
 

--- a/tests/Datagrid/DatagridTest.php
+++ b/tests/Datagrid/DatagridTest.php
@@ -691,4 +691,22 @@ final class DatagridTest extends TestCase
         static::assertSame($page, $result['filter'][DatagridInterface::PAGE]);
         static::assertSame($name, $result['filter'][DatagridInterface::SORT_BY]);
     }
+
+    public function testSortOrderDefaultsAscending(): void
+    {
+        $field = $this->createMock(FieldDescriptionInterface::class);
+        $field->method('isSortable')->willReturn(true);
+
+        $this->datagrid = new Datagrid(
+            $this->query,
+            $this->columns,
+            $this->pager,
+            $this->formBuilder,
+            [DatagridInterface::SORT_BY => $field, DatagridInterface::SORT_ORDER => '']
+        );
+
+        $this->datagrid->buildPager();
+        $values = $this->datagrid->getValues();
+        static::assertSame('ASC', $values[DatagridInterface::SORT_ORDER]);
+    }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

For some reason my clients send a `?_sort_by=sorting&_sort_order=&...`. This results in `SORT_ORDER` being an empty string - null-coalescing operator won't help here.

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it's a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

~Closes #{put_issue_number_here}.~

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- Sending empty `_sort_order` defaults to 'ASC'
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
