### PR TITLE
fix remaining Symfony 7.4 deprecations for Request::get

### DIFF
--- a/src/Resources/views/CRUD/base_acl_macro.html.twig
+++ b/src/Resources/views/CRUD/base_acl_macro.html.twig
@@ -11,7 +11,7 @@ file that was distributed with this source code.
 
 {% macro render_form(form, permissions, td_type, admin, admin_configuration, object) %}
     <form class="form-horizontal"
-          action="{{ admin.generateUrl('acl', {(admin.idParameter): admin.id(object), 'uniqid': admin.uniqid, 'subclass': app.request.get('subclass')}) }}"
+          action="{{ admin.generateUrl('acl', {(admin.idParameter): admin.id(object), 'uniqid': admin.uniqid, 'subclass': app.request.attributes.get('subclass', app.request.query.get('subclass', app.request.request.get('subclass')))}) }}"
           {% if form.vars.multipart %} enctype="multipart/form-data"{% endif %}
           method="POST"
             {% if not admin_configuration.getOption('html5_validate') %}novalidate="novalidate"{% endif %}

--- a/src/Resources/views/CRUD/base_edit_form.html.twig
+++ b/src/Resources/views/CRUD/base_edit_form.html.twig
@@ -11,7 +11,7 @@
         <form
               {% if sonata_config.getOption('form_type') == 'horizontal' %}class="form-horizontal"{% endif %}
               role="form"
-              action="{% block sonata_form_action_url %}{{ admin.generateUrl(url, {(admin.idParameter): objectId, 'uniqid': admin.uniqid, 'subclass': app.request.get('subclass')}) }}{% endblock %}"
+              action="{% block sonata_form_action_url %}{{ admin.generateUrl(url, {(admin.idParameter): objectId, 'uniqid': admin.uniqid, 'subclass': app.request.attributes.get('subclass', app.request.query.get('subclass', app.request.request.get('subclass')))}) }}{% endblock %}"
               {% if form.vars.multipart %} enctype="multipart/form-data"{% endif %}
               method="POST"
               {% if not sonata_config.getOption('html5_validate') %}novalidate="novalidate"{% endif %}

--- a/src/Resources/views/standard_layout.html.twig
+++ b/src/Resources/views/standard_layout.html.twig
@@ -192,7 +192,7 @@ file that was distributed with this source code.
                                 {% if sonata_config.getOption('search') %}
                                     <form action="{{ path('sonata_admin_search') }}" method="GET" class="sidebar-form" role="search">
                                         <div class="input-group custom-search-form">
-                                            <input type="text" name="q" value="{{ app.request.get('q') }}" class="form-control" placeholder="{{ 'search_placeholder'|trans({}, 'SonataAdminBundle') }}">
+                                            <input type="text" name="q" value="{{ app.request.attributes.get('q', app.request.query.get('q', app.request.request.get('q'))) }}" class="form-control" placeholder="{{ 'search_placeholder'|trans({}, 'SonataAdminBundle') }}">
                                             <span class="input-group-btn">
                                                 <button class="btn btn-flat" type="submit">
                                                     <i class="fas fa-search" aria-hidden="true"></i>


### PR DESCRIPTION
Closes #8352 

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Fixed
- fix remaining Symfony 7.4 deprecations for Request::get in twig templates
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
