### PR TITLE
Validate list mode exists before setting it

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -117,7 +117,7 @@ class CRUDController extends AbstractController
         }
 
         $listMode = $request->get('_list_mode');
-        if (\is_string($listMode)) {
+        if (\is_string($listMode) && \array_key_exists($listMode, $this->admin->getListModes())) {
             $this->admin->setListMode($listMode);
         }
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
While pentesting one of our applications, it was discovered that one could set an arbitrary admin list mode string via query parameter (besides the valid `list` and `mosaic`) which would then result in a fatal error. The list mode is used to build the list template name in [base_list.html.twig](https://github.com/sonata-project/SonataAdminBundle/blob/3bc926242ee9ba67923b4d02af574701563863d4/src/Resources/views/CRUD/base_list.html.twig#L107). If the template does not exists we get a RuntimeError.

This fix validates that the given list mode exists before setting it and silently ignores any invalid values.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch 4.x, because it's a bugfix with no BC breaks.

## Changelog

```markdown
### Security
- Validate admin list mode exists before setting it
```
