### PR TITLE
make symfony/security-acl integration optional

### DIFF
--- a/UPGRADE-4.x.md
+++ b/UPGRADE-4.x.md
@@ -1,6 +1,17 @@
 UPGRADE 4.x
 ===========
 
+UPGRADE FROM 4.41 to 4.42
+=========================
+
+## Optional Symfony ACL integration
+
+Before 4.42.0 the `symfony/security-acl` package was a hard dependency even if no ACL features were used.
+Starting with 4.42.0 the dependency is now optional and users who are using ACL features should not be impacted as they
+also need to have `symfony/acl-bundle` installed anyway (which requires `symfony/security-acl`).
+
+In case `symfony/security-acl` is not installed we are now also skipping registration of some ACL related services.
+
 UPGRADE FROM 4.18 to 4.19
 =========================
 

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,6 @@
         "symfony/options-resolver": "^6.4 || ^7.3 || ^8.0",
         "symfony/property-access": "^6.4 || ^7.3 || ^8.0",
         "symfony/routing": "^6.4 || ^7.3 || ^8.0",
-        "symfony/security-acl": "^3.1",
         "symfony/security-bundle": "^6.4 || ^7.3 || ^8.0",
         "symfony/security-core": "^6.4 || ^7.3 || ^8.0",
         "symfony/security-csrf": "^6.4 || ^7.3 || ^8.0",
@@ -85,7 +84,11 @@
         "symfony/css-selector": "^6.4 || ^7.3 || ^8.0",
         "symfony/filesystem": "^6.4 || ^7.3 || ^8.0",
         "symfony/maker-bundle": "^1.25",
+        "symfony/security-acl": "^3.1",
         "symfony/yaml": "^6.4 || ^7.3 || ^8.0"
+    },
+    "conflict": {
+        "symfony/security-acl": "<3.1 >=4.0"
     },
     "suggest": {
         "twig/extra-bundle": "Auto configures the Twig Intl extension"

--- a/src/Admin/AbstractAdmin.php
+++ b/src/Admin/AbstractAdmin.php
@@ -48,14 +48,36 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface as RoutingUrlGener
 use Symfony\Component\Security\Acl\Model\DomainObjectInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
+if (interface_exists(DomainObjectInterface::class)) {
+    /**
+     * @internal
+     *
+     * @phpstan-template T of object
+     * @phpstan-extends AbstractTaggedAdmin<T>
+     */
+    abstract class BaseAbstractAdmin extends AbstractTaggedAdmin implements DomainObjectInterface
+    {
+    }
+} else {
+    /**
+     * @internal
+     *
+     * @phpstan-template T of object
+     * @phpstan-extends AbstractTaggedAdmin<T>
+     */
+    abstract class BaseAbstractAdmin extends AbstractTaggedAdmin
+    {
+    }
+}
+
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
  *
  * @phpstan-template T of object
- * @phpstan-extends AbstractTaggedAdmin<T>
+ * @phpstan-extends BaseAbstractAdmin<T>
  * @phpstan-implements AdminInterface<T>
  */
-abstract class AbstractAdmin extends AbstractTaggedAdmin implements AdminInterface, DomainObjectInterface, AdminTreeInterface
+abstract class AbstractAdmin extends BaseAbstractAdmin implements AdminInterface, AdminTreeInterface
 {
     // NEXT_MAJOR: Remove the CONTEXT constants.
     /** @deprecated */

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -85,7 +85,7 @@ class CRUDController extends AbstractController
         return [
             'sonata.admin.pool' => Pool::class,
             'sonata.admin.audit.manager' => AuditManagerInterface::class,
-            'sonata.admin.object.manipulator.acl.admin' => AdminObjectAclManipulator::class,
+            'sonata.admin.object.manipulator.acl.admin' => '?'.AdminObjectAclManipulator::class,
             'sonata.admin.request.fetcher' => AdminFetcherInterface::class,
             'sonata.exporter.exporter' => '?'.ExporterInterface::class,
             'sonata.admin.admin_exporter' => '?'.AdminExporter::class,

--- a/src/DependencyInjection/Compiler/ObjectAclManipulatorCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ObjectAclManipulatorCompilerPass.php
@@ -28,6 +28,10 @@ final class ObjectAclManipulatorCompilerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
+        if (!$container->has('sonata.admin.command.generate_object_acl')) {
+            return;
+        }
+
         $availableManagers = [];
 
         foreach ($container->getServiceIds() as $id) {

--- a/src/DependencyInjection/SonataAdminExtension.php
+++ b/src/DependencyInjection/SonataAdminExtension.php
@@ -30,6 +30,7 @@ use Symfony\Component\Form\Extension\Core\Type\EmailType as SymfonyEmailType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType as SymfonyIntegerType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType as SymfonyTextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType as SymfonyTextType;
+use Symfony\Component\Security\Acl\Model\ObjectIdentityInterface;
 
 /**
  * @author Thomas Rabaix <thomas.rabaix@sonata-project.org>
@@ -183,6 +184,11 @@ final class SonataAdminExtension extends Extension
         $container->setParameter('sonata.admin.configuration.security.object_permissions', $config['security']['object_permissions']);
 
         $loader->load('security.php');
+
+        if (interface_exists(ObjectIdentityInterface::class)) {
+            // only load this in case the optional symfony/security-acl package is installed
+            $loader->load('acl.php');
+        }
 
         $container->setParameter('sonata.admin.extension.map', $config['extensions']);
 

--- a/src/Resources/config/acl.php
+++ b/src/Resources/config/acl.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Sonata Project package.
+ *
+ * (c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Sonata\AdminBundle\Command\GenerateObjectAclCommand;
+use Sonata\AdminBundle\Command\SetupAclCommand;
+use Sonata\AdminBundle\Security\Acl\Permission\MaskBuilder;
+use Sonata\AdminBundle\Security\Handler\AclSecurityHandler;
+use Sonata\AdminBundle\Util\AdminAclManipulator;
+use Sonata\AdminBundle\Util\AdminObjectAclManipulator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->parameters()
+        ->set('sonata.admin.security.handler.acl.class', AclSecurityHandler::class)
+
+        ->set('sonata.admin.security.mask.builder.class', MaskBuilder::class)
+
+        ->set('sonata.admin.manipulator.acl.admin.class', AdminAclManipulator::class)
+
+        ->set('sonata.admin.object.manipulator.acl.admin.class', AdminObjectAclManipulator::class);
+
+    $containerConfigurator->services()
+        ->set('sonata.admin.command.generate_object_acl', GenerateObjectAclCommand::class)
+            ->tag('console.command')
+            ->args([
+                service('sonata.admin.pool'),
+                abstract_arg('acl object manipulators'),
+            ])
+
+        ->set('sonata.admin.command.setup_acl', SetupAclCommand::class)
+            ->tag('console.command')
+            ->args([
+                service('sonata.admin.pool'),
+                service('sonata.admin.manipulator.acl.admin'),
+            ])
+
+        ->set('sonata.admin.security.handler.acl', (string) param('sonata.admin.security.handler.acl.class'))
+            ->args([
+                service('security.token_storage'),
+                service('security.authorization_checker'),
+                service('security.acl.provider')->nullOnInvalid(),
+                param('sonata.admin.security.mask.builder.class'),
+                param('sonata.admin.configuration.security.role_super_admin'),
+            ])
+            ->call('setAdminPermissions', [param('sonata.admin.configuration.security.admin_permissions')])
+            ->call('setObjectPermissions', [param('sonata.admin.configuration.security.object_permissions')])
+
+        ->set('sonata.admin.manipulator.acl.admin', (string) param('sonata.admin.manipulator.acl.admin.class'))
+            ->args([
+                param('sonata.admin.security.mask.builder.class'),
+            ])
+
+        ->set('sonata.admin.object.manipulator.acl.admin', (string) param('sonata.admin.object.manipulator.acl.admin.class'))
+            ->args([
+                service('form.factory'),
+                param('sonata.admin.security.mask.builder.class'),
+            ])
+
+        ->alias(AdminObjectAclManipulator::class, 'sonata.admin.object.manipulator.acl.admin');
+};

--- a/src/Resources/config/commands.php
+++ b/src/Resources/config/commands.php
@@ -14,9 +14,7 @@ declare(strict_types=1);
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Sonata\AdminBundle\Command\ExplainAdminCommand;
-use Sonata\AdminBundle\Command\GenerateObjectAclCommand;
 use Sonata\AdminBundle\Command\ListAdminCommand;
-use Sonata\AdminBundle\Command\SetupAclCommand;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->services()
@@ -27,23 +25,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
                 service('sonata.admin.pool'),
             ])
 
-        ->set('sonata.admin.command.generate_object_acl', GenerateObjectAclCommand::class)
-            ->tag('console.command')
-            ->args([
-                service('sonata.admin.pool'),
-                abstract_arg('acl object manipulators'),
-            ])
-
         ->set('sonata.admin.command.list', ListAdminCommand::class)
             ->tag('console.command')
             ->args([
                 service('sonata.admin.pool'),
-            ])
-
-        ->set('sonata.admin.command.setup_acl', SetupAclCommand::class)
-            ->tag('console.command')
-            ->args([
-                service('sonata.admin.pool'),
-                service('sonata.admin.manipulator.acl.admin'),
             ]);
 };

--- a/src/Resources/config/security.php
+++ b/src/Resources/config/security.php
@@ -13,27 +13,15 @@ declare(strict_types=1);
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Sonata\AdminBundle\Security\Acl\Permission\MaskBuilder;
-use Sonata\AdminBundle\Security\Handler\AclSecurityHandler;
 use Sonata\AdminBundle\Security\Handler\NoopSecurityHandler;
 use Sonata\AdminBundle\Security\Handler\RoleSecurityHandler;
-use Sonata\AdminBundle\Util\AdminAclManipulator;
-use Sonata\AdminBundle\Util\AdminObjectAclManipulator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->parameters()
 
         ->set('sonata.admin.security.handler.noop.class', NoopSecurityHandler::class)
 
-        ->set('sonata.admin.security.handler.role.class', RoleSecurityHandler::class)
-
-        ->set('sonata.admin.security.handler.acl.class', AclSecurityHandler::class)
-
-        ->set('sonata.admin.security.mask.builder.class', MaskBuilder::class)
-
-        ->set('sonata.admin.manipulator.acl.admin.class', AdminAclManipulator::class)
-
-        ->set('sonata.admin.object.manipulator.acl.admin.class', AdminObjectAclManipulator::class);
+        ->set('sonata.admin.security.handler.role.class', RoleSecurityHandler::class);
 
     $containerConfigurator->services()
 
@@ -43,29 +31,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
             ->args([
                 service('security.authorization_checker'),
                 param('sonata.admin.configuration.security.role_super_admin'),
-            ])
-
-        ->set('sonata.admin.security.handler.acl', (string) param('sonata.admin.security.handler.acl.class'))
-            ->args([
-                service('security.token_storage'),
-                service('security.authorization_checker'),
-                service('security.acl.provider')->nullOnInvalid(),
-                param('sonata.admin.security.mask.builder.class'),
-                param('sonata.admin.configuration.security.role_super_admin'),
-            ])
-            ->call('setAdminPermissions', [param('sonata.admin.configuration.security.admin_permissions')])
-            ->call('setObjectPermissions', [param('sonata.admin.configuration.security.object_permissions')])
-
-        ->set('sonata.admin.manipulator.acl.admin', (string) param('sonata.admin.manipulator.acl.admin.class'))
-            ->args([
-                param('sonata.admin.security.mask.builder.class'),
-            ])
-
-        ->set('sonata.admin.object.manipulator.acl.admin', (string) param('sonata.admin.object.manipulator.acl.admin.class'))
-            ->args([
-                service('form.factory'),
-                param('sonata.admin.security.mask.builder.class'),
-            ])
-
-        ->alias(AdminObjectAclManipulator::class, 'sonata.admin.object.manipulator.acl.admin');
+            ]);
 };

--- a/src/Security/Acl/Permission/AdminPermissionMap.php
+++ b/src/Security/Acl/Permission/AdminPermissionMap.php
@@ -15,6 +15,22 @@ namespace Sonata\AdminBundle\Security\Acl\Permission;
 
 use Symfony\Component\Security\Acl\Permission\PermissionMapInterface;
 
+if (interface_exists(PermissionMapInterface::class)) {
+    /**
+     * @internal
+     */
+    abstract class BaseAdminPermissionMap implements PermissionMapInterface
+    {
+    }
+} else {
+    /**
+     * @internal
+     */
+    abstract class BaseAdminPermissionMap
+    {
+    }
+}
+
 /**
  * This is basic permission map complements the masks which have been defined
  * on the standard implementation of the MaskBuilder.
@@ -22,7 +38,7 @@ use Symfony\Component\Security\Acl\Permission\PermissionMapInterface;
  * @author Johannes M. Schmitt <schmittjoh@gmail.com>
  * @author Thomas Rabaix <thomas.rabaix@gmail.com>
  */
-final class AdminPermissionMap implements PermissionMapInterface
+final class AdminPermissionMap extends BaseAdminPermissionMap
 {
     public const PERMISSION_VIEW = 'VIEW';
     public const PERMISSION_EDIT = 'EDIT';
@@ -42,80 +58,12 @@ final class AdminPermissionMap implements PermissionMapInterface
      *
      * @var array<string, int[]>
      */
-    private array $map = [
-        self::PERMISSION_VIEW => [
-            MaskBuilder::MASK_VIEW,
-            MaskBuilder::MASK_LIST,
-            MaskBuilder::MASK_EDIT,
-            MaskBuilder::MASK_OPERATOR,
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ],
+    private array $map;
 
-        self::PERMISSION_EDIT => [
-            MaskBuilder::MASK_EDIT,
-            MaskBuilder::MASK_OPERATOR,
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ],
-
-        self::PERMISSION_HISTORY => [
-            MaskBuilder::MASK_HISTORY,
-            MaskBuilder::MASK_OPERATOR,
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ],
-
-        self::PERMISSION_CREATE => [
-            MaskBuilder::MASK_CREATE,
-            MaskBuilder::MASK_OPERATOR,
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ],
-
-        self::PERMISSION_DELETE => [
-            MaskBuilder::MASK_DELETE,
-            MaskBuilder::MASK_OPERATOR,
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ],
-
-        self::PERMISSION_UNDELETE => [
-            MaskBuilder::MASK_UNDELETE,
-            MaskBuilder::MASK_OPERATOR,
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ],
-
-        self::PERMISSION_LIST => [
-            MaskBuilder::MASK_LIST,
-            MaskBuilder::MASK_OPERATOR,
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ],
-
-        self::PERMISSION_EXPORT => [
-            MaskBuilder::MASK_EXPORT,
-            MaskBuilder::MASK_OPERATOR,
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ],
-
-        self::PERMISSION_OPERATOR => [
-            MaskBuilder::MASK_OPERATOR,
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ],
-
-        self::PERMISSION_MASTER => [
-            MaskBuilder::MASK_MASTER,
-            MaskBuilder::MASK_OWNER,
-        ],
-
-        self::PERMISSION_OWNER => [
-            MaskBuilder::MASK_OWNER,
-        ],
-    ];
+    public function __construct()
+    {
+        $this->map = $this->getMap();
+    }
 
     /**
      * @param string $permission
@@ -135,5 +83,102 @@ final class AdminPermissionMap implements PermissionMapInterface
     public function contains($permission): bool
     {
         return isset($this->map[$permission]);
+    }
+
+    /**
+     * @return array<string, int[]>
+     */
+    private function getMap(): array
+    {
+        if (!class_exists(Symfony\Component\Security\Acl\Permission\MaskBuilder::class)) {
+            return [
+                self::PERMISSION_VIEW => [],
+                self::PERMISSION_EDIT => [],
+                self::PERMISSION_HISTORY => [],
+                self::PERMISSION_CREATE => [],
+                self::PERMISSION_DELETE => [],
+                self::PERMISSION_UNDELETE => [],
+                self::PERMISSION_LIST => [],
+                self::PERMISSION_EXPORT => [],
+                self::PERMISSION_OPERATOR => [],
+                self::PERMISSION_MASTER => [],
+                self::PERMISSION_OWNER => [],
+            ];
+        }
+
+        return [
+            self::PERMISSION_VIEW => [
+                MaskBuilder::MASK_VIEW,
+                MaskBuilder::MASK_LIST,
+                MaskBuilder::MASK_EDIT,
+                MaskBuilder::MASK_OPERATOR,
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ],
+
+            self::PERMISSION_EDIT => [
+                MaskBuilder::MASK_EDIT,
+                MaskBuilder::MASK_OPERATOR,
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ],
+
+            self::PERMISSION_HISTORY => [
+                MaskBuilder::MASK_HISTORY,
+                MaskBuilder::MASK_OPERATOR,
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ],
+
+            self::PERMISSION_CREATE => [
+                MaskBuilder::MASK_CREATE,
+                MaskBuilder::MASK_OPERATOR,
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ],
+
+            self::PERMISSION_DELETE => [
+                MaskBuilder::MASK_DELETE,
+                MaskBuilder::MASK_OPERATOR,
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ],
+
+            self::PERMISSION_UNDELETE => [
+                MaskBuilder::MASK_UNDELETE,
+                MaskBuilder::MASK_OPERATOR,
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ],
+
+            self::PERMISSION_LIST => [
+                MaskBuilder::MASK_LIST,
+                MaskBuilder::MASK_OPERATOR,
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ],
+
+            self::PERMISSION_EXPORT => [
+                MaskBuilder::MASK_EXPORT,
+                MaskBuilder::MASK_OPERATOR,
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ],
+
+            self::PERMISSION_OPERATOR => [
+                MaskBuilder::MASK_OPERATOR,
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ],
+
+            self::PERMISSION_MASTER => [
+                MaskBuilder::MASK_MASTER,
+                MaskBuilder::MASK_OWNER,
+            ],
+
+            self::PERMISSION_OWNER => [
+                MaskBuilder::MASK_OWNER,
+            ],
+        ];
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

<!-- Describe your Pull Request content here -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #7303

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Changed
- the `symfony/security-acl` dependency is now optional. You need to explicitly require it as a dependency if you are using ACL. 
```

## Todo
- [x] test on real app
- [x] add docs/upgrade notice?
- [x] should we remove some services if `symfony/security-acl` is not present?
- [x] make it also optional on SonataDoctrineORMBundle (https://github.com/sonata-project/SonataDoctrineORMAdminBundle/pull/1858)

