### PR TITLE
Sanitize xml http error responses

### DIFF
--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -52,6 +52,9 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\String\UnicodeString;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 

--- a/src/Controller/CRUDController.php
+++ b/src/Controller/CRUDController.php
@@ -52,9 +52,6 @@ use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 use Symfony\Component\String\UnicodeString;
-use Symfony\Component\Validator\Constraint;
-use Symfony\Component\Validator\ConstraintViolation;
-use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Twig\Environment;
 

--- a/src/Form/FormErrorIteratorToConstraintViolationList.php
+++ b/src/Form/FormErrorIteratorToConstraintViolationList.php
@@ -29,13 +29,13 @@ final class FormErrorIteratorToConstraintViolationList
     /**
      * @param FormErrorIterator<FormError> $errors
      */
-    public static function transform(FormErrorIterator $errors): ConstraintViolationListInterface
+    public static function transform(FormErrorIterator $errors, bool $removeSensitiveData = false): ConstraintViolationListInterface
     {
         $form = $errors->getForm();
         $list = new ConstraintViolationList();
 
         foreach ($errors as $error) {
-            $violation = static::buildViolation($error, $form);
+            $violation = static::buildViolation($error, $form, $removeSensitiveData);
 
             if (null === $violation) {
                 continue;
@@ -47,7 +47,7 @@ final class FormErrorIteratorToConstraintViolationList
         return $list;
     }
 
-    private static function buildViolation(FormError $error, FormInterface $form): ?ConstraintViolationInterface
+    private static function buildViolation(FormError $error, FormInterface $form, bool $removeSensitiveData): ?ConstraintViolationInterface
     {
         $cause = $error->getCause();
 
@@ -57,8 +57,8 @@ final class FormErrorIteratorToConstraintViolationList
 
         return new ConstraintViolation(
             $cause->getMessage(),
-            $cause->getMessageTemplate(),
-            $cause->getParameters(),
+            $removeSensitiveData ? null : $cause->getMessageTemplate(),
+            $removeSensitiveData ? [] : $cause->getParameters(),
             $cause->getRoot(),
             self::buildName($error->getOrigin() ?? $form),
             $cause->getInvalidValue(),


### PR DESCRIPTION
## Subject

This PR introduces an optional mechanism to prevent validation error messages returned during XMLHttp requests from exposing sensitive information (e.g. internal file paths like `/var/www/.../phpXXXX` via parameters such as `{{ file }}`).

It adds an optional flag to `FormErrorIteratorToConstraintViolationList::transform()` that sanitizes error messages before they are returned in the response.

The feature is disabled by default for backward compatibility.

To enable it, override handleXmlHttpRequestErrorResponse() in your CRUD controller:

```
protected function handleXmlHttpRequestErrorResponse(Request $request, FormInterface $form): ?JsonResponse
{
    if ([] === array_intersect(['application/json', '*/*'], $request->getAcceptableContentTypes())) {
        return $this->renderJson([], Response::HTTP_NOT_ACCEPTABLE);
    }

    return $this->json(
        FormErrorIteratorToConstraintViolationList::transform($form->getErrors(true), true),
        Response::HTTP_BAD_REQUEST
    );
}
```

I am targeting this branch, because 4.x is the correct branch for backwards compatible bug fixes and security-related patches that do not introduce BC breaks.

## Changelog
```markdown
### Added
- Added optional flag to `FormErrorIteratorToConstraintViolationList::transform()` to sanitize error messages and prevent leaking sensitive information (e.g. internal file system paths)

### Security
- Added opt-in protection against exposing sensitive system information (e.g. temporary upload paths) in validation error payloads
```
