### PR TITLE
#8315 introduce asset package names

### DIFF
--- a/docs/reference/configuration.rst
+++ b/docs/reference/configuration.rst
@@ -172,12 +172,15 @@ Full Configuration Options
             filter_theme: []
 
         assets:
+            # all `stylesheets`, `extra_stylesheets`, `javascripts` and `extra_javascripts`
+            # can be simple strings or {path, package_name} pairs in case you have to set specific package name for the asset
             stylesheets:
 
                 # The default stylesheet list:
                 - bundles/sonataadmin/app.css
+                - bundles/sonataform/app.css
 
-            # stylesheet paths to add to the page in addition to the list above
+            # stylesheets to add to the page in addition to the list above
             extra_stylesheets: []
 
             # stylesheet paths to remove from the page
@@ -187,8 +190,9 @@ Full Configuration Options
 
                 # The default javascript list:
                 - bundles/sonataadmin/app.js
+                - bundles/sonataform/app.js
 
-            # javascript paths to add to the page in addition to the list above
+            # javascripts to add to the page in addition to the list above
             extra_javascripts: []
 
             # javascript paths to remove from the page

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -789,7 +789,7 @@ final class Configuration implements ConfigurationInterface
 
         // 2) Array forms
         if (\is_array($item)) {
-            // Positional short form: [asset] or [asset, package_name]
+            // Positional form: [asset, package_name]
             if (array_is_list($item)) {
                 return match (\count($item)) {
                     2 => [

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -622,7 +622,7 @@ final class Configuration implements ConfigurationInterface
                     ->children()
                         ->arrayNode('stylesheets')
                             ->beforeNormalization()
-                                ->always(static fn ($value) => self::normalizeAssetList($value, 'stylesheets'))
+                                ->always(static fn (array $value) => self::normalizeAssetList($value, 'stylesheets'))
                             ->end()
                             ->arrayPrototype()
                                 ->children()
@@ -638,7 +638,7 @@ final class Configuration implements ConfigurationInterface
                         ->arrayNode('extra_stylesheets')
                             ->info('stylesheets to add to the page')
                             ->beforeNormalization()
-                                ->always(static fn ($value) => self::normalizeAssetList($value, 'stylesheets'))
+                                ->always(static fn (array $value) => self::normalizeAssetList($value, 'stylesheets'))
                             ->end()
                             ->arrayPrototype()
                                 ->children()
@@ -655,7 +655,7 @@ final class Configuration implements ConfigurationInterface
                         ->end()
                         ->arrayNode('javascripts')
                             ->beforeNormalization()
-                                ->always(static fn ($value) => self::normalizeAssetList($value, 'stylesheets'))
+                                ->always(static fn (array $value) => self::normalizeAssetList($value, 'stylesheets'))
                             ->end()
                             ->defaultValue(self::normalizeDefaultAssets([
                                 'bundles/sonataadmin/app.js',
@@ -671,7 +671,7 @@ final class Configuration implements ConfigurationInterface
                         ->arrayNode('extra_javascripts')
                             ->info('javascripts to add to the page')
                             ->beforeNormalization()
-                                ->always(static fn ($value) => self::normalizeAssetList($value, 'stylesheets'))
+                                ->always(static fn (array $value) => self::normalizeAssetList($value, 'stylesheets'))
                             ->end()
                             ->defaultValue([])
                             ->arrayPrototype()
@@ -757,7 +757,7 @@ final class Configuration implements ConfigurationInterface
      * Supports input elements as string, positional array [asset, package_name],
      * or associative array {asset: ..., package_name: ...}.
      *
-     * @param list<mixed> $value
+     * @param array<mixed> $value
      *
      * @return list<SonataAdminAsset>
      */
@@ -771,7 +771,7 @@ final class Configuration implements ConfigurationInterface
             throw new \InvalidArgumentException(\sprintf('The "%s" node must be an array.', $nodeName));
         }
 
-        return array_values(array_map(static fn ($item) => self::normalizeAssetItem($item, $nodeName), $value));
+        return array_values(array_map(static fn (mixed $item) => self::normalizeAssetItem($item, $nodeName), $value));
     }
 
     /**

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -622,7 +622,7 @@ final class Configuration implements ConfigurationInterface
                     ->children()
                         ->arrayNode('stylesheets')
                             ->beforeNormalization()
-                                ->always(fn ($value) => self::normalizeAssetList($value, 'stylesheets'))
+                                ->always(static fn ($value) => self::normalizeAssetList($value, 'stylesheets'))
                             ->end()
                             ->arrayPrototype()
                                 ->children()
@@ -638,7 +638,7 @@ final class Configuration implements ConfigurationInterface
                         ->arrayNode('extra_stylesheets')
                             ->info('stylesheets to add to the page')
                             ->beforeNormalization()
-                                ->always(fn ($value) => self::normalizeAssetList($value, 'stylesheets'))
+                                ->always(static fn ($value) => self::normalizeAssetList($value, 'stylesheets'))
                             ->end()
                             ->arrayPrototype()
                                 ->children()
@@ -655,7 +655,7 @@ final class Configuration implements ConfigurationInterface
                         ->end()
                         ->arrayNode('javascripts')
                             ->beforeNormalization()
-                                ->always(fn ($value) => self::normalizeAssetList($value, 'stylesheets'))
+                                ->always(static fn ($value) => self::normalizeAssetList($value, 'stylesheets'))
                             ->end()
                             ->defaultValue(self::normalizeDefaultAssets([
                                 'bundles/sonataadmin/app.js',
@@ -671,7 +671,7 @@ final class Configuration implements ConfigurationInterface
                         ->arrayNode('extra_javascripts')
                             ->info('javascripts to add to the page')
                             ->beforeNormalization()
-                                ->always(fn ($value) => self::normalizeAssetList($value, 'stylesheets'))
+                                ->always(static fn ($value) => self::normalizeAssetList($value, 'stylesheets'))
                             ->end()
                             ->defaultValue([])
                             ->arrayPrototype()
@@ -754,11 +754,9 @@ final class Configuration implements ConfigurationInterface
     /**
      * Normalizes an asset list node to an array of items with shape:
      *   [ ['asset' => string, 'package_name' => string], ... ]
-     * Supports input elements as string, positional array [asset] or [asset, package_name],
+     * Supports input elements as string, positional array [asset, package_name],
      * or associative array {asset: ..., package_name: ...}.
      *
-     * @param mixed $value
-     * @param string $nodeName
      * @return list<SonataAdminAsset>
      */
     private static function normalizeAssetList(mixed $value, string $nodeName): array
@@ -768,15 +766,13 @@ final class Configuration implements ConfigurationInterface
         }
 
         if (!\is_array($value)) {
-            throw new \InvalidArgumentException(sprintf('The "%s" node must be an array.', $nodeName));
+            throw new \InvalidArgumentException(\sprintf('The "%s" node must be an array.', $nodeName));
         }
 
-        return \array_map(static fn ($item) => self::normalizeAssetItem($item, $nodeName), $value);
+        return array_map(static fn ($item) => self::normalizeAssetItem($item, $nodeName), $value);
     }
 
     /**
-     * @param mixed $item
-     * @param string $nodeName
      * @return SonataAdminAsset
      */
     private static function normalizeAssetItem(mixed $item, string $nodeName): array
@@ -784,7 +780,7 @@ final class Configuration implements ConfigurationInterface
         // 1) Simple string form
         if (\is_string($item)) {
             return [
-                'asset'        => $item,
+                'asset' => $item,
                 'package_name' => self::DEFAULT_PACKAGE,
             ];
         }
@@ -792,14 +788,14 @@ final class Configuration implements ConfigurationInterface
         // 2) Array forms
         if (\is_array($item)) {
             // Positional short form: [asset] or [asset, package_name]
-            if (\array_is_list($item)) {
+            if (array_is_list($item)) {
                 return match (\count($item)) {
-                    2       => [
-                        'asset'        => (string)$item[0],
-                        'package_name' => $item[1] === null ? null : (string) $item[1],
+                    2 => [
+                        'asset' => (string) $item[0],
+                        'package_name' => null === $item[1] ? null : (string) $item[1],
                     ],
                     default => throw new \InvalidArgumentException(
-                        sprintf(
+                        \sprintf(
                             'Each "%s" item must be string, [asset], [asset, package_name] or {asset: ..., package_name: ...}.',
                             $nodeName
                         )
@@ -809,29 +805,31 @@ final class Configuration implements ConfigurationInterface
 
             // Associative form: {asset: ..., package_name: ...}
             if (!isset($item['asset'])) {
-                throw new \InvalidArgumentException(sprintf('The associative "%s" item must contain the "asset" key.', $nodeName));
+                throw new \InvalidArgumentException(\sprintf('The associative "%s" item must contain the "asset" key.', $nodeName));
             }
 
-            $pkg = array_key_exists('package_name', $item) ? $item['package_name'] : self::DEFAULT_PACKAGE;
+            $pkg = \array_key_exists('package_name', $item) ? $item['package_name'] : self::DEFAULT_PACKAGE;
 
             return [
-                'asset'        => (string)$item['asset'],
-                'package_name' => $pkg === null ? null : (string) $pkg,
+                'asset' => (string) $item['asset'],
+                'package_name' => null === $pkg ? null : (string) $pkg,
             ];
         }
 
-        throw new \InvalidArgumentException(sprintf('Invalid "%s" item type.', $nodeName));
+        throw new \InvalidArgumentException(\sprintf('Invalid "%s" item type.', $nodeName));
     }
 
     /**
      * Helper to build normalized defaults from a list of asset strings.
+     *
      * @param array<int, string> $assets
+     *
      * @return list<SonataAdminAsset>
      */
     private static function normalizeDefaultAssets(array $assets): array
     {
-        return array_map(static fn(string $asset) => [
-            'asset'        => $asset,
+        return array_map(static fn (string $asset) => [
+            'asset' => $asset,
             'package_name' => self::DEFAULT_PACKAGE,
         ], $assets);
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -55,14 +55,18 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  *     use_select2: bool,
  *     use_stickyforms: bool,
  * }
+ * @phpstan-type SonataAdminAsset = array{
+ *     asset: string,
+ *     package_name: string,
+ * }
  * @phpstan-type SonataAdminConfiguration = array{
  *     assets: array{
- *         extra_javascripts: list<string>,
- *         extra_stylesheets: list<string>,
- *         javascripts: list<string>,
+ *         extra_javascripts: list<SonataAdminAsset>,
+ *         extra_stylesheets: list<SonataAdminAsset>,
+ *         javascripts: list<SonataAdminAsset>,
  *         remove_javascripts: list<string>,
  *         remove_stylesheets: list<string>,
- *         stylesheets: list<string>,
+ *         stylesheets: list<SonataAdminAsset>,
  *     },
  *     breadcrumbs: array{
  *         child_admin_route: string,
@@ -172,6 +176,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 final class Configuration implements ConfigurationInterface
 {
+    private const DEFAULT_PACKAGE = 'sonata_admin';
+
     /**
      * @psalm-suppress UndefinedInterfaceMethod
      *
@@ -615,16 +621,32 @@ final class Configuration implements ConfigurationInterface
                     ->addDefaultsIfNotSet()
                     ->children()
                         ->arrayNode('stylesheets')
-                            ->defaultValue([
+                            ->beforeNormalization()
+                                ->always(fn ($value) => self::normalizeAssetList($value, 'stylesheets'))
+                            ->end()
+                            ->arrayPrototype()
+                                ->children()
+                                    ->scalarNode('asset')->isRequired()->cannotBeEmpty()->end()
+                                    ->scalarNode('package_name')->defaultValue(self::DEFAULT_PACKAGE)->end()
+                                ->end()
+                            ->end()
+                            ->defaultValue(self::normalizeDefaultAssets([
                                 'bundles/sonataadmin/app.css',
                                 'bundles/sonataform/app.css',
-                            ])
-                            ->prototype('scalar')->end()
+                            ]))
                         ->end()
                         ->arrayNode('extra_stylesheets')
                             ->info('stylesheets to add to the page')
+                            ->beforeNormalization()
+                                ->always(fn ($value) => self::normalizeAssetList($value, 'stylesheets'))
+                            ->end()
+                            ->arrayPrototype()
+                                ->children()
+                                    ->scalarNode('asset')->isRequired()->cannotBeEmpty()->end()
+                                    ->scalarNode('package_name')->defaultValue(self::DEFAULT_PACKAGE)->end()
+                                ->end()
+                            ->end()
                             ->defaultValue([])
-                            ->prototype('scalar')->end()
                         ->end()
                         ->arrayNode('remove_stylesheets')
                             ->info('stylesheets to remove from the page')
@@ -632,16 +654,32 @@ final class Configuration implements ConfigurationInterface
                             ->prototype('scalar')->end()
                         ->end()
                         ->arrayNode('javascripts')
-                            ->defaultValue([
+                            ->beforeNormalization()
+                                ->always(fn ($value) => self::normalizeAssetList($value, 'stylesheets'))
+                            ->end()
+                            ->defaultValue(self::normalizeDefaultAssets([
                                 'bundles/sonataadmin/app.js',
                                 'bundles/sonataform/app.js',
-                            ])
-                            ->prototype('scalar')->end()
+                            ]))
+                            ->arrayPrototype()
+                                ->children()
+                                    ->scalarNode('asset')->isRequired()->cannotBeEmpty()->end()
+                                    ->scalarNode('package_name')->defaultValue(self::DEFAULT_PACKAGE)->end()
+                                ->end()
+                            ->end()
                         ->end()
                         ->arrayNode('extra_javascripts')
                             ->info('javascripts to add to the page')
+                            ->beforeNormalization()
+                                ->always(fn ($value) => self::normalizeAssetList($value, 'stylesheets'))
+                            ->end()
                             ->defaultValue([])
-                            ->prototype('scalar')->end()
+                            ->arrayPrototype()
+                                ->children()
+                                    ->scalarNode('asset')->isRequired()->cannotBeEmpty()->end()
+                                    ->scalarNode('package_name')->defaultValue(self::DEFAULT_PACKAGE)->end()
+                                ->end()
+                            ->end()
                         ->end()
                         ->arrayNode('remove_javascripts')
                             ->info('javascripts to remove from the page')
@@ -711,5 +749,90 @@ final class Configuration implements ConfigurationInterface
         ->end();
 
         return $treeBuilder;
+    }
+
+    /**
+     * Normalizes an asset list node to an array of items with shape:
+     *   [ ['asset' => string, 'package_name' => string], ... ]
+     * Supports input elements as string, positional array [asset] or [asset, package_name],
+     * or associative array {asset: ..., package_name: ...}.
+     *
+     * @param mixed $value
+     * @param string $nodeName
+     * @return list<SonataAdminAsset>
+     */
+    private static function normalizeAssetList(mixed $value, string $nodeName): array
+    {
+        if (null === $value) {
+            return [];
+        }
+
+        if (!\is_array($value)) {
+            throw new \InvalidArgumentException(sprintf('The "%s" node must be an array.', $nodeName));
+        }
+
+        return \array_map(static fn ($item) => self::normalizeAssetItem($item, $nodeName), $value);
+    }
+
+    /**
+     * @param mixed $item
+     * @param string $nodeName
+     * @return SonataAdminAsset
+     */
+    private static function normalizeAssetItem(mixed $item, string $nodeName): array
+    {
+        // 1) Simple string form
+        if (\is_string($item)) {
+            return [
+                'asset'        => $item,
+                'package_name' => self::DEFAULT_PACKAGE,
+            ];
+        }
+
+        // 2) Array forms
+        if (\is_array($item)) {
+            // Positional short form: [asset] or [asset, package_name]
+            if (\array_is_list($item)) {
+                return match (\count($item)) {
+                    2       => [
+                        'asset'        => (string)$item[0],
+                        'package_name' => $item[1] === null ? null : (string) $item[1],
+                    ],
+                    default => throw new \InvalidArgumentException(
+                        sprintf(
+                            'Each "%s" item must be string, [asset], [asset, package_name] or {asset: ..., package_name: ...}.',
+                            $nodeName
+                        )
+                    ),
+                };
+            }
+
+            // Associative form: {asset: ..., package_name: ...}
+            if (!isset($item['asset'])) {
+                throw new \InvalidArgumentException(sprintf('The associative "%s" item must contain the "asset" key.', $nodeName));
+            }
+
+            $pkg = array_key_exists('package_name', $item) ? $item['package_name'] : self::DEFAULT_PACKAGE;
+
+            return [
+                'asset'        => (string)$item['asset'],
+                'package_name' => $pkg === null ? null : (string) $pkg,
+            ];
+        }
+
+        throw new \InvalidArgumentException(sprintf('Invalid "%s" item type.', $nodeName));
+    }
+
+    /**
+     * Helper to build normalized defaults from a list of asset strings.
+     * @param array<int, string> $assets
+     * @return list<SonataAdminAsset>
+     */
+    private static function normalizeDefaultAssets(array $assets): array
+    {
+        return array_map(static fn(string $asset) => [
+            'asset'        => $asset,
+            'package_name' => self::DEFAULT_PACKAGE,
+        ], $assets);
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -754,8 +754,7 @@ final class Configuration implements ConfigurationInterface
     /**
      * Normalizes an asset list node to an array of items with shape:
      *   [ ['path' => string, 'package_name' => string], ... ]
-     * Supports input elements as string, positional array [asset, package_name],
-     * or associative array {asset: ..., package_name: ...}.
+     * Supports input elements as string or associative array {path: ..., package_name: ...}.
      *
      * @param array<mixed> $value
      *
@@ -787,38 +786,23 @@ final class Configuration implements ConfigurationInterface
             ];
         }
 
-        // 2) Array forms
+        // 2) Associative form: {path: ..., package_name: ...}
         if (\is_array($item)) {
-            // Positional form: [path, package_name]
-            if (array_is_list($item)) {
-                return match (\count($item)) {
-                    2 => [
-                        'path' => (string) $item[0],
-                        'package_name' => null === $item[1] ? null : (string) $item[1],
-                    ],
-                    default => throw new \InvalidArgumentException(
-                        \sprintf(
-                            'Each "%s" item must be string, [path], [path, package_name] or {path: ..., package_name: ...}.',
-                            $nodeName
-                        )
-                    ),
-                };
+            if (!\array_key_exists('path', $item) || !\array_key_exists('package_name', $item)) {
+                throw new \InvalidArgumentException(\sprintf('The "%s" item with array form must contain the "path" and "package_name" keys.', $nodeName));
             }
 
-            // Associative form: {path: ..., package_name: ...}
-            if (!isset($item['path'])) {
-                throw new \InvalidArgumentException(\sprintf('The associative "%s" item must contain the "path" key.', $nodeName));
+            if (null === $item['path']) {
+                throw new \InvalidArgumentException(\sprintf('The "path" key of the "%s" item can not be null.', $nodeName));
             }
-
-            $pkg = \array_key_exists('package_name', $item) ? $item['package_name'] : self::DEFAULT_PACKAGE;
 
             return [
                 'path' => (string) $item['path'],
-                'package_name' => null === $pkg ? null : (string) $pkg,
+                'package_name' => null === $item['package_name'] ? null : (string) $item['package_name'],
             ];
         }
 
-        throw new \InvalidArgumentException(\sprintf('Invalid "%s" item type.', $nodeName));
+        throw new \InvalidArgumentException(\sprintf('Invalid "%s" item type. String or associative array are allowed.', $nodeName));
     }
 
     /**

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -57,7 +57,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  * }
  * @phpstan-type SonataAdminAsset = array{
  *     asset: string,
- *     package_name: string,
+ *     package_name: string|null,
  * }
  * @phpstan-type SonataAdminConfiguration = array{
  *     assets: array{
@@ -757,6 +757,8 @@ final class Configuration implements ConfigurationInterface
      * Supports input elements as string, positional array [asset, package_name],
      * or associative array {asset: ..., package_name: ...}.
      *
+     * @param list<mixed> $value
+     *
      * @return list<SonataAdminAsset>
      */
     private static function normalizeAssetList(mixed $value, string $nodeName): array
@@ -769,7 +771,7 @@ final class Configuration implements ConfigurationInterface
             throw new \InvalidArgumentException(\sprintf('The "%s" node must be an array.', $nodeName));
         }
 
-        return array_map(static fn ($item) => self::normalizeAssetItem($item, $nodeName), $value);
+        return array_values(array_map(static fn ($item) => self::normalizeAssetItem($item, $nodeName), $value));
     }
 
     /**
@@ -828,9 +830,11 @@ final class Configuration implements ConfigurationInterface
      */
     private static function normalizeDefaultAssets(array $assets): array
     {
-        return array_map(static fn (string $asset) => [
-            'asset' => $asset,
-            'package_name' => self::DEFAULT_PACKAGE,
-        ], $assets);
+        return array_values(
+            array_map(static fn (string $asset) => [
+                'asset' => $asset,
+                'package_name' => self::DEFAULT_PACKAGE,
+            ], $assets)
+        );
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -638,7 +638,7 @@ final class Configuration implements ConfigurationInterface
                         ->arrayNode('extra_stylesheets')
                             ->info('stylesheets to add to the page')
                             ->beforeNormalization()
-                                ->always(static fn (array $value) => self::normalizeAssetList($value, 'stylesheets'))
+                                ->always(static fn (array $value) => self::normalizeAssetList($value, 'extra_stylesheets'))
                             ->end()
                             ->arrayPrototype()
                                 ->children()
@@ -655,7 +655,7 @@ final class Configuration implements ConfigurationInterface
                         ->end()
                         ->arrayNode('javascripts')
                             ->beforeNormalization()
-                                ->always(static fn (array $value) => self::normalizeAssetList($value, 'stylesheets'))
+                                ->always(static fn (array $value) => self::normalizeAssetList($value, 'javascripts'))
                             ->end()
                             ->defaultValue(self::normalizeDefaultAssets([
                                 'bundles/sonataadmin/app.js',
@@ -671,7 +671,7 @@ final class Configuration implements ConfigurationInterface
                         ->arrayNode('extra_javascripts')
                             ->info('javascripts to add to the page')
                             ->beforeNormalization()
-                                ->always(static fn (array $value) => self::normalizeAssetList($value, 'stylesheets'))
+                                ->always(static fn (array $value) => self::normalizeAssetList($value, 'extra_javascripts'))
                             ->end()
                             ->defaultValue([])
                             ->arrayPrototype()
@@ -789,7 +789,7 @@ final class Configuration implements ConfigurationInterface
         // 2) Associative form: {path: ..., package_name: ...}
         if (\is_array($item)) {
             if (!\array_key_exists('path', $item) || !\array_key_exists('package_name', $item)) {
-                throw new \InvalidArgumentException(\sprintf('The "%s" item with array form must contain the "path" and "package_name" keys.', $nodeName));
+                throw new \InvalidArgumentException(\sprintf('The "%s" item with array form must contain the "path" and the "package_name" keys.', $nodeName));
             }
 
             if (null === $item['path']) {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -56,7 +56,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  *     use_stickyforms: bool,
  * }
  * @phpstan-type SonataAdminAsset = array{
- *     asset: string,
+ *     path: string,
  *     package_name: string|null,
  * }
  * @phpstan-type SonataAdminConfiguration = array{
@@ -626,7 +626,7 @@ final class Configuration implements ConfigurationInterface
                             ->end()
                             ->arrayPrototype()
                                 ->children()
-                                    ->scalarNode('asset')->isRequired()->cannotBeEmpty()->end()
+                                    ->scalarNode('path')->isRequired()->cannotBeEmpty()->end()
                                     ->scalarNode('package_name')->defaultValue(self::DEFAULT_PACKAGE)->end()
                                 ->end()
                             ->end()
@@ -642,7 +642,7 @@ final class Configuration implements ConfigurationInterface
                             ->end()
                             ->arrayPrototype()
                                 ->children()
-                                    ->scalarNode('asset')->isRequired()->cannotBeEmpty()->end()
+                                    ->scalarNode('path')->isRequired()->cannotBeEmpty()->end()
                                     ->scalarNode('package_name')->defaultValue(self::DEFAULT_PACKAGE)->end()
                                 ->end()
                             ->end()
@@ -663,7 +663,7 @@ final class Configuration implements ConfigurationInterface
                             ]))
                             ->arrayPrototype()
                                 ->children()
-                                    ->scalarNode('asset')->isRequired()->cannotBeEmpty()->end()
+                                    ->scalarNode('path')->isRequired()->cannotBeEmpty()->end()
                                     ->scalarNode('package_name')->defaultValue(self::DEFAULT_PACKAGE)->end()
                                 ->end()
                             ->end()
@@ -676,7 +676,7 @@ final class Configuration implements ConfigurationInterface
                             ->defaultValue([])
                             ->arrayPrototype()
                                 ->children()
-                                    ->scalarNode('asset')->isRequired()->cannotBeEmpty()->end()
+                                    ->scalarNode('path')->isRequired()->cannotBeEmpty()->end()
                                     ->scalarNode('package_name')->defaultValue(self::DEFAULT_PACKAGE)->end()
                                 ->end()
                             ->end()
@@ -753,7 +753,7 @@ final class Configuration implements ConfigurationInterface
 
     /**
      * Normalizes an asset list node to an array of items with shape:
-     *   [ ['asset' => string, 'package_name' => string], ... ]
+     *   [ ['path' => string, 'package_name' => string], ... ]
      * Supports input elements as string, positional array [asset, package_name],
      * or associative array {asset: ..., package_name: ...}.
      *
@@ -782,38 +782,38 @@ final class Configuration implements ConfigurationInterface
         // 1) Simple string form
         if (\is_string($item)) {
             return [
-                'asset' => $item,
+                'path' => $item,
                 'package_name' => self::DEFAULT_PACKAGE,
             ];
         }
 
         // 2) Array forms
         if (\is_array($item)) {
-            // Positional form: [asset, package_name]
+            // Positional form: [path, package_name]
             if (array_is_list($item)) {
                 return match (\count($item)) {
                     2 => [
-                        'asset' => (string) $item[0],
+                        'path' => (string) $item[0],
                         'package_name' => null === $item[1] ? null : (string) $item[1],
                     ],
                     default => throw new \InvalidArgumentException(
                         \sprintf(
-                            'Each "%s" item must be string, [asset], [asset, package_name] or {asset: ..., package_name: ...}.',
+                            'Each "%s" item must be string, [path], [path, package_name] or {path: ..., package_name: ...}.',
                             $nodeName
                         )
                     ),
                 };
             }
 
-            // Associative form: {asset: ..., package_name: ...}
-            if (!isset($item['asset'])) {
-                throw new \InvalidArgumentException(\sprintf('The associative "%s" item must contain the "asset" key.', $nodeName));
+            // Associative form: {path: ..., package_name: ...}
+            if (!isset($item['path'])) {
+                throw new \InvalidArgumentException(\sprintf('The associative "%s" item must contain the "path" key.', $nodeName));
             }
 
             $pkg = \array_key_exists('package_name', $item) ? $item['package_name'] : self::DEFAULT_PACKAGE;
 
             return [
-                'asset' => (string) $item['asset'],
+                'path' => (string) $item['path'],
                 'package_name' => null === $pkg ? null : (string) $pkg,
             ];
         }
@@ -832,7 +832,7 @@ final class Configuration implements ConfigurationInterface
     {
         return array_values(
             array_map(static fn (string $asset) => [
-                'asset' => $asset,
+                'path' => $asset,
                 'package_name' => self::DEFAULT_PACKAGE,
             ], $assets)
         );

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -91,7 +91,7 @@ final class SonataAdminExtension extends Extension
         $javascript = $this->buildJavascripts($config);
 
         $config['assets']['stylesheets'][] = [
-            'asset' => \sprintf(
+            'path' => \sprintf(
                 'bundles/sonataadmin/admin-lte-skins/%s.min.css',
                 $config['options']['skin']
             ),
@@ -276,7 +276,7 @@ final class SonataAdminExtension extends Extension
         }
         foreach ($removeArray as $toRemove) {
             foreach ($array as $i => $item) {
-                if ($item['asset'] === $toRemove) {
+                if ($item['path'] === $toRemove) {
                     array_splice($array, $i, 1);
                     break;
                 }

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -91,7 +91,7 @@ final class SonataAdminExtension extends Extension
         $javascript = $this->buildJavascripts($config);
 
         $config['assets']['stylesheets'][] = [
-            'asset'        => \sprintf(
+            'asset' => \sprintf(
                 'bundles/sonataadmin/admin-lte-skins/%s.min.css',
                 $config['options']['skin']
             ),
@@ -265,7 +265,7 @@ final class SonataAdminExtension extends Extension
     /**
      * @param array<int, SonataAdminAsset> $array
      * @param array<int, SonataAdminAsset> $addArray
-     * @param array<int, string> $removeArray
+     * @param array<int, string>           $removeArray
      *
      * @return array<int, SonataAdminAsset>
      */
@@ -277,7 +277,7 @@ final class SonataAdminExtension extends Extension
         foreach ($removeArray as $toRemove) {
             foreach ($array as $i => $item) {
                 if ($item['asset'] === $toRemove) {
-                    \array_splice($array, $i, 1);
+                    array_splice($array, $i, 1);
                     break;
                 }
             }

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -36,6 +36,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType as SymfonyTextType;
  * @author Michael Williams <michael.williams@funsational.com>
  *
  * @phpstan-import-type SonataAdminConfiguration from Configuration
+ * @phpstan-import-type SonataAdminAsset from Configuration
  */
 final class SonataAdminExtension extends Extension
 {
@@ -89,10 +90,14 @@ final class SonataAdminExtension extends Extension
 
         $javascript = $this->buildJavascripts($config);
 
-        $config['assets']['stylesheets'][] = \sprintf(
-            'bundles/sonataadmin/admin-lte-skins/%s.min.css',
-            $config['options']['skin']
-        );
+        $config['assets']['stylesheets'][] = [
+            'asset'        => \sprintf(
+                'bundles/sonataadmin/admin-lte-skins/%s.min.css',
+                $config['options']['skin']
+            ),
+            'package_name' => 'sonata_admin',
+        ];
+
         $stylesheet = $this->buildStylesheets($config);
 
         $config['options']['javascripts'] = $javascript;
@@ -228,7 +233,7 @@ final class SonataAdminExtension extends Extension
     /**
      * @param array<string, mixed> $config
      *
-     * @return string[]
+     * @return SonataAdminAsset[]
      *
      * @phpstan-param SonataAdminConfiguration $config
      */
@@ -244,7 +249,7 @@ final class SonataAdminExtension extends Extension
     /**
      * @param array<string, mixed> $config
      *
-     * @return string[]
+     * @return SonataAdminAsset[]
      *
      * @phpstan-param SonataAdminConfiguration $config
      */
@@ -258,11 +263,11 @@ final class SonataAdminExtension extends Extension
     }
 
     /**
-     * @param array<int, string> $array
-     * @param array<int, string> $addArray
+     * @param array<int, SonataAdminAsset> $array
+     * @param array<int, SonataAdminAsset> $addArray
      * @param array<int, string> $removeArray
      *
-     * @return array<int, string>
+     * @return array<int, SonataAdminAsset>
      */
     private function mergeArray(array $array, array $addArray, array $removeArray = []): array
     {
@@ -270,9 +275,11 @@ final class SonataAdminExtension extends Extension
             $array[] = $toAdd;
         }
         foreach ($removeArray as $toRemove) {
-            $key = array_search($toRemove, $array, true);
-            if (false !== $key) {
-                array_splice($array, $key, 1);
+            foreach ($array as $i => $item) {
+                if ($item['asset'] === $toRemove) {
+                    \array_splice($array, $i, 1);
+                    break;
+                }
             }
         }
 

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -50,7 +50,7 @@ file that was distributed with this source code.
 
         {% block stylesheets %}
             {% for stylesheet in sonata_config.getOption('stylesheets', []) %}
-                <link rel="stylesheet" href="{{ asset(stylesheet, 'sonata_admin') }}">
+                <link rel="stylesheet" href="{{ asset(stylesheet.asset, stylesheet.package_name) }}">
             {% endfor %}
         {% endblock %}
 
@@ -60,7 +60,7 @@ file that was distributed with this source code.
 
             {% block sonata_javascript_pool %}
                 {% for javascript in sonata_config.getOption('javascripts', []) %}
-                    <script src="{{ asset(javascript, 'sonata_admin') }}"></script>
+                    <script src="{{ asset(javascript.asset, javascript.package_name) }}"></script>
                 {% endfor %}
             {% endblock %}
 

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -50,7 +50,7 @@ file that was distributed with this source code.
 
         {% block stylesheets %}
             {% for stylesheet in sonata_config.getOption('stylesheets', []) %}
-                <link rel="stylesheet" href="{{ asset(stylesheet.asset, stylesheet.package_name) }}">
+                <link rel="stylesheet" href="{{ asset(stylesheet.path, stylesheet.package_name) }}">
             {% endfor %}
         {% endblock %}
 
@@ -60,7 +60,7 @@ file that was distributed with this source code.
 
             {% block sonata_javascript_pool %}
                 {% for javascript in sonata_config.getOption('javascripts', []) %}
-                    <script src="{{ asset(javascript.asset, javascript.package_name) }}"></script>
+                    <script src="{{ asset(javascript.path, javascript.package_name) }}"></script>
                 {% endfor %}
             {% endblock %}
 

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -248,7 +248,7 @@ final class ConfigurationTest extends TestCase
         static::assertSame([], $config['assets']['remove_javascripts']);
     }
 
-    public function testNormalizationForAllNodes(): void
+    public function testNormalizationForAssetNodes(): void
     {
         $config = $this->process([[
             'assets' => [
@@ -276,6 +276,51 @@ final class ConfigurationTest extends TestCase
             ['path' => 'bar.js', 'package_name' => 'pkg'],
             ['path' => 'baz.js', 'package_name' => null],
         ], $config['assets']['extra_javascripts']);
+    }
+
+    public function testAssetWithWrongType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid "stylesheets" item type. String or associative array are allowed.');
+
+        $this->process([[
+            'assets' => [
+                'stylesheets' => [
+                    'foo.css',
+                    null,
+                ],
+            ],
+        ]]);
+    }
+
+    public function testAssetWithNullPath(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "path" key of the "extra_stylesheets" item can not be null.');
+
+        $this->process([[
+            'assets' => [
+                'extra_stylesheets' => [
+                    'foo.css',
+                    ['path' => null, 'package_name' => 'pkg'],
+                    ['path' => 'bar.css', 'package_name' => null],
+                ],
+            ],
+        ]]);
+    }
+
+    public function testAssetWithNoPackageName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "javascripts" item with array form must contain the "path" and the "package_name" keys.');
+
+        $this->process([[
+            'assets' => [
+                'javascripts' => [
+                    ['path' => 'bar.js'],
+                ],
+            ],
+        ]]);
     }
 
     public function testDefaultControllerIsCRUDController(): void

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -263,18 +263,18 @@ final class ConfigurationTest extends TestCase
                     ['bar.js', 'pkg'],
                     ['baz.js', null],
                     ['asset' => 'zap.js', 'package_name' => null],
-                ]
-            ]
+                ],
+            ],
         ]]);
 
-        self::assertSame([
+        static::assertSame([
             ['asset' => 'foo.css', 'package_name' => 'sonata_admin'],
             ['asset' => 'bar.css', 'package_name' => 'pkg'],
             ['asset' => 'baz.css', 'package_name' => null],
             ['asset' => 'zap.css', 'package_name' => null],
         ], $config['assets']['extra_stylesheets']);
 
-        self::assertSame([
+        static::assertSame([
             ['asset' => 'foo.js', 'package_name' => 'sonata_admin'],
             ['asset' => 'bar.js', 'package_name' => 'pkg'],
             ['asset' => 'baz.js', 'package_name' => null],

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -254,15 +254,13 @@ final class ConfigurationTest extends TestCase
             'assets' => [
                 'extra_stylesheets' => [
                     'foo.css',
-                    ['bar.css', 'pkg'],
-                    ['baz.css', null],
-                    ['path' => 'zap.css', 'package_name' => null],
+                    ['path' => 'bar.css', 'package_name' => 'pkg'],
+                    ['path' => 'baz.css', 'package_name' => null],
                 ],
                 'extra_javascripts' => [
                     'foo.js',
-                    ['bar.js', 'pkg'],
-                    ['baz.js', null],
-                    ['path' => 'zap.js', 'package_name' => null],
+                    ['path' => 'bar.js', 'package_name' => 'pkg'],
+                    ['path' => 'baz.js', 'package_name' => null],
                 ],
             ],
         ]]);
@@ -271,14 +269,12 @@ final class ConfigurationTest extends TestCase
             ['path' => 'foo.css', 'package_name' => 'sonata_admin'],
             ['path' => 'bar.css', 'package_name' => 'pkg'],
             ['path' => 'baz.css', 'package_name' => null],
-            ['path' => 'zap.css', 'package_name' => null],
         ], $config['assets']['extra_stylesheets']);
 
         static::assertSame([
             ['path' => 'foo.js', 'package_name' => 'sonata_admin'],
             ['path' => 'bar.js', 'package_name' => 'pkg'],
             ['path' => 'baz.js', 'package_name' => null],
-            ['path' => 'zap.js', 'package_name' => null],
         ], $config['assets']['extra_javascripts']);
     }
 

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -256,29 +256,29 @@ final class ConfigurationTest extends TestCase
                     'foo.css',
                     ['bar.css', 'pkg'],
                     ['baz.css', null],
-                    ['asset' => 'zap.css', 'package_name' => null],
+                    ['path' => 'zap.css', 'package_name' => null],
                 ],
                 'extra_javascripts' => [
                     'foo.js',
                     ['bar.js', 'pkg'],
                     ['baz.js', null],
-                    ['asset' => 'zap.js', 'package_name' => null],
+                    ['path' => 'zap.js', 'package_name' => null],
                 ],
             ],
         ]]);
 
         static::assertSame([
-            ['asset' => 'foo.css', 'package_name' => 'sonata_admin'],
-            ['asset' => 'bar.css', 'package_name' => 'pkg'],
-            ['asset' => 'baz.css', 'package_name' => null],
-            ['asset' => 'zap.css', 'package_name' => null],
+            ['path' => 'foo.css', 'package_name' => 'sonata_admin'],
+            ['path' => 'bar.css', 'package_name' => 'pkg'],
+            ['path' => 'baz.css', 'package_name' => null],
+            ['path' => 'zap.css', 'package_name' => null],
         ], $config['assets']['extra_stylesheets']);
 
         static::assertSame([
-            ['asset' => 'foo.js', 'package_name' => 'sonata_admin'],
-            ['asset' => 'bar.js', 'package_name' => 'pkg'],
-            ['asset' => 'baz.js', 'package_name' => null],
-            ['asset' => 'zap.js', 'package_name' => null],
+            ['path' => 'foo.js', 'package_name' => 'sonata_admin'],
+            ['path' => 'bar.js', 'package_name' => 'pkg'],
+            ['path' => 'baz.js', 'package_name' => null],
+            ['path' => 'zap.js', 'package_name' => null],
         ], $config['assets']['extra_javascripts']);
     }
 

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -248,6 +248,40 @@ final class ConfigurationTest extends TestCase
         static::assertSame([], $config['assets']['remove_javascripts']);
     }
 
+    public function testNormalizationForAllNodes(): void
+    {
+        $config = $this->process([[
+            'assets' => [
+                'extra_stylesheets' => [
+                    'foo.css',
+                    ['bar.css', 'pkg'],
+                    ['baz.css', null],
+                    ['asset' => 'zap.css', 'package_name' => null],
+                ],
+                'extra_javascripts' => [
+                    'foo.js',
+                    ['bar.js', 'pkg'],
+                    ['baz.js', null],
+                    ['asset' => 'zap.js', 'package_name' => null],
+                ]
+            ]
+        ]]);
+
+        self::assertSame([
+            ['asset' => 'foo.css', 'package_name' => 'sonata_admin'],
+            ['asset' => 'bar.css', 'package_name' => 'pkg'],
+            ['asset' => 'baz.css', 'package_name' => null],
+            ['asset' => 'zap.css', 'package_name' => null],
+        ], $config['assets']['extra_stylesheets']);
+
+        self::assertSame([
+            ['asset' => 'foo.js', 'package_name' => 'sonata_admin'],
+            ['asset' => 'bar.js', 'package_name' => 'pkg'],
+            ['asset' => 'baz.js', 'package_name' => null],
+            ['asset' => 'zap.js', 'package_name' => null],
+        ], $config['assets']['extra_javascripts']);
+    }
+
     public function testDefaultControllerIsCRUDController(): void
     {
         $config = $this->process([]);

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -113,7 +113,20 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
     {
         $this->container->setParameter('kernel.bundles', []);
 
-        $extraStylesheets = ['foo/bar.css', 'bar/quux.css'];
+        $extraStylesheets = [
+            'foo/bar.css',
+            'bar/quux.css',
+            ['foo/bazz.css', 'another_package'],
+            ['bar/asd.css', null],
+        ];
+
+        $extraStylesheetsNormalized = [
+            ['asset' => 'foo/bar.css', 'package_name' => 'sonata_admin'],
+            ['asset' => 'bar/quux.css', 'package_name' => 'sonata_admin'],
+            ['asset' => 'foo/bazz.css', 'package_name' => 'another_package'],
+            ['asset' => 'bar/asd.css', 'package_name' =>  null],
+        ];
+
         $this->load([
             'assets' => [
                 'extra_stylesheets' => $extraStylesheets,
@@ -125,7 +138,7 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
 
         $stylesheets = $options['stylesheets'];
         static::assertSame(
-            array_merge($this->getDefaultStylesheets(), $extraStylesheets),
+            array_merge($this->getDefaultStylesheets(), $extraStylesheetsNormalized),
             $stylesheets
         );
     }
@@ -147,18 +160,36 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
         static::assertIsArray($options);
 
         $stylesheets = $options['stylesheets'];
-        static::assertSame(
-            array_values(
-                array_diff($this->defaultConfiguration['assets']['stylesheets'], $removeStylesheets)
-            ),
-            $stylesheets
+        static::assertIsArray($stylesheets);
+
+        $expected = array_values(
+            array_filter(
+                $this->defaultConfiguration['assets']['stylesheets'],
+                static fn(array $item) => !in_array($item['asset'], $removeStylesheets, true)
+            )
         );
+
+        static::assertSame($expected, $stylesheets);
     }
 
     public function testExtraJavascriptsGetAdded(): void
     {
         $this->container->setParameter('kernel.bundles', []);
-        $extraJavascripts = ['foo/bar.js', 'bar/quux.js'];
+
+        $extraJavascripts = [
+            'foo/bar.js',
+            'bar/quux.js',
+            ['foo/bazz.js', 'another_package'],
+            ['bar/asd.js', null],
+        ];
+
+        $extraJavascriptsNormalized = [
+            ['asset' => 'foo/bar.js', 'package_name' => 'sonata_admin'],
+            ['asset' => 'bar/quux.js', 'package_name' => 'sonata_admin'],
+            ['asset' => 'foo/bazz.js', 'package_name' => 'another_package'],
+            ['asset' => 'bar/asd.js', 'package_name' =>  null],
+        ];
+
         $this->load([
             'assets' => [
                 'extra_javascripts' => $extraJavascripts,
@@ -170,7 +201,7 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
 
         $javascripts = $options['javascripts'];
         static::assertSame(
-            [...$this->defaultConfiguration['assets']['javascripts'], ...$extraJavascripts],
+            [...$this->defaultConfiguration['assets']['javascripts'], ...$extraJavascriptsNormalized],
             $javascripts
         );
     }
@@ -191,19 +222,45 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
         static::assertIsArray($options);
 
         $javascripts = $options['javascripts'];
-        static::assertSame(
-            array_values(
-                array_diff($this->defaultConfiguration['assets']['javascripts'], $removeJavascripts)
-            ),
-            $javascripts
+        static::assertIsArray($javascripts);
+
+        $expected = array_values(
+            array_filter(
+                $this->defaultConfiguration['assets']['javascripts'],
+                static fn(array $item) => !in_array($item['asset'], $removeJavascripts, true)
+            )
         );
+
+        static::assertSame($expected, $javascripts);
     }
 
     public function testAssetsCanBeAddedAndRemoved(): void
     {
         $this->container->setParameter('kernel.bundles', []);
-        $extraStylesheets = ['foo/bar.css', 'bar/quux.css'];
-        $extraJavascripts = ['foo/bar.js', 'bar/quux.js'];
+        $extraStylesheets = [
+            'foo/bar.css',
+            'bar/quux.css',
+            ['foo/bazz.css', 'another_package'],
+            ['bar/asd.css', null],
+        ];
+        $extraStylesheetsNormalized = [
+            ['asset' => 'foo/bar.css', 'package_name' => 'sonata_admin'],
+            ['asset' => 'bar/quux.css', 'package_name' => 'sonata_admin'],
+            ['asset' => 'foo/bazz.css', 'package_name' => 'another_package'],
+            ['asset' => 'bar/asd.css', 'package_name' =>  null],
+        ];
+        $extraJavascripts = [
+            'foo/bar.js',
+            'bar/quux.js',
+            ['foo/bazz.js', 'another_package'],
+            ['bar/asd.js', null],
+        ];
+        $extraJavascriptsNormalized = [
+            ['asset' => 'foo/bar.js', 'package_name' => 'sonata_admin'],
+            ['asset' => 'bar/quux.js', 'package_name' => 'sonata_admin'],
+            ['asset' => 'foo/bazz.js', 'package_name' => 'another_package'],
+            ['asset' => 'bar/asd.js', 'package_name' =>  null],
+        ];
         $removeStylesheets = [
             'bundles/sonataadmin/app.css',
             'bundles/sonataadmin/admin-lte-skins/skin-black.min.css',
@@ -224,14 +281,27 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
         static::assertIsArray($options);
 
         $stylesheets = $options['stylesheets'];
+
         static::assertSame(
-            [...array_diff($this->defaultConfiguration['assets']['stylesheets'], $removeStylesheets), ...$extraStylesheets],
+            [
+                ...array_filter(
+                    $this->defaultConfiguration['assets']['stylesheets'],
+                    static fn(array $item) => !in_array($item['asset'], $removeStylesheets, true)
+                ),
+                ...$extraStylesheetsNormalized,
+            ],
             $stylesheets
         );
 
         $javascripts = $options['javascripts'];
         static::assertSame(
-            [...array_diff($this->defaultConfiguration['assets']['javascripts'], $removeJavascripts), ...$extraJavascripts],
+            [
+                ...array_filter(
+                    $this->defaultConfiguration['assets']['javascripts'],
+                    static fn(array $item) => !in_array($item['asset'], $removeJavascripts, true)
+                ),
+                ...$extraJavascriptsNormalized,
+            ],
             $javascripts
         );
     }
@@ -398,10 +468,13 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
         $skin = $options['skin'];
 
         $defaultStylesheets = $this->defaultConfiguration['assets']['stylesheets'];
-        $defaultStylesheets[] = \sprintf(
-            'bundles/sonataadmin/admin-lte-skins/%s.min.css',
-            $skin
-        );
+        $defaultStylesheets[] = [
+            'asset'        => \sprintf(
+                'bundles/sonataadmin/admin-lte-skins/%s.min.css',
+                $skin
+            ),
+            'package_name' => 'sonata_admin',
+        ];
 
         return $defaultStylesheets;
     }

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -32,6 +32,7 @@ use Symfony\Component\Config\Definition\Processor;
 
 /**
  * @phpstan-import-type SonataAdminConfiguration from Configuration
+ * @phpstan-import-type SonataAdminAsset from Configuration
  */
 final class SonataAdminExtensionTest extends AbstractExtensionTestCase
 {
@@ -452,7 +453,7 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
     }
 
     /**
-     * @return string[]
+     * @return list<SonataAdminAsset>
      */
     private function getDefaultStylesheets(?string $skin = 'skin-black'): array
     {

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -117,8 +117,8 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
         $extraStylesheets = [
             'foo/bar.css',
             'bar/quux.css',
-            ['foo/bazz.css', 'another_package'],
-            ['bar/asd.css', null],
+            ['path' => 'foo/bazz.css', 'package_name' => 'another_package'],
+            ['path' => 'bar/asd.css', 'package_name' => null],
         ];
 
         $extraStylesheetsNormalized = [
@@ -180,8 +180,8 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
         $extraJavascripts = [
             'foo/bar.js',
             'bar/quux.js',
-            ['foo/bazz.js', 'another_package'],
-            ['bar/asd.js', null],
+            ['path' => 'foo/bazz.js', 'package_name' => 'another_package'],
+            ['path' => 'bar/asd.js', 'package_name' => null],
         ];
 
         $extraJavascriptsNormalized = [
@@ -241,8 +241,8 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
         $extraStylesheets = [
             'foo/bar.css',
             'bar/quux.css',
-            ['foo/bazz.css', 'another_package'],
-            ['bar/asd.css', null],
+            ['path' => 'foo/bazz.css', 'package_name' => 'another_package'],
+            ['path' => 'bar/asd.css', 'package_name' => null],
         ];
         $extraStylesheetsNormalized = [
             ['path' => 'foo/bar.css', 'package_name' => 'sonata_admin'],
@@ -253,8 +253,8 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
         $extraJavascripts = [
             'foo/bar.js',
             'bar/quux.js',
-            ['foo/bazz.js', 'another_package'],
-            ['bar/asd.js', null],
+            ['path' => 'foo/bazz.js', 'package_name' => 'another_package'],
+            ['path' => 'bar/asd.js', 'package_name' => null],
         ];
         $extraJavascriptsNormalized = [
             ['path' => 'foo/bar.js', 'package_name' => 'sonata_admin'],

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -124,7 +124,7 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
             ['asset' => 'foo/bar.css', 'package_name' => 'sonata_admin'],
             ['asset' => 'bar/quux.css', 'package_name' => 'sonata_admin'],
             ['asset' => 'foo/bazz.css', 'package_name' => 'another_package'],
-            ['asset' => 'bar/asd.css', 'package_name' =>  null],
+            ['asset' => 'bar/asd.css', 'package_name' => null],
         ];
 
         $this->load([
@@ -165,7 +165,7 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
         $expected = array_values(
             array_filter(
                 $this->defaultConfiguration['assets']['stylesheets'],
-                static fn(array $item) => !in_array($item['asset'], $removeStylesheets, true)
+                static fn (array $item) => !\in_array($item['asset'], $removeStylesheets, true)
             )
         );
 
@@ -187,7 +187,7 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
             ['asset' => 'foo/bar.js', 'package_name' => 'sonata_admin'],
             ['asset' => 'bar/quux.js', 'package_name' => 'sonata_admin'],
             ['asset' => 'foo/bazz.js', 'package_name' => 'another_package'],
-            ['asset' => 'bar/asd.js', 'package_name' =>  null],
+            ['asset' => 'bar/asd.js', 'package_name' => null],
         ];
 
         $this->load([
@@ -227,7 +227,7 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
         $expected = array_values(
             array_filter(
                 $this->defaultConfiguration['assets']['javascripts'],
-                static fn(array $item) => !in_array($item['asset'], $removeJavascripts, true)
+                static fn (array $item) => !\in_array($item['asset'], $removeJavascripts, true)
             )
         );
 
@@ -247,7 +247,7 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
             ['asset' => 'foo/bar.css', 'package_name' => 'sonata_admin'],
             ['asset' => 'bar/quux.css', 'package_name' => 'sonata_admin'],
             ['asset' => 'foo/bazz.css', 'package_name' => 'another_package'],
-            ['asset' => 'bar/asd.css', 'package_name' =>  null],
+            ['asset' => 'bar/asd.css', 'package_name' => null],
         ];
         $extraJavascripts = [
             'foo/bar.js',
@@ -259,7 +259,7 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
             ['asset' => 'foo/bar.js', 'package_name' => 'sonata_admin'],
             ['asset' => 'bar/quux.js', 'package_name' => 'sonata_admin'],
             ['asset' => 'foo/bazz.js', 'package_name' => 'another_package'],
-            ['asset' => 'bar/asd.js', 'package_name' =>  null],
+            ['asset' => 'bar/asd.js', 'package_name' => null],
         ];
         $removeStylesheets = [
             'bundles/sonataadmin/app.css',
@@ -286,7 +286,7 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
             [
                 ...array_filter(
                     $this->defaultConfiguration['assets']['stylesheets'],
-                    static fn(array $item) => !in_array($item['asset'], $removeStylesheets, true)
+                    static fn (array $item) => !\in_array($item['asset'], $removeStylesheets, true)
                 ),
                 ...$extraStylesheetsNormalized,
             ],
@@ -298,7 +298,7 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
             [
                 ...array_filter(
                     $this->defaultConfiguration['assets']['javascripts'],
-                    static fn(array $item) => !in_array($item['asset'], $removeJavascripts, true)
+                    static fn (array $item) => !\in_array($item['asset'], $removeJavascripts, true)
                 ),
                 ...$extraJavascriptsNormalized,
             ],
@@ -469,7 +469,7 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
 
         $defaultStylesheets = $this->defaultConfiguration['assets']['stylesheets'];
         $defaultStylesheets[] = [
-            'asset'        => \sprintf(
+            'asset' => \sprintf(
                 'bundles/sonataadmin/admin-lte-skins/%s.min.css',
                 $skin
             ),

--- a/tests/DependencyInjection/SonataAdminExtensionTest.php
+++ b/tests/DependencyInjection/SonataAdminExtensionTest.php
@@ -122,10 +122,10 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
         ];
 
         $extraStylesheetsNormalized = [
-            ['asset' => 'foo/bar.css', 'package_name' => 'sonata_admin'],
-            ['asset' => 'bar/quux.css', 'package_name' => 'sonata_admin'],
-            ['asset' => 'foo/bazz.css', 'package_name' => 'another_package'],
-            ['asset' => 'bar/asd.css', 'package_name' => null],
+            ['path' => 'foo/bar.css', 'package_name' => 'sonata_admin'],
+            ['path' => 'bar/quux.css', 'package_name' => 'sonata_admin'],
+            ['path' => 'foo/bazz.css', 'package_name' => 'another_package'],
+            ['path' => 'bar/asd.css', 'package_name' => null],
         ];
 
         $this->load([
@@ -166,7 +166,7 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
         $expected = array_values(
             array_filter(
                 $this->defaultConfiguration['assets']['stylesheets'],
-                static fn (array $item) => !\in_array($item['asset'], $removeStylesheets, true)
+                static fn (array $item) => !\in_array($item['path'], $removeStylesheets, true)
             )
         );
 
@@ -185,10 +185,10 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
         ];
 
         $extraJavascriptsNormalized = [
-            ['asset' => 'foo/bar.js', 'package_name' => 'sonata_admin'],
-            ['asset' => 'bar/quux.js', 'package_name' => 'sonata_admin'],
-            ['asset' => 'foo/bazz.js', 'package_name' => 'another_package'],
-            ['asset' => 'bar/asd.js', 'package_name' => null],
+            ['path' => 'foo/bar.js', 'package_name' => 'sonata_admin'],
+            ['path' => 'bar/quux.js', 'package_name' => 'sonata_admin'],
+            ['path' => 'foo/bazz.js', 'package_name' => 'another_package'],
+            ['path' => 'bar/asd.js', 'package_name' => null],
         ];
 
         $this->load([
@@ -228,7 +228,7 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
         $expected = array_values(
             array_filter(
                 $this->defaultConfiguration['assets']['javascripts'],
-                static fn (array $item) => !\in_array($item['asset'], $removeJavascripts, true)
+                static fn (array $item) => !\in_array($item['path'], $removeJavascripts, true)
             )
         );
 
@@ -245,10 +245,10 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
             ['bar/asd.css', null],
         ];
         $extraStylesheetsNormalized = [
-            ['asset' => 'foo/bar.css', 'package_name' => 'sonata_admin'],
-            ['asset' => 'bar/quux.css', 'package_name' => 'sonata_admin'],
-            ['asset' => 'foo/bazz.css', 'package_name' => 'another_package'],
-            ['asset' => 'bar/asd.css', 'package_name' => null],
+            ['path' => 'foo/bar.css', 'package_name' => 'sonata_admin'],
+            ['path' => 'bar/quux.css', 'package_name' => 'sonata_admin'],
+            ['path' => 'foo/bazz.css', 'package_name' => 'another_package'],
+            ['path' => 'bar/asd.css', 'package_name' => null],
         ];
         $extraJavascripts = [
             'foo/bar.js',
@@ -257,10 +257,10 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
             ['bar/asd.js', null],
         ];
         $extraJavascriptsNormalized = [
-            ['asset' => 'foo/bar.js', 'package_name' => 'sonata_admin'],
-            ['asset' => 'bar/quux.js', 'package_name' => 'sonata_admin'],
-            ['asset' => 'foo/bazz.js', 'package_name' => 'another_package'],
-            ['asset' => 'bar/asd.js', 'package_name' => null],
+            ['path' => 'foo/bar.js', 'package_name' => 'sonata_admin'],
+            ['path' => 'bar/quux.js', 'package_name' => 'sonata_admin'],
+            ['path' => 'foo/bazz.js', 'package_name' => 'another_package'],
+            ['path' => 'bar/asd.js', 'package_name' => null],
         ];
         $removeStylesheets = [
             'bundles/sonataadmin/app.css',
@@ -287,7 +287,7 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
             [
                 ...array_filter(
                     $this->defaultConfiguration['assets']['stylesheets'],
-                    static fn (array $item) => !\in_array($item['asset'], $removeStylesheets, true)
+                    static fn (array $item) => !\in_array($item['path'], $removeStylesheets, true)
                 ),
                 ...$extraStylesheetsNormalized,
             ],
@@ -299,7 +299,7 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
             [
                 ...array_filter(
                     $this->defaultConfiguration['assets']['javascripts'],
-                    static fn (array $item) => !\in_array($item['asset'], $removeJavascripts, true)
+                    static fn (array $item) => !\in_array($item['path'], $removeJavascripts, true)
                 ),
                 ...$extraJavascriptsNormalized,
             ],
@@ -470,7 +470,7 @@ final class SonataAdminExtensionTest extends AbstractExtensionTestCase
 
         $defaultStylesheets = $this->defaultConfiguration['assets']['stylesheets'];
         $defaultStylesheets[] = [
-            'asset' => \sprintf(
+            'path' => \sprintf(
                 'bundles/sonataadmin/admin-lte-skins/%s.min.css',
                 $skin
             ),


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

New `package_name` option added to `stylesheets`, `extra_stylesheets`, `javascripts` and `extra_javascripts` assets. `package_name` may be missed and by default it is `sonata_admin`. Theese lines are equivalent:
```
sonata_admin
    assets:
        extra_stylesheets:
            - foo/bar.css
            - { path: foo/bar.css, package_name: sonata_admin }
```

`package_name` can also be null:
```
sonata_admin
    assets:
        extra_stylesheets:
            - { path: bar/bazz.css, package_name: ~ }
```
null `package_name` is useful when you are using e.g. `AssetMapper` component (it can handle all assets from all bundles).

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because there are no BC-breaks.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #8315.

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

```markdown
### Added
- Optional package_name for assets
```

