### PR TITLE
fix(form): Error messages displayed twice with form type "sonata_type_native_collection" or "sonata_type_immutable_array" when "error_bubbling" sets to false

### DIFF
--- a/src/Resources/views/Form/form_admin_fields.html.twig
+++ b/src/Resources/views/Form/form_admin_fields.html.twig
@@ -402,7 +402,6 @@ file that was distributed with this source code.
         {% set allow_delete = allow_delete_backup %}
     {% endif %}
     <div {{ block('widget_container_attributes') }}>
-        {{ form_errors(form) }}
         {% for child in form %}
             {{ block('sonata_type_native_collection_widget_row') }}
         {% endfor %}
@@ -418,8 +417,6 @@ file that was distributed with this source code.
 {% block sonata_type_immutable_array_widget %}
     <div {{ block('widget_container_attributes') }}>
         {{ form_help(form) }}
-
-        {{ form_errors(form) }}
 
         {% for key, child in form %}
             {{ block('sonata_type_immutable_array_widget_row') }}

--- a/tests/App/Admin/FooAdmin.php
+++ b/tests/App/Admin/FooAdmin.php
@@ -19,13 +19,18 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Form\Type\CollectionType;
 use Sonata\AdminBundle\Form\Type\ModelAutocompleteType;
 use Sonata\AdminBundle\Form\Type\TemplateType;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\AdminBundle\Tests\App\Model\Bar;
 use Sonata\AdminBundle\Tests\App\Model\Foo;
 use Sonata\AdminBundle\Tests\Fixtures\Controller\BatchOtherController;
+use Sonata\Form\Type\ImmutableArrayType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Validator\Constraints\Collection;
+use Symfony\Component\Validator\Constraints\Count;
+use Symfony\Component\Validator\Constraints\NotBlank;
 
 /**
  * @phpstan-extends AbstractAdmin<Foo>
@@ -65,6 +70,45 @@ class FooAdmin extends AbstractAdmin
                 [
                     'admin_code' => 'sonata_bar_admin',
                 ]
+            )
+            ->add(
+                'elements',
+                ImmutableArrayType::class,
+                [
+                    'help' => 'elements help message',
+                    'error_bubbling' => false,
+                    'constraints' => [
+                        new Collection([
+                            'fields' => [
+                                'elements_item' => new NotBlank(),
+                                'missing_field' => new NotBlank(),
+                            ],
+                            'allowMissingFields' => false,
+                        ]),
+                    ],
+                    'keys' => [
+                        [
+                            'elements_item',
+                            TextType::class,
+                            [
+                                'help' => 'elements_item help message',
+                            ],
+                        ],
+                    ],
+                ],
+            )
+            ->add(
+                'collection',
+                CollectionType::class,
+                [
+                    'error_bubbling' => false,
+                    'constraints' => [
+                        new Count([
+                            'min' => 2,
+                        ]),
+                    ],
+                    'entry_type' => TextType::class,
+                ],
             );
     }
 

--- a/tests/App/Model/Foo.php
+++ b/tests/App/Model/Foo.php
@@ -18,12 +18,18 @@ final class Foo implements EntityInterface
     private ?Bar $referenced;
 
     /**
-     * @param string[] $elements
+     * @var array<string, string>
      */
+    private array $elements = [];
+
+    /**
+     * @var string[]
+     */
+    private array $collection = [];
+
     public function __construct(
         private string $id,
         private string $name,
-        private array $elements = [],
     ) {
         $this->referenced = null;
     }
@@ -49,10 +55,34 @@ final class Foo implements EntityInterface
     }
 
     /**
-     * @return string[]
+     * @param array<string, string> $elements
+     */
+    public function setElements(array $elements): void
+    {
+        $this->elements = $elements;
+    }
+
+    /**
+     * @return array<string, string>
      */
     public function getElements(): array
     {
         return $this->elements;
+    }
+
+    /**
+     * @param string[] $collection
+     */
+    public function setCollection(array $collection): void
+    {
+        $this->collection = $collection;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getCollection(): array
+    {
+        return $this->collection;
     }
 }

--- a/tests/Functional/Controller/CRUDControllerTest.php
+++ b/tests/Functional/Controller/CRUDControllerTest.php
@@ -47,6 +47,35 @@ final class CRUDControllerTest extends WebTestCase
         );
     }
 
+    public function testImmutableArrayErrorMessageIsDisplayOnce(): void
+    {
+        $client = static::createClient();
+        $client->followRedirects();
+        $client->setMaxRedirects(1);
+        $client->request(Request::METHOD_GET, '/admin/tests/app/foo/create', ['with_form_errors' => '1']);
+        $crawler = $client->submitForm('Create', []);
+        file_put_contents('tmp.html', $crawler->html());
+        static::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        static::assertCount(
+            1,
+            $crawler->filter('.sonata-ba-field li:contains("This field is missing.")')
+        );
+    }
+
+    public function testCollectionErrorMessageIsDisplayOnce(): void
+    {
+        $client = static::createClient();
+        $client->followRedirects();
+        $client->setMaxRedirects(1);
+        $client->request(Request::METHOD_GET, '/admin/tests/app/foo/create', ['with_form_errors' => '1']);
+        $crawler = $client->submitForm('Create', []);
+        static::assertSame(Response::HTTP_OK, $client->getResponse()->getStatusCode());
+        static::assertCount(
+            1,
+            $crawler->filter('.sonata-ba-field li:contains("This collection should contain 2 elements or more.")')
+        );
+    }
+
     /**
      * https://github.com/sonata-project/SonataAdminBundle/issues/6904.
      */


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

fix error messages displayed twice with form type "sonata_type_native_collection" or "sonata_type_immutable_array" when "error_bubbling" sets to false.



<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it's a fix.


Closes #2761

(related to https://github.com/sonata-project/SonataAdminBundle/pull/8208)

## Step To Reproduce
- Add an array property on an entity
- Add `Count` constraints with `min=2`
- On the Admin of this entity add `Sonata\AdminBundle\Form\Type\CollectionType` or  `Sonata\Form\Type\ImmutableArrayType` field targeting this new property.
- Add `'error_bubbling' => false` form option on this field
- Go to the creation form of this entity and try to submit.


## Screenshot
<img width="719" alt="Screenshot 2024-08-29 at 16 37 40" src="https://github.com/user-attachments/assets/68202e01-e0fc-4bac-83af-caa498cde3cd">

## Changelog

```markdown
### Fixed
- Error messages displayed twice with form type `sonata_type_native_collection` or `sonata_type_immutable_array` when `error_bubbling` sets to `false` #2761
```

The error is already displayed by `form_row` block.

I add some tests to ensure that the error message will be displayed, but I think it's not the best way as the FooAdmin form will not be able to be submit (it will always have validation errors)