### PR TITLE
fix ImmutableArrayType field helper message must not displayed twice 

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -416,8 +416,6 @@ file that was distributed with this source code.
 
 {% block sonata_type_immutable_array_widget %}
     <div {{ block('widget_container_attributes') }}>
-        {{ form_help(form) }}
-
         {% for key, child in form %}
             {{ block('sonata_type_immutable_array_widget_row') }}
         {% endfor %}

--- a/tests/App/Admin/FooAdmin.php
+++ b/tests/App/Admin/FooAdmin.php
@@ -75,7 +75,7 @@ class FooAdmin extends AbstractAdmin
                 'elements',
                 ImmutableArrayType::class,
                 [
-                    'help' => 'elements help message',
+                    'help' => 'Elements main field help message',
                     'error_bubbling' => false,
                     'constraints' => [
                         new Collection([
@@ -91,7 +91,7 @@ class FooAdmin extends AbstractAdmin
                             'elements_item',
                             TextType::class,
                             [
-                                'help' => 'elements_item help message',
+                                'help' => 'Elements sub field help message',
                             ],
                         ],
                     ],

--- a/tests/Functional/Controller/CRUDControllerTest.php
+++ b/tests/Functional/Controller/CRUDControllerTest.php
@@ -77,6 +77,36 @@ final class CRUDControllerTest extends WebTestCase
     }
 
     /**
+     * @see https://github.com/sonata-project/SonataAdminBundle/issues/8328
+     */
+    public function testImmutableArrayHelpAttributeIsDisplayed(): void
+    {
+        $client = static::createClient();
+        $crawler = $client->request(Request::METHOD_GET, '/admin/tests/app/foo/create');
+
+        static::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        static::assertCount(
+            1,
+            $crawler->filter('.help-block.sonata-ba-field-help:contains("Elements main field help message")')
+        );
+    }
+
+    /**
+     * @see https://github.com/sonata-project/SonataAdminBundle/issues/8328
+     */
+    public function testImmutableArrayKeysItemHelpAttributeAreDisplayed(): void
+    {
+        $client = static::createClient();
+        $crawler = $client->request(Request::METHOD_GET, '/admin/tests/app/foo/create');
+
+        static::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        static::assertCount(
+            1,
+            $crawler->filter('.help-block.sonata-ba-field-help:contains("Elements sub field help message")')
+        );
+    }
+
+    /**
      * https://github.com/sonata-project/SonataAdminBundle/issues/6904.
      */
     public function testCreateModelAutoCompleteNotPassingSubclassParameter(): void


### PR DESCRIPTION
## Subject

fix ImmutableArrayType field helper message must not displayed twice introduced in (sonata-project#8329) and tests immutable array field and subfields help message

I am targeting this branch, because it is a bugfix.

Closes #8328.

While writing tests for #8329, I see that the helper message of ImmutableArrayType field is displayed twice. It was already displayed by inheritance of `form_row` blocks in bottom of all subfields, and not in top of subfields like before, it confused me, my bad. I removed `form_help(form)` added in #8329 and I only keep the `form_help(child)` to display the help message of subfields which is really missing.

It's all good now, and confirmed by test this time 😄 

## Changelog

```markdown
### Fixed
* ImmutableArrayType field helper message must not displayed twice
```
