### PR TITLE
Drop support for sonata-project/block-bundle 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "knplabs/knp-menu-bundle": "^3.0",
         "psr/container": "^1.0 || ^2.0",
         "psr/log": "^2.0 || ^3.0",
-        "sonata-project/block-bundle": "^4.11 || ^5.0",
+        "sonata-project/block-bundle": "^5.0",
         "sonata-project/doctrine-extensions": "^1.8 || ^2.0",
         "sonata-project/exporter": "^2.14 || ^3.1.1",
         "sonata-project/form-extensions": "^1.15 || ^2.0",

--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -15,7 +15,6 @@ namespace Sonata\AdminBundle\Tests\App;
 
 use Knp\Bundle\MenuBundle\KnpMenuBundle;
 use Sonata\AdminBundle\SonataAdminBundle;
-use Sonata\BlockBundle\Cache\HttpCacheHandler;
 use Sonata\BlockBundle\SonataBlockBundle;
 use Sonata\Doctrine\Bridge\Symfony\SonataDoctrineBundle;
 use Sonata\Form\Bridge\Symfony\SonataFormBundle;
@@ -110,11 +109,6 @@ final class AppKernel extends Kernel
         ]);
 
         $loader->load(\sprintf('%s/config/services.yml', $this->getProjectDir()));
-
-        /*
-         * TODO: Remove when support for SonataBlockBundle 4 is dropped.
-         */
-        $containerBuilder->loadFromExtension('sonata_block', class_exists(HttpCacheHandler::class) ? ['http_cache' => false] : []);
     }
 
     private function getBaseDir(): string

--- a/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/AddDependencyCallsCompilerPassTest.php
@@ -16,7 +16,6 @@ namespace Sonata\AdminBundle\Tests\DependencyInjection\Compiler;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
-use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Admin\Pool;
@@ -24,8 +23,6 @@ use Sonata\AdminBundle\DependencyInjection\Admin\TaggedAdminInterface;
 use Sonata\AdminBundle\DependencyInjection\Compiler\AddDependencyCallsCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
 use Sonata\AdminBundle\Tests\Fixtures\Controller\FooAdminController;
-use Sonata\BlockBundle\Cache\HttpCacheHandler;
-use Sonata\BlockBundle\DependencyInjection\SonataBlockExtension;
 use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\PassConfig;
@@ -830,17 +827,6 @@ final class AddDependencyCallsCompilerPassTest extends AbstractCompilerPassTestC
             ->register('translator.default')
             ->setClass(Translator::class);
         $this->container->setAlias('translator', 'translator.default');
-
-        $blockExtension = new SonataBlockExtension();
-        /*
-         * TODO: remove "http_cache" parameter when support for SonataBlockBundle 4 is dropped.
-         */
-        $blockExtension->load(
-            [
-                'sonata_block' => class_exists(HttpCacheHandler::class) ? ['http_cache' => false] : [],
-            ],
-            $this->container
-        );
     }
 
     private function allowToResolveChildren(): void

--- a/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
+++ b/tests/DependencyInjection/Compiler/ExtensionCompilerPassTest.php
@@ -25,8 +25,6 @@ use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\DependencyInjection\Admin\TaggedAdminInterface;
 use Sonata\AdminBundle\DependencyInjection\Compiler\ExtensionCompilerPass;
 use Sonata\AdminBundle\DependencyInjection\SonataAdminExtension;
-use Sonata\BlockBundle\Cache\HttpCacheHandler;
-use Sonata\BlockBundle\DependencyInjection\SonataBlockExtension;
 use Symfony\Bundle\FrameworkBundle\Translation\Translator;
 use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -544,17 +542,6 @@ final class ExtensionCompilerPassTest extends TestCase
         $container
             ->register('file_locator')
             ->setClass(FileLocatorInterface::class);
-
-        $blockExtension = new SonataBlockExtension();
-        /*
-         * TODO: remove "http_cache" parameter when support for SonataBlockBundle 4 is dropped.
-         */
-        $blockExtension->load(
-            [
-                'sonata_block' => class_exists(HttpCacheHandler::class) ? ['http_cache' => false] : [],
-            ],
-            $container
-        );
 
         return $container;
     }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because its BC.

Let's drop support for v4 to simplify things. Will also look into dropping support for other unmaintained sonata package versions as well.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Removed
- support for `sonata-project/block-bundle` v4 was removed
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
