### PR TITLE
Autocomplete results - ID retrieving fixed

### DIFF
--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -204,7 +204,7 @@ final class RetrieveAutocompleteItemsAction
             }
 
             $item = [
-                'id' => $admin->id($model),
+                'id' => $targetAdmin->id($model),
                 'label' => $label,
             ];
 

--- a/tests/Action/RetrieveAutocompleteItemsActionTest.php
+++ b/tests/Action/RetrieveAutocompleteItemsActionTest.php
@@ -238,8 +238,8 @@ final class RetrieveAutocompleteItemsActionTest extends TestCase
         $this->admin->method('hasFormFieldDescription')->with('barField')->willReturn(true);
         $this->admin->method('getFormFieldDescription')->with('barField')->willReturn($fieldDescription);
         $this->admin->method('getFormFieldDescriptions')->willReturn([]);
-        $this->admin->method('id')->with($model)->willReturn('123');
         $targetAdmin->expects(static::once())->method('checkAccess')->with('list');
+        $targetAdmin->method('id')->with($model)->willReturn('123');
         $targetAdmin->method('getDatagrid')->willReturn($datagrid);
         $targetAdmin->method('getObjectMetadata')->with($model)->willReturn($metadata);
         $metadata->method('getTitle')->willReturn('FOO');


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->
In the autocomplete response, each item is returned as an array in the format:
```
['id' => $admin->id($model), 'label' => $label]
```
However, the `$admin` variable refers to the current Admin class where the autocomplete filter is used (e.g. `Products`), not the Admin class of the related entity being searched (e.g. `Categories`).

The correct ID should be generated using the `$targetAdmin` variable, which represents the actual Admin class for the autocomplete target.

**Fix**:
Replaced `$admin->id($model)` with `$targetAdmin->id($model)` to ensure correct ID resolution in autocomplete results.

I am targeting this branch, because everything backwards compatible.


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

```markdown
### Fixed
- ID retrieving in autocomplete results 
```