### PR TITLE
Turn Acl optional or replace to Voter

### DIFF
--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -45,7 +45,6 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyAccess\Exception\UninitializedPropertyException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface as RoutingUrlGeneratorInterface;
-use Symfony\Component\Security\Acl\Model\DomainObjectInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
@@ -55,7 +54,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
  * @phpstan-extends AbstractTaggedAdmin<T>
  * @phpstan-implements AdminInterface<T>
  */
-abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterface, DomainObjectInterface, AdminTreeInterface
+abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterface, AdminTreeInterface
 {
     // NEXT_MAJOR: Remove the CONTEXT constants.
     /** @deprecated */
@@ -1488,14 +1487,6 @@ abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterfa
             return $this->getParent()->getBaseCodeRoute().'|'.$this->getCode();
         }
 
-        return $this->getCode();
-    }
-
-    /**
-     * @return string
-     */
-    public function getObjectIdentifier()
-    {
         return $this->getCode();
     }
 

--- a/tests/Admin/AdminTest.php
+++ b/tests/Admin/AdminTest.php
@@ -1281,7 +1281,7 @@ final class AdminTest extends TestCase
         $admin = new PostAdmin();
         $admin->setCode('sonata.post.admin.post');
 
-        static::assertSame('sonata.post.admin.post', $admin->getObjectIdentifier());
+        static::assertSame('sonata.post.admin.post', $admin->getCode());
     }
 
     #[DoesNotPerformAssertions]


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Turn acl optional or replace to Voter

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because it needs deprecate ACL before remove on next major.

`getObjectIdentifier` was added on this commit:
https://github.com/sonata-project/SonataAdminBundle/commit/8f180e0bd0a1d13b38d680b22fcde43d3a15bc4c

the questions are:
-  why is it need here, if I could call `getCode` direct 🤔 .
- if it was needed for something else, it is missing tests.


Related #7303.

<!-- MANDATORY
## Changelog


    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.

```markdown
### Added
- Some `Class::newMethod()` to do great stuff

### Changed

### Deprecated

### Removed

### Fixed

### Security
```
-->
<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
