### PR TITLE
Stop using `Request::get`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -12,6 +12,3 @@ parameters:
         - # The phpstan-param is less precise than the psalm-param https://github.com/phpstan/phpstan/issues/4703
             message: '#^Parameter \#1 \$value of method Sonata\\AdminBundle\\Form\\DataTransformer\\ModelsToArrayTransformer\<T of object\>\:\:reverseTransform\(\) expects array\<int\|string\>\|null, array\<mixed, array\<string\>\|int\|string\> given\.$#'
             path: src/Form/DataTransformer/ModelToIdPropertyTransformer.php
-        -
-            message: '#^Call to internal method Symfony\\Component\\HttpFoundation\\Request\:\:get\(\) from outside its root namespace Symfony.$#'
-            path: .

--- a/psalm.xml
+++ b/psalm.xml
@@ -23,12 +23,12 @@
         <!-- TODO -->
         <DeprecatedMethod>
             <errorLevel type="suppress">
-                <directory name="tests" />
+                <directory name="tests"/>
             </errorLevel>
         </DeprecatedMethod>
         <UnusedPsalmSuppress>
             <errorLevel type="suppress">
-                <directory name="tests" />
+                <directory name="tests"/>
             </errorLevel>
         </UnusedPsalmSuppress>
     </issueHandlers>

--- a/psalm.xml
+++ b/psalm.xml
@@ -15,16 +15,21 @@
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>
     <issueHandlers>
-        <InternalClass errorLevel="suppress"/>
-        <InternalMethod errorLevel="suppress"/>
-        <InternalProperty errorLevel="suppress"/>
         <!-- Psalm equivalent of PHPStan config `treatPhpDocTypesAsCertain: false` -->
         <DocblockTypeContradiction errorLevel="suppress"/>
         <RedundantConditionGivenDocblockType errorLevel="suppress"/>
         <MissingClassConstType errorLevel="suppress"/>
         <MissingOverrideAttribute errorLevel="suppress"/>
         <!-- TODO -->
-        <DeprecatedMethod errorLevel="suppress"/>
-        <UnusedPsalmSuppress errorLevel="suppress"/>
+        <DeprecatedMethod>
+            <errorLevel type="suppress">
+                <directory name="tests" />
+            </errorLevel>
+        </DeprecatedMethod>
+        <UnusedPsalmSuppress>
+            <errorLevel type="suppress">
+                <directory name="tests" />
+            </errorLevel>
+        </UnusedPsalmSuppress>
     </issueHandlers>
 </psalm>

--- a/src/Action/AppendFormFieldElementAction.php
+++ b/src/Action/AppendFormFieldElementAction.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Action;
 
 use Sonata\AdminBundle\Admin\AdminHelper;
+use Sonata\AdminBundle\BCLayer\BCHelper;
 use Sonata\AdminBundle\Exception\BadRequestParamHttpException;
 use Sonata\AdminBundle\Request\AdminFetcherInterface;
 use Symfony\Component\Form\FormRenderer;
@@ -42,7 +43,7 @@ final class AppendFormFieldElementAction
             throw new NotFoundHttpException($e->getMessage());
         }
 
-        $objectId = $request->get('objectId');
+        $objectId = BCHelper::getFromRequest($request, 'objectId');
         if (null === $objectId) {
             $subject = $admin->getNewInstance();
         } elseif (\is_string($objectId) || \is_int($objectId)) {
@@ -60,7 +61,7 @@ final class AppendFormFieldElementAction
 
         $admin->setSubject($subject);
 
-        $elementId = $request->get('elementId');
+        $elementId = BCHelper::getFromRequest($request, 'elementId');
         if (!\is_string($elementId)) {
             throw new BadRequestParamHttpException('elementId', 'string', $elementId);
         }

--- a/src/Action/GetShortObjectDescriptionAction.php
+++ b/src/Action/GetShortObjectDescriptionAction.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Action;
 
+use Sonata\AdminBundle\BCLayer\BCHelper;
 use Sonata\AdminBundle\Exception\BadRequestParamHttpException;
 use Sonata\AdminBundle\Request\AdminFetcherInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -41,7 +42,7 @@ final class GetShortObjectDescriptionAction
             throw new NotFoundHttpException($e->getMessage());
         }
 
-        $objectId = $request->get('objectId');
+        $objectId = BCHelper::getFromRequest($request, 'objectId');
         if (!\is_string($objectId) && !\is_int($objectId)) {
             throw new BadRequestParamHttpException('objectId', ['string', 'int'], $objectId);
         }
@@ -63,21 +64,21 @@ final class GetShortObjectDescriptionAction
             }
         }
 
-        if ('json' === $request->get('_format')) {
+        if ('json' === BCHelper::getFromRequest($request, '_format')) {
             return new JsonResponse(['result' => [
                 'id' => $admin->id($object),
                 'label' => $admin->toString($object),
             ]]);
         }
 
-        if ('html' === $request->get('_format')) {
+        if ('html' === BCHelper::getFromRequest($request, '_format')) {
             $templateRegistry = $admin->getTemplateRegistry();
 
             return new Response($this->twig->render($templateRegistry->getTemplate('short_object_description'), [
                 'admin' => $admin,
                 'description' => $admin->toString($object),
                 'object' => $object,
-                'link_parameters' => $request->get('linkParameters', []),
+                'link_parameters' => BCHelper::getFromRequest($request, 'linkParameters', []),
             ]));
         }
 

--- a/src/Action/RetrieveAutocompleteItemsAction.php
+++ b/src/Action/RetrieveAutocompleteItemsAction.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Action;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\BCLayer\BCHelper;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
 use Sonata\AdminBundle\Exception\AbstractClassException;
 use Sonata\AdminBundle\Exception\BadRequestParamHttpException;
@@ -49,7 +50,7 @@ final class RetrieveAutocompleteItemsAction
             throw new NotFoundHttpException($e->getMessage());
         }
 
-        $context = $request->get('_context', '');
+        $context = BCHelper::getFromRequest($request, '_context', '');
         if ('filter' === $context) {
             $admin->checkAccess('list');
         } elseif (!$admin->hasAccess('create') && !$admin->hasAccess('edit')) {
@@ -63,7 +64,7 @@ final class RetrieveAutocompleteItemsAction
             // in case the subject is an abstract entity, we continue because the admin subject is non-mandatory here
         }
 
-        $field = $request->get('field');
+        $field = BCHelper::getFromRequest($request, 'field');
         if (!\is_string($field)) {
             throw new BadRequestParamHttpException('field', 'string', $field);
         }
@@ -103,7 +104,7 @@ final class RetrieveAutocompleteItemsAction
             $responseItemCallback = $formAutocompleteConfig->getAttribute('response_item_callback');
         }
 
-        $searchText = $request->get('q', '');
+        $searchText = BCHelper::getFromRequest($request, 'q', '');
         if (!\is_string($searchText)) {
             throw new BadRequestParamHttpException('q', 'string', $searchText);
         }

--- a/src/Action/RetrieveFormFieldElementAction.php
+++ b/src/Action/RetrieveFormFieldElementAction.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Action;
 
 use Sonata\AdminBundle\Admin\AdminHelper;
+use Sonata\AdminBundle\BCLayer\BCHelper;
 use Sonata\AdminBundle\Exception\BadRequestParamHttpException;
 use Sonata\AdminBundle\Request\AdminFetcherInterface;
 use Symfony\Component\Form\FormRenderer;
@@ -42,7 +43,7 @@ final class RetrieveFormFieldElementAction
             throw new NotFoundHttpException($e->getMessage());
         }
 
-        $objectId = $request->get('objectId');
+        $objectId = BCHelper::getFromRequest($request, 'objectId');
         if (null === $objectId) {
             $subject = $admin->getNewInstance();
         } elseif (\is_string($objectId) || \is_int($objectId)) {
@@ -66,7 +67,7 @@ final class RetrieveFormFieldElementAction
         $form->setData($subject);
         $form->handleRequest($request);
 
-        $elementId = $request->get('elementId');
+        $elementId = BCHelper::getFromRequest($request, 'elementId');
         if (!\is_string($elementId)) {
             throw new BadRequestParamHttpException('elementId', 'string', $elementId);
         }

--- a/src/Action/SearchAction.php
+++ b/src/Action/SearchAction.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Action;
 
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\BCLayer\BCHelper;
 use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -34,7 +35,7 @@ final class SearchAction
             'base_template' => $request->isXmlHttpRequest() ?
                 $this->templateRegistry->getTemplate('ajax') :
                 $this->templateRegistry->getTemplate('layout'),
-            'query' => $request->get('q', ''),
+            'query' => BCHelper::getFromRequest($request, 'q', ''),
             'groups' => $this->pool->getDashboardGroups(),
         ]));
     }

--- a/src/Action/SetObjectFieldValueAction.php
+++ b/src/Action/SetObjectFieldValueAction.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Action;
 
+use Sonata\AdminBundle\BCLayer\BCHelper;
 use Sonata\AdminBundle\Exception\BadRequestParamHttpException;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 use Sonata\AdminBundle\Form\DataTransformerResolverInterface;
@@ -76,7 +77,7 @@ final class SetObjectFieldValueAction
             ), Response::HTTP_METHOD_NOT_ALLOWED);
         }
 
-        $objectId = $request->get('objectId');
+        $objectId = BCHelper::getFromRequest($request, 'objectId');
         if (!\is_string($objectId) && !\is_int($objectId)) {
             throw new BadRequestParamHttpException('objectId', ['string', 'int'], $objectId);
         }
@@ -91,12 +92,12 @@ final class SetObjectFieldValueAction
             return new JsonResponse('Invalid permissions', Response::HTTP_FORBIDDEN);
         }
 
-        $context = $request->get('context');
+        $context = BCHelper::getFromRequest($request, 'context');
         if ('list' !== $context) {
             return new JsonResponse('Invalid context', Response::HTTP_BAD_REQUEST);
         }
 
-        $field = $request->get('field');
+        $field = BCHelper::getFromRequest($request, 'field');
         if (!\is_string($field)) {
             throw new BadRequestParamHttpException('field', 'string', $field);
         }
@@ -126,7 +127,7 @@ final class SetObjectFieldValueAction
             $propertyPath = new PropertyPath($field);
         }
 
-        $value = $request->get('value');
+        $value = BCHelper::getFromRequest($request, 'value');
 
         if ('' === $value) {
             $this->propertyAccessor->setValue($object, $propertyPath, null);

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -485,7 +485,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
                 $parentAssociationMapping = $this->getParentAssociationMapping();
                 if (null !== $parentAssociationMapping) {
                     $name = str_replace('.', '__', $parentAssociationMapping);
-                    $parameters[$name] = ['value' => $this->getRequest()->get($this->getParent()->getIdParameter())];
+                    $parameters[$name] = ['value' => BCHelper::getFromRequest($this->getRequest(), $this->getParent()->getIdParameter())];
                 }
             }
         }
@@ -734,7 +734,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
         }
 
         $request = $this->getRequest();
-        $route = $request->get('_route');
+        $route = BCHelper::getFromRequest($request, '_route');
 
         if (null !== $adminCode) {
             $pool = $this->getConfigurationPool();
@@ -1078,7 +1078,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
     final public function hasSubject(): bool
     {
         if (null === $this->subject && $this->hasRequest() && !$this->hasParentFieldDescription()) {
-            $id = $this->getRequest()->get($this->getIdParameter());
+            $id = BCHelper::getFromRequest($this->getRequest(), $this->getIdParameter());
 
             if (null !== $id) {
                 $this->subject = $this->getObject($id);
@@ -2276,7 +2276,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
 
             if (null !== $parentAssociationMapping) {
                 $parentAdmin = $this->getParent();
-                $parentObject = $parentAdmin->getObject($this->getRequest()->get($parentAdmin->getIdParameter()));
+                $parentObject = $parentAdmin->getObject(BCHelper::getFromRequest($this->getRequest(), $parentAdmin->getIdParameter()));
 
                 if (null !== $parentObject) {
                     $propertyAccessor = PropertyAccess::createPropertyAccessor();
@@ -2301,7 +2301,7 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
 
         if ($this->hasParentFieldDescription()) {
             $parentAdmin = $this->getParentFieldDescription()->getAdmin();
-            $parentObject = $parentAdmin->getObject($this->getRequest()->get($parentAdmin->getIdParameter()));
+            $parentObject = $parentAdmin->getObject(BCHelper::getFromRequest($this->getRequest(), $parentAdmin->getIdParameter()));
 
             if (null !== $parentObject) {
                 ObjectManipulator::setObject($object, $parentObject, $this->getParentFieldDescription());

--- a/src/Admin/AdminHelper.php
+++ b/src/Admin/AdminHelper.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Sonata\AdminBundle\Admin;
 
+use Sonata\AdminBundle\BCLayer\BCHelper;
 use Sonata\AdminBundle\Exception\NoValueException;
 use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
 use Sonata\AdminBundle\Manipulator\ObjectManipulator;
@@ -95,14 +96,14 @@ final class AdminHelper
         $childFormBuilder = $this->getChildFormBuilder($formBuilder, $elementId);
 
         if (null !== $childFormBuilder) {
-            $formData = $admin->getRequest()->get($formBuilder->getName(), []);
+            $formData = BCHelper::getFromRequest($admin->getRequest(), $formBuilder->getName(), []);
             \assert(\is_array($formData));
 
             if (
                 \array_key_exists($childFormBuilder->getName(), $formData)
                 && is_iterable($formData[$childFormBuilder->getName()])
             ) {
-                $formData = $admin->getRequest()->get($formBuilder->getName(), []);
+                $formData = BCHelper::getFromRequest($admin->getRequest(), $formBuilder->getName(), []);
                 \assert(\is_array($formData));
 
                 $i = 0;
@@ -143,7 +144,7 @@ final class AdminHelper
             }
 
             // retrieve the posted data
-            $data = $admin->getRequest()->get($formBuilder->getName());
+            $data = BCHelper::getFromRequest($admin->getRequest(), $formBuilder->getName());
 
             if (!isset($data[$childFormBuilder->getName()])) {
                 $data[$childFormBuilder->getName()] = [];

--- a/src/Admin/BreadcrumbsBuilder.php
+++ b/src/Admin/BreadcrumbsBuilder.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Sonata\AdminBundle\Admin;
 
 use Knp\Menu\ItemInterface;
+use Sonata\AdminBundle\BCLayer\BCHelper;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -105,7 +106,7 @@ final class BreadcrumbsBuilder implements BreadcrumbsBuilderInterface
         $childAdmin = $admin->getCurrentChildAdmin();
 
         if (null !== $childAdmin && $admin->hasSubject()) {
-            $id = $admin->getRequest()->get($admin->getIdParameter());
+            $id = BCHelper::getFromRequest($admin->getRequest(), $admin->getIdParameter());
 
             $menu = $menu->addChild(
                 $admin->toString($admin->getSubject()),

--- a/src/Admin/Extension/LockExtension.php
+++ b/src/Admin/Extension/LockExtension.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Admin\Extension;
 
 use Sonata\AdminBundle\Admin\AbstractAdminExtension;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\BCLayer\BCHelper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Model\LockInterface;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -66,7 +67,7 @@ final class LockExtension extends AbstractAdminExtension
             return;
         }
 
-        $data = $admin->getRequest()->get($admin->getUniqId());
+        $data = BCHelper::getFromRequest($admin->getRequest(), $admin->getUniqId());
         if (!\is_array($data)) {
             return;
         }

--- a/src/BCLayer/BCHelper.php
+++ b/src/BCLayer/BCHelper.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\BCLayer;
 
 use Doctrine\Common\Util\ClassUtils;
 use Sonata\AdminBundle\Model\ProxyResolverInterface;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * @internal
@@ -39,5 +40,26 @@ final class BCHelper
         }
 
         return $classFromDoctrine;
+    }
+
+    /**
+     * Simulate the Symfony deprecated method Request::get.
+     *
+     * Should be used a few as possible, but migration is not easy...
+     */
+    public static function getFromRequest(Request $request, string $key, mixed $default = null): mixed
+    {
+        $result = $request->attributes->get($key, $request);
+        if ($request !== $result) {
+            return $result;
+        }
+        if ($request->query->has($key)) {
+            return $request->query->all()[$key];
+        }
+        if ($request->request->has($key)) {
+            return $request->request->all()[$key];
+        }
+
+        return $default;
     }
 }

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -17,6 +17,7 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\BCLayer\BCHelper;
 use Sonata\AdminBundle\Bridge\Exporter\AdminExporter;
 use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
 use Sonata\AdminBundle\Exception\BadRequestParamHttpException;
@@ -116,7 +117,7 @@ class CRUDController extends AbstractController
             return $preResponse;
         }
 
-        $listMode = $request->get('_list_mode');
+        $listMode = BCHelper::getFromRequest($request, '_list_mode');
         if (\is_string($listMode) && \array_key_exists($listMode, $this->admin->getListModes())) {
             $this->admin->setListMode($listMode);
         }
@@ -405,11 +406,11 @@ class CRUDController extends AbstractController
         // check the csrf token
         $this->validateCsrfToken($request, 'sonata.batch');
 
-        $confirmation = $request->get('confirmation', false);
+        $confirmation = BCHelper::getFromRequest($request, 'confirmation', false);
 
         $forwardedRequest = $request->duplicate();
 
-        $encodedData = $request->get('data');
+        $encodedData = BCHelper::getFromRequest($request, 'data');
 
         if (null === $encodedData) {
             $action = $forwardedRequest->request->get('action');
@@ -861,7 +862,7 @@ class CRUDController extends AbstractController
     {
         $this->admin->checkAccess('export');
 
-        $format = $request->get('format');
+        $format = BCHelper::getFromRequest($request, 'format');
         if (!\is_string($format)) {
             throw new BadRequestParamHttpException('format', 'string', $format);
         }
@@ -1164,23 +1165,23 @@ class CRUDController extends AbstractController
      */
     protected function redirectTo(Request $request, object $object): RedirectResponse
     {
-        if (null !== $request->get('btn_update_and_list')) {
+        if (null !== BCHelper::getFromRequest($request, 'btn_update_and_list')) {
             return $this->redirectToList();
         }
-        if (null !== $request->get('btn_create_and_list')) {
+        if (null !== BCHelper::getFromRequest($request, 'btn_create_and_list')) {
             return $this->redirectToList();
         }
 
-        if (null !== $request->get('btn_create_and_create')) {
+        if (null !== BCHelper::getFromRequest($request, 'btn_create_and_create')) {
             $params = [];
             if ($this->admin->hasActiveSubClass()) {
-                $params['subclass'] = $request->get('subclass');
+                $params['subclass'] = BCHelper::getFromRequest($request, 'subclass');
             }
 
             return new RedirectResponse($this->admin->generateUrl('create', $params));
         }
 
-        if (null !== $request->get('btn_delete')) {
+        if (null !== BCHelper::getFromRequest($request, 'btn_delete')) {
             return $this->redirectToList();
         }
 
@@ -1219,7 +1220,7 @@ class CRUDController extends AbstractController
      */
     final protected function isPreviewRequested(Request $request): bool
     {
-        return null !== $request->get('btn_preview');
+        return null !== BCHelper::getFromRequest($request, 'btn_preview');
     }
 
     /**
@@ -1227,7 +1228,7 @@ class CRUDController extends AbstractController
      */
     final protected function isPreviewApproved(Request $request): bool
     {
-        return null !== $request->get('btn_preview_approve');
+        return null !== BCHelper::getFromRequest($request, 'btn_preview_approve');
     }
 
     /**
@@ -1249,7 +1250,7 @@ class CRUDController extends AbstractController
      */
     final protected function isPreviewDeclined(Request $request): bool
     {
-        return null !== $request->get('btn_preview_decline');
+        return null !== BCHelper::getFromRequest($request, 'btn_preview_decline');
     }
 
     /**
@@ -1314,7 +1315,7 @@ class CRUDController extends AbstractController
             return;
         }
 
-        $token = $request->get('_sonata_csrf_token');
+        $token = BCHelper::getFromRequest($request, '_sonata_csrf_token');
         $tokenManager = $this->container->get('security.csrf.token_manager');
         \assert($tokenManager instanceof CsrfTokenManagerInterface);
 
@@ -1450,7 +1451,7 @@ class CRUDController extends AbstractController
         $object = null;
 
         while (null !== $admin) {
-            $objectId = $request->get($admin->getIdParameter());
+            $objectId = BCHelper::getFromRequest($request, $admin->getIdParameter());
             if (\is_string($objectId) || \is_int($objectId)) {
                 $adminObject = $admin->getObject($objectId);
                 if (null === $adminObject) {
@@ -1515,7 +1516,7 @@ class CRUDController extends AbstractController
         }
 
         $parentAdmin = $this->admin->getParent();
-        $parentId = $request->get($parentAdmin->getIdParameter());
+        $parentId = BCHelper::getFromRequest($request, $parentAdmin->getIdParameter());
         \assert(\is_string($parentId) || \is_int($parentId));
 
         $parentAdminObject = $parentAdmin->getObject($parentId);

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -202,7 +202,7 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
                     'priority' => $attributes['priority'] ?? 0,
                 ];
 
-                if (isset($groupDefaults[$resolvedGroupName]['on_top']) && true === $groupDefaults[$resolvedGroupName]['on_top']
+                if (true === $groupDefaults[$resolvedGroupName]['on_top']
                     || true === $onTop && (\count($groupDefaults[$resolvedGroupName]['items']) > 1)) {
                     throw new \RuntimeException('You can\'t use "on_top" option with multiple same name groups.');
                 }

--- a/src/Menu/Matcher/Voter/AdminVoter.php
+++ b/src/Menu/Matcher/Voter/AdminVoter.php
@@ -16,6 +16,7 @@ namespace Sonata\AdminBundle\Menu\Matcher\Voter;
 use Knp\Menu\ItemInterface;
 use Knp\Menu\Matcher\Voter\VoterInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
+use Sonata\AdminBundle\BCLayer\BCHelper;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -41,13 +42,13 @@ final class AdminVoter implements VoterInterface
         if (
             $admin instanceof AdminInterface
             && $admin->hasRoute('list') && $admin->hasAccess('list')
-            && $this->match($admin, $request->get('_sonata_admin'))
+            && $this->match($admin, BCHelper::getFromRequest($request, '_sonata_admin'))
         ) {
             return true;
         }
 
         $route = $item->getExtra('route');
-        if (null !== $route && $route === $request->get('_route')) {
+        if (null !== $route && $route === BCHelper::getFromRequest($request, '_route')) {
             return true;
         }
 

--- a/src/Request/AdminFetcher.php
+++ b/src/Request/AdminFetcher.php
@@ -15,6 +15,7 @@ namespace Sonata\AdminBundle\Request;
 
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\BCLayer\BCHelper;
 use Symfony\Component\HttpFoundation\Request;
 
 final class AdminFetcher implements AdminFetcherInterface
@@ -26,10 +27,10 @@ final class AdminFetcher implements AdminFetcherInterface
 
     public function get(Request $request): AdminInterface
     {
-        $adminCode = $request->get('_sonata_admin');
+        $adminCode = BCHelper::getFromRequest($request, '_sonata_admin');
 
         if (!\is_string($adminCode)) {
-            $route = $request->get('_route', '');
+            $route = BCHelper::getFromRequest($request, '_route', '');
             \assert(\is_string($route));
 
             throw new \InvalidArgumentException(\sprintf(
@@ -48,8 +49,8 @@ final class AdminFetcher implements AdminFetcherInterface
 
         $rootAdmin->setRequest($request);
 
-        if (\is_string($request->get('uniqid'))) {
-            $admin->setUniqId($request->get('uniqid'));
+        if (\is_string(BCHelper::getFromRequest($request, 'uniqid'))) {
+            $admin->setUniqId(BCHelper::getFromRequest($request, 'uniqid'));
         }
 
         return $admin;

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1397,8 +1397,7 @@ final class AdminTest extends TestCase
         $tagAdmin->setModelClass(Tag::class);
         $tagAdmin->setParent($postAdmin, 'post');
 
-        $request = $this->createMock(Request::class);
-        $request->method('get')->with('parent_id')->willReturn(42);
+        $request = new Request(['parent_id' => 42]);
         $tagAdmin->setRequest($request);
 
         $tag = $tagAdmin->getNewInstance();
@@ -1438,8 +1437,7 @@ final class AdminTest extends TestCase
         $postCategoryAdmin->setModelClass(PostCategory::class);
         $postCategoryAdmin->setParent($postAdmin, 'posts');
 
-        $request = $this->createMock(Request::class);
-        $request->method('get')->with('parent_id')->willReturn(42);
+        $request = new Request(['parent_id' => 42]);
         $postCategoryAdmin->setRequest($request);
 
         $postCategory = $postCategoryAdmin->getNewInstance();
@@ -1471,8 +1469,7 @@ final class AdminTest extends TestCase
         $tagAdmin->setModelClass(Tag::class);
         $tagAdmin->setParentFieldDescription($parentField);
 
-        $request = $this->createMock(Request::class);
-        $request->method('get')->with('parent_id')->willReturn(42);
+        $request = new Request(['parent_id' => 42]);
         $tagAdmin->setRequest($request);
 
         $tag = $tagAdmin->getNewInstance();

--- a/tests/Admin/BreadcrumbsBuilderTest.php
+++ b/tests/Admin/BreadcrumbsBuilderTest.php
@@ -85,8 +85,7 @@ final class BreadcrumbsBuilderTest extends TestCase
         ]);
 
         $admin->method('getCurrentChildAdmin')->willReturn($childAdmin);
-        $request = $this->createMock(Request::class);
-        $request->method('get')->with('slug')->willReturn('my-object');
+        $request = new Request(['slug' => 'my-object']);
 
         $admin->method('getIdParameter')->willReturn('slug');
         $admin->method('getRequest')->willReturn($request);
@@ -223,8 +222,7 @@ final class BreadcrumbsBuilderTest extends TestCase
             $menu->expects(static::never())->method('setUri');
         }
 
-        $request = $this->createMock(Request::class);
-        $request->method('get')->with('slug')->willReturn('my-object');
+        $request = new Request(['slug' => 'my-object']);
 
         $admin->method('getIdParameter')->willReturn('slug');
         $admin->method('getRequest')->willReturn($request);

--- a/tests/Controller/CRUDControllerTest.php
+++ b/tests/Controller/CRUDControllerTest.php
@@ -21,6 +21,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Admin\Pool;
+use Sonata\AdminBundle\BCLayer\BCHelper;
 use Sonata\AdminBundle\Bridge\Exporter\AdminExporter;
 use Sonata\AdminBundle\Controller\CRUDController;
 use Sonata\AdminBundle\Datagrid\DatagridInterface;
@@ -4071,11 +4072,11 @@ final class CRUDControllerTest extends TestCase
         $this->request->request->set('data', json_encode(['action' => 'delete', 'idx' => ['123', '456'], 'all_elements' => false]));
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
-        static::assertNull($this->request->get('idx'));
+        static::assertNull(BCHelper::getFromRequest($this->request, 'idx'));
 
         $result = $this->controller->batchAction($this->request);
 
-        static::assertNull($this->request->get('idx'), 'Ensure original request is not modified by calling `CRUDController::batchAction()`.');
+        static::assertNull(BCHelper::getFromRequest($this->request, 'idx'), 'Ensure original request is not modified by calling `CRUDController::batchAction()`.');
         static::assertSame($response, $result);
     }
 
@@ -4252,11 +4253,11 @@ NEXT_MAJOR: Remove this test')]
         $this->request->request->set('idx', ['789']);
         $this->request->request->set('_sonata_csrf_token', 'csrf-token-123_sonata.batch');
 
-        static::assertNull($this->request->get('all_elements'));
+        static::assertNull(BCHelper::getFromRequest($this->request, 'all_elements'));
 
         $result = $controller->batchAction($this->request);
 
-        static::assertNull($this->request->get('all_elements'), 'Ensure original request is not modified by calling `CRUDController::batchAction()`.');
+        static::assertNull(BCHelper::getFromRequest($this->request, 'all_elements'), 'Ensure original request is not modified by calling `CRUDController::batchAction()`.');
         static::assertInstanceOf(RedirectResponse::class, $result);
         static::assertSame(['flash_batch_empty'], $this->session->getFlashBag()->get('sonata_flash_info'));
         static::assertSame('list', $result->getTargetUrl());

--- a/tests/Maker/AdminMakerTest.php
+++ b/tests/Maker/AdminMakerTest.php
@@ -67,6 +67,9 @@ final class AdminMakerTest extends TestCase
         $this->filesystem->remove($this->projectDirectory);
     }
 
+    /**
+     * @psalm-suppress InternalClass, InternalMethod
+     */
     public function testExecute(): void
     {
         $maker = new AdminMaker($this->projectDirectory, $this->modelManagers, CRUDController::class);

--- a/tests/Route/DefaultRouteGeneratorTest.php
+++ b/tests/Route/DefaultRouteGeneratorTest.php
@@ -180,7 +180,7 @@ final class DefaultRouteGeneratorTest extends TestCase
         // no request attached in this test, so this will not be used
         $parentAdmin->expects(static::never())->method('getPersistentParameters')->willReturn(['from' => 'parent']);
 
-        $request = $this->createMock(Request::class);
+        $request = new Request();
         $request->attributes = $this->createMock(ParameterBag::class);
         $request->attributes->method('has')->willReturn(true);
         $request->attributes
@@ -340,7 +340,7 @@ final class DefaultRouteGeneratorTest extends TestCase
         // no request attached in this test, so this will not be used
         $parentAdmin->expects(static::never())->method('getPersistentParameters')->willReturn(['from' => 'parent']);
 
-        $request = $this->createMock(Request::class);
+        $request = new Request();
         $request->attributes = $this->createMock(ParameterBag::class);
         $request->attributes->method('has')->willReturn(true);
         $request->attributes

--- a/tests/Twig/Extension/RenderElementExtensionTest.php
+++ b/tests/Twig/Extension/RenderElementExtensionTest.php
@@ -33,7 +33,6 @@ use Sonata\AdminBundle\Twig\XEditableRuntime;
 use Symfony\Bridge\Twig\Extension\RoutingExtension;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Loader\XmlFileLoader;
@@ -102,9 +101,6 @@ final class RenderElementExtensionTest extends TestCase
 
         $this->templateRegistry = $this->createMock(MutableTemplateRegistryInterface::class);
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
-
-        $request = $this->createMock(Request::class);
-        $request->method('get')->with('_sonata_admin')->willReturn('sonata_admin_foo_service');
 
         $loader = new StubFilesystemLoader([
             __DIR__.'/../../../src/Resources/views/CRUD',

--- a/tests/Twig/Extension/SonataAdminExtensionTest.php
+++ b/tests/Twig/Extension/SonataAdminExtensionTest.php
@@ -23,7 +23,6 @@ use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
 use Sonata\AdminBundle\Twig\SonataAdminRuntime;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Loader\XmlFileLoader;
 use Twig\Environment;
 use Twig\Extra\String\StringExtension;
@@ -64,9 +63,6 @@ final class SonataAdminExtensionTest extends TestCase
         $this->pool = new Pool($this->container, ['sonata_admin_foo_service'], [], [Foo::class => ['sonata_admin_foo_service']]);
 
         $this->twigExtension = new SonataAdminExtension(new SonataAdminRuntime($this->pool));
-
-        $request = $this->createMock(Request::class);
-        $request->method('get')->with('_sonata_admin')->willReturn('sonata_admin_foo_service');
 
         $loader = new FilesystemLoader([
             __DIR__.'/../../../src/Resources/views/CRUD',

--- a/tests/Twig/RenderElementRuntimeTest.php
+++ b/tests/Twig/RenderElementRuntimeTest.php
@@ -32,7 +32,6 @@ use Sonata\AdminBundle\Twig\XEditableRuntime;
 use Symfony\Bridge\Twig\Extension\RoutingExtension;
 use Symfony\Bridge\Twig\Extension\TranslationExtension;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Loader\XmlFileLoader;
@@ -89,9 +88,6 @@ final class RenderElementRuntimeTest extends TestCase
 
         $this->templateRegistry = $this->createMock(MutableTemplateRegistryInterface::class);
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
-
-        $request = $this->createMock(Request::class);
-        $request->method('get')->with('_sonata_admin')->willReturn('sonata_admin_foo_service');
 
         $loader = new StubFilesystemLoader([
             __DIR__.'/../../src/Resources/views/CRUD',

--- a/tests/Twig/SonataAdminRuntimeTest.php
+++ b/tests/Twig/SonataAdminRuntimeTest.php
@@ -23,7 +23,6 @@ use Sonata\AdminBundle\Twig\Extension\SonataAdminExtension;
 use Sonata\AdminBundle\Twig\SonataAdminRuntime;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Loader\XmlFileLoader;
 use Twig\Environment;
 use Twig\Extra\String\StringExtension;
@@ -60,9 +59,6 @@ final class SonataAdminRuntimeTest extends TestCase
         $this->pool = new Pool($this->container, ['sonata_admin_foo_service'], [], [Foo::class => ['sonata_admin_foo_service']]);
 
         $this->sonataAdminRuntime = new SonataAdminRuntime($this->pool);
-
-        $request = $this->createMock(Request::class);
-        $request->method('get')->with('_sonata_admin')->willReturn('sonata_admin_foo_service');
 
         $loader = new FilesystemLoader([
             __DIR__.'/../../src/Resources/views/CRUD',


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

This could be an easy solution

Closes #7365.

## Changelog

```markdown
### Fixed
- Stop using internal/deprecated method `Request::get()`
```