### PR TITLE
Add Rector 2.x config

### DIFF
--- a/UPGRADE-4.0.md
+++ b/UPGRADE-4.0.md
@@ -152,6 +152,86 @@ Use the below config in your `rector.php` config as a starting point to automate
 ```php
 <?php
 
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\ObjectWithoutClassType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\UnionType;
+use PHPStan\Type\VoidType;
+use Rector\Config\RectorConfig;
+use Rector\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethodRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddParamTypeDeclarationRector;
+use Rector\TypeDeclaration\Rector\ClassMethod\AddReturnTypeDeclarationRector;
+use Rector\TypeDeclaration\ValueObject\AddParamTypeDeclaration;
+use Rector\TypeDeclaration\ValueObject\AddReturnTypeDeclaration;
+use Sonata\AdminBundle\Admin\AbstractAdmin;
+use Sonata\AdminBundle\Datagrid\ProxyQueryInterface;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/Acme',
+        __DIR__ . '/Magix',
+        __DIR__ . '/PatreonBundle',
+        __DIR__ . '/config',
+        __DIR__ . '/public',
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withConfiguredRule(AddReturnTypeDeclarationRector::class, [
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'preBatchAction', new VoidType()),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'configure', new VoidType()),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'alterNewInstance', new VoidType()),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'alterObject', new VoidType()),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'preValidate', new VoidType()),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'preUpdate', new VoidType()),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'postUpdate', new VoidType()),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'prePersist', new VoidType()),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'postPersist', new VoidType()),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'preRemove', new VoidType()),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'postRemove', new VoidType()),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'configureFormFields', new VoidType()),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'configureListFields', new VoidType()),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'configureDatagridFilters', new VoidType()),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'configureShowFields', new VoidType()),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'configureRoutes', new VoidType()),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'configureTabMenu', new VoidType()),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'generateBaseRoutePattern', new StringType()),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'generateBaseRouteName', new StringType()),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'getSubClass', new StringType()),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'createNewInstance', new ObjectWithoutClassType()),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'configurePersistentParameters', new ArrayType(new StringType(), new MixedType())),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'configureFilterParameters', new ArrayType(new StringType(), new MixedType())),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'configureActionButtons', new ArrayType(new StringType(), new MixedType())),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'configureExportFields', new ArrayType(new IntegerType(), new StringType())),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'configureDashboardActions', new ArrayType(new StringType(), new ArrayType(new StringType(), new MixedType()))),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'configureBatchActions', new ArrayType(new StringType(), new ArrayType(new StringType(), new MixedType()))),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'getAccessMapping', new ArrayType(new StringType(), new UnionType([new StringType(), new ArrayType(new IntegerType(), new StringType())]))),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'getPermissionsShow', new ArrayType(new IntegerType(), new StringType())),
+        new AddReturnTypeDeclaration(AbstractAdmin::class, 'configureQuery', new ObjectType(ProxyQueryInterface::class)),
+    ])
+    ->withConfiguredRule(AddParamTypeDeclarationRector::class, [
+        new AddParamTypeDeclaration(AbstractAdmin::class, 'alterNewInstance', 0, new ObjectWithoutClassType()),
+        new AddParamTypeDeclaration(AbstractAdmin::class, 'alterObject', 0, new ObjectWithoutClassType()),
+        new AddParamTypeDeclaration(AbstractAdmin::class, 'preValidate', 0, new ObjectWithoutClassType()),
+        new AddParamTypeDeclaration(AbstractAdmin::class, 'preUpdate', 0, new ObjectWithoutClassType()),
+        new AddParamTypeDeclaration(AbstractAdmin::class, 'postUpdate', 0, new ObjectWithoutClassType()),
+        new AddParamTypeDeclaration(AbstractAdmin::class, 'prePersist', 0, new ObjectWithoutClassType()),
+        new AddParamTypeDeclaration(AbstractAdmin::class, 'postPersist', 0, new ObjectWithoutClassType()),
+        new AddParamTypeDeclaration(AbstractAdmin::class, 'preRemove', 0, new ObjectWithoutClassType()),
+        new AddParamTypeDeclaration(AbstractAdmin::class, 'postRemove', 0, new ObjectWithoutClassType()),
+    ])
+    ->withRules([
+        AddParamBasedOnParentClassMethodRector::class,
+    ]);
+```
+
+And for Rector 1.x:
+
+```php
+<?php
+
 declare(strict_types=1);
 
 use PHPStan\Type\ArrayType;


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject

Rector has changed its config format in 2.x. This updates the config to work with new version while keeping the legacy config as well.

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - 4.x is for everything backwards compatible, like patches, features and deprecation notices
    - 5.x is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/sonata-project/SonataAdminBundle/blob/4.x/CONTRIBUTING.md#base-branch
-->
I am targeting this branch, because the UPGRADE doc is referencing 4.x migration.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: https://keepachangelog.com/
    This will end up on https://github.com/sonata-project/SonataAdminBundle/releases,
    please keep it short and clear and to the point
-->

<!--
    If you are updating something that doesn't require
    a release, you can delete the whole "Changelog" section.
    (eg. update to docs, tests)
-->

<!-- REMOVE EMPTY SECTIONS
    - Don't repeat the verb in the messages (don't use "Added", "Changed", etc).
    - Don't use a full stop at the end of the messages.
-->
```markdown
### Added
Rector config for 4.x upgrade.

```
