### PR TITLE
Bugfix: Overrides symfonys return value in `AclSecurityHandler::findObjectAcls`

### DIFF
--- a/src/Security/Handler/AclSecurityHandler.php
+++ b/src/Security/Handler/AclSecurityHandler.php
@@ -184,13 +184,10 @@ final class AclSecurityHandler implements AclSecurityHandlerInterface
     public function findObjectAcls(\Traversable $oids, array $sids = []): \SplObjectStorage
     {
         try {
-            /** @var \SplObjectStorage<ObjectIdentityInterface, MutableAclInterface> $acls */
             $acls = $this->aclProvider->findAcls(iterator_to_array($oids), $sids);
         } catch (NotAllAclsFoundException $e) {
-            /**
-             * @var \SplObjectStorage<ObjectIdentityInterface, MutableAclInterface> $acls
-             */
-            $acls = $e->getPartialResult();
+            /** @var \SplObjectStorage<ObjectIdentityInterface, MutableAclInterface> $acls */
+            $acls = $e->getPartialResult(); // @phpstan-ignore varTag.type
         } catch (AclNotFoundException) { // if only one oid, this error is thrown
             /** @var \SplObjectStorage<ObjectIdentityInterface, MutableAclInterface> $acls */
             $acls = new \SplObjectStorage();


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This PR fixes PHPStan telling us, that Symfony's `MutableAclProviderInterface` does not throw an Exception with covariant MutableAclInterface in `AclSecurityHandler::findObjectAcls`.  It's correct about that. Symfony needs to change it's interface. However, the code excepts `MutableAclInterface` as a return value already. So why not asking PHPStan to ignore it for now (until Symfony fixed it)?

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it's a patch.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

~~Closes #{put_issue_number_here}.~~