### PR TITLE
In addition to menu group icons also add support for icons on item level

### DIFF
--- a/src/Admin/Pool.php
+++ b/src/Admin/Pool.php
@@ -27,12 +27,14 @@ use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
  *     roles: list<string>,
  *     route: string,
  *     route_absolute: bool,
- *     route_params: array<string, string>
+ *     route_params: array<string, string>,
+ *     icon?: string
  * }|array{
  *     admin: string,
  *     roles: list<string>,
  *     route_absolute: bool,
- *     route_params: array<string, string>
+ *     route_params: array<string, string>,
+ *     icon?: string
  * }
  * NEXT_MAJOR: Remove the label_catalogue key.
  * @phpstan-type Group = array{

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -200,6 +200,7 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
                     'route_params' => [],
                     'route_absolute' => false,
                     'priority' => $attributes['priority'] ?? 0,
+                    'icon' => $attributes['icon'] ?? null,
                 ];
 
                 if (true === $groupDefaults[$resolvedGroupName]['on_top']

--- a/src/Menu/Provider/GroupMenuProvider.php
+++ b/src/Menu/Provider/GroupMenuProvider.php
@@ -156,6 +156,7 @@ final class GroupMenuProvider implements MenuProviderInterface
                 'label_catalogue' => $admin->getTranslationDomain(), // NEXT_MAJOR: Remove this line.
                 'translation_domain' => $admin->getTranslationDomain(),
                 'admin' => $admin,
+                'icon' => $item['icon'],
             ];
 
             return $this->menuFactory->createItem($admin->getLabel() ?? '', $options);

--- a/src/Menu/Provider/GroupMenuProvider.php
+++ b/src/Menu/Provider/GroupMenuProvider.php
@@ -156,7 +156,7 @@ final class GroupMenuProvider implements MenuProviderInterface
                 'label_catalogue' => $admin->getTranslationDomain(), // NEXT_MAJOR: Remove this line.
                 'translation_domain' => $admin->getTranslationDomain(),
                 'admin' => $admin,
-                'icon' => $item['icon'],
+                'icon' => $item['icon'] ?? null,
             ];
 
             return $this->menuFactory->createItem($admin->getLabel() ?? '', $options);


### PR DESCRIPTION
## Subject

Add `icon` support to individual `sonata.admin` service tag items, allowing per-item sidebar icons to be configured directly  without requiring a menu event listener.

I am targeting the `4.x` branch, because this is a new backwards-compatible feature addition with no BC-break.

## Changelog

```markdown
### Added
- Support for `icon` attribute on individual `sonata.admin` service tags, allowing per-item sidebar menu icons to be set directly in `services.yaml`
```

## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.

