### PR TITLE
Allow symfony/stimulus-bundle ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "symfony/security-core": "^6.4 || ^7.3 || ^8.0",
         "symfony/security-csrf": "^6.4 || ^7.3 || ^8.0",
         "symfony/serializer": "^6.4 || ^7.3 || ^8.0",
-        "symfony/stimulus-bundle": "^2.22",
+        "symfony/stimulus-bundle": "^2.22 || ^3.0",
         "symfony/string": "^6.4 || ^7.3 || ^8.0",
         "symfony/translation": "^6.4 || ^7.3 || ^8.0",
         "symfony/translation-contracts": "^2.3 || ^3.0",


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Allow symfony/stimulus-bundle ^3.0 in addition to existing ^2.22

I am targeting this branch, because it's a bc compatible update.

## Changelog

```markdown
### Added
- Support for symfony/stimulus-bundle 3.
```