### PR TITLE
Guard edit button script against missing edit route in ModelListType

### DIFF
--- a/src/Resources/views/CRUD/Association/edit_many_script.html.twig
+++ b/src/Resources/views/CRUD/Association/edit_many_script.html.twig
@@ -560,7 +560,7 @@ This code manages the many-to-[one|many] association field popup
             if (undefined === objectId || null === objectId || '' === objectId) {
                 jQuery('#field_widget_{{ id }}').html('{{ 'short_object_description_placeholder'|trans({}, 'SonataAdminBundle') }}');
 
-                {% if btn_edit %}
+                {% if associationadmin.hasroute('edit') and associationadmin.hasAccess('edit') and btn_edit %}
                     jQuery('#field_actions_{{ id }} a.btn-warning').addClass('hidden');
                 {% endif %}
 
@@ -587,7 +587,7 @@ This code manages the many-to-[one|many] association field popup
                 }
             });
 
-            {% if btn_edit %}
+            {% if associationadmin.hasroute('edit') and associationadmin.hasAccess('edit') and btn_edit %}
                 var edit_button_url = '{{
                     associationadmin.generateUrl('edit', {(associationadmin.idParameter) : 'OBJECT_ID'})
                 }}'.replace('OBJECT_ID', objectId);


### PR DESCRIPTION
## Subject

When a `ModelListType` (`sonata_type_model_list`) field points to an admin whose `edit` route has been
removed in `configureRoutes()`, rendering the edit form throws
`RuntimeException: unable to find the route "<admin>.edit"`.

The visible edit button in `Form/form_admin_fields.html.twig` is correctly guarded by
`hasroute('edit') and hasAccess('edit') and btn_edit`, but the companion script in
`CRUD/Association/edit_many_script.html.twig` guarded the `associationadmin.generateUrl('edit', ...)`
call (and the related `btn-warning` toggle) with `btn_edit` only. As `btn_edit` defaults to the truthy
`'link_edit'`, the URL generation runs even when the route does not exist, crashing the whole form
rendering.

This aligns the script's guards with the widget's, so the edit URL is only generated when the associated
admin actually has an accessible `edit` route.

I am targeting this branch, because it is a backwards-compatible bugfix.

## Steps to reproduce

1. Create an admin whose `configureRoutes()` calls `$collection->remove('edit')`.
2. Reference it from another admin via a `ModelListType` form field, and set a value on that field.
3. Open the other admin's edit page → `RuntimeException: unable to find the route "...edit"`.

## Changelog

```markdown
### Fixed
- Do not generate the edit button URL in `edit_many_script` when the associated admin has no accessible `edit` route
```
