### PR TITLE
Theme in TemplateRegistry

### DIFF
--- a/docs/reference/templates.rst
+++ b/docs/reference/templates.rst
@@ -167,12 +167,13 @@ can specify the templates to use in the ``Admin`` service definition:
             class: App\Admin\PostAdmin
             calls:
                 - [setTemplate, ['edit', 'PostAdmin/edit.html.twig']]
+                - [setTemplate, ['edit', 'PostAdmin/custom_theme/edit.html.twig', 'custom_theme']]
             tags:
                 - { name: sonata.admin, model_class: App\Entity\Post, manager_type: orm, group: 'Content', label: 'Post' }
 
 .. note::
 
-    A ``setTemplates(array $templates)`` (notice the plural) method also
+    A ``setTemplates(array $templates, string $theme = 'default')`` (notice the plural) method also
     exists, that allows you to set multiple templates at once.
 
 Changes made using the ``setTemplate()`` and ``setTemplates()`` methods
@@ -184,7 +185,7 @@ Finding configured templates
 ----------------------------
 Each ``Admin`` has a ``TemplateRegistry`` service connected to it that holds
 the templates registered through the configuration above. Through the method
-``getTemplate($name)`` of that class, you can access the templates set for
+``getTemplate($name, $theme = 'default')`` of that class, you can access the templates set for
 that ``Admin``. The ``TemplateRegistry`` is available through ``$this->getTemplateRegistry()``
 within the ``Admin``. Using the service container the template registries can
 be accessed outside an ``Admin``. Use the ``Admin`` code + ``.template_registry``
@@ -194,13 +195,13 @@ as the service ID (i.e. "app.admin.post" uses the Template Registry
 The ``TemplateRegistry`` service that holds the global templates can be accessed
 using the service ID "sonata.admin.global_template_registry".
 
-Within Twig templates, you can use the ``get_admin_template($name, $adminCode)``
+Within Twig templates, you can use the ``get_admin_template($name, $adminCode, $theme = 'default')``
 function to access the templates of the current ``Admin``, or the
-``get_global_template($name)`` function to access global templates.
+``get_global_template($name, $theme = 'default')`` function to access global templates.
 
 .. code-block:: html+twig
 
-    {% extends get_admin_template('base_list_field', admin.code) %}
+    {% extends get_admin_template('base_list_field', admin.code, 'default') %}
 
     {% block field %}
         {# ... #}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9,3 +9,18 @@ parameters:
         - # The phpstan-param is less precise than the psalm-param https://github.com/phpstan/phpstan/issues/4703
             message: '#^Parameter \#1 \$value of method Sonata\\AdminBundle\\Form\\DataTransformer\\ModelsToArrayTransformer\<T of object\>\:\:reverseTransform\(\) expects array\<int\|string\>\|null, array\<mixed, array\<string\>\|int\|string\> given\.$#'
             path: src/Form/DataTransformer/ModelToIdPropertyTransformer.php
+        - # https://github.com/sonata-project/SonataAdminBundle/pull/8390
+            message: '#Method Sonata\\AdminBundle\\Templating\\TemplateRegistryInterface::getTemplates\(\) invoked with 1 parameters, 0 required\.#'
+            path: .
+        - # https://github.com/sonata-project/SonataAdminBundle/pull/8390
+            message: '#Method Sonata\\AdminBundle\\Templating\\TemplateRegistryInterface::getTemplate\(\) invoked with 2 parameters, 1 required\.#'
+            path: .
+        - # https://github.com/sonata-project/SonataAdminBundle/pull/8390
+            message: '#Method Sonata\\AdminBundle\\Templating\\TemplateRegistryInterface::hasTemplate\(\) invoked with 2 parameters, 1 required\.#'
+            path: .
+        - # https://github.com/sonata-project/SonataAdminBundle/pull/8390
+            message: '#Method Sonata\\AdminBundle\\Templating\\MutableTemplateRegistryInterface::setTemplates\(\) invoked with 2 parameters, 1 required\.#'
+            path: .
+        - # https://github.com/sonata-project/SonataAdminBundle/pull/8390
+            message: '#Method Sonata\\AdminBundle\\Templating\\MutableTemplateRegistryInterface::setTemplate\(\) invoked with 3 parameters, 2 required\.#'
+            path: .

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -10,7 +10,7 @@ parameters:
             message: '#^Parameter \#1 \$value of method Sonata\\AdminBundle\\Form\\DataTransformer\\ModelsToArrayTransformer\<T of object\>\:\:reverseTransform\(\) expects array\<int\|string\>\|null, array\<mixed, array\<string\>\|int\|string\> given\.$#'
             path: src/Form/DataTransformer/ModelToIdPropertyTransformer.php
         - # https://github.com/sonata-project/SonataAdminBundle/pull/8390
-            message: '#Method Sonata\\AdminBundle\\Templating\\TemplateRegistryInterface::getTemplates\(\) invoked with 1 parameters, 0 required\.#'
+            message: '#Method Sonata\\AdminBundle\\Templating\\TemplateRegistryInterface::getTemplates\(\) invoked with 1 parameter, 0 required\.#'
             path: .
         - # https://github.com/sonata-project/SonataAdminBundle/pull/8390
             message: '#Method Sonata\\AdminBundle\\Templating\\TemplateRegistryInterface::getTemplate\(\) invoked with 2 parameters, 1 required\.#'

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -17,7 +17,6 @@ use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Datagrid\Pager;
 use Sonata\AdminBundle\DependencyInjection\Admin\TaggedAdminInterface;
 use Sonata\AdminBundle\Templating\MutableTemplateRegistry;
-use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -468,13 +468,21 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
         Definition $definition,
     ): void {
         $definedTemplates = $container->getParameter('sonata.admin.configuration.templates');
+        $definedThemedTemplates = [];
+        $definedThemedTemplates['default'] = $container->getParameter('sonata.admin.configuration.templates');
         \assert(\is_array($definedTemplates));
+        \assert(\is_array($definedThemedTemplates));
 
         $methods = [];
         $pos = 0;
         foreach ($definition->getMethodCalls() as [$method, $args]) {
             if ('setTemplates' === $method) {
-                $definedTemplates = array_merge($definedTemplates, $args[0]);
+                if (isset($args[1]) && 'default' === $args[1]) {
+                    $definedThemedTemplates[$args[1]] = $args[0] + ($definedThemedTemplates[$args[1]] ?? []);
+                } else {
+
+                    $definedTemplates = array_merge($definedTemplates, $args[0]);
+                }
 
                 continue;
             }

--- a/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
+++ b/src/DependencyInjection/Compiler/AddDependencyCallsCompilerPass.php
@@ -17,6 +17,7 @@ use Sonata\AdminBundle\Admin\Pool;
 use Sonata\AdminBundle\Datagrid\Pager;
 use Sonata\AdminBundle\DependencyInjection\Admin\TaggedAdminInterface;
 use Sonata\AdminBundle\Templating\MutableTemplateRegistry;
+use Sonata\AdminBundle\Templating\TemplateRegistryInterface;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Compiler\ServiceLocatorTagPass;
@@ -477,10 +478,9 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
         $pos = 0;
         foreach ($definition->getMethodCalls() as [$method, $args]) {
             if ('setTemplates' === $method) {
-                if (isset($args[1]) && 'default' === $args[1]) {
+                if (isset($args[1]) && \is_string($args['1'])) {
                     $definedThemedTemplates[$args[1]] = $args[0] + ($definedThemedTemplates[$args[1]] ?? []);
                 } else {
-
                     $definedTemplates = array_merge($definedTemplates, $args[0]);
                 }
 
@@ -488,7 +488,11 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
             }
 
             if ('setTemplate' === $method) {
-                $definedTemplates[$args[0]] = $args[1];
+                if (isset($args[2]) && \is_string($args['2'])) {
+                    $definedThemedTemplates[$args[2]][$args[0]] = $args[1];
+                } else {
+                    $definedTemplates[$args[0]] = $args[1];
+                }
 
                 continue;
             }
@@ -522,6 +526,7 @@ final class AddDependencyCallsCompilerPass implements CompilerPassInterface
             $templateRegistryDefinition->addArgument('%sonata.admin.configuration.templates%');
         }
 
+        $templateRegistryDefinition->addArgument($definedThemedTemplates);
         $definition->addMethodCall('setTemplateRegistry', [new Reference($templateRegistryId)]);
     }
 

--- a/src/Templating/AbstractTemplateRegistry.php
+++ b/src/Templating/AbstractTemplateRegistry.php
@@ -40,9 +40,9 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
         $this->templates = $this->themedTemplates[TemplateRegistryInterface::DEFAULT_THEME];
     }
 
-    // NEXT_MAJOR: Remove phpstan-ignore line and if section.
     final public function getTemplates(string $theme = TemplateRegistryInterface::DEFAULT_THEME): array
     {
+        // NEXT_MAJOR: Remove if section.
         if (TemplateRegistryInterface::DEFAULT_THEME === $theme) {
             return $this->templates;
         }
@@ -50,9 +50,10 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
         return $this->themedTemplates[$theme] ?? [];
     }
 
-    // NEXT_MAJOR: Remove phpstan-ignore line and if section.
+
     final public function hasTemplate(string $name, string $theme = TemplateRegistryInterface::DEFAULT_THEME): bool
     {
+        // NEXT_MAJOR: Remove if section.
         if (TemplateRegistryInterface::DEFAULT_THEME === $theme) {
             return isset($this->templates[$name]);
         }
@@ -62,8 +63,6 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
 
     /**
      * NEXT_MAJOR: remove phpstan-ignore line and if section.
-     *
-     * @phpstan-ignore arguments.count
      */
     final public function getTemplate(string $name, string $theme = TemplateRegistryInterface::DEFAULT_THEME): string
     {

--- a/src/Templating/AbstractTemplateRegistry.php
+++ b/src/Templating/AbstractTemplateRegistry.php
@@ -19,6 +19,7 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
      * @var array<string, string>
      *
      * @deprecated since sonata-project/admin-bundle x.x, will be removed in x.x.
+     *
      * NEXT_MAJOR: Remove this property.
      */
     protected $templates = [];
@@ -41,6 +42,7 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
 
     /**
      * NEXT_MAJOR: Remove phpstan-ignore line and if section.
+     *
      * @phpstan-ignore arguments.count
      */
     final public function getTemplates(string $theme = TemplateRegistryInterface::DEFAULT_THEME): array
@@ -54,6 +56,7 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
 
     /**
      * NEXT_MAJOR: Remove phpstan-ignore line and if section.
+     *
      * @phpstan-ignore arguments.count
      */
     final public function hasTemplate(string $name, string $theme = TemplateRegistryInterface::DEFAULT_THEME): bool
@@ -67,6 +70,7 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
 
     /**
      * NEXT_MAJOR: remove phpstan-ignore line and if section.
+     *
      * @phpstan-ignore arguments.count
      */
     final public function getTemplate(string $name, string $theme = TemplateRegistryInterface::DEFAULT_THEME): string
@@ -81,6 +85,7 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
 
         /*
          * NEXT_MAJOR: Remove phpstan-ignore line.
+         *
          * @phpstan-ignore arguments.count
          */
         if ($this->hasTemplate($name, $theme)) {

--- a/src/Templating/AbstractTemplateRegistry.php
+++ b/src/Templating/AbstractTemplateRegistry.php
@@ -19,7 +19,7 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
      * @var array<string, string>
      *
      * @deprecated since sonata-project/admin-bundle x.x, will be removed in x.x.
-     * NEXT_MAJOR: remove this property
+     * NEXT_MAJOR: Remove this property.
      */
     protected $templates = [];
 
@@ -40,8 +40,8 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
     }
 
     /**
+     * NEXT_MAJOR: Remove phpstan-ignore line and if section.
      * @phpstan-ignore arguments.count
-     * NEXT_MAJOR: remove phpstan-ignore and if section
      */
     final public function getTemplates(string $theme = TemplateRegistryInterface::DEFAULT_THEME): array
     {
@@ -53,8 +53,8 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
     }
 
     /**
+     * NEXT_MAJOR: Remove phpstan-ignore line and if section.
      * @phpstan-ignore arguments.count
-     * NEXT_MAJOR: remove phpstan-ignore and if section
      */
     final public function hasTemplate(string $name, string $theme = TemplateRegistryInterface::DEFAULT_THEME): bool
     {
@@ -66,8 +66,8 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
     }
 
     /**
+     * NEXT_MAJOR: remove phpstan-ignore line and if section.
      * @phpstan-ignore arguments.count
-     * NEXT_MAJOR: remove phpstan-ignore and if section
      */
     final public function getTemplate(string $name, string $theme = TemplateRegistryInterface::DEFAULT_THEME): string
     {
@@ -80,8 +80,8 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
         }
 
         /*
+         * NEXT_MAJOR: Remove phpstan-ignore line.
          * @phpstan-ignore arguments.count
-         * NEXT_MAJOR: remove phpstan-ignore
          */
         if ($this->hasTemplate($name, $theme)) {
             return $this->themedTemplates[$theme][$name];

--- a/src/Templating/AbstractTemplateRegistry.php
+++ b/src/Templating/AbstractTemplateRegistry.php
@@ -73,7 +73,6 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
 
         /*
          * NEXT_MAJOR: Remove phpstan-ignore line.
-         * @phpstan-ignore arguments.count
          */
         if ($this->hasTemplate($name, $theme)) {
             return $this->themedTemplates[$theme][$name];

--- a/src/Templating/AbstractTemplateRegistry.php
+++ b/src/Templating/AbstractTemplateRegistry.php
@@ -79,7 +79,7 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
             throw new \InvalidArgumentException(\sprintf('Template named "%s" doesn\'t exist.', $name));
         }
 
-        /**
+        /*
          * @phpstan-ignore arguments.count
          * NEXT_MAJOR: remove phpstan-ignore
          */

--- a/src/Templating/AbstractTemplateRegistry.php
+++ b/src/Templating/AbstractTemplateRegistry.php
@@ -36,16 +36,16 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
     {
         $this->templates = $templates;
         $this->themedTemplates = $themedTemplates;
-        $this->themedTemplates['default'] = $templates + ($this->themedTemplates['default'] ?? []);
+        $this->themedTemplates[TemplateRegistryInterface::DEFAULT_THEME] = $templates + ($this->themedTemplates[TemplateRegistryInterface::DEFAULT_THEME] ?? []);
     }
 
     /**
      * @phpstan-ignore arguments.count
      * NEXT_MAJOR: remove phpstan-ignore and if section
      */
-    final public function getTemplates(string $theme = 'default'): array
+    final public function getTemplates(string $theme = TemplateRegistryInterface::DEFAULT_THEME): array
     {
-        if ('default' === $theme) {
+        if (TemplateRegistryInterface::DEFAULT_THEME === $theme) {
             return $this->templates;
         }
 
@@ -56,9 +56,9 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
      * @phpstan-ignore arguments.count
      * NEXT_MAJOR: remove phpstan-ignore and if section
      */
-    final public function hasTemplate(string $name, string $theme = 'default'): bool
+    final public function hasTemplate(string $name, string $theme = TemplateRegistryInterface::DEFAULT_THEME): bool
     {
-        if ('default' === $theme) {
+        if (TemplateRegistryInterface::DEFAULT_THEME === $theme) {
             return isset($this->templates[$name]);
         }
 
@@ -69,9 +69,9 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
      * @phpstan-ignore arguments.count
      * NEXT_MAJOR: remove phpstan-ignore and if section
      */
-    final public function getTemplate(string $name, string $theme = 'default'): string
+    final public function getTemplate(string $name, string $theme = TemplateRegistryInterface::DEFAULT_THEME): string
     {
-        if ('default' === $theme) {
+        if (TemplateRegistryInterface::DEFAULT_THEME === $theme) {
             if ($this->hasTemplate($name)) {
                 return $this->templates[$name];
             }

--- a/src/Templating/AbstractTemplateRegistry.php
+++ b/src/Templating/AbstractTemplateRegistry.php
@@ -39,9 +39,12 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
         $this->themedTemplates['default'] = $templates + ($this->themedTemplates['default'] ?? []);
     }
 
+    /**
+     * @phpstan-ignore arguments.count
+     * NEXT_MAJOR: remove phpstan-ignore and if section
+     */
     final public function getTemplates(string $theme = 'default'): array
     {
-        // NEXT_MAJOR: remove if
         if ('default' === $theme) {
             return $this->templates;
         }
@@ -49,9 +52,12 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
         return $this->themedTemplates[$theme] ?? [];
     }
 
+    /**
+     * @phpstan-ignore arguments.count
+     * NEXT_MAJOR: remove phpstan-ignore and if section
+     */
     final public function hasTemplate(string $name, string $theme = 'default'): bool
     {
-        // NEXT_MAJOR: remove if
         if ('default' === $theme) {
             return isset($this->templates[$name]);
         }
@@ -59,9 +65,12 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
         return isset($this->themedTemplates[$theme][$name]);
     }
 
+    /**
+     * @phpstan-ignore arguments.count
+     * NEXT_MAJOR: remove phpstan-ignore and if section
+     */
     final public function getTemplate(string $name, string $theme = 'default'): string
     {
-        // NEXT_MAJOR: remove if
         if ('default' === $theme) {
             if ($this->hasTemplate($name)) {
                 return $this->templates[$name];

--- a/src/Templating/AbstractTemplateRegistry.php
+++ b/src/Templating/AbstractTemplateRegistry.php
@@ -30,8 +30,8 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
     protected $themedTemplates = [];
 
     /**
-     * @param array<string, string>                $templates       ['template_name' => 'template']
-     * @param array<string, array<string, string>> $themedTemplates ['theme_name' => ['template_name' => 'template']]
+     * @param array<string, string>                $templates       ['name' => 'file_path.html.twig']
+     * @param array<string, array<string, string>> $themedTemplates ['theme_name' => ['name' => 'file_path.html.twig']]
      */
     public function __construct(array $templates = [], array $themedTemplates = [])
     {
@@ -40,11 +40,7 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
         $this->templates = $this->themedTemplates[TemplateRegistryInterface::DEFAULT_THEME];
     }
 
-    /**
-     * NEXT_MAJOR: Remove phpstan-ignore line and if section.
-     *
-     * @phpstan-ignore arguments.count
-     */
+    // NEXT_MAJOR: Remove phpstan-ignore line and if section.
     final public function getTemplates(string $theme = TemplateRegistryInterface::DEFAULT_THEME): array
     {
         if (TemplateRegistryInterface::DEFAULT_THEME === $theme) {
@@ -54,11 +50,7 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
         return $this->themedTemplates[$theme] ?? [];
     }
 
-    /**
-     * NEXT_MAJOR: Remove phpstan-ignore line and if section.
-     *
-     * @phpstan-ignore arguments.count
-     */
+    // NEXT_MAJOR: Remove phpstan-ignore line and if section.
     final public function hasTemplate(string $name, string $theme = TemplateRegistryInterface::DEFAULT_THEME): bool
     {
         if (TemplateRegistryInterface::DEFAULT_THEME === $theme) {
@@ -83,11 +75,6 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
             throw new \InvalidArgumentException(\sprintf('Template named "%s" doesn\'t exist.', $name));
         }
 
-        /*
-         * NEXT_MAJOR: Remove phpstan-ignore line.
-         *
-         * @phpstan-ignore arguments.count
-         */
         if ($this->hasTemplate($name, $theme)) {
             return $this->themedTemplates[$theme][$name];
         }

--- a/src/Templating/AbstractTemplateRegistry.php
+++ b/src/Templating/AbstractTemplateRegistry.php
@@ -17,33 +17,63 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
 {
     /**
      * @var array<string, string>
+     *
+     * @deprecated since sonata-project/admin-bundle x.x, will be removed in x.x.
+     * NEXT_MAJOR: remove this property
      */
     protected $templates = [];
 
     /**
-     * @param string[] $templates
+     * @var array<string, array<string, string>>
      */
-    public function __construct(array $templates = [])
+    protected $themedTemplates = [];
+
+    /**
+     * @param array<string, string>                $templates       ['template_name' => 'template']
+     * @param array<string, array<string, string>> $themedTemplates ['theme_name' => ['template_name' => 'template']]
+     */
+    public function __construct(array $templates = [], array $themedTemplates = [])
     {
         $this->templates = $templates;
+        $this->themedTemplates = $themedTemplates;
+        $this->themedTemplates['default'] = $templates + ($this->themedTemplates['default'] ?? []);
     }
 
-    final public function getTemplates(): array
+    final public function getTemplates(string $theme = 'default'): array
     {
-        return $this->templates;
-    }
-
-    final public function hasTemplate(string $name): bool
-    {
-        return isset($this->templates[$name]);
-    }
-
-    final public function getTemplate(string $name): string
-    {
-        if ($this->hasTemplate($name)) {
-            return $this->templates[$name];
+        // NEXT_MAJOR: remove if
+        if ('default' === $theme) {
+            return $this->templates;
         }
 
-        throw new \InvalidArgumentException(\sprintf('Template named "%s" doesn\'t exist.', $name));
+        return $this->themedTemplates[$theme] ?? [];
+    }
+
+    final public function hasTemplate(string $name, string $theme = 'default'): bool
+    {
+        // NEXT_MAJOR: remove if
+        if ('default' === $theme) {
+            return isset($this->templates[$name]);
+        }
+
+        return isset($this->themedTemplates[$theme][$name]);
+    }
+
+    final public function getTemplate(string $name, string $theme = 'default'): string
+    {
+        // NEXT_MAJOR: remove if
+        if ('default' === $theme) {
+            if ($this->hasTemplate($name)) {
+                return $this->templates[$name];
+            }
+
+            throw new \InvalidArgumentException(\sprintf('Template named "%s" doesn\'t exist.', $name));
+        }
+
+        if ($this->hasTemplate($name, $theme)) {
+            return $this->themedTemplates[$theme][$name];
+        }
+
+        throw new \InvalidArgumentException(\sprintf('Template named "%s" doesn\'t exist for "%s" theme.', $name, $theme));
     }
 }

--- a/src/Templating/AbstractTemplateRegistry.php
+++ b/src/Templating/AbstractTemplateRegistry.php
@@ -50,7 +50,6 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
         return $this->themedTemplates[$theme] ?? [];
     }
 
-
     final public function hasTemplate(string $name, string $theme = TemplateRegistryInterface::DEFAULT_THEME): bool
     {
         // NEXT_MAJOR: Remove if section.
@@ -61,11 +60,9 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
         return isset($this->themedTemplates[$theme][$name]);
     }
 
-    /**
-     * NEXT_MAJOR: remove phpstan-ignore line and if section.
-     */
     final public function getTemplate(string $name, string $theme = TemplateRegistryInterface::DEFAULT_THEME): string
     {
+        // NEXT_MAJOR: Remove if section.
         if (TemplateRegistryInterface::DEFAULT_THEME === $theme) {
             if ($this->hasTemplate($name)) {
                 return $this->templates[$name];
@@ -74,6 +71,10 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
             throw new \InvalidArgumentException(\sprintf('Template named "%s" doesn\'t exist.', $name));
         }
 
+        /*
+         * NEXT_MAJOR: Remove phpstan-ignore line.
+         * @phpstan-ignore arguments.count
+         */
         if ($this->hasTemplate($name, $theme)) {
             return $this->themedTemplates[$theme][$name];
         }

--- a/src/Templating/AbstractTemplateRegistry.php
+++ b/src/Templating/AbstractTemplateRegistry.php
@@ -34,9 +34,9 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
      */
     public function __construct(array $templates = [], array $themedTemplates = [])
     {
-        $this->templates = $templates;
         $this->themedTemplates = $themedTemplates;
         $this->themedTemplates[TemplateRegistryInterface::DEFAULT_THEME] = $templates + ($this->themedTemplates[TemplateRegistryInterface::DEFAULT_THEME] ?? []);
+        $this->templates = $this->themedTemplates[TemplateRegistryInterface::DEFAULT_THEME];
     }
 
     /**

--- a/src/Templating/AbstractTemplateRegistry.php
+++ b/src/Templating/AbstractTemplateRegistry.php
@@ -79,6 +79,10 @@ abstract class AbstractTemplateRegistry implements TemplateRegistryInterface
             throw new \InvalidArgumentException(\sprintf('Template named "%s" doesn\'t exist.', $name));
         }
 
+        /**
+         * @phpstan-ignore arguments.count
+         * NEXT_MAJOR: remove phpstan-ignore
+         */
         if ($this->hasTemplate($name, $theme)) {
             return $this->themedTemplates[$theme][$name];
         }

--- a/src/Templating/MutableTemplateRegistry.php
+++ b/src/Templating/MutableTemplateRegistry.php
@@ -18,13 +18,9 @@ namespace Sonata\AdminBundle\Templating;
  */
 final class MutableTemplateRegistry extends AbstractTemplateRegistry implements MutableTemplateRegistryInterface
 {
-    /**
-     * NEXT_MAJOR: Remove phpstan-ignore line and if section.
-     *
-     * @phpstan-ignore arguments.count
-     */
     public function setTemplates(array $templates, string $theme = TemplateRegistryInterface::DEFAULT_THEME): void
     {
+        // NEXT_MAJOR: Remove if section.
         if (TemplateRegistryInterface::DEFAULT_THEME === $theme) {
             $this->templates = $templates + $this->templates;
         }
@@ -32,13 +28,9 @@ final class MutableTemplateRegistry extends AbstractTemplateRegistry implements 
         $this->themedTemplates[$theme] = $templates + ($this->themedTemplates[$theme] ?? []);
     }
 
-    /**
-     * NEXT_MAJOR: Remove phpstan-ignore line and if section.
-     *
-     * @phpstan-ignore arguments.count
-     */
     public function setTemplate(string $name, string $template, string $theme = TemplateRegistryInterface::DEFAULT_THEME): void
     {
+        // NEXT_MAJOR: Remove if section.
         if (TemplateRegistryInterface::DEFAULT_THEME === $theme) {
             $this->templates[$name] = $template;
         }

--- a/src/Templating/MutableTemplateRegistry.php
+++ b/src/Templating/MutableTemplateRegistry.php
@@ -32,7 +32,7 @@ final class MutableTemplateRegistry extends AbstractTemplateRegistry implements 
             return;
         }
 
-        $this->themedTemplates[$theme] = $templates + $this->themedTemplates[$theme];
+        $this->themedTemplates[$theme] = $templates + ($this->themedTemplates[$theme] ?? []);
     }
 
     /**

--- a/src/Templating/MutableTemplateRegistry.php
+++ b/src/Templating/MutableTemplateRegistry.php
@@ -19,12 +19,11 @@ namespace Sonata\AdminBundle\Templating;
 final class MutableTemplateRegistry extends AbstractTemplateRegistry implements MutableTemplateRegistryInterface
 {
     /**
+     * NEXT_MAJOR: Remove phpstan-ignore line and if section.
      * @phpstan-ignore arguments.count
-     * NEXT_MAJOR: remove phpstan-ignore and if section
      */
     public function setTemplates(array $templates, string $theme = TemplateRegistryInterface::DEFAULT_THEME): void
     {
-        // NEXT_MAJOR: remove if
         if (TemplateRegistryInterface::DEFAULT_THEME === $theme) {
             $this->templates = $templates + $this->templates;
         }
@@ -33,8 +32,8 @@ final class MutableTemplateRegistry extends AbstractTemplateRegistry implements 
     }
 
     /**
+     * NEXT_MAJOR: Remove phpstan-ignore line and if section.
      * @phpstan-ignore arguments.count
-     * NEXT_MAJOR: remove phpstan-ignore and if section
      */
     public function setTemplate(string $name, string $template, string $theme = TemplateRegistryInterface::DEFAULT_THEME): void
     {

--- a/src/Templating/MutableTemplateRegistry.php
+++ b/src/Templating/MutableTemplateRegistry.php
@@ -22,14 +22,11 @@ final class MutableTemplateRegistry extends AbstractTemplateRegistry implements 
      * @phpstan-ignore arguments.count
      * NEXT_MAJOR: remove phpstan-ignore and if section
      */
-    public function setTemplates(array $templates, string $theme = 'default'): void
+    public function setTemplates(array $templates, string $theme = TemplateRegistryInterface::DEFAULT_THEME): void
     {
         // NEXT_MAJOR: remove if
         if ('default' === $theme) {
             $this->templates = $templates + $this->templates;
-            $this->themedTemplates['default'] = $templates + $this->themedTemplates['default'];
-
-            return;
         }
 
         $this->themedTemplates[$theme] = $templates + ($this->themedTemplates[$theme] ?? []);
@@ -39,13 +36,10 @@ final class MutableTemplateRegistry extends AbstractTemplateRegistry implements 
      * @phpstan-ignore arguments.count
      * NEXT_MAJOR: remove phpstan-ignore and if section
      */
-    public function setTemplate(string $name, string $template, string $theme = 'default'): void
+    public function setTemplate(string $name, string $template, string $theme = TemplateRegistryInterface::DEFAULT_THEME): void
     {
-        if ('default' === $theme) {
+        if (TemplateRegistryInterface::DEFAULT_THEME === $theme) {
             $this->templates[$name] = $template;
-            $this->themedTemplates['default'][$name] = $template;
-
-            return;
         }
 
         $this->themedTemplates[$theme][$name] = $template;

--- a/src/Templating/MutableTemplateRegistry.php
+++ b/src/Templating/MutableTemplateRegistry.php
@@ -18,13 +18,29 @@ namespace Sonata\AdminBundle\Templating;
  */
 final class MutableTemplateRegistry extends AbstractTemplateRegistry implements MutableTemplateRegistryInterface
 {
-    public function setTemplates(array $templates): void
+    public function setTemplates(array $templates, string $theme = 'default'): void
     {
-        $this->templates = $templates + $this->templates;
+        // NEXT_MAJOR: remove if
+        if ('default' === $theme) {
+            $this->templates = $templates + $this->templates;
+            $this->themedTemplates['default'] = $templates + $this->themedTemplates['default'];
+
+            return;
+        }
+
+        $this->themedTemplates[$theme] = $templates + $this->themedTemplates[$theme];
     }
 
-    public function setTemplate(string $name, string $template): void
+    public function setTemplate(string $name, string $template, string $theme = 'default'): void
     {
-        $this->templates[$name] = $template;
+        // NEXT_MAJOR: remove if
+        if ('default' === $theme) {
+            $this->templates[$name] = $template;
+            $this->themedTemplates['default'][$name] = $template;
+
+            return;
+        }
+
+        $this->themedTemplates[$theme][$name] = $template;
     }
 }

--- a/src/Templating/MutableTemplateRegistry.php
+++ b/src/Templating/MutableTemplateRegistry.php
@@ -25,7 +25,7 @@ final class MutableTemplateRegistry extends AbstractTemplateRegistry implements 
     public function setTemplates(array $templates, string $theme = TemplateRegistryInterface::DEFAULT_THEME): void
     {
         // NEXT_MAJOR: remove if
-        if ('default' === $theme) {
+        if (TemplateRegistryInterface::DEFAULT_THEME === $theme) {
             $this->templates = $templates + $this->templates;
         }
 

--- a/src/Templating/MutableTemplateRegistry.php
+++ b/src/Templating/MutableTemplateRegistry.php
@@ -20,6 +20,7 @@ final class MutableTemplateRegistry extends AbstractTemplateRegistry implements 
 {
     /**
      * NEXT_MAJOR: Remove phpstan-ignore line and if section.
+     *
      * @phpstan-ignore arguments.count
      */
     public function setTemplates(array $templates, string $theme = TemplateRegistryInterface::DEFAULT_THEME): void
@@ -33,6 +34,7 @@ final class MutableTemplateRegistry extends AbstractTemplateRegistry implements 
 
     /**
      * NEXT_MAJOR: Remove phpstan-ignore line and if section.
+     *
      * @phpstan-ignore arguments.count
      */
     public function setTemplate(string $name, string $template, string $theme = TemplateRegistryInterface::DEFAULT_THEME): void

--- a/src/Templating/MutableTemplateRegistry.php
+++ b/src/Templating/MutableTemplateRegistry.php
@@ -18,6 +18,10 @@ namespace Sonata\AdminBundle\Templating;
  */
 final class MutableTemplateRegistry extends AbstractTemplateRegistry implements MutableTemplateRegistryInterface
 {
+    /**
+     * @phpstan-ignore arguments.count
+     * NEXT_MAJOR: remove phpstan-ignore and if section
+     */
     public function setTemplates(array $templates, string $theme = 'default'): void
     {
         // NEXT_MAJOR: remove if
@@ -31,9 +35,12 @@ final class MutableTemplateRegistry extends AbstractTemplateRegistry implements 
         $this->themedTemplates[$theme] = $templates + $this->themedTemplates[$theme];
     }
 
+    /**
+     * @phpstan-ignore arguments.count
+     * NEXT_MAJOR: remove phpstan-ignore and if section
+     */
     public function setTemplate(string $name, string $template, string $theme = 'default'): void
     {
-        // NEXT_MAJOR: remove if
         if ('default' === $theme) {
             $this->templates[$name] = $template;
             $this->themedTemplates['default'][$name] = $template;

--- a/src/Templating/MutableTemplateRegistryAwareInterface.php
+++ b/src/Templating/MutableTemplateRegistryAwareInterface.php
@@ -24,11 +24,11 @@ interface MutableTemplateRegistryAwareInterface
 
     public function hasTemplateRegistry(): bool;
 
-    // NEXT_MAJOR: uncomment extra arg.
+    // NEXT_MAJOR: Uncomment extra arg.
     public function setTemplate(string $name, string $template/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 
     /**
-     * NEXT_MAJOR: uncomment extra arg.
+     * NEXT_MAJOR: Uncomment extra arg.
      *
      * @param array<string, string> $templates
      */

--- a/src/Templating/MutableTemplateRegistryAwareInterface.php
+++ b/src/Templating/MutableTemplateRegistryAwareInterface.php
@@ -24,19 +24,13 @@ interface MutableTemplateRegistryAwareInterface
 
     public function hasTemplateRegistry(): bool;
 
-    /**
-     * NEXT_MAJOR: Remove phpstan-ignore line and uncomment extra arg.
-     *
-     * @phpstan-ignore arguments.count
-     */
+    //NEXT_MAJOR: Uncomment extra arg.
     public function setTemplate(string $name, string $template/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 
     /**
-     * NEXT_MAJOR: Remove phpstan-ignore line and uncomment extra arg.
+     * NEXT_MAJOR: Uncomment extra arg.
      *
      * @param array<string, string> $templates 'name' => 'file_path.html.twig'
-     *
-     * @phpstan-ignore arguments.count
      */
     public function setTemplates(array $templates/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 }

--- a/src/Templating/MutableTemplateRegistryAwareInterface.php
+++ b/src/Templating/MutableTemplateRegistryAwareInterface.php
@@ -25,11 +25,11 @@ interface MutableTemplateRegistryAwareInterface
     public function hasTemplateRegistry(): bool;
 
     // NEXT_MAJOR: uncomment extra arg
-    public function setTemplate(string $name, string $template/* , string $theme = 'default' */): void;
+    public function setTemplate(string $name, string $template/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 
     /**
+     * NEXT_MAJOR: uncomment extra arg
      * @param array<string, string> $templates
-     *                                         NEXT_MAJOR: uncomment extra arg
      */
-    public function setTemplates(array $templates/* , string $theme = 'default' */): void;
+    public function setTemplates(array $templates/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 }

--- a/src/Templating/MutableTemplateRegistryAwareInterface.php
+++ b/src/Templating/MutableTemplateRegistryAwareInterface.php
@@ -24,13 +24,19 @@ interface MutableTemplateRegistryAwareInterface
 
     public function hasTemplateRegistry(): bool;
 
-    // NEXT_MAJOR: Uncomment extra arg.
+    /**
+     * NEXT_MAJOR: Remove phpstan-ignore line and uncomment extra arg.
+     *
+     * @phpstan-ignore arguments.count
+     */
     public function setTemplate(string $name, string $template/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 
     /**
-     * NEXT_MAJOR: Uncomment extra arg.
+     * NEXT_MAJOR: Remove phpstan-ignore line and uncomment extra arg.
      *
-     * @param array<string, string> $templates
+     * @param array<string, string> $templates 'name' => 'file_path.html.twig'
+     *
+     * @phpstan-ignore arguments.count
      */
     public function setTemplates(array $templates/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 }

--- a/src/Templating/MutableTemplateRegistryAwareInterface.php
+++ b/src/Templating/MutableTemplateRegistryAwareInterface.php
@@ -24,7 +24,7 @@ interface MutableTemplateRegistryAwareInterface
 
     public function hasTemplateRegistry(): bool;
 
-    //NEXT_MAJOR: Uncomment extra arg.
+    // NEXT_MAJOR: Uncomment extra arg.
     public function setTemplate(string $name, string $template/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 
     /**

--- a/src/Templating/MutableTemplateRegistryAwareInterface.php
+++ b/src/Templating/MutableTemplateRegistryAwareInterface.php
@@ -24,11 +24,11 @@ interface MutableTemplateRegistryAwareInterface
 
     public function hasTemplateRegistry(): bool;
 
-    // NEXT_MAJOR: uncomment extra arg
+    // NEXT_MAJOR: uncomment extra arg.
     public function setTemplate(string $name, string $template/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 
     /**
-     * NEXT_MAJOR: uncomment extra arg
+     * NEXT_MAJOR: uncomment extra arg.
      * @param array<string, string> $templates
      */
     public function setTemplates(array $templates/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;

--- a/src/Templating/MutableTemplateRegistryAwareInterface.php
+++ b/src/Templating/MutableTemplateRegistryAwareInterface.php
@@ -24,10 +24,12 @@ interface MutableTemplateRegistryAwareInterface
 
     public function hasTemplateRegistry(): bool;
 
-    public function setTemplate(string $name, string $template): void;
+    // NEXT_MAJOR: uncomment extra arg
+    public function setTemplate(string $name, string $template/* , string $theme = 'default' */): void;
 
     /**
      * @param array<string, string> $templates
+     *                                         NEXT_MAJOR: uncomment extra arg
      */
-    public function setTemplates(array $templates): void;
+    public function setTemplates(array $templates/* , string $theme = 'default' */): void;
 }

--- a/src/Templating/MutableTemplateRegistryAwareInterface.php
+++ b/src/Templating/MutableTemplateRegistryAwareInterface.php
@@ -29,6 +29,7 @@ interface MutableTemplateRegistryAwareInterface
 
     /**
      * NEXT_MAJOR: uncomment extra arg.
+     *
      * @param array<string, string> $templates
      */
     public function setTemplates(array $templates/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;

--- a/src/Templating/MutableTemplateRegistryInterface.php
+++ b/src/Templating/MutableTemplateRegistryInterface.php
@@ -20,6 +20,7 @@ interface MutableTemplateRegistryInterface extends TemplateRegistryInterface
 {
     /**
      * NEXT_MAJOR: uncomment extra arg.
+     *
      * @param array<string, string> $templates 'name' => 'file_path.html.twig'
      */
     public function setTemplates(array $templates/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;

--- a/src/Templating/MutableTemplateRegistryInterface.php
+++ b/src/Templating/MutableTemplateRegistryInterface.php
@@ -18,15 +18,18 @@ namespace Sonata\AdminBundle\Templating;
  */
 interface MutableTemplateRegistryInterface extends TemplateRegistryInterface
 {
+
     /**
-     * NEXT_MAJOR: Uncomment extra arg.
+     * NEXT_MAJOR: Remove phpstan-ignore line and uncomment extra arg.
      *
      * @param array<string, string> $templates 'name' => 'file_path.html.twig'
+     *
+     * @phpstan-ignore arguments.count
      */
     public function setTemplates(array $templates/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 
     /**
-     * NEXT_MAJOR: Uncomment extra arg.
+     * NEXT_MAJOR: Remove phpstan-ignore line and uncomment extra arg.
      *
      * @phpstan-ignore arguments.count
      */

--- a/src/Templating/MutableTemplateRegistryInterface.php
+++ b/src/Templating/MutableTemplateRegistryInterface.php
@@ -22,8 +22,8 @@ interface MutableTemplateRegistryInterface extends TemplateRegistryInterface
      * @param array<string, string> $templates 'name' => 'file_path.html.twig'
      *                                         NEXT_MAJOR: uncomment extra arg
      */
-    public function setTemplates(array $templates/* , string $theme = 'default' */): void;
+    public function setTemplates(array $templates/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 
     // NEXT_MAJOR: uncomment extra arg
-    public function setTemplate(string $name, string $template/* , string $theme = 'default' */): void;
+    public function setTemplate(string $name, string $template/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 }

--- a/src/Templating/MutableTemplateRegistryInterface.php
+++ b/src/Templating/MutableTemplateRegistryInterface.php
@@ -20,8 +20,10 @@ interface MutableTemplateRegistryInterface extends TemplateRegistryInterface
 {
     /**
      * @param array<string, string> $templates 'name' => 'file_path.html.twig'
+     *                                         NEXT_MAJOR: uncomment extra arg
      */
-    public function setTemplates(array $templates): void;
+    public function setTemplates(array $templates/* , string $theme = 'default */): void;
 
-    public function setTemplate(string $name, string $template): void;
+    // NEXT_MAJOR: uncomment extra arg
+    public function setTemplate(string $name, string $template/* , string $theme = 'default' */): void;
 }

--- a/src/Templating/MutableTemplateRegistryInterface.php
+++ b/src/Templating/MutableTemplateRegistryInterface.php
@@ -25,6 +25,10 @@ interface MutableTemplateRegistryInterface extends TemplateRegistryInterface
      */
     public function setTemplates(array $templates/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 
-    // NEXT_MAJOR: Uncomment extra arg.
+    /**
+     * NEXT_MAJOR: Uncomment extra arg.
+     *
+     * @phpstan-ignore arguments.count
+     */
     public function setTemplate(string $name, string $template/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 }

--- a/src/Templating/MutableTemplateRegistryInterface.php
+++ b/src/Templating/MutableTemplateRegistryInterface.php
@@ -22,7 +22,7 @@ interface MutableTemplateRegistryInterface extends TemplateRegistryInterface
      * @param array<string, string> $templates 'name' => 'file_path.html.twig'
      *                                         NEXT_MAJOR: uncomment extra arg
      */
-    public function setTemplates(array $templates/* , string $theme = 'default */): void;
+    public function setTemplates(array $templates/* , string $theme = 'default' */): void;
 
     // NEXT_MAJOR: uncomment extra arg
     public function setTemplate(string $name, string $template/* , string $theme = 'default' */): void;

--- a/src/Templating/MutableTemplateRegistryInterface.php
+++ b/src/Templating/MutableTemplateRegistryInterface.php
@@ -25,7 +25,6 @@ interface MutableTemplateRegistryInterface extends TemplateRegistryInterface
      */
     public function setTemplates(array $templates/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 
-
     // NEXT_MAJOR: Uncomment extra arg and remove dependent record from phpstan-baseline.neon.
     public function setTemplate(string $name, string $template/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 }

--- a/src/Templating/MutableTemplateRegistryInterface.php
+++ b/src/Templating/MutableTemplateRegistryInterface.php
@@ -19,11 +19,11 @@ namespace Sonata\AdminBundle\Templating;
 interface MutableTemplateRegistryInterface extends TemplateRegistryInterface
 {
     /**
+     * NEXT_MAJOR: uncomment extra arg.
      * @param array<string, string> $templates 'name' => 'file_path.html.twig'
-     *                                         NEXT_MAJOR: uncomment extra arg
      */
     public function setTemplates(array $templates/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 
-    // NEXT_MAJOR: uncomment extra arg
+    // NEXT_MAJOR: uncomment extra arg.
     public function setTemplate(string $name, string $template/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 }

--- a/src/Templating/MutableTemplateRegistryInterface.php
+++ b/src/Templating/MutableTemplateRegistryInterface.php
@@ -19,14 +19,13 @@ namespace Sonata\AdminBundle\Templating;
 interface MutableTemplateRegistryInterface extends TemplateRegistryInterface
 {
     /**
-     * NEXT_MAJOR: Uncomment extra arg.
+     * NEXT_MAJOR: Uncomment extra arg and remove dependent record from phpstan-baseline.neon.
      *
      * @param array<string, string> $templates 'name' => 'file_path.html.twig'
      */
     public function setTemplates(array $templates/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 
-    /**
-     * NEXT_MAJOR: Uncomment extra arg.
-     */
+
+    // NEXT_MAJOR: Uncomment extra arg and remove dependent record from phpstan-baseline.neon.
     public function setTemplate(string $name, string $template/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 }

--- a/src/Templating/MutableTemplateRegistryInterface.php
+++ b/src/Templating/MutableTemplateRegistryInterface.php
@@ -18,20 +18,15 @@ namespace Sonata\AdminBundle\Templating;
  */
 interface MutableTemplateRegistryInterface extends TemplateRegistryInterface
 {
-
     /**
-     * NEXT_MAJOR: Remove phpstan-ignore line and uncomment extra arg.
+     * NEXT_MAJOR: Uncomment extra arg.
      *
      * @param array<string, string> $templates 'name' => 'file_path.html.twig'
-     *
-     * @phpstan-ignore arguments.count
      */
     public function setTemplates(array $templates/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 
     /**
-     * NEXT_MAJOR: Remove phpstan-ignore line and uncomment extra arg.
-     *
-     * @phpstan-ignore arguments.count
+     * NEXT_MAJOR: Uncomment extra arg.
      */
     public function setTemplate(string $name, string $template/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 }

--- a/src/Templating/MutableTemplateRegistryInterface.php
+++ b/src/Templating/MutableTemplateRegistryInterface.php
@@ -19,12 +19,12 @@ namespace Sonata\AdminBundle\Templating;
 interface MutableTemplateRegistryInterface extends TemplateRegistryInterface
 {
     /**
-     * NEXT_MAJOR: uncomment extra arg.
+     * NEXT_MAJOR: Uncomment extra arg.
      *
      * @param array<string, string> $templates 'name' => 'file_path.html.twig'
      */
     public function setTemplates(array $templates/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 
-    // NEXT_MAJOR: uncomment extra arg.
+    // NEXT_MAJOR: Uncomment extra arg.
     public function setTemplate(string $name, string $template/* , string $theme = TemplateRegistryInterface::DEFAULT_THEME */): void;
 }

--- a/src/Templating/TemplateRegistryInterface.php
+++ b/src/Templating/TemplateRegistryInterface.php
@@ -84,14 +84,14 @@ interface TemplateRegistryInterface
      */
     public function getTemplates(/* string $theme = self::DEFAULT_THEME */): array;
 
-    /*
+    /**
      * NEXT_MAJOR: Remove phpstan-ignore line and uncomment extra arg.
      *
      * @phpstan-ignore arguments.count
      */
     public function getTemplate(string $name/* , string $theme = self::DEFAULT_THEME */): string;
 
-    /*
+    /**
      * NEXT_MAJOR: Remove phpstan-ignore line and uncomment extra arg.
      *
      * @phpstan-ignore arguments.count

--- a/src/Templating/TemplateRegistryInterface.php
+++ b/src/Templating/TemplateRegistryInterface.php
@@ -85,7 +85,6 @@ interface TemplateRegistryInterface
     // NEXT_MAJOR: Uncomment extra arg and remove dependent record from phpstan-baseline.neon.
     public function getTemplate(string $name/* , string $theme = self::DEFAULT_THEME */): string;
 
-
     // NEXT_MAJOR: Uncomment extra arg and remove dependent record from phpstan-baseline.neon.
     public function hasTemplate(string $name/* , string $theme = self::DEFAULT_THEME */): bool;
 }

--- a/src/Templating/TemplateRegistryInterface.php
+++ b/src/Templating/TemplateRegistryInterface.php
@@ -20,6 +20,7 @@ use Sonata\AdminBundle\FieldDescription\FieldDescriptionInterface;
  */
 interface TemplateRegistryInterface
 {
+    public const DEFAULT_THEME = 'default';
     /**
      * @internal
      */
@@ -78,11 +79,11 @@ interface TemplateRegistryInterface
      * @return array<string, string> 'name' => 'file_path.html.twig'
      *                               NEXT_MAJOR: uncomment extra arg
      */
-    public function getTemplates(/* string $theme = 'default' */): array;
+    public function getTemplates(/* string $theme = self::DEFAULT_THEME */): array;
 
     // NEXT_MAJOR: uncomment extra arg
-    public function getTemplate(string $name/* , string $theme = 'default' */): string;
+    public function getTemplate(string $name/* , string $theme = self::DEFAULT_THEME */): string;
 
     // NEXT_MAJOR: uncomment extra arg
-    public function hasTemplate(string $name/* , string $theme = 'default' */): bool;
+    public function hasTemplate(string $name/* , string $theme = self::DEFAULT_THEME */): bool;
 }

--- a/src/Templating/TemplateRegistryInterface.php
+++ b/src/Templating/TemplateRegistryInterface.php
@@ -76,15 +76,25 @@ interface TemplateRegistryInterface
     ];
 
     /**
-     * NEXT_MAJOR: Uncomment extra arg.
+     * NEXT_MAJOR: Remove phpstan-ignore line and uncomment extra arg.
      *
      * @return array<string, string> 'name' => 'file_path.html.twig'
+     *
+     * @phpstan-ignore arguments.count
      */
     public function getTemplates(/* string $theme = self::DEFAULT_THEME */): array;
 
-    // NEXT_MAJOR: Uncomment extra arg.
+    /*
+     * NEXT_MAJOR: Remove phpstan-ignore line and uncomment extra arg.
+     *
+     * @phpstan-ignore arguments.count
+     */
     public function getTemplate(string $name/* , string $theme = self::DEFAULT_THEME */): string;
 
-    // NEXT_MAJOR: Uncomment extra arg.
+    /*
+     * NEXT_MAJOR: Remove phpstan-ignore line and uncomment extra arg.
+     *
+     * @phpstan-ignore arguments.count
+     */
     public function hasTemplate(string $name/* , string $theme = self::DEFAULT_THEME */): bool;
 }

--- a/src/Templating/TemplateRegistryInterface.php
+++ b/src/Templating/TemplateRegistryInterface.php
@@ -76,25 +76,16 @@ interface TemplateRegistryInterface
     ];
 
     /**
-     * NEXT_MAJOR: Remove phpstan-ignore line and uncomment extra arg.
+     * NEXT_MAJOR: Uncomment extra arg.
      *
      * @return array<string, string> 'name' => 'file_path.html.twig'
-     *
-     * @phpstan-ignore arguments.count
      */
     public function getTemplates(/* string $theme = self::DEFAULT_THEME */): array;
 
-    /**
-     * NEXT_MAJOR: Remove phpstan-ignore line and uncomment extra arg.
-     *
-     * @phpstan-ignore arguments.count
-     */
+    // NEXT_MAJOR: Uncomment extra arg.
     public function getTemplate(string $name/* , string $theme = self::DEFAULT_THEME */): string;
 
-    /**
-     * NEXT_MAJOR: Remove phpstan-ignore line and uncomment extra arg.
-     *
-     * @phpstan-ignore arguments.count
-     */
+
+    // NEXT_MAJOR: Uncomment extra arg.
     public function hasTemplate(string $name/* , string $theme = self::DEFAULT_THEME */): bool;
 }

--- a/src/Templating/TemplateRegistryInterface.php
+++ b/src/Templating/TemplateRegistryInterface.php
@@ -76,15 +76,15 @@ interface TemplateRegistryInterface
     ];
 
     /**
-     * NEXT_MAJOR: uncomment extra arg.
+     * NEXT_MAJOR: Uncomment extra arg.
      *
      * @return array<string, string> 'name' => 'file_path.html.twig'
      */
     public function getTemplates(/* string $theme = self::DEFAULT_THEME */): array;
 
-    // NEXT_MAJOR: uncomment extra arg.
+    // NEXT_MAJOR: Uncomment extra arg.
     public function getTemplate(string $name/* , string $theme = self::DEFAULT_THEME */): string;
 
-    // NEXT_MAJOR: uncomment extra arg.
+    // NEXT_MAJOR: Uncomment extra arg.
     public function hasTemplate(string $name/* , string $theme = self::DEFAULT_THEME */): bool;
 }

--- a/src/Templating/TemplateRegistryInterface.php
+++ b/src/Templating/TemplateRegistryInterface.php
@@ -77,6 +77,7 @@ interface TemplateRegistryInterface
 
     /**
      * NEXT_MAJOR: uncomment extra arg.
+     *
      * @return array<string, string> 'name' => 'file_path.html.twig'
      */
     public function getTemplates(/* string $theme = self::DEFAULT_THEME */): array;

--- a/src/Templating/TemplateRegistryInterface.php
+++ b/src/Templating/TemplateRegistryInterface.php
@@ -76,10 +76,13 @@ interface TemplateRegistryInterface
 
     /**
      * @return array<string, string> 'name' => 'file_path.html.twig'
+     *                               NEXT_MAJOR: uncomment extra arg
      */
-    public function getTemplates(): array;
+    public function getTemplates(/* string $theme = 'default' */): array;
 
-    public function getTemplate(string $name): string;
+    // NEXT_MAJOR: uncomment extra arg
+    public function getTemplate(string $name/* , string $theme = 'default' */): string;
 
-    public function hasTemplate(string $name): bool;
+    // NEXT_MAJOR: uncomment extra arg
+    public function hasTemplate(string $name/* , string $theme = 'default' */): bool;
 }

--- a/src/Templating/TemplateRegistryInterface.php
+++ b/src/Templating/TemplateRegistryInterface.php
@@ -76,14 +76,14 @@ interface TemplateRegistryInterface
     ];
 
     /**
+     * NEXT_MAJOR: uncomment extra arg.
      * @return array<string, string> 'name' => 'file_path.html.twig'
-     *                               NEXT_MAJOR: uncomment extra arg
      */
     public function getTemplates(/* string $theme = self::DEFAULT_THEME */): array;
 
-    // NEXT_MAJOR: uncomment extra arg
+    // NEXT_MAJOR: uncomment extra arg.
     public function getTemplate(string $name/* , string $theme = self::DEFAULT_THEME */): string;
 
-    // NEXT_MAJOR: uncomment extra arg
+    // NEXT_MAJOR: uncomment extra arg.
     public function hasTemplate(string $name/* , string $theme = self::DEFAULT_THEME */): bool;
 }

--- a/src/Templating/TemplateRegistryInterface.php
+++ b/src/Templating/TemplateRegistryInterface.php
@@ -76,16 +76,16 @@ interface TemplateRegistryInterface
     ];
 
     /**
-     * NEXT_MAJOR: Uncomment extra arg.
+     * NEXT_MAJOR: Uncomment extra arg and remove dependent record from phpstan-baseline.neon.
      *
      * @return array<string, string> 'name' => 'file_path.html.twig'
      */
     public function getTemplates(/* string $theme = self::DEFAULT_THEME */): array;
 
-    // NEXT_MAJOR: Uncomment extra arg.
+    // NEXT_MAJOR: Uncomment extra arg and remove dependent record from phpstan-baseline.neon.
     public function getTemplate(string $name/* , string $theme = self::DEFAULT_THEME */): string;
 
 
-    // NEXT_MAJOR: Uncomment extra arg.
+    // NEXT_MAJOR: Uncomment extra arg and remove dependent record from phpstan-baseline.neon.
     public function hasTemplate(string $name/* , string $theme = self::DEFAULT_THEME */): bool;
 }

--- a/src/Twig/TemplateRegistryRuntime.php
+++ b/src/Twig/TemplateRegistryRuntime.php
@@ -43,6 +43,7 @@ final class TemplateRegistryRuntime implements RuntimeExtensionInterface
 
         /*
          * NEXT_MAJOR: Remove phpstan-ignore line.
+         *
          * @phpstan-ignore arguments.count
          */
         return $this->getTemplateRegistry($adminCode)->getTemplate($name, $theme);
@@ -56,6 +57,7 @@ final class TemplateRegistryRuntime implements RuntimeExtensionInterface
 
         /*
          * NEXT_MAJOR: Remove phpstan-ignore line.
+         *
          * @phpstan-ignore arguments.count
          */
         return $this->globalTemplateRegistry->getTemplate($name, $theme);

--- a/src/Twig/TemplateRegistryRuntime.php
+++ b/src/Twig/TemplateRegistryRuntime.php
@@ -42,7 +42,7 @@ final class TemplateRegistryRuntime implements RuntimeExtensionInterface
         }
 
         /*
-         * NEXT_MAJOR: remove phpstan-ignore
+         * NEXT_MAJOR: Remove phpstan-ignore line.
          * @phpstan-ignore arguments.count
          */
         return $this->getTemplateRegistry($adminCode)->getTemplate($name, $theme);
@@ -55,7 +55,7 @@ final class TemplateRegistryRuntime implements RuntimeExtensionInterface
         }
 
         /*
-         * NEXT_MAJOR: remove phpstan-ignore
+         * NEXT_MAJOR: Remove phpstan-ignore line.
          * @phpstan-ignore arguments.count
          */
         return $this->globalTemplateRegistry->getTemplate($name, $theme);

--- a/src/Twig/TemplateRegistryRuntime.php
+++ b/src/Twig/TemplateRegistryRuntime.php
@@ -35,14 +35,14 @@ final class TemplateRegistryRuntime implements RuntimeExtensionInterface
      * @throws ServiceNotFoundException
      * @throws ServiceCircularReferenceException
      */
-    public function getAdminTemplate(string $name, string $adminCode): string
+    public function getAdminTemplate(string $name, string $adminCode, string $theme = 'default'): string
     {
-        return $this->getTemplateRegistry($adminCode)->getTemplate($name);
+        return $this->getTemplateRegistry($adminCode)->getTemplate($name, $theme);
     }
 
-    public function getGlobalTemplate(string $name): string
+    public function getGlobalTemplate(string $name, string $theme = 'default'): string
     {
-        return $this->globalTemplateRegistry->getTemplate($name);
+        return $this->globalTemplateRegistry->getTemplate($name, $theme);
     }
 
     /**

--- a/src/Twig/TemplateRegistryRuntime.php
+++ b/src/Twig/TemplateRegistryRuntime.php
@@ -41,7 +41,7 @@ final class TemplateRegistryRuntime implements RuntimeExtensionInterface
             return $this->getTemplateRegistry($adminCode)->getTemplate($name);
         }
 
-        /**
+        /*
          * NEXT_MAJOR: remove phpstan-ignore
          * @phpstan-ignore arguments.count
          */
@@ -54,7 +54,7 @@ final class TemplateRegistryRuntime implements RuntimeExtensionInterface
             return $this->globalTemplateRegistry->getTemplate($name);
         }
 
-        /**
+        /*
          * NEXT_MAJOR: remove phpstan-ignore
          * @phpstan-ignore arguments.count
          */

--- a/src/Twig/TemplateRegistryRuntime.php
+++ b/src/Twig/TemplateRegistryRuntime.php
@@ -35,9 +35,9 @@ final class TemplateRegistryRuntime implements RuntimeExtensionInterface
      * @throws ServiceNotFoundException
      * @throws ServiceCircularReferenceException
      */
-    public function getAdminTemplate(string $name, string $adminCode, ?string $theme = null): string
+    public function getAdminTemplate(string $name, string $adminCode, string $theme = TemplateRegistryInterface::DEFAULT_THEME): string
     {
-        if (null === $theme) {
+        if (TemplateRegistryInterface::DEFAULT_THEME === $theme) {
             return $this->getTemplateRegistry($adminCode)->getTemplate($name);
         }
 
@@ -48,9 +48,9 @@ final class TemplateRegistryRuntime implements RuntimeExtensionInterface
         return $this->getTemplateRegistry($adminCode)->getTemplate($name, $theme);
     }
 
-    public function getGlobalTemplate(string $name, ?string $theme = null): string
+    public function getGlobalTemplate(string $name, string $theme = TemplateRegistryInterface::DEFAULT_THEME): string
     {
-        if (null === $theme) {
+        if (TemplateRegistryInterface::DEFAULT_THEME === $theme) {
             return $this->globalTemplateRegistry->getTemplate($name);
         }
 

--- a/src/Twig/TemplateRegistryRuntime.php
+++ b/src/Twig/TemplateRegistryRuntime.php
@@ -35,13 +35,29 @@ final class TemplateRegistryRuntime implements RuntimeExtensionInterface
      * @throws ServiceNotFoundException
      * @throws ServiceCircularReferenceException
      */
-    public function getAdminTemplate(string $name, string $adminCode, string $theme = 'default'): string
+    public function getAdminTemplate(string $name, string $adminCode, ?string $theme = null): string
     {
+        if (null === $theme) {
+            return $this->getTemplateRegistry($adminCode)->getTemplate($name);
+        }
+
+        /**
+         * NEXT_MAJOR: remove phpstan-ignore
+         * @phpstan-ignore arguments.count
+         */
         return $this->getTemplateRegistry($adminCode)->getTemplate($name, $theme);
     }
 
-    public function getGlobalTemplate(string $name, string $theme = 'default'): string
+    public function getGlobalTemplate(string $name, ?string $theme = null): string
     {
+        if (null === $theme) {
+            return $this->globalTemplateRegistry->getTemplate($name);
+        }
+
+        /**
+         * NEXT_MAJOR: remove phpstan-ignore
+         * @phpstan-ignore arguments.count
+         */
         return $this->globalTemplateRegistry->getTemplate($name, $theme);
     }
 

--- a/tests/Templating/MutableTemplateRegistryTest.php
+++ b/tests/Templating/MutableTemplateRegistryTest.php
@@ -25,7 +25,13 @@ final class MutableTemplateRegistryTest extends TestCase
     {
         parent::setUp();
 
-        $this->templateRegistry = new MutableTemplateRegistry(['list' => '@FooAdmin/CRUD/list.html.twig']);
+        $this->templateRegistry = new MutableTemplateRegistry(
+            ['list' => '@FooAdmin/CRUD/list.html.twig'],
+            [
+                'default' => ['list' => '@FooAdmin/CRUD/list.html.twig'],
+                'second_theme' => ['list' => '@FooAdmin/CRUD_v2/list.html.twig'],
+            ]
+        );
     }
 
     public function testGetTemplates(): void
@@ -39,6 +45,18 @@ final class MutableTemplateRegistryTest extends TestCase
 
         $this->templateRegistry->setTemplates($templates);
         static::assertSame($templates + ['list' => '@FooAdmin/CRUD/list.html.twig'], $this->templateRegistry->getTemplates());
+    }
+
+    public function testGetThemedTemplates(): void
+    {
+        $templates = [
+            'show' => '@FooAdmin/CRUD/show.html.twig',
+            'edit' => '@FooAdmin/CRUD/edit.html.twig',
+        ];
+
+        static::assertSame(['list' => '@FooAdmin/CRUD_v2/list.html.twig'], $this->templateRegistry->getTemplates('second_theme'));
+        $this->templateRegistry->setTemplates($templates, 'second_theme');
+        static::assertSame($templates + ['list' => '@FooAdmin/CRUD_v2/list.html.twig'], $this->templateRegistry->getTemplates('second_theme'));
     }
 
     public function testGetTemplateAfterSetTemplate(): void
@@ -64,5 +82,20 @@ final class MutableTemplateRegistryTest extends TestCase
         static::assertSame('@FooAdmin/CRUD/edit.html.twig', $this->templateRegistry->getTemplate('edit'));
 
         static::assertFalse($this->templateRegistry->hasTemplate('nonexist_template'));
+    }
+
+    public function testGetThemedTemplateAfterSetTemplates(): void
+    {
+        $templates = [
+            'show' => '@FooAdmin/CRUD/show.html.twig',
+            'edit' => '@FooAdmin/CRUD/edit.html.twig',
+        ];
+
+        $this->templateRegistry->setTemplates($templates, 'second_theme');
+
+        static::assertTrue($this->templateRegistry->hasTemplate('edit', 'second_theme'));
+        static::assertSame('@FooAdmin/CRUD/edit.html.twig', $this->templateRegistry->getTemplate('edit', 'second_theme'));
+
+        static::assertFalse($this->templateRegistry->hasTemplate('nonexist_template', 'second_theme'));
     }
 }

--- a/tests/Templating/MutableTemplateRegistryTest.php
+++ b/tests/Templating/MutableTemplateRegistryTest.php
@@ -98,4 +98,19 @@ final class MutableTemplateRegistryTest extends TestCase
 
         static::assertFalse($this->templateRegistry->hasTemplate('nonexist_template', 'second_theme'));
     }
+
+    public function testSetThemedTemplatesOnNewThem(): void
+    {
+        $templates = [
+            'show' => '@FooAdmin/CRUD/show.html.twig',
+            'edit' => '@FooAdmin/CRUD/edit.html.twig',
+        ];
+
+        $this->templateRegistry->setTemplates($templates, 'empty_theme');
+
+        static::assertTrue($this->templateRegistry->hasTemplate('edit', 'empty_theme'));
+        static::assertSame('@FooAdmin/CRUD/edit.html.twig', $this->templateRegistry->getTemplate('edit', 'empty_theme'));
+
+        static::assertFalse($this->templateRegistry->hasTemplate('nonexist_template', 'empty_theme'));
+    }
 }

--- a/tests/Templating/TemplateRegistryTest.php
+++ b/tests/Templating/TemplateRegistryTest.php
@@ -52,15 +52,10 @@ final class TemplateRegistryTest extends TestCase
         ];
 
         static::assertSame($templates, $this->templateRegistry->getTemplates());
+    }
 
-        $templates = [
-            'list' => '@FooAdmin/CRUD/list.html.twig',
-            'show' => '@FooAdmin/CRUD/show.html.twig',
-            'edit' => '@FooAdmin/CRUD/edit.html.twig',
-        ];
-
-        static::assertSame($templates, $this->templateRegistry->getTemplates('default'));
-
+    public function testGetThemedTemplates(): void
+    {
         $templates = [
             'list' => '@FooAdmin/CRUD_v2/list.html.twig',
             'show' => '@FooAdmin/CRUD_v2/show.html.twig',
@@ -78,12 +73,15 @@ final class TemplateRegistryTest extends TestCase
         static::assertFalse($this->templateRegistry->hasTemplate('foo'));
 
         $this->templateRegistry->getTemplate('foo');
+    }
 
+    public function testThrowExceptionIfTheThemedTemplateDoesNotExist(): void
+    {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Template named "foo" doesn\'t exist for "second_theme" theme.');
 
         static::assertFalse($this->templateRegistry->hasTemplate('foo', 'second_theme'));
 
-        $this->templateRegistry->getTemplate('foo');
+        $this->templateRegistry->getTemplate('foo', 'second_theme');
     }
 }

--- a/tests/Templating/TemplateRegistryTest.php
+++ b/tests/Templating/TemplateRegistryTest.php
@@ -22,11 +22,25 @@ final class TemplateRegistryTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->templateRegistry = new TemplateRegistry([
-            'list' => '@FooAdmin/CRUD/list.html.twig',
-            'show' => '@FooAdmin/CRUD/show.html.twig',
-            'edit' => '@FooAdmin/CRUD/edit.html.twig',
-        ]);
+        $this->templateRegistry = new TemplateRegistry(
+            [
+                'list' => '@FooAdmin/CRUD/list.html.twig',
+                'show' => '@FooAdmin/CRUD/show.html.twig',
+                'edit' => '@FooAdmin/CRUD/edit.html.twig',
+            ],
+            [
+                'default' => [
+                    'list' => '@FooAdmin/CRUD/list.html.twig',
+                    'show' => '@FooAdmin/CRUD/show.html.twig',
+                    'edit' => '@FooAdmin/CRUD/edit.html.twig',
+                ],
+                'second_theme' => [
+                    'list' => '@FooAdmin/CRUD_v2/list.html.twig',
+                    'show' => '@FooAdmin/CRUD_v2/show.html.twig',
+                    'edit' => '@FooAdmin/CRUD_v2/edit.html.twig',
+                ],
+            ]
+        );
     }
 
     public function testGetTemplates(): void
@@ -38,6 +52,22 @@ final class TemplateRegistryTest extends TestCase
         ];
 
         static::assertSame($templates, $this->templateRegistry->getTemplates());
+
+        $templates = [
+            'list' => '@FooAdmin/CRUD/list.html.twig',
+            'show' => '@FooAdmin/CRUD/show.html.twig',
+            'edit' => '@FooAdmin/CRUD/edit.html.twig',
+        ];
+
+        static::assertSame($templates, $this->templateRegistry->getTemplates('default'));
+
+        $templates = [
+            'list' => '@FooAdmin/CRUD_v2/list.html.twig',
+            'show' => '@FooAdmin/CRUD_v2/show.html.twig',
+            'edit' => '@FooAdmin/CRUD_v2/edit.html.twig',
+        ];
+
+        static::assertSame($templates, $this->templateRegistry->getTemplates('second_theme'));
     }
 
     public function testThrowExceptionIfTheTemplateDoesNotExist(): void
@@ -46,6 +76,13 @@ final class TemplateRegistryTest extends TestCase
         $this->expectExceptionMessage('Template named "foo" doesn\'t exist.');
 
         static::assertFalse($this->templateRegistry->hasTemplate('foo'));
+
+        $this->templateRegistry->getTemplate('foo');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Template named "foo" doesn\'t exist for "second_theme" theme.');
+
+        static::assertFalse($this->templateRegistry->hasTemplate('foo', 'second_theme'));
 
         $this->templateRegistry->getTemplate('foo');
     }

--- a/tests/Twig/TemplateRegistryRuntimeTest.php
+++ b/tests/Twig/TemplateRegistryRuntimeTest.php
@@ -32,7 +32,7 @@ final class TemplateRegistryRuntimeTest extends TestCase
         $globalTemplateRegistry
             ->method('getTemplate')
             ->willReturnMap([
-                ['edit', 'default', '@SonataAdmin/CRUD/edit.html.twig'],
+                ['edit', '@SonataAdmin/CRUD/edit.html.twig'],
                 ['show', 'custom_theme', '@SonataAdmin/custom_theme/CRUD/show.html.twig'],
             ]);
 
@@ -40,7 +40,7 @@ final class TemplateRegistryRuntimeTest extends TestCase
         $adminTemplateRegistry
             ->method('getTemplate')
             ->willReturnMap([
-                ['edit', 'default', '@SonataAdmin/CRUD/edit.html.twig'],
+                ['edit', '@SonataAdmin/CRUD/edit.html.twig'],
                 ['show', 'custom_theme', '@SonataAdmin/custom_theme/CRUD/show.html.twig'],
             ]);
 

--- a/tests/Twig/TemplateRegistryRuntimeTest.php
+++ b/tests/Twig/TemplateRegistryRuntimeTest.php
@@ -28,11 +28,21 @@ final class TemplateRegistryRuntimeTest extends TestCase
 
     protected function setUp(): void
     {
-        $templateRegistry = $this->createMock(TemplateRegistryInterface::class);
-        $templateRegistry->method('getTemplate')->with('edit')->willReturn('@SonataAdmin/CRUD/edit.html.twig');
+        $globalTemplateRegistry = $this->createMock(TemplateRegistryInterface::class);
+        $globalTemplateRegistry
+            ->method('getTemplate')
+            ->willReturnMap([
+                ['edit', 'default', '@SonataAdmin/CRUD/edit.html.twig'],
+                ['show', 'custom_theme', '@SonataAdmin/custom_theme/CRUD/show.html.twig'],
+            ]);
 
         $adminTemplateRegistry = $this->createMock(MutableTemplateRegistryInterface::class);
-        $adminTemplateRegistry->method('getTemplate')->with('edit')->willReturn('@SonataAdmin/CRUD/edit.html.twig');
+        $adminTemplateRegistry
+            ->method('getTemplate')
+            ->willReturnMap([
+                ['edit', 'default', '@SonataAdmin/CRUD/edit.html.twig'],
+                ['show', 'custom_theme', '@SonataAdmin/custom_theme/CRUD/show.html.twig'],
+            ]);
 
         $admin = static::createStub(AdminInterface::class);
         $admin
@@ -44,7 +54,7 @@ final class TemplateRegistryRuntimeTest extends TestCase
         $pool = new Pool($container, ['admin.post']);
 
         $this->templateRegistryRuntime = new TemplateRegistryRuntime(
-            $templateRegistry,
+            $globalTemplateRegistry,
             $pool
         );
     }
@@ -54,6 +64,10 @@ final class TemplateRegistryRuntimeTest extends TestCase
         static::assertSame(
             '@SonataAdmin/CRUD/edit.html.twig',
             $this->templateRegistryRuntime->getAdminTemplate('edit', 'admin.post')
+        );
+        static::assertSame(
+            '@SonataAdmin/custom_theme/CRUD/show.html.twig',
+            $this->templateRegistryRuntime->getAdminTemplate('show', 'admin.post', 'custom_theme')
         );
     }
 
@@ -74,6 +88,10 @@ final class TemplateRegistryRuntimeTest extends TestCase
         static::assertSame(
             '@SonataAdmin/CRUD/edit.html.twig',
             $this->templateRegistryRuntime->getGlobalTemplate('edit')
+        );
+        static::assertSame(
+            '@SonataAdmin/custom_theme/CRUD/show.html.twig',
+            $this->templateRegistryRuntime->getGlobalTemplate('show', 'custom_theme')
         );
     }
 }


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->
## Subject
This PR will allow to add and using multiple list of templates in `TemplateRegistry` by adding `theme` as array key (identifier).

<!-- Describe your Pull Request content here -->


I am targeting this branch, because this features is BC.

Part of #8389

## Changelog

```markdown
### Added
- extra `string $theme = 'default'` argument for temples methods in `Templating` classes 

### Deprecated
- Sonata\AdminBundle\Templating\AbstractTemplateRegistry::templates 
```

<!--
    If this is a work in progress, uncomment the "To do" section.
    You can add as many tasks as you want.
    If some are not relevant, just remove them.
-->
<!--
## To do

- [ ] Update the tests;
- [ ] Update the documentation;
- [ ] Add an upgrade note.
-->
