### PR TITLE
Fix ImmutableArrayType field and it subfields help message are not displayed

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -417,6 +417,8 @@ file that was distributed with this source code.
 
 {% block sonata_type_immutable_array_widget %}
     <div {{ block('widget_container_attributes') }}>
+        {{ form_help(form) }}
+
         {{ form_errors(form) }}
 
         {% for key, child in form %}
@@ -439,6 +441,7 @@ file that was distributed with this source code.
 
         <div class="{{ div_class }} sonata-ba-field sonata-ba-field-{{ sonata_admin.edit }}-{{ sonata_admin.inline }}{% if child.vars.errors|length > 0 %} sonata-ba-field-error{% endif %}">
             {{ form_widget(child, {'horizontal': false, 'horizontal_input_wrapper_class': ''}) }} {# {'horizontal': false, 'horizontal_input_wrapper_class': ''} needed to avoid MopaBootstrapBundle messing with the DOM #}
+            {{ form_help(child) }}
         </div>
 
         {% if child.vars.errors|length > 0 %}


### PR DESCRIPTION
## Subject

Fix ImmutableArrayType field and it subfields helper message are not displayed

I am targeting this branch, because it's a fix.

Closes #8328

## Changelog

```markdown
### Fixed
- `ImmutableArrayType` field and it subfields help message are not displayed
```

## TODO
* add tests

